### PR TITLE
chore(triage): quarantine 3 recurrent flakes from the 2026-08-11 daily (#1417)

### DIFF
--- a/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
@@ -124,9 +124,14 @@ async function runFlowAndOpenChatOutputInspection(page: Page): Promise<string> {
 // Test 1 — Chat Input rendering on canvas
 // =============================================================================
 
-test(
+// Quarantined at triage (daily #1417): recurrent flake — the sidebar
+// add-component click does not place the node, so `title-Chat Input` never
+// enters the DOM (`element(s) not found`, not "present but not visible").
+// Same signature on the 2026-07-17 and 08-11 dailies. Lifting the quarantine
+// (remove test.fixme + restore @stable) is a deliverable of #1423.
+test.fixme(
   "Chat Input component — renders on canvas with Message output handle and Input Text field",
-  { tag: ["@stable", "@regression", "@components"] },
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await addChatInputComponent(page);
 

--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
@@ -135,9 +135,16 @@ async function expectReplyContainsToken(
 test.describe.configure({ mode: "serial" });
 
 test.describe("OpenAI Provider", () => {
-  test(
+  // Quarantined at triage (daily #1417): recurrent flake — the POST/PATCH
+  // /api/v1/variables/ persist call is answered non-2xx while
+  // validate-provider succeeds, so the key authenticates but does not
+  // persist. Same signature on the 2026-07-13 and 08-11 dailies; that match
+  // needs settling, because both `ok()` assertions below emit it and the
+  // 07-13 daily fell in the quota-drained window (see #1424). Lifting the
+  // quarantine (remove test.fixme + restore @stable) is a deliverable of #1424.
+  test.fixme(
     "OpenAI API key is configured via Settings → Model Providers",
-    { tag: ["@stable", "@model-provider", "@settings"] },
+    { tag: ["@model-provider", "@settings"] },
     async ({ page }) => {
       test.skip(
         !hasProviderEnvKeys(PROVIDER),

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/flow-error-message.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/flow-error-message.spec.ts
@@ -37,9 +37,15 @@ test.afterEach(async ({ request }) => {
   }
 });
 
-test(
+// Quarantined at triage (daily #1417): recurrent flake — the sidebar
+// add-component click does not place the node, so `button_run_api request`
+// never enters the DOM (`element(s) not found`, not "present but not
+// visible"). Same signature on the 2026-07-16, 07-20 and 08-11 dailies.
+// Lifting the quarantine (remove test.fixme + restore @stable) is a
+// deliverable of #1423.
+test.fixme(
   "a misconfigured flow surfaces an appropriate build-error message",
-  { tag: ["@stable", "@release", "@components", "@observability"] },
+  { tag: ["@release", "@components", "@observability"] },
   async ({ page }) => {
     trackCreatedFlows(page);
     // The build failure below is intentional — without this the fixture's


### PR DESCRIPTION
Prevention step of the triage for daily run [31475108157](https://github.com/oriontech-me/langflow-e2e/actions/runs/31475108157) (umbrella #1417). Three flakes recurred under the same `error_signature` inside the 30-day window, which under `CONTRIBUTING.md` → the criteria table means a dedicated issue **and** a quarantine via PR.

The guard did **not** trip on this run (1 hard failure against a threshold of 5), so the workflow auto-removed `@stable` from the hard failure only — flakes are never auto-removed.

## What changed

Both edits per test, always together — `@stable` removed **and** `test.fixme` added. Tag removal alone only stops the daily; the test keeps going red on the `pr-validation.yml` impacted-specs gate, which selects specs by file diff rather than by tag (#871).

| Test | Recurrence | Issue |
|---|---|---|
| `tests/tests-automations/regression/core-functionality/observability-monitoring/flow-error-message.spec.ts:40` | 3× — 2026-07-16, 07-20, 08-11 | #1423 |
| `tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts:127` | 2× — 2026-07-17, 08-11 | #1423 |
| `tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts:138` | 2× — 2026-07-13, 08-11 | #1424 |

Each `test.fixme` carries the reason, the recurrence dates and the issue number in a comment above it, so the quarantine explains itself at the call site.

## What this PR is not

It carries **no fix and no investigation** — the triage dispatches, the dedicated issue resolves. Lifting each quarantine (remove `test.fixme`, restore `@stable`, re-validate per `CONTRIBUTING.md`) is a deliverable of #1423 / #1424, so this PR deliberately uses no auto-close keyword.

The hard failure from the same run (`mcp-server.spec.ts:780`, #1422) is **not** here: the workflow already removed its `@stable` in `40f94bd`, and its `test.fixme` belongs to #1422 when it is worked.

## Validation

- `npm run typecheck` — clean
- `npx eslint` on the three specs — 0 errors (only the pre-existing `no-skipped-test` / `no-conditional-in-test` warnings that every `test.fixme` in the suite carries)
- `npm run check:checklist-coverage` — passes; every `@stable` and documented spec is still referenced by a Part II bullet, so no checklist edit is owed
- `scripts/check-checklist-guard.mjs` — no generated block touched
- `npx playwright test --list --grep @stable` on the three files: the quarantined tests no longer select, the untouched ones still do (`flow-error-message` now lists none, `chat-input-output` 5, `openai-provider` 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)