### PR TITLE
chore(triage): quarantine 2 recurrent flakes from the 2026-08-12 daily (#1430, #1424)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts
@@ -61,9 +61,17 @@ test.afterEach(async ({ request }) => {
   }
 });
 
-test(
+// Quarantined at triage (daily run 31581590030): recurrent flake — after the
+// file-management modal confirms and closes, the file chip on the NODE never
+// renders inside 15 s, so the attach is unobservable. The modal-side assertions
+// pass on the same attempt, which is what places the failure after the attach
+// PATCH rather than in the selection. Same signature on the 2026-07-23, 07-30
+// and 08-12 dailies; only the 08-12 call log has been read, so whether all three
+// share this wait point is the first thing #1430 settles. Lifting the quarantine
+// (remove test.fixme + restore @stable) is a deliverable of #1430.
+test.fixme(
   "upload a file through the Read File component and read its content",
-  { tag: ["@stable", "@release", "@files", "@components"] },
+  { tag: ["@release", "@files", "@components"] },
   async ({ page }) => {
     trackCreatedFlows(page);
     // The asset's bytes under a per-run unique name: the name is what the

--- a/tests/tests-automations/regression/core-functionality/model-provider/azure-ai-foundry-provider-setup.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/azure-ai-foundry-provider-setup.spec.ts
@@ -471,9 +471,17 @@ test.describe("Azure AI Foundry — unified provider setup", () => {
     },
   );
 
-  test(
+  // Quarantined at triage (daily run 31581590030): recurrent flake, and the same
+  // cause as #1424 — the second `POST /api/v1/variables/` of the pair is answered
+  // 400 while validate-provider succeeds, so only AZURE_AI_FOUNDRY_ENDPOINT is
+  // stored and the poll below times out on a pair that will never complete. The
+  // 30 s poll is not the problem: the write was refused, not delayed. Same
+  // signature on the 2026-08-10 and 08-12 dailies, with the 400 recorded in both
+  // runs' logs. Lifting the quarantine (remove test.fixme + restore @stable) is a
+  // deliverable of #1424.
+  test.fixme(
     "real credentials configure the provider and enable a portal deployment through the UI",
-    { tag: ["@stable", "@model-provider", "@settings"] },
+    { tag: ["@model-provider", "@settings"] },
     async ({ page, request }) => {
       const probe = await probeFoundry(request);
       test.skip(!probe.usable, `Azure AI Foundry not usable: ${probe.reason}`);


### PR DESCRIPTION
Daily run [31581590030](https://github.com/oriontech-me/langflow-e2e/actions/runs/31581590030) came back **green** — 493 passed, 0 failures, 6 flakes — so nothing was auto-removed and no umbrella was opened. Two of those six are recurrent under the same `error_signature` inside the 30-day window, which is the flake criterion's own trigger regardless of how the day ended.

Both edits land together on each test — `@stable` removed **and** `test.fixme` added — so it stops running in every context, not just the daily. Tag removal alone would leave them red on the impacted-specs gate, which selects by file diff rather than by tag (#871).

| Issue | Test | Recurrence |
|---|---|---|
| #1430 | `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts:64` | 3× — 2026-07-23, 07-30, 08-12 |
| #1424 | `tests/tests-automations/regression/core-functionality/model-provider/azure-ai-foundry-provider-setup.spec.ts:474` | 2× — 2026-08-10, 08-12 |

### Why azure joins #1424 instead of getting its own issue

Both dailies logged a `400` on `POST /api/v1/variables/` **from this spec**, which is the failure #1424 already tracks on `openai-provider.spec.ts:138` (quarantined in #1425). What the two share is the refused write, not the symptom — here it surfaces as an `expect.poll` timing out on a variable pair whose second member was never stored.

Worth stating plainly because it changes what a fix would look like: the spec **already** polls 30 s for exactly this race, with a comment recording that it was measured at ~1 run in 3 while authoring. The poll is not too short. The write was rejected.

Only azure's own test is quarantined — the other five tests in that file stay `@stable`, since they cover the unconfigured panel and a deployment path that does not depend on this write.

### Three flakes from the same run deliberately left running

- **`customComponentAdd.spec.ts:64`** crosses the rule (same signature on 07-15 and 08-12) and is **not** quarantined: it is the #1301 swallowed add, whose repair is a one-line swap onto the helper #1427 already validated. Quarantining and lifting in the same cycle buys nothing. The exception is recorded on #1365 rather than left implicit.
- **`stop-button-playground.spec.ts:79`** is the same cause, but its earlier occurrence carries a different signature, so it never crossed the rule.
- **`agent-max-iterations.spec.ts:218`** has three occurrences in the window under **three different** signatures — an unstable spec, not a recurrence. Its evidence from this run (the v2 run ended in `GRAPH_RECURSION_LIMIT`) belongs to #1264.

### Verification

- `npm run typecheck` clean; `npm run lint` 0 errors; `npm run test:units` 602 pass; `npm run test:scripts` clean.
- QA-CHECKLIST guard and coverage guard both pass — no generated block touched, and every remaining `@stable`/documented spec still carries its Part II bullet.
- `npx playwright test --list --grep @stable` on both files: the two quarantined tests are gone from the lane, azure's other five are still listed.

No `Closes` on purpose. Both issues stay open — the quarantine is prevention, and lifting it (remove `test.fixme`, restore `@stable`, re-validate per `CONTRIBUTING.md`) is a deliverable of each issue, not of this PR.
