### PR TITLE
test(quarantine): lift the LE-2020, LE-2123 and LE-2019 quarantines (#965, #932, #1235, #966)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -104,7 +104,7 @@
 #### 1.3.1 Folder (Project) CRUD via API
 - [x] POST `/api/v1/projects/` → creates folder, returns id and name → `api/flows/api-folders-crud.spec.ts`
 - [x] GET `/api/v1/projects/` → lists folders including the created one → `api/flows/api-folders-crud.spec.ts`
-- [!] DELETE `/api/v1/projects/{id}` → returns 204 and the folder leaves the listing — quarantined (#965): under concurrent writes the endpoint answers **500** (`sqlite3.OperationalError: database is locked`) and the folder survives; measured 44% of deletes on `1.12.0.dev7` vs 6% on stable `1.10.3` at the same 2-client contention. Product defect filed as [LE-2020](https://datastax.jira.com/browse/LE-2020); the `204` assertion is unchanged. The same ticket also covers `PATCH /api/v1/flows/{id}` (§12.5, #932) — one root cause, two endpoints → `api/flows/api-folders-crud.spec.ts`
+- [x] DELETE `/api/v1/projects/{id}` → returns 204 and the folder leaves the listing — quarantine lifted 2026-08-11 (#965). It answered **500** (`sqlite3.OperationalError: database is locked`) under concurrent writes with the folder surviving, 44% of deletes on `1.12.0.dev7` vs 6% on stable `1.10.3`; fixed upstream by langflow#14308 (`run_with_lock_retry`, forward-ported to `release-1.12.0`) and re-measured on `1.12.0.dev23` at 24/24 `204` at P=2 and 32/32 at P=4 ([LE-2020](https://datastax.jira.com/browse/LE-2020)). The `204` assertion is unchanged. Same ticket also covered `PATCH /api/v1/flows/{id}` (§12.5, #932) — one root cause, two endpoints → `api/flows/api-folders-crud.spec.ts`
 
 #### 1.4 Components via API
 - [x] GET `/api/v1/all` → lists all available components → `api/flows/api-custom-component-creation.spec.ts`
@@ -307,7 +307,7 @@
 #### 4.3 Global Variables (API Keys)
 - [x] Create global variable
 - [-] Use global variable in component (API key) → `ui-ux/use-global-variable-in-component.spec.ts`
-- [!] Edit existing global variable — quarantined (#1235): clicking the variable's ag-grid row does not open the Update Variable modal, recurrent on the dailies of 2026-07-27 and 2026-08-03. Same surface and same shape as the provider-credential removal below (§7.5) — filed as one cause → `ui-ux/global-variable-edit.spec.ts`
+- [x] Edit existing global variable — quarantine lifted 2026-08-11 (#1235). The row click was silently dropped while the RBAC permission query loaded, so the Update Variable modal never opened (dailies 2026-07-27 and 2026-08-03, [LE-2123](https://datastax.jira.com/browse/LE-2123)); fixed upstream by langflow#14404 (permission loading state) and re-validated on `1.12.0.dev23`. The provider-credential removal below (§7.5) was grouped here at triage and proved to be a separate *test* defect, fixed in #1276 → `ui-ux/global-variable-edit.spec.ts`
 - [x] Delete global variable → `ui-ux/global-variables-crud.spec.ts`
 - [x] Create global variable of type "Generic" → `ui-ux/global-variables-crud.spec.ts`
 - [x] Credential variable value is hidden from the variable list → `ui-ux/global-variables-crud.spec.ts`
@@ -691,12 +691,12 @@
 #### 12.5 Flow Operations
 - [x] Lock flow — prevents editing → `flow-functionality/lock-flow.spec.ts`
 - [x] Unlock flow → `flow-functionality/flow-lock.spec.ts`
-- [!] Move flow between folders via API — quarantined (#932): under concurrent writes `PATCH /api/v1/flows/{id}` answers **500** (`sqlite3.OperationalError: database is locked` on `UPDATE flow SET folder_id`) and the flow does not move; 14/24 at 2 concurrent clients, 0/30 serial. **Same root cause as #965**, not a separate one — the daily artifact shows the failing assert is `expect(patchRes.status()).toBe(200)` receiving 500, not a stale `folder_id`. Product defect tracked under [LE-2020](https://datastax.jira.com/browse/LE-2020); the `200` assertion is unchanged → `api/flows/api-folders-crud.spec.ts`
+- [x] Move flow between folders via API — quarantine lifted 2026-08-11 (#932). Under concurrent writes `PATCH /api/v1/flows/{id}` answered **500** (`sqlite3.OperationalError: database is locked` on `UPDATE flow SET folder_id`) and the flow did not move (14/24 at 2 clients, 0/30 serial). **Same root cause as #965** — the daily artifact shows the failing assert is `expect(patchRes.status()).toBe(200)` receiving 500, not a stale `folder_id`. Tracked under [LE-2020](https://datastax.jira.com/browse/LE-2020); `api/v1/flows.py` now wraps its update path in `run_with_lock_retry` and `1.12.0.dev23` measures 32/32 `200` with the association persisted at P=4. The `200` assertion is unchanged → `api/flows/api-folders-crud.spec.ts`
 - [x] Publish flow → `flow-functionality/publish-flow.spec.ts`
 - [x] Save flow components as template → `core-components/saveComponents.spec.ts`
 
 #### 12.6 Flow Execution
-- [!] Run Flow component executes another flow — runs again after the #966 quarantine lift, but **not `@stable`** while the upstream `New Flow` dead-click defect ([LE-2019](https://datastax.jira.com/browse/LE-2019)) is open; the shared helper gates on the flows list having rendered so the suite stays out of the broken window → `flow-functionality/run-flow.spec.ts`
+- [x] Run Flow component executes another flow — `@stable` restored 2026-08-11 (#966). The upstream `New Flow` dead-click defect ([LE-2019](https://datastax.jira.com/browse/LE-2019)) is fixed by langflow#14349, present on the nightly line; the shared helper still gates on the flows list having rendered, and the spec was re-validated on `1.12.0.dev23` → `flow-functionality/run-flow.spec.ts`
 - [x] Run a flow from the canvas — terminal-node run builds the whole graph; all nodes reach build success and output is produced → `flow-functionality/flow-execution-canvas.spec.ts`
 - [x] Stop building flow → `flow-functionality/stop-building.spec.ts`
 - [ ] A cyclic graph is refused with a cycle-specific error, and the flow stays editable afterwards (the engine's own contract; a total engine failure is caught indirectly by the 63 `@stable` specs that trigger a run, a subtle one by nothing)

--- a/docs/api/flows/api-folders-crud.md
+++ b/docs/api/flows/api-folders-crud.md
@@ -1,6 +1,6 @@
 # API Folders (Projects) CRUD
 
-**Last validated:** Langflow 1.12.x (`1.12.0.dev6` / `1.12.0.dev7`)
+**Last validated:** Langflow 1.12.x (`1.12.0.dev23`)
 
 ---
 
@@ -16,16 +16,21 @@ If any of these tests fail against `langflowai/langflow-nightly:latest`, the fol
 ## Tags *(required)*
 `@stable` `@release` `@api` `@regression`
 
-Tests 1 and 2 carry `@stable`. Tests 3 and 4 do **not**, and both are currently
-`test.fixme` — each for a different, independently tracked reason:
+All four tests carry `@stable`. Tests 3 and 4 spent 2026-07-24 → 2026-08-11 as
+`test.fixme` without `@stable`, each tracked by its own issue, and both
+quarantines were lifted together once the upstream fix reached the nightly:
 
-- **Test 3** (`DELETE`) — quarantined for **#965**. The endpoint returns `500`
-  instead of `204` under concurrent writes; a product defect, not a test defect
-  (measurements below). `@stable` stays off and the test stays `test.fixme`
-  until the upstream fix lands on `langflowai/langflow-nightly:latest`, at which
-  point the test is re-validated there and both are restored.
-- **Test 4** (`PATCH folder_id`) — quarantined for **#932**, a *different* root
-  cause (see *Relationship between #965 and #932* below).
+- **Test 3** (`DELETE`) — quarantined for **#965**: the endpoint returned `500`
+  instead of `204` under concurrent writes (a product defect, not a test defect —
+  measurements below). Upstream added `services/database/lock_retry.py` and
+  wrapped this endpoint in `run_with_lock_retry` (langflow#14308), which was then
+  forward-ported to `release-1.12.0`. Re-validated on `1.12.0.dev23`: the
+  contention burst returns `204` **24/24 at P=2 and 32/32 at P=4**.
+- **Test 4** (`PATCH folder_id`) — quarantined for **#932**, the *same* root cause
+  on a second endpoint (see *Relationship between #965 and #932* below).
+  `api/v1/flows.py` now wraps its update path in `run_with_lock_retry` as well;
+  re-validated on `1.12.0.dev23` at **32/32 PATCH `200` with the association
+  persisted, P=4**.
 
 ---
 
@@ -70,7 +75,7 @@ widening the assertion would hide a product defect — see the section below.
 ---
 
 ## Validation criterion *(required)*
-- The **active** tests (1 and 2) pass 3× in a row at `--retries=0 --workers=1`
+- All four tests pass 3× in a row at `--retries=0 --workers=1`
   against `langflowai/langflow-nightly:latest`.
 - Status codes match: folder `POST` returns `201`; folder `GET` returns `200`; folder `DELETE` returns `204`; flow `PATCH`/`GET` return `200`.
 - **Move is durable and observable**: after `PATCH /api/v1/flows/{id}` with a new `folder_id`, a fresh `GET /api/v1/flows/{id}` reports the new `folder_id` — proving the association moved and persisted, not just that the request was accepted.
@@ -83,17 +88,30 @@ widening the assertion would hide a product defect — see the section below.
   `500`, because a swallowed `500`
   leaves a permanent orphan (see the defect below). The observable is
   `GET /api/v1/projects/` no longer listing the id, not the status of one call.
-- **Quarantine gate for test 3 (#965)** — the concrete observable that lifts it:
-  the burst under *concurrent writes* returns `204` for every delete. Measured on
-  `1.12.0.dev7` with 2 concurrent clients issuing create+delete cycles, **44 %**
-  of the deletes come back `500` (40 of 90); the criterion is 0 of 90 with the
-  same script, at which point `test.fixme` and `@stable` are restored together.
-  A serial pass is NOT sufficient evidence — serially the endpoint is already
-  green (10/10), which is exactly why the daily saw this as a flake.
+- **Quarantine gate for tests 3 and 4 (#965 / #932) — met on 2026-08-11.** The
+  gate was never a serial pass: serially both endpoints were already green
+  (10/10, 0/30), which is exactly why the daily saw this as a flake. The
+  observable is the burst under *concurrent writes*. Measured on `1.12.0.dev23`
+  with `docs/upstream-bugs/scripts/scout-965-scope.py` and
+  `scout-932-probe.py`: `DELETE /projects` **24/24 `204` at P=2, 32/32 at P=4**
+  (against 11/24 failing at P=2 on `1.12.0.dev7`), and `PATCH /flows` **32/32
+  `200` with the association persisted at P=4** (against 20/24 failing on
+  `1.12.0.dev8`). Re-check with the same two scripts before trusting a future
+  green: the endpoints are only as safe as the retry wrapper upstream keeps.
 
 ---
 
-## Known product defect behind the quarantine of test 3 (#965)
+## Known product defect behind the quarantine of test 3 (#965) — FIXED upstream
+
+> **Status (2026-08-11): fixed on the nightly line, quarantine lifted.** Upstream
+> langflow#14308 added `services/database/lock_retry.py` and wrapped
+> `delete_project` in `run_with_lock_retry`; the module was absent from
+> `1.12.0.dev10` (which is why #932 recorded the forward-port as an open ask) and
+> is present in `1.12.0.dev23`, together with the call site in both
+> `api/v1/projects.py` and `api/v1/flows.py`. The measurements below are the
+> historical evidence for LE-2020 — keep them, they are what the contention gate
+> in *Validation criterion* compares against. Everything in the present tense in
+> this section describes builds up to `1.12.0.dev8`.
 
 `DELETE /api/v1/projects/{id}` answers **`500`** — not `204` — whenever another
 write transaction is in flight, and **the folder is not deleted**. The response

--- a/docs/flow-functionality/run-flow.md
+++ b/docs/flow-functionality/run-flow.md
@@ -1,6 +1,6 @@
 # Flow Functionality — Run Flow
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev6`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev23`)
 
 ---
 
@@ -50,7 +50,7 @@ If this breaks, users cannot compose flows via the Run Flow component — a core
 
 ---
 
-## Flake history — #966 (recurrent; quarantine partially lifted, `@stable` still off)
+## Flake history — #966 (quarantine fully lifted, `@stable` restored 2026-08-11)
 
 Failed the dailies of **2026-07-16** and **2026-07-27** with the same signature at
 `run-flow.spec.ts:98` (step 5 above): neither the `FlowBuilderWelcome` overlay nor
@@ -99,12 +99,21 @@ It is **not** a 1.12 regression: the nightly frontend tree is byte-identical to 
 1.11.x releases, and the create-then-navigate path on this button arrived in 1.10.1
 via upstream PR #12575 (1.10.0 opened the templates modal and created nothing).
 
-**Consequence for this spec's tags:** `test.fixme` is lifted so the scenario runs
-again (it carries `@release`, so parking it left a release-gate path unverified),
-but **`@stable` stays off** until LE-2019 lands on the nightly and this spec is
-re-validated there. The helper gate keeps the suite out of the broken window; it
-does not fix the product, and the suite must not claim a validated behavior that
-upstream still breaks. `#966` stays open tracking that.
+**Consequence for this spec's tags:** `test.fixme` was lifted first so the scenario
+ran again (it carries `@release`, so parking it left a release-gate path
+unverified), while **`@stable` stayed off** until LE-2019 landed on the nightly —
+the helper gate keeps the suite out of the broken window but does not fix the
+product, and the suite must not claim a validated behavior that upstream still
+breaks.
+
+**Resolved 2026-08-11.** The upstream fix is langflow#14349 (*stop flow route
+request storm*, merged 2026-07-30), whose two files
+(`customization/hooks/use-custom-navigate.ts` and the `use-load-flow-for-route`
+test) are present and byte-identical on `release-1.11.2`, `release-1.12.0` and
+`main` — so it reaches the nightly line the daily runs. Re-validated on
+`1.12.0.dev23`: 3 consecutive runs at `--workers=1 --retries=0`, all green, plus a
+force-fail of the final `toHaveValue` assertion to rule out a false positive.
+`@stable` restored and #966 closed.
 
 ### A second product defect on the same back-navigation (issue #1153)
 

--- a/docs/ui-ux/global-variable-edit.md
+++ b/docs/ui-ux/global-variable-edit.md
@@ -1,6 +1,6 @@
 # Global Variable Edit (Settings page)
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev23`)
 
 ---
 
@@ -19,6 +19,33 @@ If these break, users either lose the Settings-page entry point to global variab
 ## Tags *(required)*
 
 `@stable` `@release` `@workspace` `@regression`
+
+### Flake history — #1235 (quarantine lifted, `@stable` restored 2026-08-11)
+
+Test 2 failed the dailies of **2026-07-27** and **2026-08-03**: the row click never
+opened the Update Variable modal, so the `Update Variable` heading assertion timed
+out. Quarantined in PR #1236 (`test.fixme` + `@stable` removed).
+
+**Root cause — PRODUCT defect, filed as [LE-2123](https://datastax.jira.com/browse/LE-2123).**
+The RBAC foundations that landed on `release-1.12.0` (langflow#14215, `2e677bf843`)
+wrap this page in a `PermissionsProvider`, and `canMutateVariable()` returns
+`false` while `POST /api/v1/authz/me/permissions` is still loading — so
+`onRowClicked` returns early and the click is **silently dropped**, with no
+spinner, no disabled styling and no feedback of any kind. Normally a 1–2 s window;
+one failed first call stretches it to ~31 s through the shared request wrapper's
+5× exponential-backoff ladder, which is why it read as a flake. Evidence and the
+503-injection repro: `docs/upstream-bugs/UPSTREAM-BUG-global-variables-permission-gate-dead-window.md`.
+
+**Fixed upstream by langflow#14404** (*show Global Variables permission loading
+state*, merged into `release-1.12.0` on 2026-08-05), which hides the table behind
+a loading state instead of rendering rows that only look interactive.
+Re-validated on `1.12.0.dev23`: 3 consecutive runs at `--workers=1 --retries=0`,
+green, plus a force-fail of the heading assertion.
+
+**Not this bug:** the recorded flake of `remove-provider-api-key.spec.ts:17` was
+grouped into #1235 at triage and later shown to be a *test* defect (it reproduces
+at ~75 % on a healthy build with the gate open). That half was fixed and restored
+separately in #1276; only this spec traces to LE-2123.
 
 ---
 

--- a/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
@@ -86,17 +86,19 @@ test.describe("Folder (Projects) CRUD via API", () => {
     },
   );
 
-  // Quarantined for #965 — recurrent flake (2026-07-22 / 07-27): the DELETE
-  // answers HTTP 500 (`sqlite3.OperationalError: database is locked`) where the
-  // contract expects 204 No Content, and the folder survives. Product defect,
-  // filed upstream as LE-2020 (https://datastax.jira.com/browse/LE-2020); the
-  // 204 assertion below stays bare and this stays `test.fixme` without @stable
-  // until the fix reaches `langflowai/langflow-nightly:latest`. Evidence and the
-  // reproduction scripts: docs/api/flows/api-folders-crud.md §"Known product
-  // defect" and docs/upstream-bugs/.
-  test.fixme(
+  // Quarantine lifted (#965). This test was `test.fixme` against LE-2020
+  // (https://datastax.jira.com/browse/LE-2020): the DELETE answered HTTP 500
+  // (`sqlite3.OperationalError: database is locked`) instead of the contracted
+  // 204, and the folder survived — measured at 11/24 and 12/24 with 2 concurrent
+  // clients. Upstream shipped `services/database/lock_retry.py` and wrapped this
+  // endpoint in `run_with_lock_retry` (langflow#14308, forward-ported to
+  // `release-1.12.0`); the module and the call site are both present in
+  // `1.12.0.dev23`, and the repro script now measures 24/24 at P=2 and 32/32 at
+  // P=4 (`docs/upstream-bugs/scripts/scout-965-scope.py`). The 204 assertion
+  // deliberately stays bare — it is what surfaced the defect.
+  test(
     "DELETE removes folder and it no longer appears in listing",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const folderName = `Delete Folder ${Date.now()}`;
@@ -127,10 +129,17 @@ test.describe("Folder (Projects) CRUD via API", () => {
     },
   );
 
-  // quarantined for #932 — recurrent flaky association assertion (dailies 2026-07-15, 2026-07-24)
-  test.fixme(
+  // Quarantine lifted (#932). Same root cause and same upstream ticket as the
+  // DELETE above (LE-2020), on a second endpoint: `PATCH /api/v1/flows/{id}`
+  // answered 500 on `UPDATE flow SET folder_id` with two concurrent writers
+  // (14/24 at P=2, 0/30 serial), which Playwright rendered as an "Object.is
+  // equality" mismatch and made this read as a stale association. `flows.py` now
+  // wraps its update path in `run_with_lock_retry` on `release-1.12.0`, present
+  // in `1.12.0.dev23`; the probe measures 32/32 PATCH 200 with the association
+  // persisted at P=4 (`docs/upstream-bugs/scripts/scout-932-probe.py`).
+  test(
     "moving flow between folders via PATCH folder_id updates association",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
 

--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -17,14 +17,14 @@ import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-
 // neither the welcome overlay nor the templates modal was ever requested.
 //
 // That no-op is a PRODUCT defect, filed upstream as LE-2019 (evidence:
-// docs/upstream-bugs/UPSTREAM-BUG-new-flow-dead-click.md). The shared helper now
-// gates on the flows list having rendered, which keeps the suite out of the broken
-// window — but it does not fix the product, so `@stable` deliberately STAYS OFF
-// until LE-2019 lands on the nightly and this spec is re-validated there (#966 stays
-// open tracking it). See docs/flow-functionality/run-flow.md.
+// docs/upstream-bugs/UPSTREAM-BUG-new-flow-dead-click.md). The shared helper gates
+// on the flows list having rendered, which keeps the suite out of the broken window;
+// the product fix itself landed upstream in langflow#14349 (*stop flow route request
+// storm*), whose files are present on `release-1.12.0`, so `@stable` is restored here
+// after re-validation on `1.12.0.dev23` (#966). See docs/flow-functionality/run-flow.md.
 test(
   "user should be able to use Run Flow without any issues",
-  { tag: ["@release", "@workspace", "@api", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@api", "@regression"] },
   async ({ page, request }) => {
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });

--- a/tests/tests-automations/regression/ui-ux/global-variable-edit.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/global-variable-edit.spec.ts
@@ -73,13 +73,19 @@ test.describe("Global Variable Edit (Settings page)", () => {
     },
   );
 
-  // Quarantined for #1235 — recurrent flake (dailies 2026-07-27, 2026-08-03):
-  // clicking the variable's ag-grid row does not open the Update Variable modal,
-  // so `getByRole('heading', { name: 'Update Variable' })` never becomes visible.
-  // Lifting the quarantine and restoring @stable is a deliverable of #1235.
-  test.fixme(
+  // Quarantine lifted (#1235). This test was `test.fixme` against LE-2123
+  // (https://datastax.jira.com/browse/LE-2123): the RBAC gate introduced by
+  // langflow#14215 made `canMutateVariable()` return false while
+  // `POST /api/v1/authz/me/permissions` was loading, so the row click was
+  // silently dropped and the Update Variable modal never opened — a window that a
+  // single failed permissions call stretched to ~31 s through the request
+  // wrapper's retry ladder. Upstream langflow#14404 (*show Global Variables
+  // permission loading state*, merged into `release-1.12.0` on 2026-08-05) hides
+  // the table behind a loading state instead of rendering rows that only look
+  // interactive; re-validated on `1.12.0.dev23`.
+  test(
     "edit existing global variable by clicking its row",
-    { tag: ["@release", "@workspace", "@regression"] },
+    { tag: ["@stable", "@release", "@workspace", "@regression"] },
     async ({ page }) => {
       createdVarName = `test_edit_var_${Date.now()}`;
 


### PR DESCRIPTION
**Closes #965. Closes #932. Closes #1235. Closes #966.**

Four tests were parked against three upstream product defects. All three fixes have landed on `release-1.12.0` — the line the nightly is cut from — and are present in the running image `1.12.0.dev23`, so the quarantines are lifted and `@stable` is restored.

## Problem

| Test | Issue | Ticket | Symptom while parked |
|---|---|---|---|
| `api-folders-crud` › DELETE removes folder… | #965 | LE-2020 | `DELETE /api/v1/projects/{id}` answered `500` (`sqlite3.OperationalError: database is locked`) instead of `204` under concurrent writes, and the project survived — 11/24 at P=2 on `1.12.0.dev7` |
| `api-folders-crud` › moving flow between folders via PATCH… | #932 | LE-2020 | same root cause on `PATCH /api/v1/flows/{id}` (`UPDATE flow SET folder_id`) — 14/24 at P=2, 0/30 serial |
| `global-variable-edit` › edit existing global variable… | #1235 | LE-2123 | the RBAC gate dropped the ag-grid row click while `POST /api/v1/authz/me/permissions` loaded, so the Update Variable modal never opened |
| `run-flow` › user should be able to use Run Flow… | #966 | LE-2019 | `New Flow` click was a silent no-op while the flows list painted (`test.fixme` already lifted in #987; `@stable` was still off) |

## What changed upstream — verified in the image, not just on a ref

- `services/database/lock_retry.py` exists **inside the container**, and `run_with_lock_retry` is referenced by **both** `api/v1/projects.py` and `api/v1/flows.py`. #932's investigation recorded the module as absent from `1.12.0.dev10` and the flows half as unfixed on every ref — both asks are now closed (langflow#14308 + forward-port).
- langflow#14349 (LE-2019) merged into `release-1.11.2`; its two files are present and byte-identical on `release-1.12.0` and `main`.
- langflow#14404 (LE-2123, *show Global Variables permission loading state*) merged into `release-1.12.0` on **2026-08-05** — #1235's comment recorded it as still open. `GlobalVariablesPage/index.tsx` now imports `Loading` and threads `permissionState`.

## Fix

`test.fixme` → `test` and `@stable` restored on the three affected tests, plus `@stable` on `run-flow`. **No assertion changed** — `toBe(204)`, `toBe(200)`, the `Update Variable` heading and the echo `toHaveValue` are what surfaced these defects, and relaxing any of them would hide the next recurrence. Each call site carries a comment naming the ticket, the upstream PR and the measurement that lifted it.

Spec docs updated (`Last validated` → `1.12.0.dev23`, defect sections marked fixed, a flake-history section added to `global-variable-edit.md`) and the four `[!]` bullets in `QA-CHECKLIST.md` Part II moved to `[x]`. Generated blocks untouched — `npm run coverage:summary` was **not** committed (#741).

## Scope note

`REGRESSIONS.md` is deliberately untouched. The LE-2020 and LE-2123 rows should flip to `Fixed`, but the file carries uncommitted work from a parallel session and that edit belongs with it.

## Validation (nightly `1.12.0.dev23`, `--workers=1 --retries=0`)

**Product, under contention** — the gate here was never a serial pass; serially both endpoints were already green, which is why the daily read them as flakes:

| Endpoint | Before | Now |
|---|---|---|
| `DELETE /api/v1/projects/{id}` | 11/24 → `500` (P=2, dev7) | **24/24 `204` at P=2, 32/32 at P=4** |
| `PATCH /api/v1/flows/{id}` folder_id | 14/24 → `500` (P=2, dev8) | **32/32 `200`, association persisted, at P=4** |

Measured with the scripts committed for the original reports: `docs/upstream-bugs/scripts/scout-965-scope.py` and `scout-932-probe.py`.

**Specs**

- 3 consecutive rounds of the three files: **7 expected / 0 unexpected / 0 flaky / 0 skipped** each, read from `--reporter=json` stats rather than the line reporter.
- Force-fail: all four restored assertions mutated → exactly those four failed, the three untouched tests stayed green; mutations reverted.
- Zero `🚨 Backend Error`. Zero orphan projects or flows after the runs (1 `Starter Project`, 1 `Basic Prompting`, the 6 pre-existing variables intact).
- `npm run typecheck` ✅ · `npm run lint` (0 errors) ✅ · `npm run test:units` 602 pass / 0 fail ✅ · `npm run test:scripts` ✅ · QA-CHECKLIST guard ✅ · `check:checklist-coverage` ✅ · `regressions:check` ✅

**Environment caveat, recorded rather than hidden:** on this machine `--trace=on` makes `global-variable-edit.spec.ts` time out (2/2 at 300 s, 1/1 at 90 s) while the same file passes in ~10 s with no trace, with `retain-on-failure` or with `on-first-retry`. It is a local tracing cost, not a product or spec behaviour — the runs above used `retain-on-failure`, and the failure traces come from the force-fail pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)