### PR TITLE
Ignore typescript >= 6, and replace the measurement that was wrong

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -93,7 +93,7 @@ updates:
       - dependency-name: "@playwright/test"
       - dependency-name: "playwright"
 
-      # typescript >= 7 ONLY, and scoped by version range rather than by
+      # typescript >= 6, and scoped by version range rather than by
       # `update-types: semver-major` on purpose. TS 7 is the native (Go) port, and it
       # is not a version bump for this repo — it is three migrations at once, each
       # measured against 7.0.2 on #1204:
@@ -113,28 +113,69 @@ updates:
       # the repo's imports, and waiting for typescript-eslint support. A bot cannot
       # do that — same reasoning as the @playwright/test pin above.
       #
-      # None of it is true of TS 6, and a `semver-major` scope would have blocked TS 6
-      # while citing those three reasons. Measured against 6.0.3, the version
-      # Dependabot is proposing today (#1228): the JS compiler API is intact and
-      # ts-node runs; the same tsconfig yields `TS5107 ... is deprecated and will stop
-      # functioning in TypeScript 7.0`, silenced by one `ignoreDeprecations: "6.0"`
-      # line; and typescript-eslint 8.65.0's peer range (`<6.1.0`) admits it. So TS 6
-      # is deliberately let through — as its own PR, since the group takes no majors —
-      # for a reviewer to decide on. Blocking a major nobody has evidence against is
-      # how a rationale rots into a rule.
+      # TS 6 is none of those three things, and it was deliberately let through for a
+      # reviewer to decide on — the right call, because blocking a major nobody has
+      # evidence against is how a rationale rots into a rule. The reviewer decided
+      # (PR #1390, closed; #1419): TS 6 is ADOPTABLE and not worth adopting yet. The
+      # range therefore widened from `>=7` to `>=6`, and this is the evidence, since an
+      # ignore whose justification is left implicit rots the same way a block does.
+      #
+      # This paragraph replaces a MEASUREMENT THAT WAS WRONG (#1228 recorded that the
+      # `TS5107 moduleResolution=node10 is deprecated` error is "silenced by one
+      # `ignoreDeprecations: "6.0"` line"). It is silenced for `tsc` only. Measured
+      # against 6.0.3 with a real `npm ci`, three variants:
+      #
+      #                                                        tsc      ts-node
+      #   `ignoreDeprecations: "6.0"` only                     pass     39 FAILURES
+      #   `module` + `moduleResolution: node16`                pass     39 FAILURES
+      #   `ignoreDeprecations: "6.0"` + `types: ["node"]`      pass     pass
+      #
+      # The ts-node column is `test:units`, and the same break takes
+      # `check:checklist-coverage`, `regressions:check` and `coverage:summary` with it:
+      # `TS2591 Cannot find name 'fs' / 'process' / '__filename'`. Under TS 6 ts-node
+      # stops picking up `@types/node` automatically — isolated to `npx ts-node -e
+      # 'import * as fs from "fs"'`, which fails without `types: ["node"]` and passes
+      # with it. Note which variant is the dangerous one: the "correct"
+      # `moduleResolution` migration leaves `tsc` green and ts-node dead, a state the
+      # TypeScript job alone cannot see (the QA-CHECKLIST guard job catches it, because
+      # it runs through ts-node).
+      #
+      # So the price is TWO tsconfig lines, not one — and with them everything passes
+      # (tsc 0, `test:units` 552/552, `test:scripts` 796/796, the three ts-node gates
+      # green, lint unchanged). What made it not worth paying: no language feature this
+      # suite uses; `types: ["node"]` disables automatic `@types` inclusion, which is
+      # harmless while `@types/node` is the only one and a silent trap the day a second
+      # arrives; and `typescript-eslint@8.66` peers `typescript >=4.8.4 <6.1.0`, so
+      # 6.1 breaks `npm ci` — the install, not the typecheck. Adopting 6.0.x buys a
+      # major with no path forward until typescript-eslint 9.
+      #
+      # REVISIT when either half changes: a reason to want TS 6, or a typescript-eslint
+      # release admitting 6.1+. Adopting it is then a deliberate PR carrying the two
+      # tsconfig lines — never a merged bot PR, which cannot edit tsconfig.json and
+      # would land red.
       - dependency-name: "typescript"
         versions:
-          - ">=7"
+          - ">=6"
 
       # There is deliberately NO entry for @flakiness/playwright. 2.0.0 dropped Node
       # 20 (`engines` went to `>=22.9.0`) while every lane here pins "20" — but 2.0.1,
       # `latest` since 2026-07-30, restored `^20.17.0 || >=22.9.0`. An ignore written
       # against 2.0.0 would have blocked a release that was already compatible, and a
       # guard tying its removal to the Node pins would have failed the PR that removed
-      # it. v2 arrives as its own PR, which is where its two real breaking changes
-      # (the dropped `flakiness-playwright-shard` bin, unused here — sharding is
-      # scripts/partition-shards.mjs; and `shardBalancing` needing Playwright 1.62+,
-      # also unused) can be checked against what this repo does.
+      # it. v2 arrives as its own PR, which is where its two real breaking changes can
+      # be checked against what this repo does — and it did (2.0.1 merged in PR #1389).
+      # Both were confirmed inert against the installed package, not read off the
+      # changelog: the dropped `flakiness-playwright-shard` bin is unused (sharding is
+      # scripts/partition-shards.mjs, and only `flakiness-playwright-timings` remains in
+      # its `bin`), and `preprocess()` — the hook needing Playwright 1.62+ against the
+      # 1.58.2 pin — RETURNS IMMEDIATELY unless `shardBalancing` is configured, as does
+      # the "requires 1.62+" warning, so the version gap is unreachable. `flakinessProject`
+      # and the `FK_ENV_*` vars daily-stable.yml relies on both survive. Smoke-tested on
+      # node 20.20.2 + Playwright 1.58.2: the reporter loads, runs and writes a report,
+      # exit 0, no warning. Not covered by that, and unavoidable here: the OIDC UPLOAD
+      # path, which has no local credential and which the PR lane never exercises —
+      # a manifest-only change resolves to zero impacted specs (see this file's header),
+      # so the first real exercise of it is the next daily.
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/scripts/dependabot-config.test.mjs
+++ b/scripts/dependabot-config.test.mjs
@@ -138,28 +138,45 @@ test("the dev-dependencies group takes minor and patch only", () => {
   assert.deepEqual(types, new Set(["minor", "patch"]));
 });
 
-// ── the typescript ignore stays as narrow as its evidence ───────────────────
+// ── no typescript major arrives as a bot PR ─────────────────────────────────
 
-test("the typescript ignore blocks 7.x and up, not every major", () => {
+test("the typescript ignore starts at the NEXT major, so no bot can take one", () => {
+  // Derived from package.json rather than hardcoded, and that is the whole point.
+  // The first version of this test asserted the literal `[7]`, on the rationale that
+  // TS 6 was let through deliberately. That rationale expired the moment the reviewer
+  // decided (#1390 closed, #1419) — and the test then failed the PR implementing the
+  // decision, which is precisely the failure mode this file's header warns about: a
+  // guard pinning a proxy instead of the reason.
+  //
+  // The reason, which does not expire: a TypeScript major is never a version bump
+  // here. TS 6 needs two `tsconfig.json` lines (`ignoreDeprecations: "6.0"` and
+  // `types: ["node"]`, the latter because ts-node stops finding @types/node) and TS 7
+  // needs ts-node replaced outright. Dependabot edits package.json and the lockfile
+  // only, so its PR either lands red or — worse, and measured — lands with `tsc` green
+  // and every ts-node gate broken. So each major is gated behind a deliberate PR, and
+  // the ignore tracks whatever major the repo is on: adopting one moves BOTH numbers.
   const entry = entryFor("typescript");
   const versions = listValues(entry.body, "versions");
-
   assert.ok(versions, "the typescript ignore lost its versions: range");
-  // `update-types: semver-major` is the tempting shorthand and it is wrong here: it
-  // would also block TS 6, against which this repo has no evidence — the JS compiler
-  // API is intact there, ts-node runs, and typescript-eslint's peer range admits it.
-  assert.equal(
-    listValues(entry.body, "update-types"),
-    null,
-    "scoped by update-types instead of a version range — that blocks TS 6 too, which the file's own rationale does not justify",
-  );
+
+  const declared = PKG.devDependencies?.typescript ?? PKG.dependencies?.typescript;
+  const onMajor = Number(declared.match(/(\d+)/)[1]);
 
   const bounds = [...versions].map((v) => {
     const m = v.match(/^>=?\s*(\d+)/);
     assert.ok(m, `\`${v}\` is not a lower-bound range this guard can read`);
     return Number(m[1]);
   });
-  assert.deepEqual(bounds, [7], "the ignore no longer starts at the major the rationale is about");
+  // Exactly the next major: a higher bound would leave the majors in between open to
+  // the bot, which is the same hole from the other side. `update-types: semver-major`
+  // expresses the same thing and is deliberately NOT asserted against any more — the
+  // old test forbade it because it would have caught TS 6, and that objection is gone.
+  assert.deepEqual(
+    bounds,
+    [onMajor + 1],
+    `package.json is on typescript ${onMajor}, so the ignore must start at ${onMajor + 1} — ` +
+      `every major belongs to a human PR that can also edit tsconfig.json`,
+  );
 });
 
 test("no ignore range can block the major this repo is actually on", () => {

--- a/scripts/dependabot-config.test.mjs
+++ b/scripts/dependabot-config.test.mjs
@@ -118,6 +118,33 @@ function ignoreEntries() {
 
 const ENTRIES = ignoreEntries();
 
+/**
+ * The major version package.json declares for `name`, as a number.
+ *
+ * Both reads it replaces did `declared.match(/(\d+)/)[1]` on a value that can be
+ * absent or carry no digits, and a guard that dies with `Cannot read properties of
+ * undefined (reading 'match')` names its own plumbing instead of the config change
+ * that caused it. Two states are plausible rather than theoretical: `typescript`
+ * leaving package.json (replacing it is on the table for TS 7, per the ignore's own
+ * rationale), and a specifier with no numeric major — `"latest"`, a git URL, a
+ * `workspace:*` range. Both now fail saying which package and which specifier.
+ */
+function declaredMajor(name) {
+  const declared = PKG.devDependencies?.[name] ?? PKG.dependencies?.[name];
+  assert.ok(
+    declared,
+    `${CONFIG_PATH} ignores "${name}", which package.json does not declare — ` +
+      `remove the ignore entry or restore the dependency`,
+  );
+  const m = declared.match(/(\d+)/);
+  assert.ok(
+    m,
+    `package.json declares "${name}": "${declared}", which carries no numeric major, ` +
+      `so this guard cannot compare it against the ignore range`,
+  );
+  return Number(m[1]);
+}
+
 function entryFor(name) {
   const found = ENTRIES.filter((e) => e.name === name);
   // Exactly one: a second, wider entry for the same package later in the list would
@@ -159,8 +186,7 @@ test("the typescript ignore starts at the NEXT major, so no bot can take one", (
   const versions = listValues(entry.body, "versions");
   assert.ok(versions, "the typescript ignore lost its versions: range");
 
-  const declared = PKG.devDependencies?.typescript ?? PKG.dependencies?.typescript;
-  const onMajor = Number(declared.match(/(\d+)/)[1]);
+  const onMajor = declaredMajor("typescript");
 
   const bounds = [...versions].map((v) => {
     const m = v.match(/^>=?\s*(\d+)/);
@@ -187,12 +213,17 @@ test("no ignore range can block the major this repo is actually on", () => {
     const versions = listValues(entry.body, "versions");
     if (!versions) continue;
 
-    const declared = PKG.devDependencies?.[entry.name] ?? PKG.dependencies?.[entry.name];
-    assert.ok(declared, `${CONFIG_PATH} ignores "${entry.name}", which package.json does not declare`);
-    const onMajor = Number(declared.match(/(\d+)/)[1]);
+    const onMajor = declaredMajor(entry.name);
 
     for (const v of versions) {
-      const lower = Number(v.match(/^>=?\s*(\d+)/)[1]);
+      const m = v.match(/^>=?\s*(\d+)/);
+      assert.ok(
+        m,
+        `the ignore for "${entry.name}" carries \`${v}\`, which is not a lower-bound ` +
+          `range this guard can read (e.g. an upper bound or a wildcard) — widen the ` +
+          `guard deliberately rather than leaving it unable to judge the entry`,
+      );
+      const lower = Number(m[1]);
       assert.ok(
         lower > onMajor,
         `the ignore for "${entry.name}" starts at ${lower}, but package.json is on ${onMajor} — it would block the current line`,


### PR DESCRIPTION
Closes #1419

Two notes in `.github/dependabot.yml` had outlived what they described. The first was not merely stale — it was **false**, and false in the direction that costs the reader an afternoon.

## The TS 6 note

It recorded, from #1228, that `TS5107 moduleResolution=node10 is deprecated` is *"silenced by one `ignoreDeprecations: "6.0"` line"*. It is silenced for `tsc` **only**. Measured against 6.0.3 with a real `npm ci` (in a throwaway worktree, so nothing was read off `npm ls`):

| variant | `tsc` | ts-node |
|---|---|---|
| `ignoreDeprecations: "6.0"` only | pass | **39 failures** |
| `module` + `moduleResolution: node16` (the real migration) | pass | **39 failures** |
| `ignoreDeprecations: "6.0"` **+** `types: ["node"]` | pass | pass |

The ts-node column is `test:units`, and the same break takes `check:checklist-coverage`, `regressions:check` and `coverage:summary` with it — `TS2591 Cannot find name 'fs' / 'process' / '__filename'`. Under TS 6 ts-node stops picking up `@types/node` automatically; isolated to `npx ts-node -e 'import * as fs from "fs"'`, which fails without `types: ["node"]` and passes with it.

Worth noting which variant is the dangerous one: the *"correct"* `moduleResolution` migration leaves `tsc` green and ts-node dead — a state the TypeScript job alone cannot see. The QA-CHECKLIST guard job catches it, because it runs through ts-node.

So TS 6 costs **two** tsconfig lines, not one, and with them everything passes (tsc 0, `test:units` 552/552, `test:scripts` 796/796, three ts-node gates green, lint unchanged). What made it not worth paying — the reason PR #1390 was closed — is now in the file: no language feature this suite uses; `types: ["node"]` disables automatic `@types` inclusion, harmless while `@types/node` is the only one and a silent trap the day a second arrives; and `typescript-eslint@8.66` peers `typescript >=4.8.4 <6.1.0`, so **6.1 breaks `npm ci`** — the install, not the typecheck.

**The range widens `>=7` → `>=6`** with the exit condition named, because closing #1390 alone does not stick: Dependabot proposes 6.0.4 next week. Cost of widening, documented in this file's own header: `ignore` also suppresses **security** updates in that range. For a dev-only compiler an advisory still surfaces as an alert — it just produces no PR.

## The @flakiness/playwright note

It said v2 *"arrives as its own PR, which is where its two real breaking changes ... can be checked"*. It arrived (#1389) and they were checked — against the installed package, not the changelog: the dropped `flakiness-playwright-shard` bin is unused (only `flakiness-playwright-timings` remains in its `bin`), and `preprocess()` — the hook wanting Playwright 1.62+ against the 1.58.2 pin — **returns immediately unless `shardBalancing` is configured**, as does the "requires 1.62+" warning, so the version gap is unreachable. `flakinessProject` and the `FK_ENV_*` vars `daily-stable.yml` relies on both survive. Smoke-tested on node 20.20.2 + PW 1.58.2: loads, runs, writes a report, exit 0, no warning.

The note now records the outcome instead of the plan — **including the gap**: the OIDC upload path is exercised by neither the smoke test (no local credential) nor the PR lane (a manifest-only change resolves to zero impacted specs), so the next daily is its first real exercise.

## The guard had to change, and that is the interesting part

`scripts/dependabot-config.test.mjs` asserted the literal `[7]`, so it **failed the PR implementing the decision it exists to protect** — exactly the failure its own header warns about, and the second time this file has had it (the first was the @flakiness/playwright guard tied to the repo's `node-version:` pins, which would have failed the correct change).

It now derives the bound from `package.json`: the ignore must start at the **next** major, because a TypeScript major is never a version bump here and Dependabot edits only the manifest and lockfile. That invariant does not expire — adopting TS 6 moves both numbers. A higher bound is the same hole from the other side (it would leave the majors in between open to the bot), so the assertion is equality, not `>`.

Two mutations killed: `>=7` (leaves TS 6 to the bot) and `>=5` (blocks the line the repo is on — trips this test *and* the pre-existing `no ignore range can block the major this repo is actually on`).

The `update-types: semver-major` assertion is **deliberately dropped**: it existed because that shorthand would also have blocked TS 6, and that objection is gone now that blocking TS 6 is the decision. Keeping a guard whose stated reason expired is the defect this PR is about.

## Validation

`test:scripts` 797/797, `test:units` 598/598, typecheck clean, lint unchanged (0 errors). No spec or doc touched, so no QA-CHECKLIST bullet applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)