### PR TITLE
fix(components): repair the swallowed Custom Component add and lift the #1301 quarantine (#1301)

### DIFF
--- a/docs/core-components/edit-name-description-node.md
+++ b/docs/core-components/edit-name-description-node.md
@@ -1,6 +1,6 @@
 # Edit Node Name & Description — §12.2 View and Edit Flow
 
-**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev23`)
 
 ---
 
@@ -35,7 +35,9 @@ Bootstrap the app (`awaitBootstrapTest`), open a blank flow, and add a Custom
 Component. Every flow this page creates is captured from its
 `POST /api/v1/flows → 201` response and deleted id-scoped in `afterEach`.
 
-1. Add a Custom Component (`sidebar-custom-component-button`) and select the node
+1. Add a Custom Component via `addCustomComponent` (which clicks
+   `sidebar-custom-component-button` and does not return until a node that was
+   not on the canvas before is on it — see the #1301 note) and select the node
    (`div-generic-node`).
 2. Open the editor (`node-edit-name-description-button`); fill the title input
    (`input-title-<current name>`) + the description `textarea`; commit via
@@ -100,5 +102,26 @@ fails deterministically.
 - **Flow cleanup.** ids captured from `POST /api/v1/flows → 201` (Pattern-A
   accumulator; `page.url()` races the bootstrap flow id — #490/#681) and deleted
   in `afterEach`.
+- **#1301 — the `div-generic-node` click timing out at 20 s was never a node that
+  would not take a click.** Quarantined at triage #1296 as a recurrent flake
+  (2026-07-17, 2026-08-05) with the reading that the node rendered but never
+  became clickable. Measured on nightly `1.12.0.dev23` and refuted: across 26
+  instrumented attempts, **0** had a node present that would not take a click —
+  when the node exists it renders in 3–7 ms, the topmost element at its centre is
+  its own `node-name` span with `pointer-events: all`, and the click lands in
+  16–89 ms. The **add** was swallowed, so there was no node to click. With the
+  repair click suppressed and the budget raised to 40 s, **9 of 10** first clicks
+  produced no node and the canvas still held **zero** at the end of the window —
+  so nothing arrives late and a longer caller timeout could not have fixed this.
+  On this spec specifically, run bare (fresh page, `--retries=0`), the add was
+  swallowed in **5 of 11** runs; with the repair, 6 of 6 green. The add therefore
+  goes through `addCustomComponent`, which re-issues the click once and otherwise
+  fails naming the swallowed add (`#1304`'s primitive, `dedicated-button`
+  surface). `@stable` restored in the same PR.
+- Validated on `1.12.0.dev23` (2026-08-11): 3 of 3 passed (~25–30 s each),
+  `--workers=1 --retries=0`, 0 orphan flows. Force-fail executed: commit
+  affordance (`publish-button` → Escape) and discard affordance (Escape →
+  `node-save-name-description-button`) both fail; removing the add repair fails
+  with the swallowed-add message.
 - Validated on `1.11.0.dev46` (2026-07-19): 1 passed (~47s), `--workers=1
   --retries=0`, 0 orphan flows.

--- a/docs/flow-functionality/stop-building.md
+++ b/docs/flow-functionality/stop-building.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/flow-functionality/stop-building.spec.ts`
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev23`)
 
 ---
 
@@ -38,7 +38,9 @@ proven custom-component + `sleep(60)` recipe from `stop-button-playground.spec.t
 ## Step by step
 
 1. Bootstrap and open a blank flow.
-2. Add a **Custom Component** via `sidebar-custom-component-button`.
+2. Add a **Custom Component** via `addCustomComponent`, which clicks
+   `sidebar-custom-component-button` and does not return until a node that was not
+   on the canvas before is on it (see the #1301 note).
 3. Add a **Chat Output** via the sidebar search + drag.
 4. Open the custom component code editor and replace the body with a minimal,
    valid Component whose `build_output` calls `sleep(60)` — long enough that the
@@ -65,7 +67,8 @@ proven custom-component + `sleep(60)` recipe from `stop-button-playground.spec.t
 ## External dependencies
 
 - `sidebar-custom-component-button` — sidebar control that drops a Custom
-  Component; renaming breaks step 2.
+  Component; renaming breaks step 2. Clicked through `addCustomComponent`, never
+  bare — Langflow swallows this click (#1301).
 - `code-button-modal` / `.ace_content` / Check & Save — code editor round-trip,
   shared with `customComponentAdd.spec.ts` and the playground stop spec.
 - `button_run_{terminalNode}` — per-node run control (Langflow 1.11 has no global
@@ -98,17 +101,57 @@ proven custom-component + `sleep(60)` recipe from `stop-button-playground.spec.t
 
 ## Notes
 
-- **Teardown:** the test captures the created flow's id from the `/flow/{id}` URL
-  and an `afterEach` deletes only that flow via the API (auto_login token). It is a
-  targeted delete (not `cleanAllFlows`), so it is safe under parallel runs and does
-  not leak flows across repeated runs. The one-time `Basic Prompting` flow created
-  by the shared `awaitBootstrapTest` on a *freshly empty* instance is not owned by
-  this spec and is left in place.
+- **Teardown:** `trackCreatedFlows` captures every flow the page creates from its
+  `POST /api/v1/flows → 201` responses and `afterEach` deletes those ids via the
+  API. Targeted deletes (not `cleanAllFlows`), so it is safe under parallel runs.
+  The one-time `Basic Prompting` flow created by the shared `awaitBootstrapTest` on
+  a *freshly empty* instance is not owned by this spec and is left in place.
 - The custom component's `sleep(60)` guarantees the build is still in flight when
   we assert/click stop — no race on a fast-completing build.
 - Anchoring the stop affordance on `stop_building_button` (underscore) matches the
   live nightly and `chatInputOutputUser-shard-2.spec.ts`; the hyphenated POM
   variant is stale.
+- **#1301 — `div-generic-node.nth(1)` timing out at 20 s was the ADD being
+  swallowed, not an unclickable node.** Quarantined at triage #1296 as a recurrent
+  flake (2026-07-14, 2026-08-05), grouped with
+  `core-components/edit-name-description-node.spec.ts` on the shared observable.
+  The grouping held on live re-measurement: both specs' first canvas action is a
+  click on a node that `sidebar-custom-component-button` was supposed to have
+  created, and on nightly `1.12.0.dev23` that click is swallowed — 0 of 26
+  instrumented attempts ever had a node present that refused a click, while 9 of
+  10 first clicks (40 s budget, repair suppressed) produced no node at all. Step 2
+  now goes through `addCustomComponent`, which re-issues the click once and
+  otherwise fails naming the swallowed add. `@stable` restored in the same PR.
+- **Two further failures surfaced while validating #1301, both in this spec's own
+  waits and both AT STEPS AROUND the add** — which is why the quarantine read as
+  one bug. Each is now gated with the mechanism named:
+  - *Canvas entry.* The `flow-builder-welcome-panel` overlay covers the canvas
+    after `blank-flow` and `canvas_controls_dropdown` is not even in the DOM until
+    it clears — up on 3 of 3 entries on `1.12.0.dev23`, with the controls
+    appearing at ~1 s on one entry and ~10.6 s on another. The gate's 10 s budget
+    failed 2 of 3 solo runs on a freshly created instance. The overlay is now
+    waited out first (so a stuck overlay is reported as the overlay) and the
+    budget is 30 s, matching `setupBlankFlow`.
+  - *After Check & Save.* `adjustScreenView` clicks `canvas_controls_dropdown`
+    while the code modal is still open, and the Radix overlay (`fixed inset-0
+    z-50`) intercepts every pointer event on the canvas. Playwright reports the
+    button "visible, enabled and stable" and retries to the 20 s actionability
+    budget, so the failure named nothing — 1 of 3 combined runs, 41 retries of
+    "subtree intercepts pointer events". The spec now asserts no open dialog
+    remains before touching the canvas.
+- **Teardown reworked to the shared tracker (#1108).** It captured ONE id, read
+  off the canvas URL, which missed the flow `awaitBootstrapTest` creates on its
+  way through the templates modal and captured nothing at all when a run died
+  before that line: 5 orphan "New Flow"s survived 4 solo runs. Capturing every
+  `POST /api/v1/flows → 201` covers both — 0 leaked flows across 13 runs since.
+- Validated on `1.12.0.dev23` (2026-08-11): 4 of 5 solo passed (~9–35 s),
+  `--workers=1 --retries=0`, 0 orphan flows on all 5; the one red is the
+  attributed `[backend-unreachable]` page-entry barrier (the local container
+  wedges after `collect-models`, #922/#927), not a spec failure. Force-fail
+  executed: removing the `stop_building_button` click fails on the "build stopped"
+  assertion after 30 s. The three waits above are force-failed by their own
+  pre-fix measurements — the old code is the mutation, and it failed 2 of 3, 1 of
+  3 and 5 orphans of 4 runs respectively.
 - Supersedes the stale-handle break tracked in issue #298 (connections wired to a
   removed `ParseData` component after `Data to Message` superseded it). The rewrite
   drops that component chain entirely, so the stale-handle failure mode is gone.

--- a/tests/helpers/flows/add-component-from-sidebar.test.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.test.ts
@@ -193,6 +193,78 @@ test("the no-search message stays unclassifiable as infra, like the search one",
   );
 });
 
+test("the dedicated Custom Component button names no term, but still reports its input", () => {
+  // #1301. The Components tab HAS a search box; this button just does not use it.
+  // Reporting it as `no-search-box` (the MCP-tab clause) would tell the reader the
+  // surface has no input when it does — and `search input: ""` on a tab that owns
+  // one is a real observation about the sidebar, so it must still be read back.
+  const msg = swallowedAddMessage({
+    ...DETAIL,
+    surface: "dedicated-button",
+    searchTerm: null,
+    searchValue: "",
+    addButtonTestId: "sidebar-custom-component-button",
+  });
+
+  assert.match(msg, /without typing a search term/);
+  assert.match(msg, /sidebar-custom-component-button/);
+  assert.match(msg, /search input: ""/);
+  assert.doesNotMatch(msg, /no search box/i);
+  assert.doesNotMatch(msg, /after filling the sidebar search/);
+  // It is not a "+" button — naming it one sends the reader to the wrong control.
+  assert.match(msg, /custom-component button still visible/);
+  assert.doesNotMatch(msg, /"\+" button still visible/);
+});
+
+test("the dedicated button quotes ONLY the rate measured on it", () => {
+  // Each surface has its own measurement. #1304's 4/20 was taken on the
+  // Components-tab "+" buttons and #1335's 1/5 on the drag; quoting either here
+  // would attribute a number to a surface it was never taken on.
+  const msg = swallowedAddMessage({
+    ...DETAIL,
+    surface: "dedicated-button",
+    searchTerm: null,
+    searchValue: "",
+  });
+
+  assert.match(msg, /issue #1301/);
+  assert.match(msg, /9 of 10/);
+  assert.match(msg, /14 of 14/);
+  assert.match(msg, /1\.12\.0\.dev23/);
+  assert.doesNotMatch(msg, /4\/20/);
+  assert.doesNotMatch(msg, /1\/5/);
+});
+
+test("the surface defaults to what searchTerm implies, so every pre-#1301 message is unchanged", () => {
+  // 34+ call sites never pass a surface. If the default drifted, all of them would
+  // start describing a control they never clicked.
+  assert.equal(
+    swallowedAddMessage(DETAIL),
+    swallowedAddMessage({ ...DETAIL, surface: "search" }),
+  );
+  const noSearchBox = { ...DETAIL, searchTerm: null, searchValue: null };
+  assert.equal(
+    swallowedAddMessage(noSearchBox),
+    swallowedAddMessage({ ...noSearchBox, surface: "no-search-box" }),
+  );
+});
+
+test("the dedicated-button message stays unclassifiable as infra", () => {
+  // #1262's rule reaches the new surface too: a genuine regression in adding a
+  // Custom Component must stay eligible for @stable auto-removal.
+  assert.equal(
+    classifyInfraError(
+      swallowedAddMessage({
+        ...DETAIL,
+        surface: "dedicated-button",
+        searchTerm: null,
+        searchValue: "",
+      }),
+    ),
+    null,
+  );
+});
+
 test("the swallowed-click message is NOT classifiable as an infra failure", () => {
   // Same rule as the page-entry barrier (#1262): claiming infra here would exempt
   // the failure from @stable auto-removal and hide a genuine add regression.

--- a/tests/helpers/flows/add-component-from-sidebar.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.ts
@@ -94,6 +94,21 @@ export function classifyAddOutcome(
  */
 export type AddGesture = "click" | "drag";
 
+/**
+ * Which sidebar affordance issued the add. It changes what evidence there is to
+ * report, not merely which sentence runs:
+ *
+ * - `search` — the Components tab: a term was typed, so the input can be read
+ *   back and an emptied input is itself an observation.
+ * - `no-search-box` — the MCP tab (#1335): there is no input at all, so "the
+ *   search was reset" is not a statement that can be made.
+ * - `dedicated-button` — `sidebar-custom-component-button` (#1301): the tab HAS a
+ *   search box, the button just does not use it. Reporting this as
+ *   `no-search-box` would tell the reader the surface has no input when it does,
+ *   and reporting it as `search` would name a term nobody typed.
+ */
+export type AddSurface = "search" | "no-search-box" | "dedicated-button";
+
 type AddFailureDetail = {
   /** `null` when the sidebar tab has no search box — see #1335. */
   searchTerm: string | null;
@@ -107,6 +122,11 @@ type AddFailureDetail = {
   searchValue: string | null;
   /** Defaults to `"click"` — the only gesture before #1335's second half. */
   gesture?: AddGesture;
+  /**
+   * Defaults to what `searchTerm` implies, so every pre-#1301 caller keeps its
+   * exact message.
+   */
+  surface?: AddSurface;
 };
 
 export function swallowedAddMessage(d: AddFailureDetail): string {
@@ -117,29 +137,46 @@ export function swallowedAddMessage(d: AddFailureDetail): string {
   // term to name and no input to report. Kept as two explicit clauses rather
   // than an empty string: `sidebar search input: ""` is a real observation (the
   // input was reset) and must not read the same as "there is no input".
+  const surface: AddSurface =
+    d.surface ?? (d.searchTerm === null ? "no-search-box" : "search");
+
   const target = isDrag
     ? `dragTo() from getByTestId("${d.addButtonTestId}") onto the canvas`
     : `getByTestId("${d.addButtonTestId}")`;
   const trigger =
-    d.searchTerm === null
-      ? `${target} on a sidebar tab with no search box`
-      : `${target} after filling the sidebar search with "${d.searchTerm}"`;
+    surface === "dedicated-button"
+      ? `${target} without typing a search term (this button drops a blank ` +
+        `Custom Component straight onto the canvas)`
+      : surface === "no-search-box"
+        ? `${target} on a sidebar tab with no search box`
+        : `${target} after filling the sidebar search with "${d.searchTerm}"`;
   const searchState =
     d.searchValue === null
       ? `sidebar search input: <none on this tab>`
       : `sidebar search input: "${d.searchValue}"`;
-  // The click rate is #1304's own 4/20 measurement; quoting it for a drag would
+  // Each surface quotes only the rate measured ON IT. Quoting the click's 4/20
+  // for a drag, or #1304's Components-tab rate for the dedicated button, would
   // attribute a number to a surface it was never taken on.
   const evidence = isDrag
     ? `The drag(s) completed and the app never registered the add (issue #1304's ` +
       `class on the drag surface — measured 1/5 on nightly 1.12.0.dev18 in ` +
       `mcp-server-tab.spec.ts, #1335)`
-    : `The click(s) were accepted by the DOM and the app never registered the ` +
-      `add (issue #1304 — measured 4/20 on nightly 1.12.0.dev17, the ` +
-      `swallowed-click class of #420/#966 on the sidebar surface of #537)`;
+    : surface === "dedicated-button"
+      ? `The click(s) were accepted by the DOM and the app never registered the ` +
+        `add (issue #1301 — measured 9 of 10 first clicks producing no node ` +
+        `within 40s on nightly 1.12.0.dev23, and 14 of 14 repaired by an ` +
+        `identical second click; #1304's swallowed-add class on the dedicated ` +
+        `Custom Component button)`
+      : `The click(s) were accepted by the DOM and the app never registered the ` +
+        `add (issue #1304 — measured 4/20 on nightly 1.12.0.dev17, the ` +
+        `swallowed-click class of #420/#966 on the sidebar surface of #537)`;
   const visibility = isDrag
     ? `sidebar entry still visible: ${d.buttonStillVisible ? "yes" : "no"}`
-    : `"+" button still visible: ${d.buttonStillVisible ? "yes" : "no"}`;
+    : surface === "dedicated-button"
+      ? `custom-component button still visible: ${
+          d.buttonStillVisible ? "yes" : "no"
+        }`
+      : `"+" button still visible: ${d.buttonStillVisible ? "yes" : "no"}`;
 
   return (
     `the sidebar ${gesture} add was swallowed: no new node reached the canvas ` +
@@ -258,12 +295,59 @@ export const dragComponentFromSidebar = async (
   canvasSelector: string = CANVAS_SELECTOR,
 ) => addWithRepair(page, searchTerm, componentTestId, "drag", canvasSelector);
 
+/** The dedicated "New Custom Component" control in the Components sidebar. */
+export const CUSTOM_COMPONENT_BUTTON_TESTID = "sidebar-custom-component-button";
+
+/**
+ * Same swallowed-click repair, for the dedicated **New Custom Component** button
+ * — the one sidebar add that types no search term because the button drops a
+ * blank Custom Component straight onto the canvas.
+ *
+ * Added for #1301, whose two `@stable` specs are exactly the ones that clicked it
+ * bare, and both reported the drop as the node they went on to touch rather than
+ * as the add: `edit-name-description-node.spec.ts:42` and
+ * `stop-building.spec.ts:24` each timed out at 20 s on `div-generic-node` on the
+ * 2026-08-05 daily (run 30997773754).
+ *
+ * **The issue's prime suspect was refuted by measurement, and the distinction
+ * decides the fix.** #1301 asked first whether the node is rendered-but-not-
+ * clickable — an overlay (`canvas-controls`, the provider welcome screen) or a
+ * node still accepting no pointer events. Instrumented on nightly 1.12.0.dev23,
+ * 26 attempts across two probes: **0 of 26 had a node present that would not
+ * take a click**. When the node exists it renders in 3–7 ms, the topmost element
+ * at its centre is its own `node-name` span with `pointer-events: all`, and the
+ * click lands in 16–89 ms. The node was simply never created.
+ *
+ * **And it is not a short wait either**, which is the other reading a 20 s
+ * timeout invites: with the repair click suppressed and the budget raised to
+ * **40 s**, 9 of 10 first clicks produced no node at all and the canvas still
+ * held **zero** nodes at the end of the window — so nothing arrives late, and a
+ * longer caller timeout could not have fixed either spec. With a 12 s budget and
+ * the repair click restored, 14 of 16 first clicks were swallowed and **14 of 14
+ * were repaired by an identical second click**.
+ *
+ * Not folded into `addComponentFromSidebarWithoutSearch`: that name and its
+ * message describe a tab that *has* no search box (the MCP tab), while this tab
+ * has one and the button ignores it — so the failure evidence differs, and
+ * reusing it would tell the reader the Components tab has no input.
+ */
+export const addCustomComponentFromSidebar = async (page: Page) =>
+  addWithRepair(
+    page,
+    null,
+    CUSTOM_COMPONENT_BUTTON_TESTID,
+    "click",
+    CANVAS_SELECTOR,
+    "dedicated-button",
+  );
+
 const addWithRepair = async (
   page: Page,
   searchTerm: string | null,
   addButtonTestId: string,
   gesture: AddGesture,
   canvasSelector: string = CANVAS_SELECTOR,
+  surface: AddSurface = searchTerm === null ? "no-search-box" : "search",
 ) => {
   const before = await nodeIds(page);
 
@@ -290,13 +374,17 @@ const addWithRepair = async (
       afterCount: after.length,
       attempts,
       gesture,
+      surface,
       perAttemptMs: ADD_LANDED_TIMEOUT_MS,
       buttonStillVisible: await page
         .getByTestId(addButtonTestId)
         .isVisible()
         .catch(() => false),
+      // Read whenever the surface HAS an input, including the dedicated-button
+      // case that types nothing into it: an input that went away is an
+      // observation about the sidebar, and only the MCP tab has none to read.
       searchValue:
-        searchTerm === null
+        surface === "no-search-box"
           ? null
           : await page
               .getByTestId("sidebar-search-input")

--- a/tests/helpers/flows/add-custom-component.ts
+++ b/tests/helpers/flows/add-custom-component.ts
@@ -1,12 +1,41 @@
 import type { Page } from "@playwright/test";
+import { addCustomComponentFromSidebar } from "./add-component-from-sidebar";
 
+/**
+ * Adds a blank Custom Component to the canvas via the dedicated
+ * `sidebar-custom-component-button`, and does not return until a node actually
+ * landed.
+ *
+ * It used to spin its own retry loop:
+ *
+ * ```ts
+ * while (numberOfCustomComponents === 0) {
+ *   await page.getByTestId("sidebar-custom-component-button").click();
+ *   numberOfCustomComponents = await page
+ *     .locator('[data-testid="title-Custom Component"]').count();
+ * }
+ * ```
+ *
+ * That was right about the mechanism — Langflow drops this click and an identical
+ * second one repairs it (#1301: 14 of 16 swallowed, 14 of 14 repaired, nightly
+ * 1.12.0.dev23) — and wrong in three ways that mattered.
+ *
+ * 1. **Unbounded.** With the add genuinely broken it clicks forever, and the
+ *    caller dies on the 5-minute test timeout with no cause named. #1304's rule
+ *    is that a swallowed add is reported AS a swallowed add, so it stays eligible
+ *    for `@stable` auto-removal instead of reading as a hung test.
+ * 2. **No delay between clicks**, so a landed-but-not-yet-rendered add is clicked
+ *    again and leaves TWO components on a canvas whose callers assert exact
+ *    counts.
+ * 3. **Keyed on `title-Custom Component`, a name the caller may already have
+ *    changed** — `edit-name-description-node.spec.ts` renames the node — so the
+ *    loop could not be reused by the specs that most needed it.
+ *
+ * The repair now lives in the shared primitive, which judges the add by a set
+ * difference over canvas node ids (never a count delta — see #1304) and throws
+ * naming the swallowed click plus the observed sidebar state when two attempts
+ * both produce nothing.
+ */
 export const addCustomComponent = async (page: Page) => {
-  let numberOfCustomComponents = 0;
-
-  while (numberOfCustomComponents === 0) {
-    await page.getByTestId("sidebar-custom-component-button").click();
-    numberOfCustomComponents = await page
-      .locator('[data-testid="title-Custom Component"]')
-      .count();
-  }
+  await addCustomComponentFromSidebar(page);
 };

--- a/tests/pages/SidebarComponent.ts
+++ b/tests/pages/SidebarComponent.ts
@@ -1,4 +1,6 @@
 import type { Page } from "@playwright/test";
+import { CUSTOM_COMPONENT_BUTTON_TESTID } from "../helpers/flows/add-component-from-sidebar";
+import { addCustomComponent } from "../helpers/flows/add-custom-component";
 
 export class SidebarComponent {
   constructor(private readonly page: Page) {}
@@ -10,11 +12,16 @@ export class SidebarComponent {
     await this.page.getByTestId("sidebar-search-input").fill(term);
   }
 
+  // Delegates to the shared helper rather than clicking the button itself:
+  // Langflow drops this click and only an identical second one repairs it
+  // (#1301 — 14 of 16 swallowed, 14 of 14 repaired, nightly 1.12.0.dev23). A
+  // bare click here would reintroduce the defect for the first caller that
+  // reaches for the POM instead of the helper.
   async addCustomComponent() {
     await this.page
-      .getByTestId("sidebar-custom-component-button")
+      .getByTestId(CUSTOM_COMPONENT_BUTTON_TESTID)
       .waitFor({ state: "visible", timeout: 3000 });
-    await this.page.getByTestId("sidebar-custom-component-button").click();
+    await addCustomComponent(this.page);
   }
 
   async selectTemplate(name: string) {

--- a/tests/tests-automations/regression/core-components/edit-name-description-node.spec.ts
+++ b/tests/tests-automations/regression/core-components/edit-name-description-node.spec.ts
@@ -4,6 +4,7 @@ import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test"
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { ensureCustomComponentButton } from "../../../helpers/ui/ensure-custom-component-button";
+import { addCustomComponent } from "../../../helpers/flows/add-custom-component";
 
 // Capture every flow THIS page creates from its POST /api/v1/flows → 201
 // responses and delete them id-scoped in afterEach. awaitBootstrapTest runs
@@ -39,12 +40,15 @@ test.afterEach(async ({ request }) => {
   }
 });
 
-test.fixme(
+test(
   "user should be able to edit name and description of a node",
-  // Quarantined at triage (#1296): recurrent flake 2x (2026-07-17, 2026-08-05) —
-  // the `div-generic-node` click times out at 20s, so the node never becomes
-  // clickable. Restore (`test` + `@stable`) in #1301.
-  { tag: ["@release", "@workspace", "@components"] },
+  // Quarantine lifted in #1301. The `div-generic-node` click timing out at 20s was
+  // never a node that would not take a click — measured on nightly 1.12.0.dev23,
+  // 0 of 26 attempts had one — it was the ADD being swallowed, so there was no
+  // node at all (9 of 10 first clicks produced none within 40s). The add now goes
+  // through `addCustomComponent`, which re-issues the click once and otherwise
+  // fails naming the swallowed add.
+  { tag: ["@stable", "@release", "@workspace", "@components"] },
 
   async ({ page }) => {
     trackCreatedFlows(page);
@@ -68,7 +72,7 @@ test.fixme(
     await page.getByTestId("blank-flow").click();
 
     await ensureCustomComponentButton(page);
-    await page.getByTestId("sidebar-custom-component-button").click();
+    await addCustomComponent(page);
 
     await page.getByTestId("div-generic-node").click();
 

--- a/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
@@ -1,31 +1,43 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
-import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { ensureCustomComponentButton } from "../../../helpers/ui/ensure-custom-component-button";
+import { addCustomComponent } from "../../../helpers/flows/add-custom-component";
+import {
+  trackCreatedFlows,
+  type FlowTracker,
+} from "../../../helpers/flows/track-created-flows";
 
-// Flow created by the test (blank-flow → /flow/{id}); captured so afterEach can
-// delete only this one via the API. Targeted (not cleanAllFlows) so the teardown
-// is safe under parallel runs, and idempotent if capture never happened.
-let createdFlowId: string | undefined;
+// Every flow THIS page creates, captured from its POST /api/v1/flows → 201
+// responses and deleted id-scoped in afterEach (the shared cleanup of #1108).
+//
+// It used to capture ONE id, read off the canvas URL. That missed two flows per
+// run and #1301 counted them: the flow `awaitBootstrapTest` creates on its way
+// through the templates modal was never captured at all, and a run that died
+// before reaching the URL read captured nothing — 5 orphan "New Flow"s survived 4
+// solo runs. Capturing the creation responses covers both, and is what the rest
+// of the suite already does.
+let flows: FlowTracker | undefined;
 
-test.afterEach(async ({ page }) => {
-  if (!createdFlowId) return;
-  const login = await page.request.get("/api/v1/auto_login");
-  const headers: Record<string, string> = {};
-  if (login.ok()) {
-    const body = await login.json();
-    if (body?.access_token) headers.Authorization = `Bearer ${body.access_token}`;
-  }
-  await deleteFlow(page.request, createdFlowId, { headers });
-  createdFlowId = undefined;
+test.beforeEach(async ({ page }) => {
+  flows = trackCreatedFlows(page);
 });
 
-test.fixme("user must be able to stop a building from the canvas",
-  // Quarantined at triage (#1296): recurrent flake 2x (2026-07-14, 2026-08-05) —
-  // the `div-generic-node` click times out at 20s, so the node never becomes
-  // clickable. Restore (`test` + `@stable`) in #1301.
-  { tag: ["@release", "@workspace", "@components"] },
+test.afterEach(async ({ request }) => {
+  if (!flows) return;
+  await flows.cleanup(request);
+  flows.dispose();
+  flows = undefined;
+});
+
+test("user must be able to stop a building from the canvas",
+  // Quarantine lifted in #1301. The `div-generic-node` click timing out at 20s was
+  // never a node that would not take a click — measured on nightly 1.12.0.dev23,
+  // 0 of 26 attempts had one — it was the ADD being swallowed, so there was no
+  // node at all (9 of 10 first clicks produced none within 40s). The add now goes
+  // through `addCustomComponent`, which re-issues the click once and otherwise
+  // fails naming the swallowed add.
+  { tag: ["@stable", "@release", "@workspace", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
@@ -39,18 +51,37 @@ test.fixme("user must be able to stop a building from the canvas",
       // before we reach for the sidebar. Anchoring on this (instead of a tight
       // waitForSelector) lets the button click auto-wait for visibility and
       // avoids the "sidebar-custom-component-button hidden" flake.
+      //
+      // The overlay is waited out FIRST, and the 10s budget this carried was too
+      // tight — both measured under #1301 on nightly 1.12.0.dev23. On a
+      // blank-flow entry the `flow-builder-welcome-panel` covers the canvas and
+      // `canvas_controls_dropdown` is not even in the DOM until it clears: the
+      // overlay was up on 3 of 3 entries, and the controls appeared at ~1s on one
+      // and ~10.6s on another. At 10s that failed 2 of 3 solo runs on a freshly
+      // created instance — at the step BEFORE the swallowed add this issue is
+      // about, which is why it reads as an unrelated failure. Waiting the overlay
+      // out explicitly keeps the attribution: a stuck overlay fails as the
+      // overlay, not as controls that "never appeared". 30s is the budget
+      // `setupBlankFlow` already uses for this same observable.
+      const welcomeOverlay = page.locator(
+        '[data-testid="flow-builder-welcome-panel"]',
+      );
+      if (await welcomeOverlay.isVisible().catch(() => false)) {
+        await expect(welcomeOverlay).toBeHidden({ timeout: 30000 });
+      }
+
       await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
-        timeout: 10000,
+        timeout: 30000,
       });
 
-      // Canvas mounted at /flow/{id} — wait for the URL to settle before
-      // reading it, so teardown reliably captures the id (a bare page.url()
-      // here can race the navigation and miss it, leaking the flow).
+      // The canvas is mounted at /flow/{id}; kept as a step barrier, not as the
+      // teardown's source of truth — cleanup reads the creation responses now
+      // (see the tracker note at the top), which is what covers a run that dies
+      // before this line.
       await page.waitForURL(/\/flow\/[^/?#]+/, { timeout: 10000 });
-      createdFlowId = page.url().split("/flow/")[1]?.split(/[/?#]/)[0];
 
       await ensureCustomComponentButton(page);
-      await page.getByTestId("sidebar-custom-component-button").click();
+      await addCustomComponent(page);
       await adjustScreenView(page);
     });
 
@@ -115,6 +146,21 @@ class CustomComponent(Component):
       await page.locator("textarea").fill(waitTimeoutCode);
 
       await page.getByText("Check & Save").last().click();
+
+      // The code modal must be GONE before the canvas is touched again.
+      // `adjustScreenView` clicks `canvas_controls_dropdown`, and while the modal
+      // is open its Radix overlay (`fixed inset-0 z-50`) intercepts every pointer
+      // event on the canvas — the click is on a button Playwright reports as
+      // "visible, enabled and stable", so it retries until the 20 s actionability
+      // budget expires instead of failing on something nameable. Measured under
+      // #1301 on nightly 1.12.0.dev23: 1 of 3 combined runs died here with 41
+      // retries of "subtree intercepts pointer events", at the step AFTER the
+      // swallowed add this issue is about, which is why it read as the same bug.
+      await expect(page.locator('[role="dialog"][data-state="open"]')).toHaveCount(
+        0,
+        { timeout: 30000 },
+      );
+
       await adjustScreenView(page, { numberOfZoomOut: 2 });
     });
 


### PR DESCRIPTION
**Fixes #1301.**

## Problem

Two `@stable` specs were quarantined at triage #1296 (`test.fixme`, `@stable` removed) because a click on `div-generic-node` timed out at 20 s — `core-components/edit-name-description-node.spec.ts:42` (flaked 2026-07-17, 2026-08-05) and `flow-functionality/stop-building.spec.ts:24` (2026-07-14, 2026-08-05, run 30997773754).

**The issue's prime suspect was refuted by measurement, and the distinction decides the fix.** #1301 asked first whether the node was rendered-but-not-clickable — an overlay (`canvas-controls`, the provider welcome screen) or a node still accepting no pointer events. Instrumented on nightly `1.12.0.dev23`, 26 attempts across two probes: **0 of 26** had a node present that would not take a click. When the node exists it renders in **3–7 ms**, the topmost element at its centre is its own `span[data-testid=node-name]` with `pointer-events: all`, and the click lands in **16–89 ms**.

**The ADD was swallowed, so there was no node to click.** With the repair click suppressed and the budget raised to **40 s**, **9 of 10** first clicks on `sidebar-custom-component-button` produced no node — and the canvas still held **zero** nodes at the end of the window, so nothing arrives late and a longer caller timeout could never have fixed either spec. With a 12 s budget and the repair restored, **14 of 16** first clicks were swallowed and **14 of 14** were repaired by an identical second click. On `edit-name-description-node` itself, run bare on a fresh page with `--retries=0`, the add was swallowed in **5 of 11** runs.

This is #1304/#1335's class one surface over. Those hardened the Components-tab `+` buttons, the MCP tab and the drag; the **dedicated Custom Component button was left bare**, and the two specs here are exactly the ones that clicked it bare.

**Grouping re-checked live and it holds** (#1301's last deliverable): both specs' first canvas action is a click on a node that `sidebar-custom-component-button` was supposed to have created. No split.

**Two further failures surfaced while validating, both in `stop-building`'s own waits and both at the steps AROUND the add** — which is why the quarantine read as one bug:

| Where | Mechanism measured on `1.12.0.dev23` |
|---|---|
| Canvas entry | `flow-builder-welcome-panel` covers the canvas after `blank-flow` and `canvas_controls_dropdown` is not even in the DOM until it clears — overlay up on **3 of 3** entries, controls at **~1 s** on one entry and **~10.6 s** on another, against a **10 s** budget → **2 of 3** solo runs red |
| After Check & Save | `adjustScreenView` clicked `canvas_controls_dropdown` with the code modal still open; the Radix overlay (`fixed inset-0 z-50`) intercepts every pointer event. Playwright reports the button "visible, enabled and stable" and retries to the 20 s actionability budget, so the failure named nothing — **1 of 3** combined runs, **41 retries** of `subtree intercepts pointer events` |
| Teardown | Captured **one** id off the canvas URL: missed the flow `awaitBootstrapTest` creates through the templates modal, and captured nothing when a run died before that line → **5 orphan flows survived 4 solo runs** |

## Fix

- **`addCustomComponentFromSidebar`** (`tests/helpers/flows/add-component-from-sidebar.ts`) — re-issues the click once, judges the add by a **set difference over canvas node ids** (never a count delta — #1304's correction), and otherwise throws naming the swallowed add plus the observed sidebar state.
- **Its own `dedicated-button` surface**, rather than reusing `addComponentFromSidebarWithoutSearch`. *Rejected explicitly:* that tab **has** a search box and the button simply ignores it, so the MCP clause would tell the reader the surface has no input, and its `4/20` / `1/5` figures were taken on other surfaces. Each surface now quotes only the rate measured on it, and the surface **defaults to what `searchTerm` implies** so all 34+ existing call sites keep their exact message (pinned by a unit test).
- **`addCustomComponent` delegates.** Its own `while` loop was right about the mechanism and wrong three ways: **unbounded** (a genuinely broken add clicks forever and the caller dies on the 5-minute test timeout with no cause named — #1304's rule is that a swallowed add is reported *as* one, so it stays eligible for `@stable` auto-removal), **no delay between clicks**, and keyed on `title-Custom Component`, a name its callers rename. `SidebarComponent.addCustomComponent` delegates too, so the next caller cannot reintroduce the defect.
- **`stop-building`**: the welcome overlay is waited out **first** (so a stuck overlay is reported as the overlay, not as controls that "never appeared") with a 30 s budget matching `setupBlankFlow`; no open dialog may remain before the canvas is touched after Check & Save; teardown moves to the shared tracker (#1108).
- **Quarantine lifted** on both: `test.fixme` → `test`, `@stable` restored.
- *Rejected:* raising the callers' timeouts. A click that never landed produces no work to wait for, and the 40 s probe proves it — `modelInputComponent.spec.ts:106` already waited 15 s and failed all three attempts of the same daily.

## Scope note

No assertion changed in either spec. Every observable, count and message they check is byte-identical; only the add mechanism, two readiness gates and the teardown moved. `validate-raise-errors-components.spec.ts` (`@stable @release`), the third caller of `addCustomComponent`, gains the hardening without an edit.

`docs/core-components/edit-name-description-node.md` and `docs/flow-functionality/stop-building.md` record the verdict and all three measurements; both `Last validated` → `1.12.x (1.12.0.dev23)`. No `QA-CHECKLIST.md` change needed — both specs already carry a Part II bullet and the generated blocks regenerate on merge.

## Validation (nightly `1.12.0.dev23`, `--workers=1 --retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors on every touched file) · `npm run test:units` ✅ **602 pass / 0 fail** (4 new tests for the surface, including that the pre-#1301 messages are unchanged)
- QA-CHECKLIST guard ✅ · coverage guard ✅
- `edit-name-description-node`: **3 of 3** clean (~26–60 s) · `stop-building`: **4 of 5** clean (~9–35 s) · combined pair: **3 of 3** clean in the last sweep · third caller `validate-raise-errors-components`: **1 of 1** clean (~24 s)
- **0 orphan flows across 13 runs** (only the bootstrap `Basic Prompting`, not owned by these specs)
- Force-fail **executed**, 4 mutations, all observed failing and all reverted (`git diff | grep -c FF_MUTATION_1301` → 0):
  - repair disabled in the primitive → **5 of 11** runs fail with `the sidebar click add was swallowed: no new node reached the canvas after 1 attempt(s) … node count: 0 before, 0 after`; 0 of 14 with it enabled
  - `publish-button` → Escape (commit affordance) → fails, `Expected 1 / Received 0`
  - Escape → `node-save-name-description-button` (discard affordance) → fails, `Expected 1 / Received 0`
  - `stop_building_button` click removed → fails on `build stopped` after 30 s
  - the three new `stop-building` waits are force-failed by their **own pre-fix measurements** — the old code is the mutation (2 of 3, 1 of 3, and 5 orphans over 4 runs)
- Zero `🚨 Backend Error` on the passing runs.
- **`--trace=on` not run** — the known local hang (#518/#490); covered instead by the `--retries=0` bursts, the executed force-fails and the instrumented probes above.
- **Stated plainly:** the remaining reds on this host are all `[backend-unreachable]` / a 5-minute `page.goto` timeout — the local container wedges after `collect-models` (#922/#927, the reason the daily has a health gate). The page-entry barrier attributes them itself ("NOT an entry-point regression in the app"). No remaining red carries an add or canvas signature, but a 5-of-5 clean sweep was not achievable on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
