### PR TITLE
test(security): assert tweaks cannot reach template fields as executable input (#1394)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -872,8 +872,9 @@
 
 #### 17.4 Tweaks Injection
 
-- [ ] Tweak values passed to `POST /api/v1/run/{id}` cannot reach template fields as
+- [-] Tweak values passed to `POST /api/v1/run/{id}` cannot reach template fields as
       executable input (`langflow-ai/langflow#9319`, `#8672`)
+      → security/tweaks-injection.spec.ts
 
 ---
 

--- a/docs/security/tweaks-injection.md
+++ b/docs/security/tweaks-injection.md
@@ -1,0 +1,121 @@
+# Tweaks Injection
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that a **tweak value sent to `POST /api/v1/run/{flow_id}` cannot reach a template field as executable input** — the security boundary restored upstream after `langflow-ai/langflow#9319` ("Potential security issue in tweaks", closed as fixed on 2025-09-15) and deliberately *not* widened by the request in `#8672` (tweaks interpolated into component parameters).
+
+`tweaks` is the documented way for an API caller to reconfigure a flow per request. Every Langflow component also carries its own Python source in the `code` template field, and several components carry executable code (or the sandbox boundary that constrains it) in *plain-text* fields — `python_code`, `function_code`, `global_imports`, `tool_code`, `filter_instruction`, `allow_dangerous_code`. Without a refusal, an authenticated run caller could rewrite what a flow *is* at run time instead of merely reconfiguring it: `#9319` demonstrated replacing `ChatInput`'s whole class body through `tweaks.<node>.code`, and the follow-up comment confirmed the same reaches the build endpoints.
+
+The backend refusal is **silent by design** — `apply_tweaks()` consults `is_protected_tweak_field()` and, on a protected field, logs a warning and `continue`s; the run still answers `200` with the flow author's value. There is therefore **no error to assert on**: the only trustworthy evidence is *behavioral* — the flow keeps producing the author's output while a benign tweak sent the same way, in the same shape, still takes effect. Every test below pairs the refusal with that control, because a spec that only asserts "the sentinel is absent" passes just as well if the tweaks mechanism is dead altogether.
+
+Two protection routes exist and fail independently, so both are covered:
+
+- **by field type / field name** — `field_type == "code"` or `field_name == "code"` (Test 1).
+- **by component + field name** — a code-execution component (`CODE_EXECUTION_COMPONENT_TYPES`) whose executable field serializes as a plain `str` and is therefore invisible to the type check (Test 3). This is the exact bypass that made the first, name-only fix insufficient — the upstream comment in `apply_tweaks()` names it.
+
+If these tests fail, an API caller holding only run permission on a flow can execute code of their choosing inside the Langflow process.
+
+---
+
+## Tags *(required)*
+
+`@api` `@regression`
+
+No **functional** tag applies: the tag table has no security area, and the closest siblings (`api/flows/api-run-with-tweaks.spec.ts`, `api/flows/api-run-flow.spec.ts`) also carry only cross-cutting tags. `@regression` is what issue #1394 asks for; `@api` marks the layer.
+
+`@stable` is intentionally absent on first delivery — it is added only after team validation (`CONTRIBUTING.md`). The checklist bullet ships as `[-]`.
+
+---
+
+## Step by step *(required)*
+
+The spec runs **3 independent tests** via Playwright's `request` fixture. No browser, no LLM, no provider key. Two flows are created in `beforeAll` and deleted in `afterAll`.
+
+**Setup (`beforeAll`)**
+
+1. `getAuthToken(request)` → Bearer for the flow/catalog/API-key endpoints.
+2. `POST /api/v1/api_key/` → temporary key (asserts `200`); `POST /api/v1/run/{id}` authenticates with `x-api-key`, not Bearer.
+3. **Flow A** — `createRunnableChatFlowViaApi(request, { Authorization: bearer })`: the `Chat Input -> Chat Output` passthrough fixture, whose `Chat Input` (node id `ChatInput-b6UCc`, display name `Chat Input`) stores `input_value = "Hello"`.
+4. **Flow B** — `createPythonInterpreterFlowViaApi(request, headers, { authorCode })` (new helper): reads the **live** catalog (`GET /api/v1/all`), takes the `PythonREPLComponent` template, sets `python_code` to `print("AUTHOR-<unique>")`, wires it into a `Python Interpreter -> Chat Output` flow, and creates it via `POST /api/v1/flows/`. Building the node from the running instance rather than a frozen asset means a template change upstream surfaces as a real failure instead of a stale fixture silently testing nothing.
+
+**Teardown (`afterAll`)**
+
+1. `DELETE /api/v1/flows/{flowA}` and `DELETE /api/v1/flows/{flowB}` — id-scoped, with the `afterAll`'s own `request` (a `beforeAll` request cannot be reused).
+2. `DELETE /api/v1/api_key/{apiKeyId}`.
+   Each step is wrapped so a failing one cannot skip the rest; no orphan flow and no orphan key survives the file.
+
+---
+
+**Test 1 — a `code` tweak cannot replace a component's implementation** *(`@api @regression`)*
+
+1. Build `MALICIOUS_CHAT_INPUT_CODE`: a syntactically valid `ChatInput` class whose `message_response()` returns a unique sentinel `PWNED-<unique>`, ignoring `input_value`. If the tweak were honoured, that string — and only that string — is what `Chat Output` would echo.
+2. `POST /api/v1/run/{flowA}` with `x-api-key` and `{ input_type: "chat", output_type: "chat", tweaks: { "ChatInput-b6UCc": { code: MALICIOUS_CHAT_INPUT_CODE } } }` (keyed by **node id**).
+3. Assert `200`, and that the echoed output text equals the fixture default `"Hello"` and does **not** contain the sentinel.
+4. Repeat step 2 keyed by **display name** (`"Chat Input"`) — the other addressing mode `apply_tweaks` accepts — and assert the same two things.
+5. `GET /api/v1/flows/{flowA}` with the Bearer; assert the stored `ChatInput-b6UCc.data.node.template.code.value` still does not contain the sentinel, i.e. the refused tweak left no persisted trace of the run.
+
+**Test 2 — the refusal is field-scoped: a benign tweak on the same node, in both addressing modes, still applies** *(`@api @regression`)*
+
+1. `POST /api/v1/run/{flowA}` with `tweaks: { "ChatInput-b6UCc": { input_value: "BENIGN-<unique>" } }`.
+2. Assert `200` and that the echoed output equals that benign value — not `"Hello"`.
+3. Repeat keyed by display name `"Chat Input"` with a second unique value; assert the same.
+4. This is the control that makes Test 1 evidence rather than a tautology: the two tests differ **only** in which field the tweak targets, and both addressing modes used in Test 1 are shown live here.
+
+**Test 3 — a plain-text executable field on a code-execution component is refused, in a request whose other tweak lands** *(`@api @regression`)*
+
+1. `POST /api/v1/run/{flowB}` with `output_type: "debug"` (so the response carries every vertex, not just `Chat Output`) and a **single** `tweaks` object carrying three overrides at once:
+   - `{ <pythonNodeId>: { python_code: "print(\"PWNED-<unique>\")" } }` — executable code in a `str`-typed field (protected by name on a `CODE_EXECUTION_COMPONENT_TYPES` node);
+   - `{ <pythonNodeId>: { global_imports: "math,os" } }` — the documented sandbox boundary; widening it via tweaks must be refused;
+   - `{ <chatOutputNodeId>: { sender_name: "BENIGN-<unique>" } }` — an unprotected field on the same run.
+2. Assert `200`.
+3. Assert the Python Interpreter vertex's result equals the author's `AUTHOR-<unique>` and does not contain the sentinel — `python_code` was refused.
+4. Assert that vertex's build log still reads `Successfully imported modules: ['math']` — `global_imports` was refused, so `os` never entered the exec namespace.
+5. Assert the `Chat Output` message's `sender_name` equals the benign value — the same request's unprotected tweak **did** apply, so steps 3–4 cannot be explained by "tweaks were ignored".
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1:** status `200`; output text is exactly `"Hello"`; the sentinel appears in neither the response nor the stored flow's `code` field afterwards.
+- **Test 2:** status `200`; output text equals the benign tweak value for **both** the node-id and the display-name key. The contrast with Test 1 — same flow, same addressing modes, same request shape, different field — is the evidence that the refusal is targeted at executable fields rather than at tweaks in general.
+- **Test 3:** status `200`; the interpreter result is the author's `AUTHOR-…`; the import log lists `['math']` only; `sender_name` is the benign value. All four observations come from **one** response, so no timing or ordering explanation is available.
+- Teardown leaves no flow and no API key behind: `GET /api/v1/flows/?remove_example_flows=true&header_flows=true` returns the same count before and after the file runs.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The other protected fields in the same registry: `function_code` (Python Function), `tool_code`, `filter_instruction` (Smart Transform), `allow_dangerous_code` (CSVAgent), and `SQLComponent.database_url` / `query`. They share one code path (`is_protected_tweak_field`) with `python_code`, which Test 3 exercises; a per-field sweep belongs in a follow-up if the registry stops being shared.
+- The `/api/v1/build/...` and `/api/v2/workflows` entry points, which the `#9319` follow-up comment reports as reachable with the same payload. This spec is scoped to the endpoint named in the checklist bullet (`POST /api/v1/run/{flow_id}`).
+- The unauthenticated public-flow path (`/api/v1/build_public_tmp/{flow_id}/flow`) and the `block_code_interpreter_components` opt-in gate — separate enforcement points on the same component set.
+- Whether the refusal is *logged* server-side. It is (`logger.warning`), but the API caller cannot observe it, and asserting on container logs would couple the spec to the deployment shape.
+- `#8672`'s requested feature (referencing `{{ input.tweaks.* }}` inside a component parameter). It was never implemented; nothing here asserts the absence of a feature.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL`.
+- Superuser credentials (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) for `getAuthToken`.
+- The instance allows API-key creation via `POST /api/v1/api_key/`.
+- `PythonREPLComponent` present in `GET /api/v1/all` (category `utilities` — a **core** family, so it survives the `lfx-bundles` M4 shim deletion; `docs/component-distribution-policy.md`). The helper fails loudly naming the component when it is absent, rather than skipping silently.
+- `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` on the instance. With it `false`, `run_python_repl()` refuses to execute at all (`ensure_code_execution_enabled`, GHSA-8qpj-27x8-pwpq) and Test 3's *author* baseline would never appear — the test would fail on the baseline assertion, not pass vacuously. Every CI lane and both start scripts set it (#668/#746).
+
+---
+
+## External dependencies *(required)*
+
+- `tests/helpers/auth/get-auth-token.ts` — Bearer via `/api/v1/auto_login`; a contract change breaks `beforeAll`.
+- `tests/helpers/flows/create-runnable-chat-flow-via-api.ts` and `tests/assets/flows/chat-io-ok-trace-fixture.json` — Flow A. Renaming the `Chat Input` display name, changing its node id, or changing the stored `input_value` default breaks the tweak keys and the `"Hello"` baseline.
+- `tests/helpers/flows/create-python-interpreter-flow-via-api.ts` (new) — Flow B, built from the live catalog.
+- `src/lfx/src/lfx/processing/process.py` — `apply_tweaks()`: where the protection is consulted and where a refused tweak is skipped without erroring.
+- `src/lfx/src/lfx/utils/flow_validation.py` — `is_protected_tweak_field()`, `CODE_EXECUTION_COMPONENT_TYPES`, `CODE_EXECUTION_FIELD_NAMES`, `PROTECTED_TWEAK_FIELDS_BY_COMPONENT`. This is the registry the spec pins; a component or field leaving it is exactly the regression to catch.
+- `src/lfx/src/lfx/components/utilities/python_repl_core.py` — `PythonREPLComponent`: the `python_code` / `global_imports` field names, the `Successfully imported modules: [...]` log line asserted in Test 3, and the `ensure_code_execution_enabled()` precondition.
+- `src/lfx/src/lfx/components/input_output/chat.py` and `chat_output.py` — `ChatInput.message_response()` (the method the malicious class overrides) and `ChatOutput.sender_name` (Test 3's control field).
+- `src/backend/base/langflow/api/v1/endpoints.py` — `POST /api/v1/run/{flow_id}`: the `SimplifiedAPIRequest` schema, `output_type: "debug"`, and the `RunResponse` shape the assertions read.
+- `src/backend/base/langflow/api/v1/api_key.py` — temporary API-key lifecycle.
+- Upstream references: `langflow-ai/langflow#9319` (the defect, fixed) and `#8672` (the interpolation request that defines the boundary's other side).

--- a/tests/helpers/flows/create-python-interpreter-flow-via-api.test.ts
+++ b/tests/helpers/flows/create-python-interpreter-flow-via-api.test.ts
@@ -1,0 +1,161 @@
+// Unit tests for buildPythonInterpreterFlowData (#1394).
+// Run with: npm run test:units
+//
+// The helper's network half needs a live instance, but its load-bearing half is
+// pure: turning a live `GET /api/v1/all` catalog into a runnable two-node flow
+// payload. Two properties there cannot be seen from a green spec.
+//
+// (1) The EDGE. A tweak refused on a component is only observable if that
+// component actually RUNS, and a Langflow vertex only runs when it is reachable
+// from the graph's entry point — a disconnected Python Interpreter node is
+// silently absent from the run response (measured on 1.12.0.dev23), which would
+// make `tweaks-injection.spec.ts` Test 3 pass while asserting nothing. So the
+// edge's handle encoding is pinned here rather than trusted.
+//
+// (2) The CATALOG LOOKUP. If a component the flow needs is not in the image, the
+// helper must fail naming it — an undefined template would otherwise reach
+// `POST /api/v1/flows/` and surface as an unattributable 422 (#1012's rule:
+// never let a missing precondition read like a test failure).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildPythonInterpreterFlowData,
+  CHAT_OUTPUT_COMPONENT_TYPE,
+  PYTHON_INTERPRETER_COMPONENT_TYPE,
+  unescapeHandle,
+} from "./create-python-interpreter-flow-via-api";
+
+/** A minimal stand-in for the two catalog entries the helper reads. */
+function fakeCatalog(
+  overrides: { python?: unknown; chatOutput?: unknown } = {},
+): Record<string, unknown> {
+  const python = "python" in overrides
+    ? overrides.python
+    : {
+        display_name: "Python Interpreter",
+        template: {
+          code: { type: "code", value: "class PythonREPLComponent: ..." },
+          global_imports: { type: "str", value: "math" },
+          python_code: { type: "str", value: "print('Hello, World!')" },
+        },
+      };
+  const chatOutput = "chatOutput" in overrides
+    ? overrides.chatOutput
+    : {
+        display_name: "Chat Output",
+        template: {
+          code: { type: "code", value: "class ChatOutput: ..." },
+          input_value: {
+            type: "str",
+            input_types: ["Data", "JSON", "DataFrame", "Table", "Message"],
+          },
+          sender_name: { type: "str", value: "AI" },
+        },
+      };
+
+  const catalog: Record<string, Record<string, unknown>> = {
+    utilities: {},
+    input_output: {},
+  };
+  if (python !== undefined) {
+    catalog.utilities[PYTHON_INTERPRETER_COMPONENT_TYPE] = python;
+  }
+  if (chatOutput !== undefined) {
+    catalog.input_output[CHAT_OUTPUT_COMPONENT_TYPE] = chatOutput;
+  }
+  return catalog;
+}
+
+const IDS = {
+  pythonNodeId: "PythonREPLComponent-t1",
+  chatOutputNodeId: "ChatOutput-t1",
+  authorCode: 'print("AUTHOR-42")',
+};
+
+test("stores the author's code in the Python Interpreter's python_code field", () => {
+  const data = buildPythonInterpreterFlowData(fakeCatalog(), IDS);
+
+  const python = data.nodes.find((n) => n.id === IDS.pythonNodeId);
+  assert.ok(python, "the python node must be present");
+  assert.equal(python.data.type, PYTHON_INTERPRETER_COMPONENT_TYPE);
+  assert.equal(python.data.node.template.python_code.value, IDS.authorCode);
+});
+
+test("wires the interpreter's results output into Chat Output's input_value", () => {
+  const data = buildPythonInterpreterFlowData(fakeCatalog(), IDS);
+
+  assert.equal(data.edges.length, 1);
+  const [edge] = data.edges;
+  assert.equal(edge.source, IDS.pythonNodeId);
+  assert.equal(edge.target, IDS.chatOutputNodeId);
+
+  // The serialized handles are what the backend reads; a well-formed pair is the
+  // difference between a flow that runs both vertices and one that runs neither.
+  const source = unescapeHandle(edge.sourceHandle);
+  assert.deepEqual(source, {
+    dataType: PYTHON_INTERPRETER_COMPONENT_TYPE,
+    id: IDS.pythonNodeId,
+    name: "results",
+    output_types: ["Data"],
+  });
+
+  const target = unescapeHandle(edge.targetHandle);
+  assert.equal(target.id, IDS.chatOutputNodeId);
+  assert.equal(target.fieldName, "input_value");
+});
+
+test("takes the target handle's types from the live template, not from a copy", () => {
+  // Drift resistance: if upstream narrows or widens what Chat Output accepts, the
+  // edge follows the running image instead of a constant frozen at authoring time.
+  const catalog = fakeCatalog({
+    chatOutput: {
+      display_name: "Chat Output",
+      template: {
+        input_value: { type: "other", input_types: ["Message"] },
+      },
+    },
+  });
+
+  const target = unescapeHandle(
+    buildPythonInterpreterFlowData(catalog, IDS).edges[0].targetHandle,
+  );
+  assert.deepEqual(target.inputTypes, ["Message"]);
+  assert.equal(target.type, "other");
+});
+
+test("names the missing component when the image does not ship it", () => {
+  assert.throws(
+    () => buildPythonInterpreterFlowData(fakeCatalog({ python: undefined }), IDS),
+    (err: Error) => err.message.includes(PYTHON_INTERPRETER_COMPONENT_TYPE),
+    "a missing Python Interpreter must be named, not surface as a 422 from the create call",
+  );
+
+  assert.throws(
+    () =>
+      buildPythonInterpreterFlowData(fakeCatalog({ chatOutput: undefined }), IDS),
+    (err: Error) => err.message.includes(CHAT_OUTPUT_COMPONENT_TYPE),
+  );
+});
+
+test("leaves the caller's catalog untouched", () => {
+  // The spec fetches the catalog once and builds from it; mutating the shared
+  // object would leak one test's author code into the next flow built from it.
+  const catalog = fakeCatalog();
+  const before = JSON.stringify(catalog);
+
+  buildPythonInterpreterFlowData(catalog, IDS);
+
+  assert.equal(JSON.stringify(catalog), before);
+});
+
+test("rejects a catalog that is not the /api/v1/all shape", () => {
+  assert.throws(
+    () =>
+      buildPythonInterpreterFlowData(
+        { detail: "Not authenticated" } as unknown as Record<string, unknown>,
+        IDS,
+      ),
+    (err: Error) => err.message.includes(PYTHON_INTERPRETER_COMPONENT_TYPE),
+    "an auth failure must not read as 'the component moved'",
+  );
+});

--- a/tests/helpers/flows/create-python-interpreter-flow-via-api.ts
+++ b/tests/helpers/flows/create-python-interpreter-flow-via-api.ts
@@ -1,0 +1,273 @@
+import type { APIRequestContext } from "@playwright/test";
+import { createFlow } from "./create-flow";
+import { deleteFlow } from "./delete-flow";
+
+/**
+ * Builds a runnable `Python Interpreter -> Chat Output` flow from the LIVE
+ * component catalog (`GET /api/v1/all`) and creates it via the REST API.
+ *
+ * Why a live catalog instead of a committed fixture: this flow exists to prove
+ * that the Tweaks API refuses to overwrite a code-execution component's
+ * executable fields (`python_code`, `global_imports`). Those field names and the
+ * component's output shape are exactly what upstream may rename — a frozen
+ * fixture would keep testing the old shape and stay green while the guard it
+ * covers no longer applies to anything the image ships. Building the node from
+ * the running instance turns that drift into a real failure.
+ *
+ * Why an edge is required: a Langflow vertex only runs when it is reachable from
+ * the graph's entry point. A two-node flow with no edge answers 200 with the
+ * unreachable vertex simply absent from `outputs` (measured on 1.12.0.dev23), so
+ * a spec asserting "the interpreter still ran the author's code" would pass
+ * while asserting nothing at all.
+ */
+
+/** Catalog key of the Python Interpreter (`CODE_EXECUTION_COMPONENT_TYPES` member). */
+export const PYTHON_INTERPRETER_COMPONENT_TYPE = "PythonREPLComponent";
+
+/** Catalog key of the Chat Output that renders the interpreter's `Data`. */
+export const CHAT_OUTPUT_COMPONENT_TYPE = "ChatOutput";
+
+/** The interpreter's default `python_code`, kept only as documentation of the shape. */
+export const DEFAULT_AUTHOR_CODE = 'print("AUTHOR")';
+
+interface TemplateField {
+  type?: string;
+  value?: unknown;
+  input_types?: string[];
+  [key: string]: unknown;
+}
+
+interface ComponentTemplate {
+  template: Record<string, TemplateField>;
+  [key: string]: unknown;
+}
+
+export interface FlowNode {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: { id: string; type: string; node: ComponentTemplate };
+}
+
+export interface FlowEdge {
+  animated: boolean;
+  className: string;
+  data: { sourceHandle: Record<string, unknown>; targetHandle: Record<string, unknown> };
+  id: string;
+  selected: boolean;
+  source: string;
+  sourceHandle: string;
+  target: string;
+  targetHandle: string;
+}
+
+export interface FlowData {
+  nodes: FlowNode[];
+  edges: FlowEdge[];
+  viewport: { x: number; y: number; zoom: number };
+}
+
+export interface BuildPythonInterpreterFlowOptions {
+  /** Node id given to the Python Interpreter — also the `tweaks` key. */
+  pythonNodeId: string;
+  /** Node id given to the Chat Output — also the `tweaks` key. */
+  chatOutputNodeId: string;
+  /** The code the flow AUTHOR stores; a refused tweak must leave this running. */
+  authorCode: string;
+}
+
+/**
+ * Langflow serializes edge handles as JSON with every `"` replaced by `œ`
+ * (`scapedJSONStringfy` in the frontend). The backend reads these strings, so
+ * they must be produced in the same encoding — not as plain JSON.
+ */
+function escapeHandle(handle: Record<string, unknown>): string {
+  return JSON.stringify(handle).replace(/"/g, "œ");
+}
+
+/** Inverse of {@link escapeHandle}; used by the unit tests to read an edge back. */
+export function unescapeHandle(handle: string): Record<string, never> &
+  Record<string, unknown> {
+  return JSON.parse(handle.replace(/œ/g, '"'));
+}
+
+/**
+ * Finds a component template in a `GET /api/v1/all` payload, whose top level is
+ * `category -> { componentType: template }`.
+ *
+ * Throws naming the component when it is absent: the image may not ship its
+ * distribution (`docs/component-distribution-policy.md`), and an undefined
+ * template reaching `POST /api/v1/flows/` surfaces as an unattributable 422.
+ */
+function findComponentTemplate(
+  catalog: Record<string, unknown>,
+  componentType: string,
+): ComponentTemplate {
+  for (const category of Object.values(catalog)) {
+    if (!category || typeof category !== "object") continue;
+    const entry = (category as Record<string, unknown>)[componentType];
+    if (entry && typeof entry === "object" && "template" in entry) {
+      // Deep copy: the caller fetches the catalog once and may build several
+      // flows from it, and every build mutates field values.
+      return JSON.parse(JSON.stringify(entry)) as ComponentTemplate;
+    }
+  }
+
+  throw new Error(
+    `Component "${componentType}" is not present in GET /api/v1/all on this instance. ` +
+      "Either the image does not ship its distribution, or the response was not a component catalog " +
+      "(an auth failure answers with a `detail` body). See docs/component-distribution-policy.md.",
+  );
+}
+
+/**
+ * Turns a live catalog into the flow payload. Pure — no network, no clock, no
+ * randomness — so the edge encoding and the failure mode are unit-testable.
+ */
+export function buildPythonInterpreterFlowData(
+  catalog: Record<string, unknown>,
+  { pythonNodeId, chatOutputNodeId, authorCode }: BuildPythonInterpreterFlowOptions,
+): FlowData {
+  const pythonTemplate = findComponentTemplate(
+    catalog,
+    PYTHON_INTERPRETER_COMPONENT_TYPE,
+  );
+  const chatOutputTemplate = findComponentTemplate(
+    catalog,
+    CHAT_OUTPUT_COMPONENT_TYPE,
+  );
+
+  pythonTemplate.template.python_code = {
+    ...pythonTemplate.template.python_code,
+    value: authorCode,
+  };
+
+  const node = (
+    id: string,
+    type: string,
+    template: ComponentTemplate,
+    x: number,
+  ): FlowNode => ({
+    id,
+    type: "genericNode",
+    position: { x, y: 0 },
+    data: { id, type, node: template },
+  });
+
+  const sourceHandle = {
+    dataType: PYTHON_INTERPRETER_COMPONENT_TYPE,
+    id: pythonNodeId,
+    name: "results",
+    output_types: ["Data"],
+  };
+  const chatOutputInput = chatOutputTemplate.template.input_value ?? {};
+  const targetHandle = {
+    fieldName: "input_value",
+    id: chatOutputNodeId,
+    inputTypes: chatOutputInput.input_types ?? [],
+    type: chatOutputInput.type ?? "str",
+  };
+
+  const edge: FlowEdge = {
+    animated: false,
+    className: "",
+    data: { sourceHandle, targetHandle },
+    id:
+      `reactflow__edge-${pythonNodeId}${escapeHandle(sourceHandle)}` +
+      `-${chatOutputNodeId}${escapeHandle(targetHandle)}`,
+    selected: false,
+    source: pythonNodeId,
+    sourceHandle: escapeHandle(sourceHandle),
+    target: chatOutputNodeId,
+    targetHandle: escapeHandle(targetHandle),
+  };
+
+  return {
+    nodes: [
+      node(pythonNodeId, PYTHON_INTERPRETER_COMPONENT_TYPE, pythonTemplate, 0),
+      node(chatOutputNodeId, CHAT_OUTPUT_COMPONENT_TYPE, chatOutputTemplate, 500),
+    ],
+    edges: [edge],
+    viewport: { x: 0, y: 0, zoom: 1 },
+  };
+}
+
+export interface PythonInterpreterFlow {
+  /** The created flow's id, for `POST /api/v1/run/{flow_id}`. */
+  flowId: string;
+  /** Node id of the Python Interpreter — use as the `tweaks` key. */
+  pythonNodeId: string;
+  /** Node id of the Chat Output — use as the `tweaks` key. */
+  chatOutputNodeId: string;
+  /** The code stored by the flow author, echoed by a run the tweaks did not alter. */
+  authorCode: string;
+  /** Deletes the created flow. Safe to call in `afterAll` with its own `request`. */
+  deleteFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+}
+
+/**
+ * Creates the `Python Interpreter -> Chat Output` flow on the instance.
+ *
+ * `headers` carries the auth the caller already holds (`{ Authorization: bearer }`
+ * or `{ "x-api-key": key }`); the same header is reused for the catalog read and
+ * for teardown.
+ *
+ * Note the instance must run with `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` for the
+ * interpreter to execute at all (`ensure_code_execution_enabled`,
+ * GHSA-8qpj-27x8-pwpq) — with it off the flow builds but produces no author
+ * output, which a caller asserting on that output will surface immediately.
+ */
+export async function createPythonInterpreterFlowViaApi(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  options: { authorCode?: string } = {},
+): Promise<PythonInterpreterFlow> {
+  const authorCode = options.authorCode ?? DEFAULT_AUTHOR_CODE;
+
+  const catalogRes = await request.get("/api/v1/all", { headers });
+  if (!catalogRes.ok()) {
+    throw new Error(
+      `GET /api/v1/all answered ${catalogRes.status()} — cannot build the ` +
+        "Python Interpreter flow without the component catalog.",
+    );
+  }
+  const catalog = (await catalogRes.json()) as Record<string, unknown>;
+
+  // Unique per call for the same reason as create-runnable-chat-flow-via-api:
+  // Langflow's unique-name fallback is not transaction-safe under parallel
+  // creation (#588). The node ids are unique too so a tweaks key can never
+  // address a node from another flow.
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const pythonNodeId = `${PYTHON_INTERPRETER_COMPONENT_TYPE}-${uniqueSuffix}`;
+  const chatOutputNodeId = `${CHAT_OUTPUT_COMPONENT_TYPE}-${uniqueSuffix}`;
+
+  const data = buildPythonInterpreterFlowData(catalog, {
+    pythonNodeId,
+    chatOutputNodeId,
+    authorCode,
+  });
+
+  const flowId = await createFlow(
+    request,
+    {
+      name: `Python Interpreter Flow ${uniqueSuffix}`,
+      description:
+        "Python Interpreter -> Chat Output for tweaks-injection API tests",
+      data,
+      is_component: false,
+    },
+    { headers },
+  );
+
+  return {
+    flowId,
+    pythonNodeId,
+    chatOutputNodeId,
+    authorCode,
+    // `reqOverride` exists for the same fixture-scope rule as the chat-flow
+    // helper: a `beforeAll` request cannot be reused inside `afterAll`.
+    deleteFlow: async (reqOverride?: APIRequestContext) => {
+      await deleteFlow(reqOverride ?? request, flowId, { headers });
+    },
+  };
+}

--- a/tests/tests-automations/regression/security/tweaks-injection.spec.ts
+++ b/tests/tests-automations/regression/security/tweaks-injection.spec.ts
@@ -1,0 +1,297 @@
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createPythonInterpreterFlowViaApi } from "../../../helpers/flows/create-python-interpreter-flow-via-api";
+import {
+  createRunnableChatFlowViaApi,
+  RUNNABLE_CHAT_FLOW_CHAT_INPUT_DISPLAY_NAME,
+  RUNNABLE_CHAT_FLOW_DEFAULT_INPUT,
+} from "../../../helpers/flows/create-runnable-chat-flow-via-api";
+
+// A tweak value sent to POST /api/v1/run/{flow_id} must not reach a template
+// field as executable input (langflow-ai/langflow#9319, fixed upstream; #8672 is
+// the interpolation request that defines the other side of the same boundary).
+//
+// The backend refusal is SILENT by design: apply_tweaks() asks
+// is_protected_tweak_field() and, on a protected field, logs a warning and skips
+// it — the run still answers 200 with the flow author's value. There is no error
+// to assert on, so every refusal below is paired with a benign tweak sent the
+// same way: without that control, a spec asserting only "the sentinel is absent"
+// passes just as well when the tweaks mechanism is dead altogether.
+//
+// Two protection routes exist and fail independently:
+//   - by field type / name — `code` (Tests 1 and 2), and
+//   - by component + field name — an executable field that serializes as a plain
+//     `str` on a CODE_EXECUTION_COMPONENT_TYPES node (Test 3). That is the exact
+//     bypass which made the first, name-only fix insufficient.
+
+// Flow A's Chat Input, addressable by node id and by display name — apply_tweaks
+// accepts both, so both are exercised on the refusal AND on the control.
+const CHAT_INPUT_NODE_ID = "ChatInput-b6UCc";
+const CHAT_INPUT_DISPLAY_NAME = RUNNABLE_CHAT_FLOW_CHAT_INPUT_DISPLAY_NAME;
+
+/**
+ * A syntactically valid ChatInput whose `message_response()` ignores the stored
+ * input and returns `sentinel`. If the `code` tweak were honoured, the flow's
+ * Chat Output would echo that string and nothing else — which is what makes the
+ * assertion "the output is still the author's value" meaningful.
+ */
+function maliciousChatInputCode(sentinel: string): string {
+  return `from lfx.custom.custom_component.component import Component
+from lfx.io import MessageTextInput, Output
+from lfx.schema.message import Message
+
+
+class ChatInput(Component):
+    display_name = "Chat Input"
+    description = "Get chat inputs from the Playground."
+    icon = "MessagesSquare"
+    name = "ChatInput"
+
+    inputs = [
+        MessageTextInput(name="input_value", display_name="Text", value=""),
+    ]
+    outputs = [
+        Output(display_name="Message", name="message", method="message_response"),
+    ]
+
+    def message_response(self) -> Message:
+        return Message(text="${sentinel}")
+`;
+}
+
+/** Minimal shape of the run response needed by the assertions below. */
+interface RunVertexOutput {
+  component_id?: string;
+  results?: { message?: { text?: string; sender_name?: string } };
+  outputs?: { results?: { message?: { result?: string } } };
+  logs?: { results?: Array<{ message?: string }> };
+}
+
+interface RunResponseBody {
+  outputs?: Array<{ outputs?: RunVertexOutput[] }>;
+}
+
+/** Chat Output's echoed text (the `output_type: "chat"` shape). */
+function getOutputText(body: RunResponseBody): string | undefined {
+  return body?.outputs?.[0]?.outputs?.[0]?.results?.message?.text;
+}
+
+/** One vertex of an `output_type: "debug"` response, by node id. */
+function getVertex(
+  body: RunResponseBody,
+  componentId: string,
+): RunVertexOutput | undefined {
+  return body?.outputs?.[0]?.outputs?.find((v) => v.component_id === componentId);
+}
+
+test.describe("Tweaks injection — POST /api/v1/run refuses executable fields", () => {
+  let bearerToken: string;
+  let apiKey: string;
+  let apiKeyId: string;
+
+  // Flow A — Chat Input -> Chat Output passthrough (stored input "Hello").
+  let chatFlowId: string;
+  let deleteChatFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  // Flow B — Python Interpreter -> Chat Output, built from the live catalog.
+  let pythonFlowId: string;
+  let pythonNodeId: string;
+  let chatOutputNodeId: string;
+  let authorMark: string;
+  let deletePythonFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  test.beforeAll(async ({ request }) => {
+    bearerToken = await getAuthToken(request);
+
+    // The run endpoint authenticates with x-api-key, not Bearer.
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: { Authorization: bearerToken },
+      data: { name: `tweaks-injection-key-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const keyBody = await keyRes.json();
+    apiKey = keyBody.api_key;
+    apiKeyId = keyBody.id;
+
+    const chatFlow = await createRunnableChatFlowViaApi(request, {
+      Authorization: bearerToken,
+    });
+    chatFlowId = chatFlow.flowId;
+    deleteChatFlow = chatFlow.deleteFlow;
+
+    authorMark = `AUTHOR-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    const pythonFlow = await createPythonInterpreterFlowViaApi(
+      request,
+      { Authorization: bearerToken },
+      { authorCode: `print("${authorMark}")` },
+    );
+    pythonFlowId = pythonFlow.flowId;
+    pythonNodeId = pythonFlow.pythonNodeId;
+    chatOutputNodeId = pythonFlow.chatOutputNodeId;
+    deletePythonFlow = pythonFlow.deleteFlow;
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Both flows are deleted id-scoped, and a failure in one must not skip the
+    // rest of the teardown. `afterAll` uses its OWN request — the beforeAll one
+    // cannot be reused (Playwright fixture-scope rule).
+    try {
+      if (deleteChatFlow) await deleteChatFlow(request);
+    } finally {
+      try {
+        if (deletePythonFlow) await deletePythonFlow(request);
+      } finally {
+        if (apiKeyId) {
+          await request
+            .delete(`/api/v1/api_key/${apiKeyId}`, {
+              headers: { Authorization: bearerToken },
+            })
+            .catch(() => {});
+        }
+      }
+    }
+  });
+
+  test(
+    "a code tweak cannot replace a component's implementation",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      const sentinel = `PWNED-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const code = maliciousChatInputCode(sentinel);
+
+      await test.step("the code tweak is refused when keyed by node id", async () => {
+        const res = await request.post(`/api/v1/run/${chatFlowId}`, {
+          headers: { "x-api-key": apiKey },
+          data: {
+            input_type: "chat",
+            output_type: "chat",
+            tweaks: { [CHAT_INPUT_NODE_ID]: { code } },
+          },
+        });
+
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        // The author's component still ran: the echo is the stored default and
+        // the injected class's sentinel appears nowhere in the response.
+        expect(getOutputText(body)).toBe(RUNNABLE_CHAT_FLOW_DEFAULT_INPUT);
+        expect(JSON.stringify(body)).not.toContain(sentinel);
+      });
+
+      await test.step("the code tweak is refused when keyed by display name", async () => {
+        const res = await request.post(`/api/v1/run/${chatFlowId}`, {
+          headers: { "x-api-key": apiKey },
+          data: {
+            input_type: "chat",
+            output_type: "chat",
+            tweaks: { [CHAT_INPUT_DISPLAY_NAME]: { code } },
+          },
+        });
+
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(getOutputText(body)).toBe(RUNNABLE_CHAT_FLOW_DEFAULT_INPUT);
+        expect(JSON.stringify(body)).not.toContain(sentinel);
+      });
+
+      await test.step("the refused tweak left no trace on the stored flow", async () => {
+        const res = await request.get(`/api/v1/flows/${chatFlowId}`, {
+          headers: { Authorization: bearerToken },
+        });
+        expect(res.status()).toBe(200);
+        const flow = await res.json();
+        const storedCode = JSON.stringify(
+          flow?.data?.nodes?.find(
+            (n: { id?: string }) => n.id === CHAT_INPUT_NODE_ID,
+          )?.data?.node?.template?.code?.value ?? "",
+        );
+        expect(storedCode).not.toContain(sentinel);
+      });
+    },
+  );
+
+  test(
+    "the refusal is field-scoped: an unprotected field on the same node still applies",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // The control that makes the test above evidence rather than a tautology:
+      // same flow, same node, same addressing modes, same request shape — only
+      // the targeted field differs.
+      for (const [label, tweakKey] of [
+        ["node id", CHAT_INPUT_NODE_ID],
+        ["display name", CHAT_INPUT_DISPLAY_NAME],
+      ] as const) {
+        await test.step(`a benign tweak keyed by ${label} takes effect`, async () => {
+          const benign = `BENIGN-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+          // No top-level input_value: passing it together with a Chat Input
+          // tweak on the same field is rejected with 400 by the backend.
+          const res = await request.post(`/api/v1/run/${chatFlowId}`, {
+            headers: { "x-api-key": apiKey },
+            data: {
+              input_type: "chat",
+              output_type: "chat",
+              tweaks: { [tweakKey]: { input_value: benign } },
+            },
+          });
+
+          expect(res.status()).toBe(200);
+          const body = await res.json();
+          expect(getOutputText(body)).toBe(benign);
+        });
+      }
+    },
+  );
+
+  test(
+    "an executable field on a code-execution component is refused while the same request's benign tweak lands",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      const sentinel = `PWNED-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const benignSender = `BENIGN-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+      // ONE request carrying three overrides: two protected fields on the Python
+      // Interpreter (python_code is executable code, global_imports is the
+      // documented sandbox boundary — both plain `str`, so the field-type guard
+      // does not see them) and one unprotected field on Chat Output.
+      const res = await request.post(`/api/v1/run/${pythonFlowId}`, {
+        headers: { "x-api-key": apiKey },
+        data: {
+          // "debug" so the response carries every vertex, not just Chat Output.
+          output_type: "debug",
+          tweaks: {
+            [pythonNodeId]: {
+              python_code: `print("${sentinel}")`,
+              global_imports: "math,os",
+            },
+            [chatOutputNodeId]: { sender_name: benignSender },
+          },
+        },
+      });
+
+      expect(res.status()).toBe(200);
+      const body: RunResponseBody = await res.json();
+
+      await test.step("the benign tweak in the same request took effect", async () => {
+        // Asserted FIRST: it is what rules out "tweaks were ignored wholesale"
+        // as an explanation for the two refusals below.
+        const chatOutput = getVertex(body, chatOutputNodeId);
+        expect(chatOutput?.results?.message?.sender_name).toBe(benignSender);
+      });
+
+      await test.step("python_code kept the flow author's code", async () => {
+        const python = getVertex(body, pythonNodeId);
+        expect(python?.outputs?.results?.message?.result).toBe(authorMark);
+        expect(JSON.stringify(body)).not.toContain(sentinel);
+      });
+
+      await test.step("global_imports did not widen the exec namespace", async () => {
+        const python = getVertex(body, pythonNodeId);
+        const logs = (python?.logs?.results ?? []).map((l) => l.message ?? "");
+        // The component logs exactly which modules entered the namespace; the
+        // tweak asked for "math,os" and only the author's "math" is there.
+        expect(logs).toContain("Successfully imported modules: ['math']");
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1394.

Closes the `[ ]` gap in `QA-CHECKLIST.md` § 17.4 — the first spec in the new `security/` area. It is **not** a duplicate of `api/flows/api-run-with-tweaks.spec.ts`: that spec proves tweaks *do* override configuration, and its own "does not cover" section names code-field injection protection as the gap. This one proves the inverse boundary — the fields a tweak must **never** reach.

The backend refusal is **silent by design**: `apply_tweaks()` (`src/lfx/src/lfx/processing/process.py`) asks `is_protected_tweak_field()` (`src/lfx/src/lfx/utils/flow_validation.py`) and, on a protected field, logs a warning and `continue`s — the run still answers `200` with the flow author's value. There is no error to assert on, so every refusal below is paired with a benign tweak sent the same way. Without that control, a spec asserting only "the sentinel is absent" passes just as well when the tweaks mechanism is dead altogether.

Two protection routes exist and fail independently, so both are covered: **by field type/name** (`code`), and **by component + field name** — an executable field that serializes as a plain `str` on a `CODE_EXECUTION_COMPONENT_TYPES` node. The second is the exact bypass that made the first, name-only fix insufficient (the upstream comment in `apply_tweaks()` names it).

Upstream: `langflow-ai/langflow#9319` (the defect, closed as fixed 2025-09-15) and `#8672` (the interpolation request that defines the boundary's other side).

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `a code tweak cannot replace a component's implementation` | A `tweaks.<node>.code` carrying a valid `ChatInput` class that returns `PWNED-<unique>` is refused, keyed by **node id** and by **display name**: `200`, the echo is still the stored `"Hello"`, the sentinel is absent from the response, and the stored flow's `code` is untouched afterwards. Catches a regression that would let any caller holding run permission execute code of their choosing in-process. |
| 2 | `the refusal is field-scoped: an unprotected field on the same node still applies` | The same flow, same node, same two addressing modes, same request shape — only the targeted field differs (`input_value`): the output *does* become the tweak value. This is what makes Test 1 evidence rather than a tautology, and it catches the opposite regression (the guard widening until legitimate tweaks stop working). |
| 3 | `an executable field on a code-execution component is refused while the same request's benign tweak lands` | **One** run (`output_type: "debug"`) carrying three overrides on `Python Interpreter -> Chat Output`: `python_code`, `global_imports` (both plain `str`, invisible to the field-type guard) and `sender_name`. Asserts `sender_name` **did** change, the interpreter result is still the author's `AUTHOR-<unique>`, and the build log still reads `Successfully imported modules: ['math']` — `os` never entered the `exec` namespace. All four observations come from a single response, so no ordering or timing explanation is available. |

## 2. How the test was built

- **Pure API** — Playwright's `request` fixture, no browser, so there are no selectors to confirm. Auth is `getAuthToken` (Bearer) for the flow/catalog/key endpoints plus a temporary API key, because `POST /api/v1/run/{id}` authenticates with `x-api-key`.
- **Flow A** reuses `createRunnableChatFlowViaApi` (the `Chat Input -> Chat Output` passthrough, stored default `"Hello"`), so the injected class has an observable that differs from the author's by construction.
- **Flow B** is a new helper, `tests/helpers/flows/create-python-interpreter-flow-via-api.ts`, that builds `Python Interpreter -> Chat Output` from the **live** `GET /api/v1/all`. A committed fixture was rejected: the field names this spec pins (`python_code`, `global_imports`) are exactly what upstream may rename, and a frozen fixture would keep testing the old shape and stay green. A missing component fails naming it rather than reaching `POST /api/v1/flows/` as an unattributable 422.
- **The edge is hand-built** (Langflow's `œ`-escaped handle encoding) because a two-node flow with no edge is not a cheaper equivalent: an unreachable vertex never runs and is simply **absent** from `outputs` (measured on 1.12.0.dev23), which would make Test 3's refusal unobservable while the test stayed green. The helper's pure half — handle encoding, catalog lookup failure, no mutation of the caller's catalog — is covered by 6 unit tests in the `npm run test:units` lane.
- **Assertion rationale:** the refusal is silent, so absence of the sentinel is necessary but not sufficient. Each test therefore also shows a tweak that *did* land — in Test 3, inside the very same request.
- **Cleanup:** both flows are deleted id-scoped in `afterAll` with its own `request`, then the temporary API key, each step wrapped so a failure cannot skip the rest. Instance flow count after the final run: 2, both pre-existing and unrelated — zero orphans from this spec.

## 3. Dependencies

- **None external** — no LLM, no provider key, no network egress. The instance must run with `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` (every CI lane and both start scripts set it); with it off, `run_python_repl()` refuses to execute and Test 3 fails on its *author* baseline rather than passing vacuously.
- `PythonREPLComponent` must be in the catalog (category `utilities`, a **core** family — survives the `lfx-bundles` M4 shim deletion).
- **Parallel-safe.** Flow names and node ids are unique per call; nothing is name-addressed across flows. The whole file runs in ~3 s.

## Validation (nightly 1.12.0.dev23, `--retries=0 --workers=1`)

- 3/3 clean burst runs — `expected=3 unexpected=0 flaky=0` each, zero `🚨 Backend Error`
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors, no new warnings) · `npm run test:units` ✅ 608 pass / 0 fail · `npm run check:checklist-coverage` ✅
- **Force-fail, one behavioural mutation per test, all reverted** (final green run after revert ✅):
  - T1 — routed the sentinel through the unprotected `input_value` alongside the `code` tweak, i.e. simulated the tweak reaching the component → red
  - T2 — pointed the benign tweak at the protected `code` field, so the control no longer observes an applied tweak → red
  - T3 — the flow author's stored `python_code` emits a different string, which is what a honoured `python_code` tweak looks like from the response → red
- `@stable` intentionally absent on first delivery (added only after team validation); the checklist bullet ships as `[-]`.

Note on the resolved version: the instance runs `nightly:latest` as pulled locally (`1.12.0.dev23`). `1.12.0.dev24` was published ~8 h before this run and could not be pulled on this machine (Colima: `no space left on device`); the spec is API-only and touches no surface that moved in that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)