### PR TITLE
test(security): promote the tweaks-injection tests to @stable (#1394)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -872,7 +872,7 @@
 
 #### 17.4 Tweaks Injection
 
-- [-] Tweak values passed to `POST /api/v1/run/{id}` cannot reach template fields as
+- [x] Tweak values passed to `POST /api/v1/run/{id}` cannot reach template fields as
       executable input (`langflow-ai/langflow#9319`, `#8672`)
       → security/tweaks-injection.spec.ts
 

--- a/docs/security/tweaks-injection.md
+++ b/docs/security/tweaks-injection.md
@@ -23,11 +23,11 @@ If these tests fail, an API caller holding only run permission on a flow can exe
 
 ## Tags *(required)*
 
-`@api` `@regression`
+`@stable` `@api` `@regression`
 
 No **functional** tag applies: the tag table has no security area, and the closest siblings (`api/flows/api-run-with-tweaks.spec.ts`, `api/flows/api-run-flow.spec.ts`) also carry only cross-cutting tags. `@regression` is what issue #1394 asks for; `@api` marks the layer.
 
-`@stable` is intentionally absent on first delivery — it is added only after team validation (`CONTRIBUTING.md`). The checklist bullet ships as `[-]`.
+`@stable` ships with the first delivery by the maintainer's decision, so this security boundary is watched by `daily-stable.yml` from day one rather than after a validation cycle. The lane profile fits: the file is pure API (no browser, no LLM, no provider key, ~3 s for all three tests), so it costs the daily almost nothing and cannot fail for a provider-outage reason. It is **not** `@destructive` — it creates and deletes only its own two flows and its own API key, so it is safe in the daily's normal lane (`@stable` + `@destructive` would silently never run, #1010). The checklist bullet is therefore `[x]`.
 
 ---
 

--- a/tests/tests-automations/regression/security/tweaks-injection.spec.ts
+++ b/tests/tests-automations/regression/security/tweaks-injection.spec.ts
@@ -155,7 +155,7 @@ test.describe("Tweaks injection — POST /api/v1/run refuses executable fields",
 
   test(
     "a code tweak cannot replace a component's implementation",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       const sentinel = `PWNED-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
       const code = maliciousChatInputCode(sentinel);
@@ -212,7 +212,7 @@ test.describe("Tweaks injection — POST /api/v1/run refuses executable fields",
 
   test(
     "the refusal is field-scoped: an unprotected field on the same node still applies",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       // The control that makes the test above evidence rather than a tautology:
       // same flow, same node, same addressing modes, same request shape — only
@@ -245,7 +245,7 @@ test.describe("Tweaks injection — POST /api/v1/run refuses executable fields",
 
   test(
     "an executable field on a code-execution component is refused while the same request's benign tweak lands",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       const sentinel = `PWNED-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
       const benignSender = `BENIGN-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;


### PR DESCRIPTION
Follow-up to #1435, which shipped `security/tweaks-injection.spec.ts` without `@stable`. **The promotion commit was pushed to that branch after the squash-merge picked up only the first commit**, so `main` still carries the `[-]` bullet and untagged tests. This PR carries exactly that lost commit, cherry-picked onto current `main`.

Maintainer decision: this security boundary is watched by `daily-stable.yml` from day one rather than after a validation cycle.

## Why the lane profile fits

- **Pure API** — no browser, no LLM, no provider key. All three tests together run in ~3 s, so the daily pays almost nothing for them and they cannot go red for a provider-outage reason (the `Collect models` / drained-key class that dominates daily triage).
- **Not `@destructive`** — the file creates and deletes only its own two flows and its own API key, so it belongs in the normal lane. `@stable` + `@destructive` would silently never run there (#1010).
- **Parallel-safe** — flow names and node ids are unique per call; nothing is name-addressed across flows.

## Validation

Selected the way the daily selects it (`--grep @stable`), nightly 1.12.0.dev23, `--retries=0 --workers=1`:

```
run 1 {"expected":3,"unexpected":0,"flaky":0,"skipped":0}
run 2 {"expected":3,"unexpected":0,"flaky":0,"skipped":0}
run 3 {"expected":3,"unexpected":0,"flaky":0,"skipped":0}
```

Re-run once more after the cherry-pick onto current `main`: `expected=3 unexpected=0 flaky=0`.

`npm run typecheck` ✅ · `npm run lint` ✅ (no warnings on these files) · `npm run check:checklist-coverage` ✅. The force-fail proof recorded on #1435 stands unchanged — a tag array touches no assertion.

## Scope

Three files, six lines: the three `tag:` arrays, the spec doc's **Tags** section (rewritten to state why the promotion is safe for the lane instead of the old "absent until team validation" note), and the §17.4 bullet `[-]` → `[x]`. The generated `Phase 0 — Validated` block is deliberately **not** regenerated here — `update-coverage-summary.yml` does that on merge (#741).

Related: #1394 (already closed by #1435).

🤖 Generated with [Claude Code](https://claude.com/claude-code)