### PR TITLE
test(security): assert the SSRF allow-list round trip on a URL-fetching component (#1391)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -843,15 +843,22 @@
 
 #### 17.1 URL Validation and SSRF
 
-- [ ] A component that fetches a URL (API Request) rejects a loopback address when it is not
-      in `LANGFLOW_SSRF_ALLOWED_HOSTS`, and accepts it when it is — the round trip of the
+- [x] A component that fetches a URL (API Request) rejects a loopback address when it is not
+      in `LANGFLOW_SSRF_ALLOWED_HOSTS`, and accepts an address that is — the round trip of the
       guard, not just the rejection (upstream regression: `ensure_url` ignoring the allow-list
-      for loopback, `langflow-ai/langflow#14264`)
-- [ ] A private RFC-1918 address is rejected by the same guard unless allow-listed
-- [ ] The rejection surfaces to the user as an error in the UI, not as a silent empty result
-- [ ] `LANGFLOW_SSRF_ALLOWED_HOSTS` with a CIDR entry admits the whole range
-      (the mechanism `.github/actions/resolve-echo-endpoint` already depends on, currently
-      asserted nowhere)
+      for loopback, `langflow-ai/langflow#14264`). The *accepted* half is asserted on a private
+      address rather than on loopback: allow-listing `127.0.0.1` on the shared instance would
+      disarm `core-functionality/llm-agents/agent-tool-error-handling.spec.ts`, whose error
+      generator is an SSRF-blocked loopback fetch → security/ssrf-url-validation.spec.ts
+- [x] A private RFC-1918 address is rejected by the same guard unless allow-listed — asserted
+      through the cloud-metadata address (`169.254.169.254`), the blocked-range address no lane
+      allow-lists, since all three RFC-1918 ranges are allow-listed on every lane
+      → security/ssrf-url-validation.spec.ts
+- [x] The rejection surfaces to the user as an error in the UI, not as a silent empty result
+      → security/ssrf-url-validation.spec.ts
+- [x] `LANGFLOW_SSRF_ALLOWED_HOSTS` with a CIDR entry admits the whole range
+      (the mechanism `.github/actions/resolve-echo-endpoint` already depends on, previously
+      asserted nowhere) → security/ssrf-url-validation.spec.ts
 
 #### 17.2 Code Execution Endpoints
 

--- a/docs/security/ssrf-url-validation.md
+++ b/docs/security/ssrf-url-validation.md
@@ -1,0 +1,246 @@
+# SSRF URL Validation — allow-list round trip
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the **round trip of Langflow's SSRF guard on a URL-fetching component**: an address in a
+blocked-by-default range is refused when `LANGFLOW_SSRF_ALLOWED_HOSTS` does not cover it, and is
+**fetched normally when the allow-list does cover it** — and the refusal reaches the user as an
+error, never as an empty result.
+
+The guard lives in `lfx/utils/ssrf_protection.py` (`validate_and_resolve_url`) and the API Request
+component calls it before every request, converting `SSRFProtectionError` into a build-time
+`ValueError` prefixed `SSRF Protection:`. Only the *rejection* half of that mechanism is observable
+anywhere in this suite today, and always as a side effect of something else:
+`core-functionality/llm-agents/agent-tool-error-handling.spec.ts` uses an SSRF-blocked loopback
+fetch as a deterministic *tool-error generator*, and `core-components/api-request-component-regression.spec.ts`
+runs against `ECHO_BASE_URL` without ever asserting **why** that private address is reachable. The
+allow-list itself — the mechanism `.github/actions/resolve-echo-endpoint` depends on for every lane
+that self-hosts `go-httpbin` — is asserted nowhere. If a release silently stopped honouring it, the
+whole suite would fail at once on an unrelated-looking symptom (echo specs timing out), and nothing
+would name the cause.
+
+The upstream regression this pins is `langflow-ai/langflow#14264` — *"New SSRF validation logic in
+`ensure_url` ignores `LANGFLOW_SSRF_ALLOWED_HOSTS` for loopback addresses"*, reported on 1.10.2:
+the guard was rewritten, the allow-list stopped being consulted, and every operator pointing a
+component at a local service (LM Studio, Ollama, an internal API) lost it in a patch release. The
+defect class is *"the allow-list is quietly ignored"*, and it is invisible to a suite that only ever
+asserts the block.
+
+Two directions are therefore asserted together, on the same instance, in the same component, with
+the same configuration, differing **only in whether the address is covered by the allow-list**:
+
+- **refused** — loopback (`127.0.0.1`) and the cloud-metadata address (`169.254.169.254`), neither
+  of which any lane allow-lists;
+- **admitted** — the private RFC-1918 address that `ECHO_BASE_URL` points at, which is inside a
+  blocked-by-default range and is reachable **only** because a CIDR entry
+  (`172.16.0.0/12,10.0.0.0/8,192.168.0.0/16`) admits it.
+
+Asserting the refusal alone would keep passing on an instance where the allow-list was dropped
+entirely; asserting the admission alone would keep passing on an instance where SSRF protection was
+turned off. The pair is what carries the verdict.
+
+Measured on the nightly `1.12.0.dev24` while designing this spec (probe containers, one allow-list
+each, API Request run via `POST /api/v1/run/{id}`):
+
+| `LANGFLOW_SSRF_ALLOWED_HOSTS` | `http://127.0.0.1:7860/…` | `http://172.17.0.2:7860/…` | `http://169.254.169.254/…` |
+|---|---|---|---|
+| *(unset)* | 500 `SSRF Protection:` | 500 `SSRF Protection:` | 500 `SSRF Protection:` |
+| `172.16.0.0/12,10.0.0.0/8,192.168.0.0/16` | 500 `SSRF Protection:` | **200** | 500 `SSRF Protection:` |
+| `172.17.0.2,127.0.0.1` | **200** | **200** | 500 `SSRF Protection:` |
+
+The third row is `#14264`'s exact case and is **green on the nightly** — the allow-list *is* honoured
+for loopback today. It is also the row this spec cannot assert on a shared lane; see *What this test
+does not cover*.
+
+---
+
+## Tags *(required)*
+
+Tests 1–3: `@stable` `@api` `@regression` · Test 4: `@stable` `@regression` `@components`
+
+No **functional** tag applies — the tag table has no security area, and both sibling security specs
+(`credential-secret-exposure.spec.ts`, `tweaks-injection.spec.ts`) carry cross-cutting tags only.
+`@api` marks the layer for the three run-endpoint tests; `@components` marks Test 4, which drives the
+API Request node on the canvas. `@regression` is the class: this pins a reported upstream defect.
+
+`@stable` ships with the first delivery. The file needs no provider key and no LLM, the three API
+tests are sub-second HTTP calls, and Test 4 is one blank flow with one node — nothing in it can fail
+for a provider-outage reason. It is **not** `@destructive`: it creates and deletes only its own flows
+and its own API key.
+
+The four `QA-CHECKLIST.md` §17.1 bullets become `[x]`, with the loopback bullet's *"accepted when
+present"* half satisfied by the private-address arm (Test 3) rather than by loopback itself — the
+reason is recorded below and in the bullet.
+
+---
+
+## Step by step *(required)*
+
+The spec runs **4 tests** in a serial describe. Tests 1–3 use the `request` fixture (no browser);
+Test 4 uses the canvas. Every flow is created id-scoped and deleted in `afterEach`.
+
+**Shared setup**
+
+1. `getAuthToken(request)` → Bearer for flow creation/deletion.
+2. `POST /api/v1/api_key/` in `beforeAll` → the key `POST /api/v1/run/{id}` authenticates with
+   (`x-api-key`, not Bearer); deleted in `afterAll`.
+3. `createApiRequestFlowViaApi(request, headers, { url })` (new helper) — reads the **live** catalog
+   (`GET /api/v1/all`), takes the `APIRequest` component template from the `data_source` category,
+   sets `template.url_input.value` to the URL under test and `template.method.value` to `GET`, and
+   creates a single-node flow via `POST /api/v1/flows/`. Building the node from the running instance
+   rather than a committed fixture is what makes an upstream rename of `url_input` fail here instead
+   of silently testing an obsolete shape.
+
+**Test 1 — a loopback address is refused, and the refusal names the allow-list** *(`@api`)*
+
+1. Create the flow with `url_input = http://127.0.0.1:7860/api/v1/version` — an address that is live
+   and would answer 200 if the request were made, so a failure cannot be "nothing listening".
+2. `POST /api/v1/run/{id}` with `x-api-key` and `{ input_type: "text", output_type: "debug" }`.
+3. Assert the call answered **500** and its `detail` matches `/SSRF Protection/` **and**
+   `/LANGFLOW_SSRF_ALLOWED_HOSTS/` — the guard's own message, not a generic build failure.
+4. Assert the response body carries **no** `"status_code": 200` and no `source` echo: the component
+   produced no result at all, so nothing was fetched.
+
+**Test 2 — a blocked address the allow-list does not cover is refused the same way** *(`@api`)*
+
+1. Same flow shape, `url_input = http://169.254.169.254/latest/meta-data/` — the cloud-metadata
+   endpoint, the canonical SSRF target, in a blocked range (`169.254.0.0/16`) that **no** lane
+   allow-lists.
+2. Run and assert the same two-part refusal as Test 1.
+   This is the control for Test 3: a blocked-range address stays blocked on the very instance where
+   Test 3's blocked-range address goes through, so Test 3's 200 can only come from the allow-list.
+
+**Test 3 — an address inside a blocked range is admitted when a CIDR entry covers it** *(`@api`)*
+
+1. **Precondition, asserted not assumed:** `ECHO_BASE_URL` is set and its host is a literal IPv4 in
+   a blocked-by-default range (RFC-1918, loopback, link-local or CGNAT). If it is not — no echo
+   service, or the lane fell back to the public `postman-echo.com` — `test.skip` with the resolved
+   value in the reason, because a public host proves nothing about the allow-list.
+2. Create the flow with `url_input = ${ECHO_BASE_URL}/get` and run it.
+3. Assert **200**, and that the run output carries `status_code: 200` and `source` equal to the URL
+   requested — the request really left the backend and came back.
+4. Assert the run body contains no `SSRF Protection` string.
+   Together with Test 2 on the same instance: same guard, same component, same blocked-address class,
+   opposite verdicts — the difference is the CIDR entry.
+
+**Test 4 — the refusal surfaces in the editor as an error, not a silent empty result** *(`@components`)*
+
+1. `page.allowFlowErrors()` **and** `page.allowHttpErrors()` — the run is *meant* to fail, and the
+   fixture's advisory backend-error log stays trustworthy only if a deliberate 5xx is declared.
+2. Create the same loopback flow with `createApiRequestFlowViaApi`, then `openFlowById(page, id)`.
+   The node is **not** added through the sidebar: the sidebar add silently drops the click under
+   contention (#1301 and its three sibling surfaces), and this test is about the error surface, not
+   about component insertion — which `api-request-component-regression.spec.ts` already covers.
+3. Click `button_run_api request`.
+4. Assert the in-canvas build-failure banner is visible and names the cause: the header
+   (`/flow build failed|error building component/i` — both spellings, volatile across versions, as
+   the sibling spec documents) **and** the SSRF detail (`/SSRF Protection/`). Measured on
+   1.12.0.dev23 the banner reads *"Flow build failed · 0.2s · Retry · Dismiss · SSRF Protection:
+   Hostname 127.0.0.1 resolves to blocked IP address(es) …"*. It carries **no `data-testid`** — the
+   assertion is by text, which is why the helper must not put the token `SSRF` in the flow **name**
+   (the name renders in `flow_name` and would satisfy the detail match on its own).
+5. Assert the node produced no output: the output-inspection button
+   (`output-inspection-api response-apirequest`) stays disabled — an error, not an empty success.
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1:** `POST /api/v1/run/{id}` answers `500`; `detail` matches `/SSRF Protection/` and
+  `/LANGFLOW_SSRF_ALLOWED_HOSTS/`; the body carries no fetched response.
+- **Test 2:** identical verdict for `169.254.169.254`.
+- **Test 3:** the same endpoint answers `200` for the allow-listed private address, the output
+  reports `status_code: 200` with the requested URL as `source`, and no `SSRF Protection` string
+  appears — or the test skips, naming the resolved `ECHO_BASE_URL` that made it inapplicable.
+- **Test 4:** the flow editor renders a visible error whose text names SSRF protection.
+- Across the file: **Tests 2 and 3 disagree on the same instance**, which is the round trip. Every
+  flow created is deleted in `afterEach`; `GET /api/v1/flows/` returns the same count before and
+  after the file runs.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **Loopback *admitted* by an allow-list entry** — `#14264`'s literal reproduction (row 3 of the
+  table above). It is measured as working on 1.12.0.dev24 but cannot be asserted on a shared lane:
+  admitting `127.0.0.1` there would let the instance under test call itself, and it would break
+  `core-functionality/llm-agents/agent-tool-error-handling.spec.ts`, whose deterministic error
+  generator *is* a loopback fetch being SSRF-blocked (allow-listing the literal IP also allow-lists
+  the hostname path, since `is_host_allowed` matches the resolved IP). Test 3 asserts the same
+  half of the round trip through a private address instead, which is the address class our lanes
+  actually allow-list and the one `resolve-echo-endpoint` depends on.
+- **The stable `langflowai/langflow:latest` line.** A probe container on the stable 1.12.0 image
+  refused an *exact-IP* allow-list entry (`172.17.0.2,127.0.0.1`) that the nightly honoured. That
+  observation was made mid-scout on a container whose provenance was later found ambiguous, so it is
+  recorded here as an **open question, not a finding** — the suite targets the nightly, and
+  re-measuring it deserves its own issue.
+- **DNS-rebinding / redirect re-validation.** `api_request.py` re-validates each `Location` hop and
+  pins the resolved IP; both are real surfaces and neither is a §17.1 bullet.
+- **Other URL-fetching components** (URL, Web Search, RSS, and the connector paths with their own
+  loopback exemptions — `connector_ssrf_allow_loopback`). The bullets name the API Request component;
+  the connector policy is a different guard with different defaults and deserves its own spec.
+- **`LANGFLOW_SSRF_PROTECTION_ENABLED=false`** (the global off switch). Turning the guard off on a
+  shared instance would disarm it for every other spec in the run.
+- **Wildcard allow-list entries** (`*.example.com`) — supported by `is_host_allowed`, not part of
+  the bullets, and not used by any lane.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL`; superuser credentials for
+  `getAuthToken`; API-key creation allowed (`POST /api/v1/api_key/`).
+- **Tests 1, 2 and 4 need no allow-list at all** — loopback and the metadata address are refused
+  whether or not `LANGFLOW_SSRF_ALLOWED_HOSTS` is set (rows 1 and 2 of the table), so they run
+  unchanged on a stock local instance and on every CI lane.
+- **Test 3 needs the lane's allow-list and a private echo endpoint.** Every CI lane already has
+  both: `LANGFLOW_SSRF_ALLOWED_HOSTS="…172.16.0.0/12,10.0.0.0/8,192.168.0.0/16"` on the Langflow
+  service and `ECHO_BASE_URL` resolved to the `go-httpbin` container IP by
+  `.github/actions/resolve-echo-endpoint`. Locally, `scripts/start-langflow-docker.sh` sets **no**
+  allow-list today, so the test skips unless the instance is started with one:
+
+  ```bash
+  # local equivalent of a CI lane
+  docker run -d --name go-httpbin ghcr.io/mccutchen/go-httpbin
+  ECHO_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' go-httpbin)
+  LANGFLOW_SSRF_ALLOWED_HOSTS="172.16.0.0/12,10.0.0.0/8,192.168.0.0/16" \
+    ./scripts/start-langflow-docker.sh
+  ECHO_BASE_URL="http://${ECHO_IP}:8080" npx playwright test \
+    tests/tests-automations/regression/security/ssrf-url-validation.spec.ts --workers=1 --retries=0
+  ```
+
+  This spec therefore proposes adding the same default to `scripts/start-langflow-docker.sh` (and
+  the pip script), for the same reason `LANGFLOW_ALLOW_CUSTOM_COMPONENTS` and `LANGFLOW_A2A_ENABLED`
+  are set there (#668/#1240): a local instance that differs from every CI lane makes a lane-green
+  test locally inapplicable, and the divergence is silent. The change is additive — with no echo
+  container `ECHO_BASE_URL` stays unset and Test 3 skips exactly as it does today.
+
+---
+
+## External dependencies *(required)*
+
+- `tests/helpers/auth/get-auth-token.ts` — Bearer via `/api/v1/auto_login`.
+- `tests/helpers/flows/create-api-request-flow-via-api.ts` (new) — builds the single-node API Request
+  flow from the live catalog; owns the `url_input` / `method` field shape.
+- `tests/helpers/flows/delete-flow.ts` — id-scoped teardown.
+- `tests/helpers/flows/open-flow-by-id.ts` — Test 4's canvas entry (`canvas_controls_dropdown` +
+  writability gate), avoiding the sidebar-add race.
+- `ECHO_BASE_URL` — resolved per lane by `.github/actions/resolve-echo-endpoint`
+  (`scripts/resolve-echo-endpoint.mjs`); Test 3 reads it and skips when it is not a private IP.
+- `src/lfx/src/lfx/utils/ssrf_protection.py` — `validate_and_resolve_url`, `is_host_allowed`,
+  `get_allowed_hosts`, `is_ip_blocked` and the blocked-range table: the code under test.
+- `src/lfx/src/lfx/components/data_source/api_request.py` — calls `validate_and_resolve_url` and
+  wraps `SSRFProtectionError` into `ValueError("SSRF Protection: …")`, the string both the run
+  endpoint and the UI surface.
+- `src/lfx/src/lfx/utils/ssrf_transport.py` — the DNS-pinned client the component builds from the
+  validated IPs.
+- `src/lfx/src/lfx/services/settings/groups/security.py` — `ssrf_protection_enabled`,
+  `ssrf_allowed_hosts` and the connector-specific flags that make the connector paths behave
+  differently from this one.
+- `src/backend/base/langflow/api/v1/endpoints.py` — `POST /api/v1/run/{flow_id}`, the surface Tests
+  1–3 read the verdict from.
+- Upstream reference: `langflow-ai/langflow#14264`.

--- a/scripts/start-langflow-docker.sh
+++ b/scripts/start-langflow-docker.sh
@@ -77,6 +77,7 @@ docker run -d \
   -e LANGFLOW_DEACTIVATE_TRACING=true \
   -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS="${LANGFLOW_ALLOW_CUSTOM_COMPONENTS:-true}" \
   -e LANGFLOW_A2A_ENABLED="${LANGFLOW_A2A_ENABLED:-true}" \
+  -e LANGFLOW_SSRF_ALLOWED_HOSTS="${LANGFLOW_SSRF_ALLOWED_HOSTS:-172.16.0.0/12,10.0.0.0/8,192.168.0.0/16}" \
   -e LANGFLOW_WORKERS="${LANGFLOW_WORKERS:-1}" \
   "${IMAGE}"
 
@@ -87,6 +88,20 @@ docker run -d \
 # server is indistinguishable from an unmounted one — a spec written against it
 # passes while testing nothing (#1240; surface scoped in #1195). Set
 # LANGFLOW_A2A_ENABLED=false to reproduce the disabled state on purpose.
+
+# LANGFLOW_SSRF_ALLOWED_HOSTS carries the SAME value all four CI lanes set
+# (pr-validation, daily-stable, nightly, manual — the daily/nightly/manual also
+# allow the `ollama` service name). Without it a local instance behaves
+# differently from every lane: Langflow's SSRF guard blocks private addresses, so
+# a self-hosted go-httpbin (ECHO_BASE_URL) or a private-network service is
+# refused locally while working in CI. The divergence is silent — the spec that
+# needs it skips, or fails on a message that names no cause — which is the same
+# trap LANGFLOW_ALLOW_CUSTOM_COMPONENTS (#668) and LANGFLOW_A2A_ENABLED (#1240)
+# were set here to avoid. Loopback is deliberately NOT allow-listed: several
+# specs use an SSRF-blocked loopback fetch as a deterministic error generator
+# (core-functionality/llm-agents/agent-tool-error-handling.spec.ts), and
+# security/ssrf-url-validation.spec.ts asserts that refusal. Override to
+# reproduce another configuration: LANGFLOW_SSRF_ALLOWED_HOSTS="" ./scripts/...
 
 # LANGFLOW_WORKERS defaults to 1 here on purpose. Langflow's own default is
 # (2 * cpu_count) + 1 gunicorn workers, each inheriting the full in-memory

--- a/scripts/start-langflow-docker.test.mjs
+++ b/scripts/start-langflow-docker.test.mjs
@@ -158,6 +158,27 @@ test("the superuser and worker defaults are passed to the container", () => {
   assert.match(runCall, /LANGFLOW_AUTO_LOGIN=true/);
 });
 
+test("the SSRF allow-list matches the CI lanes, and keeps loopback OUT", () => {
+  // #1391: without this a local instance behaves differently from all four CI
+  // lanes — the guard refuses a self-hosted echo endpoint on a private IP, so
+  // ECHO_BASE_URL-dependent specs fail (or skip) locally while passing in CI.
+  // The value is the lanes' own; loopback is deliberately absent, because
+  // agent-tool-error-handling.spec.ts uses an SSRF-blocked loopback fetch as its
+  // deterministic error generator and ssrf-url-validation.spec.ts asserts that
+  // refusal — allow-listing 127.0.0.1 here would silently disarm both.
+  const r = runScript();
+  const runCall = r.calls.find((c) => c.startsWith("run "));
+  assert.match(runCall, /LANGFLOW_SSRF_ALLOWED_HOSTS=172\.16\.0\.0\/12,10\.0\.0\.0\/8,192\.168\.0\.0\/16/);
+  assert.doesNotMatch(runCall, /LANGFLOW_SSRF_ALLOWED_HOSTS=[^ ]*127\.0\.0\.1/);
+  assert.doesNotMatch(runCall, /LANGFLOW_SSRF_ALLOWED_HOSTS=[^ ]*localhost/);
+});
+
+test("the SSRF allow-list is a default, so another configuration is reproducible", () => {
+  const r = runScript({ env: { LANGFLOW_SSRF_ALLOWED_HOSTS: "127.0.0.1" } });
+  const runCall = r.calls.find((c) => c.startsWith("run "));
+  assert.match(runCall, /LANGFLOW_SSRF_ALLOWED_HOSTS=127\.0\.0\.1/);
+});
+
 test("LANGFLOW_A2A_ENABLED can be forced off to reproduce the disabled surface", () => {
   // The disabled state is a real thing to reproduce by hand (the Agent tab's
   // serverDisabled copy, the 404 on all three routes), so the default must be a

--- a/scripts/start-langflow-pip.sh
+++ b/scripts/start-langflow-pip.sh
@@ -29,6 +29,7 @@ LANGFLOW_SUPERUSER="${LANGFLOW_SUPERUSER:-langflow}" \
 LANGFLOW_SUPERUSER_PASSWORD="${LANGFLOW_SUPERUSER_PASSWORD:-langflow123}" \
 LANGFLOW_DEACTIVATE_TRACING=true \
 LANGFLOW_A2A_ENABLED="${LANGFLOW_A2A_ENABLED:-true}" \
+LANGFLOW_SSRF_ALLOWED_HOSTS="${LANGFLOW_SSRF_ALLOWED_HOSTS:-172.16.0.0/12,10.0.0.0/8,192.168.0.0/16}" \
   langflow run --host 0.0.0.0 --port "${PORT}" --no-open-browser \
     --workers "${LANGFLOW_WORKERS:-1}" &
 # LANGFLOW_A2A_ENABLED defaults to true: the product default is OFF, A2A's router
@@ -36,6 +37,12 @@ LANGFLOW_A2A_ENABLED="${LANGFLOW_A2A_ENABLED:-true}" \
 # the flag is off — so a spec written against a disabled server passes while
 # testing nothing (#1240; surface scoped in #1195). Set it to false to reproduce
 # the disabled state deliberately.
+# LANGFLOW_SSRF_ALLOWED_HOSTS mirrors the Docker start script and all four CI
+# lanes: the SSRF guard blocks private addresses, so without it a self-hosted
+# echo endpoint (ECHO_BASE_URL) or any private-network service is refused locally
+# while working in CI, silently. Loopback stays OUT of the list on purpose —
+# specs use an SSRF-blocked loopback fetch as a deterministic error generator and
+# security/ssrf-url-validation.spec.ts asserts that refusal.
 # --workers defaults to 1: Langflow's own default is (2*cpu)+1 workers, each
 # holding the full in-memory state, which exhausts memory on a constrained dev
 # box and gets a worker SIGKILLed mid-build (ERR_EMPTY_RESPONSE / node run never

--- a/tests/helpers/flows/create-api-request-flow-via-api.test.ts
+++ b/tests/helpers/flows/create-api-request-flow-via-api.test.ts
@@ -1,0 +1,186 @@
+// Unit tests for buildApiRequestFlowData (#1391).
+// Run with: npm run test:units
+//
+// The helper's network half needs a live instance; its load-bearing half is pure:
+// turning a live `GET /api/v1/all` catalog into a single-node API Request flow
+// whose `url_input` is the URL the caller chose. Three properties there cannot be
+// seen from a green spec.
+//
+// (1) The URL really lands on the node. `security/ssrf-url-validation.spec.ts`
+// asserts what Langflow's SSRF guard does with a specific address. If the value
+// did not reach `template.url_input`, the component would fetch its own DEFAULT
+// url — and the loopback tests would still "pass" (any default is likely
+// unreachable too), asserting a verdict about an address the test never chose.
+//
+// (2) A renamed field fails LOUDLY. `url_input`/`method` are exactly what an
+// upstream refactor renames. Silently building a node without them is the same
+// false-green as (1), so the helper throws naming the field and the fields it did
+// find.
+//
+// (3) The CATALOG LOOKUP. If the component is not in the image, the helper must
+// fail naming it — an undefined template would otherwise reach
+// `POST /api/v1/flows/` and surface as an unattributable 422 (#1012's rule).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  API_REQUEST_COMPONENT_TYPE,
+  buildApiRequestFlowData,
+} from "./create-api-request-flow-via-api";
+
+/** A minimal stand-in for the catalog entry the helper reads. */
+function fakeCatalog(apiRequest?: unknown): Record<string, unknown> {
+  const entry =
+    apiRequest === undefined
+      ? {
+          display_name: "API Request",
+          template: {
+            code: { type: "code", value: "class APIRequestComponent: ..." },
+            url_input: { type: "str", value: "" },
+            curl_input: { type: "str", value: "" },
+            method: { type: "str", value: "GET" },
+          },
+        }
+      : apiRequest;
+
+  const catalog: Record<string, Record<string, unknown>> = {
+    input_output: {},
+    data_source: {},
+  };
+  if (entry !== null) {
+    catalog.data_source[API_REQUEST_COMPONENT_TYPE] = entry;
+  }
+  return catalog;
+}
+
+test("the caller's URL lands on the node's url_input", () => {
+  const data = buildApiRequestFlowData(fakeCatalog(), {
+    nodeId: "APIRequest-1",
+    url: "http://127.0.0.1:7860/api/v1/version",
+  });
+
+  assert.equal(data.nodes.length, 1);
+  const node = data.nodes[0];
+  assert.equal(node.id, "APIRequest-1");
+  assert.equal(node.data.id, "APIRequest-1");
+  assert.equal(node.data.type, API_REQUEST_COMPONENT_TYPE);
+  assert.equal(
+    node.data.node.template.url_input.value,
+    "http://127.0.0.1:7860/api/v1/version",
+  );
+  // The default GET must be explicit on the node, not inherited by luck.
+  assert.equal(node.data.node.template.method.value, "GET");
+  // A single root node: no edge is needed for it to run, and a second node would
+  // only add a surface that can fail for reasons unrelated to the guard.
+  assert.deepEqual(data.edges, []);
+});
+
+test("the method is overridable and keeps the field's other keys", () => {
+  const data = buildApiRequestFlowData(fakeCatalog(), {
+    nodeId: "APIRequest-2",
+    url: "http://169.254.169.254/latest/meta-data/",
+    method: "POST",
+  });
+
+  const template = data.nodes[0].data.node.template;
+  assert.equal(template.method.value, "POST");
+  // Spreading, not replacing: the template field carries `type` and display
+  // metadata the backend validates against.
+  assert.equal(template.method.type, "str");
+  assert.equal(template.url_input.type, "str");
+});
+
+test("the catalog is deep-copied, so two flows do not share one template", () => {
+  const catalog = fakeCatalog();
+
+  const first = buildApiRequestFlowData(catalog, {
+    nodeId: "APIRequest-a",
+    url: "http://127.0.0.1:7860/x",
+  });
+  const second = buildApiRequestFlowData(catalog, {
+    nodeId: "APIRequest-b",
+    url: "http://10.0.0.1/y",
+  });
+
+  assert.equal(
+    first.nodes[0].data.node.template.url_input.value,
+    "http://127.0.0.1:7860/x",
+  );
+  assert.equal(
+    second.nodes[0].data.node.template.url_input.value,
+    "http://10.0.0.1/y",
+  );
+  // And the source catalog is untouched, so a caller that fetches it once and
+  // builds N flows gets N independent payloads.
+  const source = (catalog.data_source as Record<string, any>)[
+    API_REQUEST_COMPONENT_TYPE
+  ];
+  assert.equal(source.template.url_input.value, "");
+});
+
+test("a renamed url field throws naming it and the fields that exist", () => {
+  const renamed = {
+    display_name: "API Request",
+    template: {
+      code: { type: "code", value: "class APIRequestComponent: ..." },
+      // upstream renamed url_input -> url
+      url: { type: "str", value: "" },
+      method: { type: "str", value: "GET" },
+    },
+  };
+
+  assert.throws(
+    () =>
+      buildApiRequestFlowData(fakeCatalog(renamed), {
+        nodeId: "APIRequest-3",
+        url: "http://127.0.0.1:7860/x",
+      }),
+    (error: Error) =>
+      /url_input/.test(error.message) &&
+      /renamed/.test(error.message) &&
+      // the fields it DID find, so the reader can see the new spelling
+      /method/.test(error.message),
+  );
+});
+
+test("a missing method field throws too", () => {
+  const noMethod = {
+    display_name: "API Request",
+    template: {
+      url_input: { type: "str", value: "" },
+    },
+  };
+
+  assert.throws(
+    () =>
+      buildApiRequestFlowData(fakeCatalog(noMethod), {
+        nodeId: "APIRequest-4",
+        url: "http://127.0.0.1:7860/x",
+      }),
+    /"method" field/,
+  );
+});
+
+test("an absent component throws naming it, not a TypeError", () => {
+  assert.throws(
+    () =>
+      buildApiRequestFlowData(fakeCatalog(null), {
+        nodeId: "APIRequest-5",
+        url: "http://127.0.0.1:7860/x",
+      }),
+    (error: Error) =>
+      error.message.includes(API_REQUEST_COMPONENT_TYPE) &&
+      /GET \/api\/v1\/all/.test(error.message) &&
+      /component-distribution-policy/.test(error.message),
+  );
+});
+
+test("a non-catalog body (an auth failure) throws the same way", () => {
+  assert.throws(
+    () =>
+      buildApiRequestFlowData({ detail: "Not authenticated" }, {
+        nodeId: "APIRequest-6",
+        url: "http://127.0.0.1:7860/x",
+      }),
+    (error: Error) => error.message.includes(API_REQUEST_COMPONENT_TYPE),
+  );
+});

--- a/tests/helpers/flows/create-api-request-flow-via-api.ts
+++ b/tests/helpers/flows/create-api-request-flow-via-api.ts
@@ -1,0 +1,200 @@
+import type { APIRequestContext } from "@playwright/test";
+import { createFlow } from "./create-flow";
+import { deleteFlow } from "./delete-flow";
+
+/**
+ * Builds a single-node **API Request** flow from the LIVE component catalog
+ * (`GET /api/v1/all`) and creates it via the REST API.
+ *
+ * Why a live catalog instead of a committed fixture: the flow exists to prove
+ * what Langflow's SSRF guard does with a given URL, and the guard is reached
+ * only through the component's `url_input`. That field name — and the component's
+ * catalog key — are exactly what upstream may rename; a frozen fixture would keep
+ * creating a node the running image no longer understands and the spec would fail
+ * (or, worse, run something else) without naming the cause.
+ *
+ * Why a single node with no edge: the API Request component is a graph ROOT and
+ * runs on its own, so no Chat Output is needed to make it execute (measured on
+ * 1.12.0.dev23/dev24 — `POST /api/v1/run/{id}` with `output_type: "debug"`
+ * returns its vertex either way). Adding a second node would only add a surface
+ * that can fail for reasons unrelated to the guard.
+ */
+
+/** Catalog key of the API Request component (category `data_source` on 1.12.x). */
+export const API_REQUEST_COMPONENT_TYPE = "APIRequest";
+
+interface TemplateField {
+  type?: string;
+  value?: unknown;
+  input_types?: string[];
+  [key: string]: unknown;
+}
+
+interface ComponentTemplate {
+  template: Record<string, TemplateField>;
+  [key: string]: unknown;
+}
+
+export interface FlowNode {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: { id: string; type: string; node: ComponentTemplate };
+}
+
+export interface FlowData {
+  nodes: FlowNode[];
+  edges: never[];
+  viewport: { x: number; y: number; zoom: number };
+}
+
+export interface BuildApiRequestFlowOptions {
+  /** Node id given to the API Request node — also the `tweaks` key. */
+  nodeId: string;
+  /** The URL the component will fetch; the whole point of the flow. */
+  url: string;
+  /** HTTP verb. Defaults to `GET`. */
+  method?: string;
+}
+
+/**
+ * Finds a component template in a `GET /api/v1/all` payload, whose top level is
+ * `category -> { componentType: template }`.
+ *
+ * Throws naming the component when it is absent: the image may not ship its
+ * distribution (`docs/component-distribution-policy.md`), and an undefined
+ * template reaching `POST /api/v1/flows/` surfaces as an unattributable 422.
+ */
+function findComponentTemplate(
+  catalog: Record<string, unknown>,
+  componentType: string,
+): ComponentTemplate {
+  for (const category of Object.values(catalog)) {
+    if (!category || typeof category !== "object") continue;
+    const entry = (category as Record<string, unknown>)[componentType];
+    if (entry && typeof entry === "object" && "template" in entry) {
+      // Deep copy: the caller fetches the catalog once and may build several
+      // flows from it, and every build mutates field values.
+      return JSON.parse(JSON.stringify(entry)) as ComponentTemplate;
+    }
+  }
+
+  throw new Error(
+    `Component "${componentType}" is not present in GET /api/v1/all on this instance. ` +
+      "Either the image does not ship its distribution, or the response was not a component catalog " +
+      "(an auth failure answers with a `detail` body). See docs/component-distribution-policy.md.",
+  );
+}
+
+/**
+ * Turns a live catalog into the flow payload. Pure — no network, no clock, no
+ * randomness — so the field wiring and the failure mode are unit-testable.
+ *
+ * Both `url_input` and `method` must exist on the template: an upstream rename
+ * would otherwise leave the node with the component's DEFAULT url, and the spec
+ * would assert the guard's verdict on an address it never chose.
+ */
+export function buildApiRequestFlowData(
+  catalog: Record<string, unknown>,
+  { nodeId, url, method = "GET" }: BuildApiRequestFlowOptions,
+): FlowData {
+  const template = findComponentTemplate(catalog, API_REQUEST_COMPONENT_TYPE);
+
+  for (const field of ["url_input", "method"]) {
+    if (!(field in template.template)) {
+      throw new Error(
+        `The ${API_REQUEST_COMPONENT_TYPE} template on this instance has no "${field}" field ` +
+          `(fields: ${Object.keys(template.template).join(", ")}). The component was renamed ` +
+          "upstream — a flow built without it would run the component's default URL.",
+      );
+    }
+  }
+
+  template.template.url_input = { ...template.template.url_input, value: url };
+  template.template.method = { ...template.template.method, value: method };
+
+  return {
+    nodes: [
+      {
+        id: nodeId,
+        type: "genericNode",
+        position: { x: 0, y: 0 },
+        data: { id: nodeId, type: API_REQUEST_COMPONENT_TYPE, node: template },
+      },
+    ],
+    edges: [],
+    viewport: { x: 0, y: 0, zoom: 1 },
+  };
+}
+
+export interface ApiRequestFlow {
+  /** The created flow's id, for `POST /api/v1/run/{flow_id}` and teardown. */
+  flowId: string;
+  /** Node id of the API Request node. */
+  nodeId: string;
+  /** The URL the node will fetch. */
+  url: string;
+  /** Deletes the created flow. Safe to call in `afterAll`/`afterEach` with its own `request`. */
+  deleteFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+}
+
+/**
+ * Creates the single-node API Request flow on the instance.
+ *
+ * `headers` carries the auth the caller already holds (`{ Authorization: bearer }`
+ * or `{ "x-api-key": key }`); the same header is reused for the catalog read and
+ * for teardown.
+ *
+ * The flow NAME deliberately carries no reference to the URL or to SSRF: the name
+ * renders in `flow_name` in the editor, and the security spec asserts the guard's
+ * message by text (the build-failure banner has no `data-testid`), so a name
+ * containing "SSRF" would satisfy that assertion on its own.
+ */
+export async function createApiRequestFlowViaApi(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  options: { url: string; method?: string },
+): Promise<ApiRequestFlow> {
+  const catalogRes = await request.get("/api/v1/all", { headers });
+  if (!catalogRes.ok()) {
+    throw new Error(
+      `GET /api/v1/all answered ${catalogRes.status()} — cannot build the ` +
+        "API Request flow without the component catalog.",
+    );
+  }
+  const catalog = (await catalogRes.json()) as Record<string, unknown>;
+
+  // Unique per call for the same reason as create-python-interpreter-flow-via-api:
+  // Langflow's unique-name fallback is not transaction-safe under parallel
+  // creation (#588).
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const nodeId = `${API_REQUEST_COMPONENT_TYPE}-${uniqueSuffix}`;
+
+  const data = buildApiRequestFlowData(catalog, {
+    nodeId,
+    url: options.url,
+    method: options.method,
+  });
+
+  const flowId = await createFlow(
+    request,
+    {
+      name: `URL Fetch Flow ${uniqueSuffix}`,
+      description: "Single API Request node for URL-validation API tests",
+      data,
+      is_component: false,
+    },
+    { headers },
+  );
+
+  return {
+    flowId,
+    nodeId,
+    url: options.url,
+    // `reqOverride` exists for the same fixture-scope rule as the sibling
+    // helpers: a `beforeAll` request cannot be reused inside `afterAll`.
+    deleteFlow: async (reqOverride?: APIRequestContext) => {
+      await deleteFlow(reqOverride ?? request, flowId, { headers });
+    },
+  };
+}

--- a/tests/tests-automations/regression/security/ssrf-url-validation.spec.ts
+++ b/tests/tests-automations/regression/security/ssrf-url-validation.spec.ts
@@ -1,0 +1,348 @@
+import type { APIRequestContext, APIResponse } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createApiRequestFlowViaApi } from "../../../helpers/flows/create-api-request-flow-via-api";
+import { openFlowById } from "../../../helpers/flows/open-flow-by-id";
+
+/**
+ * SSRF allow-list round trip on a URL-fetching component (issue #1391).
+ *
+ * Spec doc: docs/security/ssrf-url-validation.md
+ *
+ * Langflow refuses a URL whose address falls in a blocked range unless
+ * `LANGFLOW_SSRF_ALLOWED_HOSTS` covers it. Only the REFUSAL is observable
+ * anywhere in this suite today, and always as a side effect of something else
+ * (`agent-tool-error-handling` uses it as an error generator;
+ * `api-request-component-regression` runs against a private `ECHO_BASE_URL`
+ * without ever asserting why that address is reachable). The allow-list itself —
+ * the mechanism `.github/actions/resolve-echo-endpoint` depends on — is asserted
+ * nowhere, which is exactly the defect class upstream reported in
+ * `langflow-ai/langflow#14264`: the guard was rewritten, the allow-list stopped
+ * being consulted, and every operator pointing a component at a local service
+ * lost it in a patch release.
+ *
+ * So this file asserts BOTH directions on the same instance, in the same
+ * component, differing only in whether the address is allow-listed:
+ *   - refused: loopback (Test 1) and the cloud-metadata address (Test 2), which
+ *     no lane allow-lists;
+ *   - admitted: the private RFC-1918 address `ECHO_BASE_URL` points at (Test 3),
+ *     blocked by default and reachable only because a CIDR entry admits it.
+ * Test 2 and Test 3 disagreeing on one instance is the round trip. Test 4 covers
+ * the fourth bullet: the refusal reaches the user as an error, not as silence.
+ */
+
+// Serial: every test creates a flow through the same API and the file is short;
+// running them in parallel buys nothing and adds name-collision surface (#588).
+test.describe.configure({ mode: "serial" });
+
+// A loopback address that WOULD answer 200 if the request were made — Langflow
+// listens on 7860 inside its own container regardless of the published port — so
+// a failure here can only be the guard, never "nothing listening". No lane
+// allow-lists loopback, and none may: `agent-tool-error-handling.spec.ts` uses an
+// SSRF-blocked loopback fetch as its deterministic error generator.
+const LOOPBACK_URL = "http://127.0.0.1:7860/api/v1/version";
+
+// The canonical SSRF target (AWS/GCP/Azure instance metadata). It sits in the
+// blocked link-local range 169.254.0.0/16 and is allow-listed by NO lane, so it
+// stays refused on the very instance where Test 3's private address goes
+// through — which is what makes Test 3's 200 attributable to the allow-list.
+const METADATA_URL = "http://169.254.169.254/latest/meta-data/";
+
+// The echo endpoint each CI lane self-hosts; `resolve-echo-endpoint` sets this to
+// the go-httpbin CONTAINER IP (a private RFC-1918 address), which the lane's
+// `LANGFLOW_SSRF_ALLOWED_HOSTS` CIDRs admit. Unset (or public) means the accept
+// arm has nothing to prove — see `privateEchoUrl()`.
+const ECHO_BASE = (
+  process.env.ECHO_BASE_URL ??
+  process.env.HTTPBIN_BASE_URL ??
+  ""
+).replace(/\/$/, "");
+
+/**
+ * The ranges `lfx/utils/ssrf_protection.py` blocks by default and that a lane may
+ * allow-list. Only these prove anything: a PUBLIC echo host is reachable with or
+ * without an allow-list, so asserting a 200 against it would pass on an instance
+ * that ignores `LANGFLOW_SSRF_ALLOWED_HOSTS` entirely.
+ *
+ * Deliberately wider than `isPrivateIpv4` in `scripts/resolve-echo-endpoint.mjs`,
+ * which answers a different question (may this endpoint need the allow-list?) and
+ * covers RFC-1918 only. Here the question is whether a 200 is attributable to the
+ * allow-list, which is true for every range the guard blocks by default.
+ */
+function isBlockedRangeIpv4(host: string): boolean {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host ?? "");
+  if (!match) return false;
+  const parts = match.slice(1).map(Number);
+  if (parts.some((p) => p > 255)) return false;
+  const [a, b] = parts;
+  return (
+    a === 10 || // 10.0.0.0/8
+    a === 127 || // 127.0.0.0/8 (loopback)
+    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
+    (a === 192 && b === 168) || // 192.168.0.0/16
+    (a === 169 && b === 254) || // 169.254.0.0/16 (link-local / metadata)
+    (a === 100 && b >= 64 && b <= 127) // 100.64.0.0/10 (CGNAT)
+  );
+}
+
+/** `${ECHO_BASE}/get` when the echo host is an address the guard blocks by default. */
+function privateEchoUrl(): { url: string } | { skipReason: string } {
+  if (!ECHO_BASE) {
+    return {
+      skipReason:
+        "ECHO_BASE_URL/HTTPBIN_BASE_URL is unset, so there is no private endpoint whose " +
+        "reachability could only come from LANGFLOW_SSRF_ALLOWED_HOSTS. Every CI lane sets it " +
+        "via .github/actions/resolve-echo-endpoint; locally see docs/security/ssrf-url-validation.md.",
+    };
+  }
+  let host: string;
+  try {
+    host = new URL(ECHO_BASE).hostname;
+  } catch {
+    return { skipReason: `ECHO_BASE_URL is not a URL: ${ECHO_BASE}` };
+  }
+  if (!isBlockedRangeIpv4(host)) {
+    return {
+      skipReason:
+        `the echo endpoint resolved to ${ECHO_BASE}, whose host is not an address Langflow blocks ` +
+        "by default (a public host, or a name rather than an IP). Reaching it proves nothing about " +
+        "the allow-list, so this test would be vacuous rather than green.",
+    };
+  }
+  return { url: `${ECHO_BASE}/get` };
+}
+
+/** The component's own result object inside a `POST /api/v1/run/{id}` response. */
+interface ApiRequestResult {
+  source?: string;
+  status_code?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Digs the API Request node's result out of a run response. Measured shape on
+ * 1.12.0.dev23/dev24: `outputs[0].outputs[0].artifacts.data.raw`. Throws with the
+ * body when the shape moves, so an upstream change to the run payload reports
+ * itself instead of surfacing as `undefined !== 200`.
+ */
+function apiRequestResult(body: unknown): ApiRequestResult {
+  const outer = (body as { outputs?: { outputs?: unknown[] }[] })?.outputs?.[0];
+  const inner = outer?.outputs?.[0] as
+    | { artifacts?: { data?: { raw?: ApiRequestResult } } }
+    | undefined;
+  const raw = inner?.artifacts?.data?.raw;
+  if (!raw || typeof raw !== "object") {
+    throw new Error(
+      "the run response carries no API Request result at " +
+        `outputs[0].outputs[0].artifacts.data.raw — body: ${JSON.stringify(body).slice(0, 600)}`,
+    );
+  }
+  return raw;
+}
+
+let bearer: string;
+let apiKey: string;
+let apiKeyId: string;
+
+// Every flow this file creates is pushed here and deleted id-scoped in
+// afterEach (repo convention, #490/#681/#1108).
+const createdFlows: { id: string; delete: (req: APIRequestContext) => Promise<void> }[] = [];
+
+test.beforeAll(async ({ request }) => {
+  bearer = await getAuthToken(request);
+  // POST /api/v1/run/{id} authenticates with x-api-key, not Bearer.
+  const keyRes = await request.post("/api/v1/api_key/", {
+    headers: { Authorization: bearer },
+    data: { name: `ssrf-url-validation-${Date.now()}` },
+  });
+  expect(keyRes.status(), await keyRes.text()).toBe(200);
+  const keyBody = (await keyRes.json()) as { id: string; api_key: string };
+  apiKey = keyBody.api_key;
+  apiKeyId = keyBody.id;
+});
+
+test.afterEach(async ({ request }) => {
+  for (const flow of createdFlows.splice(0)) {
+    await flow.delete(request).catch(() => {});
+  }
+});
+
+test.afterAll(async ({ request }) => {
+  if (!apiKeyId) return;
+  await request
+    .delete(`/api/v1/api_key/${apiKeyId}`, { headers: { Authorization: bearer } })
+    .catch(() => {});
+});
+
+/** Creates the single-node API Request flow for `url` and registers its cleanup. */
+async function createFlowFor(
+  request: APIRequestContext,
+  url: string,
+): Promise<string> {
+  const flow = await createApiRequestFlowViaApi(
+    request,
+    { Authorization: bearer },
+    { url },
+  );
+  createdFlows.push({ id: flow.flowId, delete: flow.deleteFlow });
+  return flow.flowId;
+}
+
+/** Runs a flow through the endpoint an API client uses. */
+async function runFlow(
+  request: APIRequestContext,
+  flowId: string,
+): Promise<APIResponse> {
+  return request.post(`/api/v1/run/${flowId}?stream=false`, {
+    headers: { "x-api-key": apiKey },
+    data: { input_type: "text", output_type: "debug", input_value: "run" },
+    // Explicit, well above `actionTimeout` (20 s): the FIRST component build
+    // after a container start pays the registry/import cost and was measured at
+    // ~60 s on a cold local instance, while every later run answers in ~4 s. On
+    // the default timeout that cold start reads as "the run never answered",
+    // i.e. an unattributable red on whichever test happens to run first — and CI
+    // starts a fresh Langflow for every lane. This bounds the transport, not the
+    // verdict: the assertions on the response are unchanged.
+    timeout: 120_000,
+  });
+}
+
+/**
+ * Both refusal tests assert the same two-part verdict: the guard's own message
+ * (not a generic build failure) AND that nothing was fetched. A single
+ * "the run failed" assertion would also pass on a broken flow, a missing
+ * component or an auth error.
+ */
+async function expectSsrfRefusal(
+  response: APIResponse,
+  url: string,
+): Promise<void> {
+  const body = await response.text();
+  expect(
+    response.status(),
+    `expected ${url} to be refused by the SSRF guard; body: ${body.slice(0, 400)}`,
+  ).toBe(500);
+  expect(body).toMatch(/SSRF Protection/);
+  // The message must name the escape hatch — that is what tells an operator the
+  // allow-list exists at all, and it is the string #14264 is about.
+  expect(body).toMatch(/LANGFLOW_SSRF_ALLOWED_HOSTS/);
+  // Nothing was fetched: no component result, so no status code came back.
+  expect(body).not.toMatch(/"status_code":\s*\d/);
+}
+
+test.describe("SSRF URL validation — allow-list round trip", () => {
+  test("a loopback address is refused, and the refusal names the allow-list",
+    { tag: ["@stable", "@api", "@regression"] },
+    async ({ request }) => {
+      let flowId = "";
+      await test.step("create a flow whose API Request targets loopback", async () => {
+        flowId = await createFlowFor(request, LOOPBACK_URL);
+      });
+
+      await test.step("running it is refused by the SSRF guard", async () => {
+        await expectSsrfRefusal(await runFlow(request, flowId), LOOPBACK_URL);
+      });
+    },
+  );
+
+  test("a blocked address the allow-list does not cover is refused the same way",
+    { tag: ["@stable", "@api", "@regression"] },
+    async ({ request }) => {
+      let flowId = "";
+      await test.step("create a flow targeting the cloud-metadata endpoint", async () => {
+        flowId = await createFlowFor(request, METADATA_URL);
+      });
+
+      // The control for the next test: on THIS instance a blocked-range address
+      // that is not allow-listed stays blocked, so the next test's 200 can only
+      // come from the allow-list.
+      await test.step("running it is refused by the SSRF guard", async () => {
+        await expectSsrfRefusal(await runFlow(request, flowId), METADATA_URL);
+      });
+    },
+  );
+
+  test("an address inside a blocked range is admitted when a CIDR entry covers it",
+    { tag: ["@stable", "@api", "@regression"] },
+    async ({ request }) => {
+      const echo = privateEchoUrl();
+      test.skip(
+        "skipReason" in echo,
+        "skipReason" in echo ? echo.skipReason : "",
+      );
+      const url = (echo as { url: string }).url;
+
+      let flowId = "";
+      await test.step(`create a flow targeting the allow-listed private endpoint ${url}`, async () => {
+        flowId = await createFlowFor(request, url);
+      });
+
+      await test.step("the request goes through and comes back", async () => {
+        const response = await runFlow(request, flowId);
+        const body = await response.text();
+        expect(
+          response.status(),
+          `expected ${url} to be admitted by LANGFLOW_SSRF_ALLOWED_HOSTS; body: ${body.slice(0, 400)}`,
+        ).toBe(200);
+        // Not merely "no error": the component fetched the URL the test chose and
+        // the endpoint answered 200.
+        const result = apiRequestResult(JSON.parse(body));
+        expect(result.status_code).toBe(200);
+        expect(result.source).toBe(url);
+        expect(body).not.toMatch(/SSRF Protection/);
+      });
+    },
+  );
+
+  test("the refusal surfaces in the editor as an error, not a silent empty result",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page, request }) => {
+      // The run is MEANT to fail: declare both so the fixture's advisory logs stay
+      // trustworthy for every other spec (#1084/#1162).
+      (page as any).allowFlowErrors();
+      (page as any).allowHttpErrors();
+
+      let flowId = "";
+      await test.step("open a flow whose API Request targets loopback", async () => {
+        // Created over the API and opened by id rather than added from the
+        // sidebar: the sidebar add silently drops the click under contention
+        // (#1301), and component insertion is already covered by
+        // core-components/api-request-component-regression.spec.ts.
+        flowId = await createFlowFor(request, LOOPBACK_URL);
+        await openFlowById(page, flowId);
+        await expect(page.getByTestId("title-API Request")).toBeVisible({
+          timeout: 30000,
+        });
+      });
+
+      await test.step("running the component raises a visible error", async () => {
+        await page.getByTestId("button_run_api request").click();
+        // 60 s rather than the default: same cold-start cost as the API tests
+        // (first build after a container start), and the banner is what proves
+        // the user was told — timing out here would report "no error surfaced"
+        // for a run that had not finished yet.
+
+        // The build-failure banner. Its header wording is volatile across
+        // versions ("Error building Component …" ≤1.10, "Flow build failed"
+        // 1.11+), so match either; the banner carries no data-testid, which is
+        // why the flow name must not contain the token asserted below (the
+        // helper keeps it out).
+        await expect(
+          page.getByText(/flow build failed|error building component/i).first(),
+        ).toBeVisible({ timeout: 60000 });
+
+        // The meaningful half: the user is told the cause, not just that
+        // something failed.
+        await expect(page.getByText(/SSRF Protection/).first()).toBeVisible();
+      });
+
+      await test.step("the node produced no output to inspect", async () => {
+        // A silent empty result would leave this enabled with an empty payload —
+        // the failure mode the checklist bullet is about.
+        await expect(
+          page.getByTestId("output-inspection-api response-apirequest"),
+        ).toBeDisabled();
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1391

Closes the four `[ ]` gaps in `QA-CHECKLIST.md` § 17.1 — the round trip of Langflow's SSRF guard on a URL-fetching component.

Why it is distinct from the sibling that looks similar: `core-components/api-request-component-regression.spec.ts` already runs the API Request component against `ECHO_BASE_URL`, but it never asserts **why** that private address is reachable. The allow-list — the mechanism `.github/actions/resolve-echo-endpoint` depends on for every lane that self-hosts `go-httpbin` — was asserted nowhere. Only the *refusal* half of the guard is observable today, and always as a side effect of something else (`agent-tool-error-handling.spec.ts` uses an SSRF-blocked loopback fetch as an error *generator*). A release that silently stopped honouring the allow-list would surface as echo specs timing out, with nothing naming the cause — which is exactly the defect class of `langflow-ai/langflow#14264` (*"New SSRF validation logic in `ensure_url` ignores `LANGFLOW_SSRF_ALLOWED_HOSTS` for loopback addresses"*, 1.10.2).

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `a loopback address is refused, and the refusal names the allow-list` | `POST /api/v1/run/{id}` answers **500** and the detail carries `SSRF Protection` **and** `LANGFLOW_SSRF_ALLOWED_HOSTS`; the body has no `status_code` at all, so nothing was fetched. Catches a guard that stops blocking loopback, and one that fails without naming the escape hatch |
| 2 | `a blocked address the allow-list does not cover is refused the same way` | Same verdict for `169.254.169.254` (cloud metadata — the canonical SSRF target, in a blocked range no lane allow-lists). This is the **control** for test 3 on the same instance |
| 3 | `an address inside a blocked range is admitted when a CIDR entry covers it` | The private `ECHO_BASE_URL` host answers **200** with `status_code: 200` and `source` echoing the requested URL, and no `SSRF Protection` string. Tests 2 and 3 disagreeing on one instance is the round trip: same guard, same component, same blocked-address class, opposite verdicts — the difference is the CIDR entry. Catches the `#14264` regression |
| 4 | `the refusal surfaces in the editor as an error, not a silent empty result` | The in-canvas banner renders `Flow build failed` **and** the `SSRF Protection:` detail, and `output-inspection-api response-apirequest` stays disabled — a refusal the user can see, not an empty success |

## 2. How the test was built

**Setup.** Every flow is a single API Request node built from the **live** catalog (`GET /api/v1/all`) by a new helper, `tests/helpers/flows/create-api-request-flow-via-api.ts`, with `url_input` parameterized. A frozen fixture would keep creating a node the running image no longer understands; the helper throws naming `url_input`/`method` if either is renamed upstream, because a node built without them would fetch the component's *default* URL and the spec would assert a verdict about an address it never chose. Tests 1–3 use the `request` fixture only (no browser). Test 4 creates the same flow over the API and enters with `openFlowById` rather than adding the node from the sidebar — the sidebar add silently drops the click under contention (#1301), and component insertion is already covered by `api-request-component-regression.spec.ts`.

**Live-confirmed selectors** (scouted on 1.12.0.dev23 with `playwright-cli`, none invented): `button_run_api request`, `title-API Request`, `output-inspection-api response-apirequest` (measured **disabled** after the failed run), and the build-failure banner, which carries **no `data-testid`** — hence the text assertion, and hence the helper deliberately keeps the token `SSRF` out of the flow **name** (the name renders in `flow_name` and would satisfy the match on its own).

**Why these assertions.** Asserting only the refusal would keep passing on an instance where the allow-list was dropped entirely; asserting only the admission would keep passing on an instance where SSRF protection was switched off. The pair carries the verdict. Measured while designing, on nightly `1.12.0.dev24`, one probe container per allow-list:

| `LANGFLOW_SSRF_ALLOWED_HOSTS` | `http://127.0.0.1:7860/…` | `http://172.17.0.2:7860/…` | `http://169.254.169.254/…` |
|---|---|---|---|
| *(unset)* | 500 `SSRF Protection:` | 500 `SSRF Protection:` | 500 `SSRF Protection:` |
| `172.16.0.0/12,10.0.0.0/8,192.168.0.0/16` | 500 `SSRF Protection:` | **200** | 500 `SSRF Protection:` |
| `172.17.0.2,127.0.0.1` | **200** | **200** | 500 `SSRF Protection:` |

Row 3 is `#14264`'s literal case and is **green on the nightly**. It is also the row this spec cannot assert on a shared lane: allow-listing `127.0.0.1` there would let the instance under test call itself and would disarm `agent-tool-error-handling.spec.ts`, whose deterministic error generator *is* a loopback fetch being SSRF-blocked. The accepted half is therefore asserted through a private address — the class our lanes actually allow-list — and the deviation is recorded in the spec doc and in the checklist bullet rather than left implicit.

**Start scripts.** `LANGFLOW_SSRF_ALLOWED_HOSTS` now defaults to the value all four CI lanes set, for the same reason `LANGFLOW_ALLOW_CUSTOM_COMPONENTS` (#668) and `LANGFLOW_A2A_ENABLED` (#1240) are set there: without it a local instance refuses a self-hosted echo endpoint that works in CI, silently. Loopback stays out of the list on purpose, and two structural tests in `scripts/start-langflow-docker.test.mjs` pin both halves (the CI value present, loopback/localhost absent, and the whole thing overridable).

## 3. Dependencies

- **No LLM, no provider key.** Pure HTTP + one canvas run.
- Tests 1, 2 and 4 need **no allow-list at all** — loopback and the metadata address are refused whether or not it is set, so they run unchanged on a stock local instance and on every lane.
- Test 3 needs the lane's allow-list **and** `ECHO_BASE_URL` resolved to a private IP (every CI lane sets both). When the echo endpoint is unset or public it **skips**, naming the resolved value, because reaching a public host proves nothing about the allow-list.
- Serial describe; parallel-safe otherwise. Each flow is deleted id-scoped in `afterEach`, the API key in `afterAll`.

## Validation (nightly `1.12.0.dev24`, `--retries=0 --workers=1`)

- typecheck ✅ · eslint ✅ (0 errors) · `npm run test:units` 623 pass ✅ · `npm run test:scripts` 798 pass / 1 pre-existing skip ✅
- **3 clean burst runs**, `expected=4 unexpected=0 flaky=0`, zero `🚨 Backend Error` ✅
- **Force-fail, all four tests** (each recorded red, then reverted; no `FF-MUTATION` marker left, final green run ✅):
  - T1 — `LOOPBACK_URL` → the allow-listed private echo ⇒ the run answers 200 and the refusal assertion has nothing to match
  - T2 — `METADATA_URL` → the same echo ⇒ 200, same collapse
  - T3 — the accept arm → loopback ⇒ 500 `SSRF Protection` instead of the fetched 200
  - T4 — the editor flow → the allow-listed echo ⇒ the run succeeds, so no banner and no SSRF text ever render
- Orphan check: `GET /api/v1/flows/` shows **0** flows left by this spec, and no residual API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
