### PR TITLE
test(security): assert a Credential global variable never reaches the trace, the export or the run response (#1393)

### DIFF
--- a/.github/workflows/adaptive-impacted.yml
+++ b/.github/workflows/adaptive-impacted.yml
@@ -170,7 +170,10 @@ jobs:
           # observability/traces specs are impacted — they need the SUT to emit
           # traces + spans, and without it their setup times out. Mirrors
           # daily-stable.yml, which keeps tracing ON for exactly these specs.
-          LANGFLOW_DEACTIVATE_TRACING: ${{ (needs.compute-impact.outputs.run_full == 'true' || contains(needs.compute-impact.outputs.specs, 'observability-monitoring')) && 'false' || 'true' }}
+          # `credential-secret-exposure` reads a trace too, from outside that
+          # directory: it proves a Credential global variable is masked in the
+          # trace detail (#1393). With tracing off there is no trace to read.
+          LANGFLOW_DEACTIVATE_TRACING: ${{ (needs.compute-impact.outputs.run_full == 'true' || contains(needs.compute-impact.outputs.specs, 'observability-monitoring') || contains(needs.compute-impact.outputs.specs, 'credential-secret-exposure')) && 'false' || 'true' }}
         options: >-
           --health-cmd "curl -f http://localhost:7860/health_check || exit 1"
           --health-interval 15s

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -561,7 +561,14 @@ jobs:
           # the lane's own verdict instead of inventing a second one, and the
           # cost is a traced boot on a class of PR that is already paying for a
           # full Langflow + `Collect models` sweep.
-          LANGFLOW_DEACTIVATE_TRACING: ${{ (contains(needs.detect-specs.outputs.specs, 'observability-monitoring') || needs.detect-specs.outputs.needs_models == 'true') && 'false' || 'true' }}
+          #
+          # `credential-secret-exposure` is the one spec outside
+          # observability-monitoring that READS a trace: it proves a Credential
+          # global variable is masked in the trace detail (#1393,
+          # langflow-ai/langflow#7313). With tracing off the instance writes no
+          # trace at all, so its first test would fail on a precondition rather
+          # than on the masking it exists to watch.
+          LANGFLOW_DEACTIVATE_TRACING: ${{ (contains(needs.detect-specs.outputs.specs, 'observability-monitoring') || contains(needs.detect-specs.outputs.specs, 'credential-secret-exposure') || needs.detect-specs.outputs.needs_models == 'true') && 'false' || 'true' }}
           # Let Langflow reach the sibling go-httpbin service below (#1128). Its
           # SSRF layer blocks private addresses unless pre-authorized, and the
           # API Request component's validators.url() rejects a single-label host

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -865,10 +865,13 @@
 
 #### 17.3 Secret Exposure
 
-- [ ] A flow run using a Credential-type global variable does **not** render the secret value
+- [x] A flow run using a Credential-type global variable does **not** render the secret value
       in the trace detail (`langflow-ai/langflow#7313` — TracingService exposing secrets)
-- [ ] The same secret is absent from the exported flow JSON
-- [ ] The same secret is absent from the API response of a run
+      → security/credential-secret-exposure.spec.ts
+- [x] The same secret is absent from the exported flow JSON
+      → security/credential-secret-exposure.spec.ts
+- [x] The same secret is absent from the API response of a run
+      → security/credential-secret-exposure.spec.ts
 
 #### 17.4 Tweaks Injection
 

--- a/docs/security/credential-secret-exposure.md
+++ b/docs/security/credential-secret-exposure.md
@@ -1,0 +1,133 @@
+# Credential Secret Exposure
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that the **value of a Credential-type global variable, once resolved into a component at run time, never reaches an observable surface** — the trace detail, the exported flow JSON, or the API response of the run. This is the boundary reported upstream in `langflow-ai/langflow#7313` ("Security issue with TracingService exposing secrets"): `_cleanup_inputs()` obfuscated only inputs whose key contained `api_key`, so any `SecretStrInput` with a different field name was sent to the tracing provider in plaintext.
+
+The fix is **type-driven, not name-driven** — `Component._get_trace_value()` returns `"**********"` for any input declaring `password=True` before the value reaches `get_trace_as_inputs()`. That distinction is what this spec pins, and it is why the flow carries **two** credential-consuming nodes with deliberately different field names:
+
+- **`secret_token`** — a name that also matches the transaction sanitizer's independent, name-based pattern (`SENSITIVE_KEYS_PATTERN` in `transactions/model.py`), so it is masked on two paths at once;
+- **`gateway_pin`** — a name that matches **no** sensitive-key pattern anywhere. It is masked in the trace **only** because the input declares `password=True`. This is the exact case `#7313` reported, and the one that regresses silently if the type check is ever replaced by a name check again.
+
+Asserting only "the secret is absent" would pass just as well on a run where the credential never resolved, on an empty span, or on a flow that never executed. Every test therefore pairs the absence with a **control that proves the secret really did reach the component**: each node returns `resolved_len=<n>`, where `n` is the length of its sentinel. The secret's *length* is the strongest observable that is not the secret itself — the run cannot produce it without having resolved the credential, and it discloses nothing.
+
+If these tests fail, a Credential global variable — the mechanism Langflow offers precisely so that a secret is *not* stored in the flow — is readable by anyone who can open a trace, export the flow, or call the run endpoint.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@api` `@regression`
+
+No **functional** tag applies: the tag table has no security area, and the sibling `security/tweaks-injection.spec.ts` also carries only cross-cutting tags. `@regression` is what issue #1393 asks for; `@api` marks the layer. `@observability` is deliberately **not** applied even though Test 1 reads `/api/v1/monitor/traces/{id}`: the tag drives lane selection and area ownership, and this file's subject is the secret boundary, not the trace payload's shape (which `core-functionality/observability-monitoring/traces-detail*.spec.ts` already owns).
+
+`@stable` ships with the first delivery, mirroring the sibling security spec: the file is pure API (no browser, no LLM, no provider key, ~10 s for all three tests), so it costs the daily almost nothing and cannot fail for a provider-outage reason. It is **not** `@destructive` — it creates and deletes only its own flow, its own two global variables and its own API key.
+
+The three `QA-CHECKLIST.md` §17.3 bullets therefore become `[x]`.
+
+---
+
+## Step by step *(required)*
+
+The spec runs **3 tests** in a serial describe via Playwright's `request` fixture. No browser, no LLM, no provider key. One flow, two global variables and one API key are created in `beforeAll` and deleted in `afterAll`; the flow is run **once** there and all three tests read that same run.
+
+**Setup (`beforeAll`)**
+
+1. `getAuthToken(request)` → Bearer for the variables/flows/monitor endpoints.
+2. `POST /api/v1/api_key/` → temporary key (asserts `200`); `POST /api/v1/run/{id}` authenticates with `x-api-key`, not Bearer.
+3. `POST /api/v1/variables/` **twice**, each `{ type: "Credential", value: <unique sentinel> }` — one per node. The sentinels are unique per run and of **different lengths**, so a `resolved_len` assertion cannot be satisfied by the wrong credential.
+4. `createCredentialConsumerFlowViaApi(request, headers, { fields })` (new helper): reads the **live** catalog (`GET /api/v1/all`), takes the `CustomComponent` template, and builds one node per requested field name. Each node's `code` declares `SecretStrInput(name=<field>)` and returns `Message(text=f"resolved_len={len(value)}")`; each node's template carries that field with `password: true`, `load_from_db: true` and `value: <variable name>` — the exact shape the UI writes when a Credential variable is bound to a secret field. The two nodes are independent roots of the same graph, so a single run executes both (measured on 1.12.0.dev23: both vertices appear in the `debug` response).
+   Building the node from the running instance rather than a committed fixture is what makes an upstream change to the `SecretStrInput` contract surface as a failure instead of a stale fixture quietly testing nothing.
+5. `POST /api/v1/run/{flowId}` with `x-api-key` and `{ input_type: "text", output_type: "debug" }` — `debug` returns every vertex, not just a terminal one. The response body is kept for Test 3.
+
+**Teardown (`afterAll`)**
+
+1. `DELETE /api/v1/flows/{flowId}` — id-scoped, with the `afterAll`'s own `request`.
+2. `DELETE /api/v1/variables/{id}` for both variables.
+3. `DELETE /api/v1/api_key/{apiKeyId}`.
+   Each step is wrapped so a failing one cannot skip the rest; no orphan flow, variable or key survives the file.
+
+---
+
+**Test 1 — the trace detail masks both credentials, whatever the field is called** *(`@api @regression`)*
+
+1. Poll `GET /api/v1/monitor/traces?flow_id={flowId}` (30 s) until `traces.length > 0`. Trace writes are asynchronous — the run answers before the trace lands. If the list stays empty, fail **naming `LANGFLOW_DEACTIVATE_TRACING`** as the cause: an instance with tracing off writes no traces at all, and an unattributed "expected 0 to be greater than 0" would read as a product defect (see Preconditions).
+2. `GET /api/v1/monitor/traces/{trace.id}` → flatten `spans[]` (children included).
+3. Assert both credential-consuming spans are present and that each carries an `inputs` object **containing its field key** — `secret_token` and `gateway_pin` respectively. This is what makes step 4 evidence: the key is there, so the value was traced, and "the sentinel is absent" is not the absence of the whole span.
+4. Assert each of those values is exactly `**********` — `Component._get_trace_value()`'s mask for a `password=True` input.
+5. Assert neither sentinel appears anywhere in the raw response body of the trace detail.
+6. Assert the same on `GET /api/v1/monitor/transactions?flow_id={flowId}` — the per-vertex record the same Traces panel renders alongside the spans. Neither sentinel appears there either. The masking on that path is name-based and therefore *different* (`secret_token` reads `***R...D***`; `gateway_pin` shows the unresolved variable **name**), so the assertion is on the sentinel's absence, not on a mask shape that would drift.
+
+**Test 2 — the export carries the binding, never the secret** *(`@api @regression`)*
+
+1. `POST /api/v1/flows/download/` with `[flowId]` — the endpoint behind the UI's Export/Download action — and assert `200`.
+2. Assert the exported payload contains **both variable names** and, for both fields, `"load_from_db": true`. The export must keep the *binding* — a flow exported without it would import as a broken flow, so this is the control that step 3 is not passing because the field vanished.
+3. Assert neither sentinel appears in the raw exported payload.
+4. Repeat steps 2–3 on `GET /api/v1/flows/{flowId}` — the read path the editor and every API client use, and the one an operator is most likely to pipe into a file.
+
+**Test 3 — the run response resolves the credential without echoing it** *(`@api @regression`)*
+
+1. Assert the run captured in `beforeAll` answered `200`.
+2. For each node, assert its vertex output text equals `resolved_len=<sentinel.length>` — the credential was fetched from the variable service and handed to the component, and the two lengths differ, so neither can stand in for the other.
+3. Assert neither sentinel appears in the raw run response body.
+4. Assert the same on `GET /api/v1/monitor/builds?flow_id={flowId}` — the vertex-build record the node inspector renders; it carries the component's params and is the surface a leak would surface on next.
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1:** the trace detail contains one span per credential-consuming node; `spans[].inputs.secret_token` and `spans[].inputs.gateway_pin` are both exactly `**********`; neither sentinel string occurs in the trace-detail body nor in the transactions body.
+- **Test 2:** `POST /api/v1/flows/download/` answers `200`; the payload carries both variable names with `"load_from_db": true`; neither sentinel occurs in it, nor in `GET /api/v1/flows/{id}`.
+- **Test 3:** the run answered `200`; each vertex output reads `resolved_len=<n>` with `n` equal to that node's sentinel length; neither sentinel occurs in the run body nor in the vertex-build records.
+- Across all three: the pairing is what carries the verdict — **the secret provably reached the component (`resolved_len`) and provably reached none of the three surfaces.**
+- Teardown leaves nothing behind: the flow, both variables and the API key are deleted, and `GET /api/v1/flows/` returns the same count before and after the file runs.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **The external tracing providers** (`#7313`'s literal reproduction was Phoenix/Arize over OpenTelemetry). Asserting there would need a collector in CI. The spec asserts on Langflow's **own** trace store, which is fed by the same `Component.get_trace_as_inputs()` → `_get_trace_value()` path — the code the upstream report is about — so a regression in that masking fails here too.
+- **The Playground / Traces UI rendering.** The check is on the payload the panel renders from; whether the React component then prints it is a separate surface.
+- **Generic (non-Credential) global variables.** They are not secrets by declaration, and Langflow deliberately shows their values.
+- **A secret typed directly into a component field** (no global variable). That path never involves the variable service, and the checklist bullets are scoped to Credential variables.
+- **The `/logs` and `/logs-stream` endpoints and container stdout.** A leak into server logs is a real class of defect, but asserting on it would couple the spec to the deployment shape (`docker logs`), and it is not one of the §17.3 bullets.
+- **Whether the *frontend* ever requests the variable's plaintext.** `GET /api/v1/variables/` is covered by `ui-ux/global-variables-crud.spec.ts`, which owns the secrecy-in-the-list guarantee.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL`.
+- Superuser credentials (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) for `getAuthToken`.
+- The instance allows API-key creation via `POST /api/v1/api_key/`.
+- `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`. With it `false`, `POST /api/v1/custom_component` and custom code execution are refused and the flow cannot run at all — the failure is loud (the `beforeAll` run assertion), never a vacuous pass. Every CI lane and both start scripts set it (#668/#746).
+- **Tracing enabled (`LANGFLOW_DEACTIVATE_TRACING=false`) — Test 1 only.** `daily-stable.yml`, `weekly-stable.yml` and `manual.yml` already set it; `pr-validation.yml` and `adaptive-impacted.yml` enable it only when the selected specs include `observability-monitoring`, so this spec's path must be added to those two conditions or Test 1 has no trace to read on the PR lane. **`scripts/start-langflow-docker.sh` sets it to `true` by decision** (local traces would pollute the token recorder — see the comment in the script), so a local run of Test 1 needs a second container:
+  ```bash
+  docker run -d --name langflow-trace-probe -p 7861:7860 \
+    -e LANGFLOW_AUTO_LOGIN=true -e LANGFLOW_SUPERUSER=langflow \
+    -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 \
+    -e LANGFLOW_DEACTIVATE_TRACING=false -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true \
+    -e LANGFLOW_WORKERS=1 langflowai/langflow-nightly:latest
+  ```
+  Tests 2 and 3 are independent of the flag.
+
+---
+
+## External dependencies *(required)*
+
+- `tests/helpers/auth/get-auth-token.ts` — Bearer via `/api/v1/auto_login`; a contract change breaks `beforeAll`.
+- `tests/helpers/flows/create-credential-consumer-flow-via-api.ts` (new) — builds the two-node flow from the live catalog; owns the `SecretStrInput` code template and the `password`/`load_from_db` field shape.
+- `tests/helpers/flows/delete-flow.ts` — id-scoped teardown.
+- `src/lfx/src/lfx/custom/custom_component/component.py` — `_get_trace_value()` (the `"**********"` mask for `password=True`), `_mask_secret_value()`, `get_trace_as_inputs()` and `_build_with_tracing()`. This is the code path `#7313` is about and the one Test 1 pins.
+- `src/lfx/src/lfx/io/inputs.py` — `SecretStrInput` (`password=True`), the declaration that drives the mask.
+- `src/backend/base/langflow/services/database/models/transactions/model.py` — `SENSITIVE_KEYS_PATTERN`, `_mask_sensitive_value()`, `sanitize_data()`: the **independent, name-based** sanitizer behind `/api/v1/monitor/transactions`. Test 1 step 6 deliberately asserts absence rather than the mask shape, because this path masks differently per field name.
+- `src/backend/base/langflow/api/v1/monitor.py` — `GET /api/v1/monitor/traces`, `/traces/{trace_id}`, `/transactions`, `/builds`: the surfaces Tests 1 and 3 read.
+- `src/backend/base/langflow/services/tracing/formatting.py` — builds the span payload (`inputs`, `outputs`) the trace detail returns.
+- `src/backend/base/langflow/api/v1/flows.py` — `GET /api/v1/flows/{id}` and `POST /api/v1/flows/download/`: Test 2's two export surfaces.
+- `src/backend/base/langflow/api/v1/variables.py` — `POST /api/v1/variables/` with `type: "Credential"`, and the variable service that resolves a `load_from_db` field at build time.
+- `src/backend/base/langflow/api/v1/endpoints.py` — `POST /api/v1/run/{flow_id}`: the `SimplifiedAPIRequest` schema, `output_type: "debug"`, and the `RunResponse` shape Test 3 reads.
+- Upstream reference: `langflow-ai/langflow#7313` — the defect that defines the boundary.

--- a/docs/security/credential-secret-exposure.md
+++ b/docs/security/credential-secret-exposure.md
@@ -65,9 +65,9 @@ The spec runs **3 tests** in a serial describe via Playwright's `request` fixtur
 **Test 2 — the export carries the binding, never the secret** *(`@api @regression`)*
 
 1. `POST /api/v1/flows/download/` with `[flowId]` — the endpoint behind the UI's Export/Download action — and assert `200`.
-2. Assert the exported payload contains **both variable names** and, for both fields, `"load_from_db": true`. The export must keep the *binding* — a flow exported without it would import as a broken flow, so this is the control that step 3 is not passing because the field vanished.
+2. Assert the exported payload contains **both variable names**. The export must keep the *binding* — a flow exported without it would import as a broken flow, so this is the control that step 3 is not passing because the field vanished. The check is textual here because a multi-id export answers with an archive rather than a flow object, and the variable name is the binding's observable in both shapes.
 3. Assert neither sentinel appears in the raw exported payload.
-4. Repeat steps 2–3 on `GET /api/v1/flows/{flowId}` — the read path the editor and every API client use, and the one an operator is most likely to pipe into a file.
+4. `GET /api/v1/flows/{flowId}` — the read path the editor and every API client use, and the one an operator is most likely to pipe into a file. Assert the same absence, and assert the binding **structurally** on the stored flow: for each node, `template.<field>.value` is the variable name, `load_from_db` is `true` and `password` is `true`.
 
 **Test 3 — the run response resolves the credential without echoing it** *(`@api @regression`)*
 
@@ -123,11 +123,11 @@ The spec runs **3 tests** in a serial describe via Playwright's `request` fixtur
 - `tests/helpers/flows/create-credential-consumer-flow-via-api.ts` (new) — builds the two-node flow from the live catalog; owns the `SecretStrInput` code template and the `password`/`load_from_db` field shape.
 - `tests/helpers/flows/delete-flow.ts` — id-scoped teardown.
 - `src/lfx/src/lfx/custom/custom_component/component.py` — `_get_trace_value()` (the `"**********"` mask for `password=True`), `_mask_secret_value()`, `get_trace_as_inputs()` and `_build_with_tracing()`. This is the code path `#7313` is about and the one Test 1 pins.
-- `src/lfx/src/lfx/io/inputs.py` — `SecretStrInput` (`password=True`), the declaration that drives the mask.
+- `src/lfx/src/lfx/inputs/inputs.py` — `SecretStrInput` (`password=True`), the declaration that drives the mask.
 - `src/backend/base/langflow/services/database/models/transactions/model.py` — `SENSITIVE_KEYS_PATTERN`, `_mask_sensitive_value()`, `sanitize_data()`: the **independent, name-based** sanitizer behind `/api/v1/monitor/transactions`. Test 1 step 6 deliberately asserts absence rather than the mask shape, because this path masks differently per field name.
 - `src/backend/base/langflow/api/v1/monitor.py` — `GET /api/v1/monitor/traces`, `/traces/{trace_id}`, `/transactions`, `/builds`: the surfaces Tests 1 and 3 read.
 - `src/backend/base/langflow/services/tracing/formatting.py` — builds the span payload (`inputs`, `outputs`) the trace detail returns.
 - `src/backend/base/langflow/api/v1/flows.py` — `GET /api/v1/flows/{id}` and `POST /api/v1/flows/download/`: Test 2's two export surfaces.
-- `src/backend/base/langflow/api/v1/variables.py` — `POST /api/v1/variables/` with `type: "Credential"`, and the variable service that resolves a `load_from_db` field at build time.
+- `src/backend/base/langflow/api/v1/variable.py` — `POST /api/v1/variables/` with `type: "Credential"`, and the variable service that resolves a `load_from_db` field at build time.
 - `src/backend/base/langflow/api/v1/endpoints.py` — `POST /api/v1/run/{flow_id}`: the `SimplifiedAPIRequest` schema, `output_type: "debug"`, and the `RunResponse` shape Test 3 reads.
 - Upstream reference: `langflow-ai/langflow#7313` — the defect that defines the boundary.

--- a/tests/helpers/flows/create-credential-consumer-flow-via-api.test.ts
+++ b/tests/helpers/flows/create-credential-consumer-flow-via-api.test.ts
@@ -1,0 +1,172 @@
+// Unit tests for buildCredentialConsumerFlowData (#1393).
+// Run with: npm run test:units
+//
+// The helper's network half needs a live instance; its load-bearing half is
+// pure — turning a live `GET /api/v1/all` catalog into a flow whose fields are
+// BOUND to Credential global variables. Three properties there decide whether
+// `security/credential-secret-exposure.spec.ts` proves anything, and none of
+// them is visible from a green spec:
+//
+// (1) The BINDING. The field must carry `load_from_db: true` with the variable
+// NAME as its value. Written without `load_from_db`, the run reads the literal
+// string "my-var-name" as the secret — the flow still runs, the trace still
+// masks, every "the sentinel is absent" assertion still passes, and the spec
+// tests nothing at all. The `password: true` half is what the upstream mask
+// keys on (`Component._get_trace_value`), so it is pinned too.
+//
+// (2) The CODE ↔ FIELD agreement. The generated component declares
+// `SecretStrInput(name=<field>)` and reads `self.<field>`; if the template field
+// and the code ever disagree, the node runs and reports length 0 — again a
+// silently vacuous spec.
+//
+// (3) The CATALOG LOOKUP and the empty-field case must fail NAMING the cause,
+// rather than reaching `POST /api/v1/flows/` as an undefined template (#1012).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCredentialConsumerFlowData,
+  credentialConsumerCode,
+  CUSTOM_COMPONENT_TYPE,
+  RESOLVED_LEN_PREFIX,
+} from "./create-credential-consumer-flow-via-api";
+
+/** A minimal stand-in for the single catalog entry the helper reads. */
+function fakeCatalog(
+  overrides: { customComponent?: unknown } = {},
+): Record<string, unknown> {
+  const customComponent =
+    "customComponent" in overrides
+      ? overrides.customComponent
+      : {
+          display_name: "Custom Component",
+          base_classes: ["JSON"],
+          field_order: ["input_value"],
+          outputs: [{ display_name: "Output", name: "output", types: ["Data"] }],
+          template: {
+            _type: "Component",
+            code: { type: "code", value: "class CustomComponent: ..." },
+            input_value: { type: "str", value: "Hello, World!" },
+          },
+        };
+
+  const catalog: Record<string, Record<string, unknown>> = {
+    input_output: {},
+    custom_component: {},
+  };
+  if (customComponent !== undefined) {
+    catalog.custom_component[CUSTOM_COMPONENT_TYPE] = customComponent;
+  }
+  return catalog;
+}
+
+const FIELDS = [
+  {
+    fieldName: "secret_token",
+    variableName: "cred-token-1",
+    nodeId: "CustomComponent-secret_token-t1",
+  },
+  {
+    fieldName: "gateway_pin",
+    variableName: "cred-pin-1",
+    nodeId: "CustomComponent-gateway_pin-t1",
+  },
+];
+
+test("binds each field to its variable with load_from_db and password set", () => {
+  const data = buildCredentialConsumerFlowData(fakeCatalog(), FIELDS);
+
+  assert.equal(data.nodes.length, 2);
+  for (const [index, field] of FIELDS.entries()) {
+    const template = data.nodes[index].data.node.template;
+    const bound = template[field.fieldName];
+
+    assert.ok(bound, `node ${index} has no ${field.fieldName} field`);
+    // The variable NAME is the stored value — the secret itself never enters
+    // the flow, which is the guarantee the spec's export test asserts on.
+    assert.equal(bound.value, field.variableName);
+    // Without this the run reads the variable name AS the secret and the whole
+    // spec passes while proving nothing.
+    assert.equal(bound.load_from_db, true);
+    // What `Component._get_trace_value()` keys the "**********" mask on.
+    assert.equal(bound.password, true);
+    assert.equal(bound._input_type, "SecretStrInput");
+  }
+});
+
+test("the generated code declares and reads the same field name", () => {
+  const data = buildCredentialConsumerFlowData(fakeCatalog(), FIELDS);
+
+  for (const [index, field] of FIELDS.entries()) {
+    const code = data.nodes[index].data.node.template.code.value as string;
+
+    assert.match(code, new RegExp(`SecretStrInput\\(name="${field.fieldName}"`));
+    assert.match(code, new RegExp(`self\\.${field.fieldName}\\b`));
+    assert.ok(code.includes(RESOLVED_LEN_PREFIX));
+    // The secret's length is the only thing the component may emit.
+    assert.ok(!code.includes("secret}"), "the component must never echo the secret");
+  }
+});
+
+test("drops the stock input the generated component does not declare", () => {
+  const data = buildCredentialConsumerFlowData(fakeCatalog(), FIELDS);
+
+  for (const node of data.nodes) {
+    assert.equal(node.data.node.template.input_value, undefined);
+    assert.deepEqual(node.data.node.field_order, [
+      // field_order mirrors the single declared input.
+      Object.keys(node.data.node.template).find((k) => k !== "_type" && k !== "code"),
+    ]);
+  }
+});
+
+test("nodes are independent roots — no edges, one node per field", () => {
+  const data = buildCredentialConsumerFlowData(fakeCatalog(), FIELDS);
+
+  assert.deepEqual(data.edges, []);
+  assert.deepEqual(
+    data.nodes.map((n) => n.id),
+    FIELDS.map((f) => f.nodeId),
+  );
+  // Distinct positions keep the canvas readable when the flow is opened by hand
+  // during triage; the run itself does not care.
+  assert.notEqual(data.nodes[0].position.x, data.nodes[1].position.x);
+});
+
+test("each node gets its own template copy", () => {
+  const catalog = fakeCatalog();
+  const data = buildCredentialConsumerFlowData(catalog, FIELDS);
+
+  // A shared reference would leave the last field's code on every node.
+  assert.notEqual(
+    data.nodes[0].data.node.template.code.value,
+    data.nodes[1].data.node.template.code.value,
+  );
+  // The catalog the caller holds is never mutated — it builds every node.
+  const source = (catalog.custom_component as Record<string, { template: Record<string, unknown> }>)[
+    CUSTOM_COMPONENT_TYPE
+  ];
+  assert.ok(source.template.input_value, "the source catalog was mutated");
+});
+
+test("fails naming the component when the catalog does not ship it", () => {
+  assert.throws(
+    () => buildCredentialConsumerFlowData(fakeCatalog({ customComponent: undefined }), FIELDS),
+    (error: Error) =>
+      error.message.includes(CUSTOM_COMPONENT_TYPE) &&
+      error.message.includes("GET /api/v1/all"),
+  );
+});
+
+test("refuses an empty field list instead of building a flow that asserts nothing", () => {
+  assert.throws(
+    () => buildCredentialConsumerFlowData(fakeCatalog(), []),
+    /at least one field/,
+  );
+});
+
+test("credentialConsumerCode is exported for the spec to document what runs", () => {
+  const code = credentialConsumerCode("db_passphrase");
+
+  assert.match(code, /SecretStrInput\(name="db_passphrase"/);
+  assert.match(code, /self\.db_passphrase/);
+});

--- a/tests/helpers/flows/create-credential-consumer-flow-via-api.ts
+++ b/tests/helpers/flows/create-credential-consumer-flow-via-api.ts
@@ -1,0 +1,276 @@
+import type { APIRequestContext } from "@playwright/test";
+import { createFlow } from "./create-flow";
+import { deleteFlow } from "./delete-flow";
+
+/**
+ * Builds a flow whose nodes each consume a **Credential-type global variable**
+ * through a `SecretStrInput`, from the LIVE component catalog (`GET /api/v1/all`),
+ * and creates it via the REST API.
+ *
+ * Why it exists: `security/credential-secret-exposure.spec.ts` has to prove that a
+ * resolved credential reaches the component and reaches NONE of the observable
+ * surfaces (trace detail, exported flow, run response). No shipped component
+ * gives that combination offline — every built-in `SecretStrInput` belongs to a
+ * vendor component that needs the vendor to answer. A `CustomComponent` whose
+ * code declares the secret input and returns only the secret's LENGTH does: the
+ * length is impossible to produce without having resolved the credential, and it
+ * discloses nothing.
+ *
+ * Why the field NAME is a parameter: the upstream defect (`langflow-ai/langflow#7313`)
+ * was a name-based mask — only inputs whose key contained `api_key` were
+ * obfuscated. The fix is type-based (`password=True`). A caller therefore passes
+ * at least one field whose name matches no sensitive-key pattern anywhere, so a
+ * regression back to name matching fails the spec instead of hiding behind a
+ * conveniently-named field.
+ *
+ * Why one flow with several ROOT nodes: each node is an independent entry point,
+ * so a single `POST /api/v1/run/{id}` with `output_type: "debug"` executes them
+ * all (measured on 1.12.0.dev23) — one run, one trace, every field covered.
+ *
+ * The instance must run with `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`; with it off
+ * the custom code never executes and the caller's `resolved_len` assertion fails
+ * loudly rather than passing vacuously.
+ */
+
+/** Catalog key of the component the nodes are built from. */
+export const CUSTOM_COMPONENT_TYPE = "CustomComponent";
+
+/** Prefix of the text each node outputs; the suffix is the resolved secret's length. */
+export const RESOLVED_LEN_PREFIX = "resolved_len=";
+
+interface TemplateField {
+  type?: string;
+  value?: unknown;
+  [key: string]: unknown;
+}
+
+interface ComponentTemplate {
+  template: Record<string, TemplateField>;
+  [key: string]: unknown;
+}
+
+export interface FlowNode {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: { id: string; type: string; node: ComponentTemplate };
+}
+
+export interface FlowData {
+  nodes: FlowNode[];
+  edges: never[];
+  viewport: { x: number; y: number; zoom: number };
+}
+
+/** One credential-consuming node: a secret field bound to a global variable. */
+export interface CredentialConsumerField {
+  /** Name of the `SecretStrInput` the component declares, e.g. `gateway_pin`. */
+  fieldName: string;
+  /** Name of the Credential global variable the field is bound to. */
+  variableName: string;
+  /** Node id — also the key the run response and the transactions are read by. */
+  nodeId: string;
+}
+
+/**
+ * The component source for one node. It reads the secret and returns only its
+ * length, so the caller can prove the credential resolved without the test
+ * itself becoming a place the secret is printed.
+ */
+export function credentialConsumerCode(fieldName: string): string {
+  return `from lfx.custom.custom_component.component import Component
+from lfx.io import Output, SecretStrInput
+from lfx.schema.message import Message
+
+
+class CustomComponent(Component):
+    display_name = "Custom Component"
+    description = "Reports the length of a credential without disclosing it."
+    icon = "code"
+    name = "CustomComponent"
+
+    inputs = [
+        SecretStrInput(name="${fieldName}", display_name="Secret Field", required=False),
+    ]
+
+    outputs = [
+        Output(display_name="Output", name="output", method="build_output"),
+    ]
+
+    def build_output(self) -> Message:
+        secret = self.${fieldName} or ""
+        return Message(text=f"${RESOLVED_LEN_PREFIX}{len(secret)}")
+`;
+}
+
+/**
+ * Finds a component template in a `GET /api/v1/all` payload, whose top level is
+ * `category -> { componentType: template }`.
+ *
+ * Throws naming the component when it is absent: an undefined template reaching
+ * `POST /api/v1/flows/` surfaces as an unattributable 422, and an auth failure
+ * answers this endpoint with a `detail` body rather than a catalog.
+ */
+function findComponentTemplate(
+  catalog: Record<string, unknown>,
+  componentType: string,
+): ComponentTemplate {
+  for (const category of Object.values(catalog)) {
+    if (!category || typeof category !== "object") continue;
+    const entry = (category as Record<string, unknown>)[componentType];
+    if (entry && typeof entry === "object" && "template" in entry) {
+      // Deep copy: one catalog read builds every node, and each build mutates
+      // the template it was given.
+      return JSON.parse(JSON.stringify(entry)) as ComponentTemplate;
+    }
+  }
+
+  throw new Error(
+    `Component "${componentType}" is not present in GET /api/v1/all on this instance. ` +
+      "Either the image does not ship it, or the response was not a component catalog " +
+      "(an auth failure answers with a `detail` body). See docs/component-distribution-policy.md.",
+  );
+}
+
+/**
+ * Turns a live catalog into the flow payload. Pure — no network, no clock, no
+ * randomness — so the credential binding it writes is unit-testable.
+ *
+ * The binding is the shape the UI writes when a Credential variable is attached
+ * to a secret field: the field's `value` is the variable NAME and `load_from_db`
+ * is `true`, which is what makes the stored flow free of the secret by
+ * construction and the run able to resolve it.
+ */
+export function buildCredentialConsumerFlowData(
+  catalog: Record<string, unknown>,
+  fields: CredentialConsumerField[],
+): FlowData {
+  if (fields.length === 0) {
+    throw new Error(
+      "buildCredentialConsumerFlowData requires at least one field — a flow with " +
+        "no credential consumer would run clean and assert nothing.",
+    );
+  }
+
+  const nodes = fields.map(({ fieldName, variableName, nodeId }, index) => {
+    const template = findComponentTemplate(catalog, CUSTOM_COMPONENT_TYPE);
+
+    template.template.code = {
+      ...template.template.code,
+      value: credentialConsumerCode(fieldName),
+    };
+    // The stock template's own input is not declared by the code above; leaving
+    // it in would make the node's template and its component disagree.
+    delete template.template.input_value;
+    template.template[fieldName] = {
+      _input_type: "SecretStrInput",
+      advanced: false,
+      display_name: "Secret Field",
+      dynamic: false,
+      info: "",
+      input_types: [],
+      load_from_db: true,
+      name: fieldName,
+      password: true,
+      placeholder: "",
+      required: false,
+      show: true,
+      title_case: false,
+      type: "str",
+      value: variableName,
+    };
+    template.field_order = [fieldName];
+    template.outputs = [
+      {
+        allows_loop: false,
+        cache: true,
+        display_name: "Output",
+        method: "build_output",
+        name: "output",
+        selected: "Message",
+        types: ["Message"],
+        value: "__UNDEFINED__",
+      },
+    ];
+    template.base_classes = ["Message"];
+
+    return {
+      id: nodeId,
+      type: "genericNode",
+      position: { x: index * 600, y: 0 },
+      data: { id: nodeId, type: CUSTOM_COMPONENT_TYPE, node: template },
+    };
+  });
+
+  // No edges on purpose: every node is its own root, so one run executes all of
+  // them and each writes its own span, transaction and vertex build.
+  return { nodes, edges: [], viewport: { x: 0, y: 0, zoom: 1 } };
+}
+
+export interface CredentialConsumerFlow {
+  /** The created flow's id, for `POST /api/v1/run/{flow_id}`. */
+  flowId: string;
+  /** The fields as created, with the node ids the caller reads results by. */
+  fields: CredentialConsumerField[];
+  /** Deletes the created flow. Safe to call in `afterAll` with its own `request`. */
+  deleteFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+}
+
+/**
+ * Creates the credential-consuming flow on the instance.
+ *
+ * `headers` carries the auth the caller already holds (`{ Authorization: bearer }`
+ * or `{ "x-api-key": key }`); the same header is reused for the catalog read and
+ * for teardown.
+ *
+ * `fields` pairs each `SecretStrInput` name with the Credential global variable
+ * it binds to — the caller creates those variables, because it owns the sentinel
+ * values it will later assert on.
+ */
+export async function createCredentialConsumerFlowViaApi(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  fields: Array<Omit<CredentialConsumerField, "nodeId">>,
+): Promise<CredentialConsumerFlow> {
+  const catalogRes = await request.get("/api/v1/all", { headers });
+  if (!catalogRes.ok()) {
+    throw new Error(
+      `GET /api/v1/all answered ${catalogRes.status()} — cannot build the ` +
+        "credential-consumer flow without the component catalog.",
+    );
+  }
+  const catalog = (await catalogRes.json()) as Record<string, unknown>;
+
+  // Unique per call for the same reason as the sibling helpers: Langflow's
+  // unique-name fallback is not transaction-safe under parallel creation (#588).
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const resolvedFields: CredentialConsumerField[] = fields.map((field) => ({
+    ...field,
+    nodeId: `${CUSTOM_COMPONENT_TYPE}-${field.fieldName}-${uniqueSuffix}`,
+  }));
+
+  const data = buildCredentialConsumerFlowData(catalog, resolvedFields);
+
+  const flowId = await createFlow(
+    request,
+    {
+      name: `Credential Consumer Flow ${uniqueSuffix}`,
+      description:
+        "Credential-typed global variables consumed by SecretStrInput fields, " +
+        "for the secret-exposure API tests",
+      data,
+      is_component: false,
+    },
+    { headers },
+  );
+
+  return {
+    flowId,
+    fields: resolvedFields,
+    // `reqOverride` exists for the fixture-scope rule the sibling helpers
+    // document: a `beforeAll` request cannot be reused inside `afterAll`.
+    deleteFlow: async (reqOverride?: APIRequestContext) => {
+      await deleteFlow(reqOverride ?? request, flowId, { headers });
+    },
+  };
+}

--- a/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
+++ b/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
@@ -1,0 +1,402 @@
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import {
+  createCredentialConsumerFlowViaApi,
+  RESOLVED_LEN_PREFIX,
+  type CredentialConsumerField,
+} from "../../../helpers/flows/create-credential-consumer-flow-via-api";
+
+// The value of a Credential-type global variable, once resolved into a component
+// at run time, must not reach the trace detail, the exported flow JSON, or the
+// API response of the run (langflow-ai/langflow#7313 — the TracingService
+// obfuscated only inputs whose key contained `api_key`, so every other
+// SecretStrInput went to the tracing provider in plaintext).
+//
+// The fix is TYPE-driven: Component._get_trace_value() returns "**********" for
+// any input declaring `password=True`, before the value reaches
+// get_trace_as_inputs(). That is why the flow carries two nodes with
+// deliberately different field names:
+//   - `secret_token` — also matches the transactions sanitizer's independent,
+//     NAME-based pattern, so it is masked on two paths at once;
+//   - `gateway_pin`  — matches no sensitive-key pattern anywhere. It is masked
+//     only because the input is a SecretStrInput. This is #7313's exact case and
+//     the one that regresses silently if the type check becomes a name check.
+//
+// Asserting "the secret is absent" alone would pass on a run where the
+// credential never resolved, on an empty span, or on a flow that never executed.
+// Every test therefore pairs the absence with a control that the secret DID
+// reach the component: each node returns `resolved_len=<n>`, the length of its
+// own sentinel — impossible to produce without resolving the credential, and
+// disclosing nothing. The two sentinels have different lengths, so neither can
+// stand in for the other.
+
+/** Field whose name ALSO matches the name-based sanitizer of the transactions path. */
+const TOKEN_FIELD = "secret_token";
+/** Field whose name matches no sensitive-key pattern — #7313's case. */
+const PIN_FIELD = "gateway_pin";
+
+/** The mask `Component._get_trace_value()` writes for a `password=True` input. */
+const TRACE_MASK = "**********";
+
+interface RunVertexOutput {
+  component_id?: string;
+  outputs?: { output?: { message?: string } };
+}
+
+interface RunResponseBody {
+  outputs?: Array<{ outputs?: RunVertexOutput[] }>;
+}
+
+interface StoredFlow {
+  data?: {
+    nodes?: Array<{
+      id: string;
+      data?: {
+        node?: { template?: Record<string, Record<string, unknown>> };
+      };
+    }>;
+  };
+}
+
+interface TraceSpan {
+  name?: string;
+  inputs?: Record<string, unknown>;
+  children?: TraceSpan[];
+}
+
+/** Every vertex of an `output_type: "debug"` response, flattened across groups. */
+function runVertices(body: RunResponseBody): RunVertexOutput[] {
+  return (body?.outputs ?? []).flatMap((group) => group?.outputs ?? []);
+}
+
+/** The text one vertex produced, by node id. */
+function vertexText(body: RunResponseBody, nodeId: string): string | undefined {
+  return runVertices(body).find((v) => v.component_id === nodeId)?.outputs?.output
+    ?.message;
+}
+
+function flattenSpans(spans: TraceSpan[]): TraceSpan[] {
+  return spans.flatMap((span) => [span, ...flattenSpans(span.children ?? [])]);
+}
+
+/** Deletes a global variable, tolerating an already-removed id. */
+async function deleteVariable(
+  request: APIRequestContext,
+  authToken: string,
+  variableId: string,
+): Promise<void> {
+  await request
+    .delete(`/api/v1/variables/${variableId}`, {
+      headers: { Authorization: authToken },
+    })
+    .catch(() => undefined);
+}
+
+test.describe("Credential secret exposure", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let bearerToken: string;
+  let apiKey: string;
+  let apiKeyId: string;
+  let flowId: string;
+  let deleteCreatedFlow: (req?: APIRequestContext) => Promise<void>;
+  let fields: CredentialConsumerField[];
+  let runBody: RunResponseBody;
+  let runStatus: number;
+
+  /** fieldName -> the Credential variable name, its id, and its sentinel value. */
+  const credentials = new Map<
+    string,
+    { variableName: string; variableId: string; sentinel: string }
+  >();
+
+  test.beforeAll(async ({ request }) => {
+    bearerToken = await getAuthToken(request);
+
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: { Authorization: bearerToken },
+      data: { name: `credential-secret-exposure-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const keyBody = await keyRes.json();
+    apiKey = keyBody.api_key;
+    apiKeyId = keyBody.id;
+
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+    // Different lengths on purpose: `resolved_len` then identifies WHICH
+    // credential a node resolved, not merely that it resolved something.
+    const seeds: Array<{ fieldName: string; sentinel: string }> = [
+      { fieldName: TOKEN_FIELD, sentinel: `CRED-TOKEN-SENTINEL-${stamp}` },
+      { fieldName: PIN_FIELD, sentinel: `CRED-PIN-SENTINEL-${stamp}-EXTRA-PAD` },
+    ];
+    expect(seeds[0].sentinel).not.toHaveLength(seeds[1].sentinel.length);
+
+    for (const { fieldName, sentinel } of seeds) {
+      const variableName = `cred-secret-exposure-${fieldName}-${stamp}`;
+      const varRes = await request.post("/api/v1/variables/", {
+        headers: { Authorization: bearerToken },
+        data: {
+          name: variableName,
+          value: sentinel,
+          type: "Credential",
+          default_fields: [],
+        },
+      });
+      expect(varRes.status()).toBe(201);
+      const variableId = (await varRes.json()).id as string;
+      credentials.set(fieldName, { variableName, variableId, sentinel });
+    }
+
+    const flow = await createCredentialConsumerFlowViaApi(
+      request,
+      { Authorization: bearerToken },
+      seeds.map(({ fieldName }) => ({
+        fieldName,
+        variableName: credentials.get(fieldName)!.variableName,
+      })),
+    );
+    flowId = flow.flowId;
+    fields = flow.fields;
+    deleteCreatedFlow = flow.deleteFlow;
+
+    // One run, read by all three tests. `debug` returns every vertex, and both
+    // nodes are independent roots, so a single run executes both.
+    const runRes = await request.post(`/api/v1/run/${flowId}`, {
+      headers: { "x-api-key": apiKey },
+      data: {
+        input_value: "credential-secret-probe",
+        input_type: "text",
+        output_type: "debug",
+      },
+    });
+    runStatus = runRes.status();
+    runBody = (await runRes.json()) as RunResponseBody;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (deleteCreatedFlow) {
+      await deleteCreatedFlow(request).catch(() => undefined);
+    }
+    for (const { variableId } of credentials.values()) {
+      await deleteVariable(request, bearerToken, variableId);
+    }
+    if (apiKeyId) {
+      await request
+        .delete(`/api/v1/api_key/${apiKeyId}`, {
+          headers: { Authorization: bearerToken },
+        })
+        .catch(() => undefined);
+    }
+  });
+
+  test(
+    "the trace detail masks the credential whatever the secret field is called",
+    { tag: ["@stable", "@api", "@regression"] },
+    async ({ request }) => {
+      let traceId = "";
+
+      await test.step("wait for the run's trace to be written", async () => {
+        // Trace writes are asynchronous — the run answers before the trace lands.
+        await expect
+          .poll(
+            async () => {
+              const res = await request.get(
+                `/api/v1/monitor/traces?flow_id=${flowId}`,
+                { headers: { Authorization: bearerToken } },
+              );
+              if (res.status() !== 200) return 0;
+              const body = await res.json();
+              const traces = body.traces ?? [];
+              if (traces.length > 0) traceId = traces[0].id;
+              return traces.length;
+            },
+            {
+              timeout: 30000,
+              intervals: [500, 1000, 2000],
+              message:
+                "No trace was written for this run. An instance started with " +
+                "LANGFLOW_DEACTIVATE_TRACING=true writes none at all — that is a " +
+                "precondition failure, not a masking defect (see the spec doc). " +
+                "scripts/start-langflow-docker.sh sets it true by decision.",
+            },
+          )
+          .toBeGreaterThan(0);
+      });
+
+      const detailRes = await request.get(`/api/v1/monitor/traces/${traceId}`, {
+        headers: { Authorization: bearerToken },
+      });
+      expect(detailRes.status()).toBe(200);
+      const detailText = await detailRes.text();
+      const detail = JSON.parse(detailText) as { spans?: TraceSpan[] };
+      const spans = flattenSpans(detail.spans ?? []);
+
+      await test.step("every secret field is traced, and masked", async () => {
+        for (const { fieldName } of fields) {
+          const span = spans.find(
+            (candidate) =>
+              candidate.inputs !== undefined && fieldName in candidate.inputs,
+          );
+
+          // The key must be PRESENT: that is what makes the absence assertion
+          // below evidence rather than the absence of the whole span.
+          expect(
+            span,
+            `no trace span carries the ${fieldName} input — the component's ` +
+              "inputs were not traced at all, so nothing here proves masking",
+          ).toBeDefined();
+          expect(span!.inputs![fieldName]).toBe(TRACE_MASK);
+        }
+      });
+
+      await test.step("no sentinel reaches the trace detail", async () => {
+        for (const { sentinel } of credentials.values()) {
+          expect(detailText).not.toContain(sentinel);
+        }
+      });
+
+      await test.step("no sentinel reaches the transactions record", async () => {
+        let txText = "";
+
+        // Transactions are written asynchronously like the trace, and on a
+        // measured run they landed AFTER it — polling for one row per vertex is
+        // what keeps the absence assertion below from being the absence of any
+        // record at all.
+        await expect
+          .poll(
+            async () => {
+              const res = await request.get(
+                `/api/v1/monitor/transactions?flow_id=${flowId}`,
+                { headers: { Authorization: bearerToken } },
+              );
+              if (res.status() !== 200) return 0;
+              txText = await res.text();
+              return (JSON.parse(txText) as { items?: unknown[] }).items?.length ?? 0;
+            },
+            {
+              timeout: 30000,
+              intervals: [500, 1000, 2000],
+              message:
+                "No transaction row was written for this run — the vertices did " +
+                "not execute, so nothing here proves the secret was withheld.",
+            },
+          )
+          .toBe(fields.length);
+
+        // Absence, not a mask shape: this path masks by field NAME
+        // (`secret_token` reads `***R...D***`, `gateway_pin` shows the
+        // unresolved variable name), so asserting the shape would pin an
+        // unrelated implementation detail.
+        for (const { sentinel } of credentials.values()) {
+          expect(txText).not.toContain(sentinel);
+        }
+      });
+    },
+  );
+
+  test(
+    "the exported flow carries the credential binding, never the secret",
+    { tag: ["@stable", "@api", "@regression"] },
+    async ({ request }) => {
+      const surfaces: Array<{ label: string; body: string }> = [];
+
+      await test.step("export the flow the way the UI does", async () => {
+        const res = await request.post("/api/v1/flows/download/", {
+          headers: { Authorization: bearerToken },
+          data: [flowId],
+        });
+        expect(res.status()).toBe(200);
+        surfaces.push({
+          label: "POST /api/v1/flows/download/",
+          body: await res.text(),
+        });
+      });
+
+      let storedFlow: StoredFlow;
+
+      await test.step("read the flow back through the API", async () => {
+        const res = await request.get(`/api/v1/flows/${flowId}`, {
+          headers: { Authorization: bearerToken },
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.text();
+        surfaces.push({ label: "GET /api/v1/flows/{id}", body });
+        storedFlow = JSON.parse(body) as StoredFlow;
+      });
+
+      await test.step("the stored flow keeps the binding, not the secret", async () => {
+        // Structural, not textual: the binding is what an import needs, and a
+        // flow that lost it would satisfy every "the sentinel is absent"
+        // assertion below for entirely the wrong reason.
+        for (const { fieldName, nodeId } of fields) {
+          const { variableName } = credentials.get(fieldName)!;
+          const node = (storedFlow.data?.nodes ?? []).find((n) => n.id === nodeId);
+          expect(node, `node ${nodeId} is missing from the stored flow`).toBeDefined();
+
+          const field = node!.data?.node?.template?.[fieldName];
+          expect(field, `${fieldName} is missing from the stored template`).toBeDefined();
+          expect(field!.value).toBe(variableName);
+          expect(field!.load_from_db).toBe(true);
+          expect(field!.password).toBe(true);
+        }
+      });
+
+      for (const { label, body } of surfaces) {
+        await test.step(`${label} drops the secret`, async () => {
+          for (const { variableName, sentinel } of credentials.values()) {
+            // The download body is checked textually because a multi-id export
+            // answers with an archive rather than a flow object — the variable
+            // name is the binding's observable there.
+            expect(body, `${label} lost the variable binding`).toContain(
+              variableName,
+            );
+            expect(body).not.toContain(sentinel);
+          }
+        });
+      }
+    },
+  );
+
+  test(
+    "the run resolves the credential without echoing it",
+    { tag: ["@stable", "@api", "@regression"] },
+    async ({ request }) => {
+      expect(runStatus).toBe(200);
+
+      await test.step("each node resolved its own credential", async () => {
+        for (const { fieldName, nodeId } of fields) {
+          const { sentinel } = credentials.get(fieldName)!;
+          expect(vertexText(runBody, nodeId)).toBe(
+            `${RESOLVED_LEN_PREFIX}${sentinel.length}`,
+          );
+        }
+      });
+
+      await test.step("no sentinel reaches the run response", async () => {
+        const runText = JSON.stringify(runBody);
+        for (const { sentinel } of credentials.values()) {
+          expect(runText).not.toContain(sentinel);
+        }
+      });
+
+      await test.step("no sentinel reaches the vertex build records", async () => {
+        const res = await request.get(`/api/v1/monitor/builds?flow_id=${flowId}`, {
+          headers: { Authorization: bearerToken },
+        });
+        expect(res.status()).toBe(200);
+        const buildsText = await res.text();
+
+        // Both vertices must have a build record, else the absence below is the
+        // absence of the run itself.
+        for (const { nodeId } of fields) {
+          expect(buildsText).toContain(nodeId);
+        }
+        for (const { sentinel } of credentials.values()) {
+          expect(buildsText).not.toContain(sentinel);
+        }
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1393.

Closes the three `[ ]` bullets in `QA-CHECKLIST.md` § 17.3 — Secret Exposure. Distinct from `security/tweaks-injection.spec.ts` (which proves a run-time *input* cannot become executable code) and from `ui-ux/global-variables-crud.spec.ts` (which owns secrecy in the variables list): this one follows one secret from the variable service, through a component that really resolves it, to the three surfaces an operator reads afterwards.

Upstream: `langflow-ai/langflow#7313` — the `TracingService` obfuscated only inputs whose key contained `api_key`, so every other `SecretStrInput` reached the tracing provider in plaintext. The fix is **type-driven**: `Component._get_trace_value()` returns `**********` for any input declaring `password=True`.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `the trace detail masks the credential whatever the secret field is called` | `GET /api/v1/monitor/traces/{id}` — both spans carry their secret field as a KEY (so the absence below is not the absence of the span) with value exactly `**********`; neither sentinel occurs in the trace-detail body nor in `/monitor/transactions` (polled until one row per vertex). Catches a regression from the `password=True` check back to a name check. |
| 2 | `the exported flow carries the credential binding, never the secret` | `POST /api/v1/flows/download/` (the Export button's endpoint) answers 200; in the stored flow each field reads `value = <variable name>`, `load_from_db: true`, `password: true`; both bodies carry the variable name and neither sentinel. The binding assertion is the control — a flow that lost it would satisfy "no secret here" for the wrong reason. |
| 3 | `the run resolves the credential without echoing it` | The run answers 200 and each vertex returns `resolved_len=<length of ITS OWN sentinel>` — proof the credential reached the component; neither sentinel occurs in the run body nor in `GET /api/v1/monitor/builds`, where both node ids are present. |

## 2. How the test was built

- **Two nodes, two field names, on purpose.** `secret_token` also matches the transactions sanitizer's independent NAME-based pattern (`SENSITIVE_KEYS_PATTERN`); **`gateway_pin` matches no sensitive-key pattern anywhere** and is masked only because the input is a `SecretStrInput`. That second node is `#7313`'s exact case and the one that regresses silently if the type check ever becomes a name check again.
- **The control is the length, never the secret.** Each node returns `resolved_len=<n>`. A run that never resolved the credential reports 0 and fails; the two sentinels have different lengths, so neither can stand in for the other. Without this pairing, every "the sentinel is absent" assertion would also pass on a flow that never executed.
- **No edges by design.** Both nodes are independent roots, so a single `POST /api/v1/run/{id}` with `output_type: "debug"` executes both — one run, one trace, every field covered (measured on 1.12.0.dev23/dev24).
- **Live catalog, not a fixture.** `createCredentialConsumerFlowViaApi` reads `GET /api/v1/all` and builds each node from the shipped `CustomComponent` template, so an upstream change to the `SecretStrInput` contract fails here instead of leaving a frozen fixture testing nothing. Its pure builder has 8 unit tests (`npm run test:units`), the load-bearing one being the binding: written without `load_from_db: true`, the run reads the variable NAME as the secret and the entire spec passes while proving nothing.
- **Both async surfaces are polled.** The trace and the transactions are written after the run answers; on a measured run the transactions landed *after* the trace. The trace poll fails with a message naming `LANGFLOW_DEACTIVATE_TRACING`, so a tracing-off instance reads as a precondition failure and not as a masking defect.
- **Absence, not mask shape, on the transactions path.** It masks by field name (`secret_token` → `***R...D***`, `gateway_pin` → the unresolved variable name), so pinning the shape would pin an unrelated implementation detail.
- **CI wiring.** `pr-validation.yml` and `adaptive-impacted.yml` now enable tracing when this spec is selected. It is the only spec outside `observability-monitoring` that reads a trace; `daily-stable.yml`, `weekly-stable.yml` and `manual.yml` already run with tracing on.

## 3. Dependencies

- **None external** — no browser, no LLM, no provider key. Pure `request` fixture, ~3.5 s for all three tests.
- Needs `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` (every lane and both start scripts set it) and, for test 1 only, tracing enabled. `scripts/start-langflow-docker.sh` pins `LANGFLOW_DEACTIVATE_TRACING=true` by decision, so a local run of test 1 uses a second container — the command is in the spec doc's Preconditions.
- Parallel-safe (unique flow, variables and API key per run); validated at `--workers=1 --retries=0`.
- Not `@destructive` — creates and deletes only its own flow, its own two global variables and its own API key.

## Validation (nightly 1.12.0.dev24, `--retries=0 --workers=1`)

- 3 clean burst runs, `expected=3 unexpected=0 flaky=0`, no flake ✅
- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm run test:units` 616/616 ✅
- QA-CHECKLIST guard + coverage guard ✅ (bullets only; generated blocks untouched)
- Zero `🚨 Backend Error` ✅
- **Force-fail, one test at a time (serial file), all three red then reverted, final green run confirmed:**
  - test 1 — span input asserted to equal the plaintext sentinel (the `#7313` leak state) instead of `**********` → red
  - test 2 — export bodies asserted to CONTAIN the sentinel → red on both surfaces
  - test 3 — `resolved_len` asserted against `sentinel.length + 1` → red
- Cleanup verified: `GET /api/v1/flows/` back to 0 owned flows on both instances after the runs ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
