### PR TITLE
fix(model-provider): locate the provider save control by testid (#1431)

### DIFF
--- a/docs/core-functionality/model-provider/provider-management.md
+++ b/docs/core-functionality/model-provider/provider-management.md
@@ -81,7 +81,27 @@ does not render); the page, not the API, is the contract here.
 `model-provider-selection`, `model-search-input`, `llm-toggle-<model>`,
 `embeddings-toggle-<model>`; Save/Cancel/Confirm buttons (by role+name);
 configured providers show a **"N models"** suffix in their list item and a
-**Replace** button in their detail. LM node: `add-component-button-language-model`,
+**Replace** button in their detail.
+
+> **There is no distinct "Replace" button** (issue #1431, re-scouted on
+> 1.12.0.dev24). The provider detail has exactly **one** submit control,
+> `provider-save-button`, and its label is chosen at render time in
+> `ProviderConfigurationForm.tsx`: `Retry save` after a failed validation,
+> `Replace` when `isAlreadyConfigured`, `Save` otherwise. `isAlreadyConfigured`
+> is derived from the credential variables, so the label reads **`Save` until
+> `GET /api/v1/variables/` resolves** — a window in which the "N models" badge
+> and `provider-variable-input-*` are already rendered. A role+name locator
+> therefore matches *nothing* in that window instead of failing on what it
+> found, which is how the daily lost this test on 2026-08-12. Locate the
+> control by testid; assert the label as a property of it.
+>
+> **Disabled has two mechanisms** (`components/ui/button.tsx`): `disabled`
+> (native) when the form cannot be submitted, and `aria-disabled` +
+> `aria-busy`, with focus retained and no native `disabled`, while the button
+> is `loading`. An assertion must say which one it means — `toBeDisabled()`
+> is satisfied by both, so it cannot tell "correctly disabled" from
+> "mid-request". Measured live: the settled configured state is native
+> `disabled=true`, no `aria-busy`. LM node: `add-component-button-language-model`,
 `model_model` / `value-dropdown-model_model`, dropdown options `<model>-option`.
 
 **`modelProviderModal.spec.ts`**
@@ -128,10 +148,23 @@ configured providers show a **"N models"** suffix in their list item and a
 2. *Anthropic listed* — `provider-item-Anthropic` visible.
 3. *Configured provider exposes the key edit surface* (skip with a reason if
    the instance has no stored `OPENAI_API_KEY`) — the OpenAI item shows the
-   `N models` badge and its detail shows **Replace** (masked key, no raw
-   input); Replace opens `provider-variable-input-OPENAI_API_KEY`; Cancel
-   restores the masked state. **Zero writes** — see the cache-poisoning note
+   `N models` badge, `provider-variable-input-OPENAI_API_KEY` is visible, and
+   `provider-save-button` — located **by testid**, never by its label —
+   settles out of `aria-busy` and reads **Replace**, proving the panel treats
+   the provider as already configured. In that state the button is disabled
+   by the **native** mechanism (`disabled === true`, no `aria-busy`): with
+   nothing typed there is nothing to replace with. Typing into the key input
+   arms it (`disabled === false`); clearing the input disarms it again.
+   **Zero writes** — nothing is ever submitted; see the cache-poisoning note
    below for why a real add cycle is not exercised.
+
+   **Validation criterion:** the label read off `provider-save-button` is
+   exactly `Replace` (not `Save`, not `Retry save`) while the button is not
+   busy, and the native `disabled` property tracks the input: `true` empty,
+   `false` with a value, `true` again once cleared. Asserting the label as a
+   *property of the located button* is what distinguishes the three panel
+   states from each other; the previous role+name locator collapsed all of
+   them, plus the loading window, into `element(s) not found` (#1431).
 
 **`remove-provider-api-key.spec.ts`**
 1. *UI removal* — create a uniquely-named credential variable via

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-api-key.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-api-key.spec.ts
@@ -16,8 +16,8 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 //  - the Save+validation path is proven by the invalid-key negative control
 //    in model-provider-modal-actions.spec.ts (Save performs a real 1-token
 //    inference and rejects bad keys), and
-//  - the configured-provider edit surface (masked key + Replace → input →
-//    Cancel) is proven here with zero writes.
+//  - the configured-provider edit surface (masked key + the `Replace`-labelled
+//    submit arming only once a value is typed) is proven here with zero writes.
 
 async function openModelProviders(page: any): Promise<void> {
   await awaitBootstrapTest(page, { skipModal: true });
@@ -80,7 +80,18 @@ test.describe("Model Provider API Key Management", () => {
       await openModelProviders(page);
       await page.getByTestId("provider-item-OpenAI").click();
 
-      const replaceButton = page.getByRole("button", { name: "Replace", exact: true });
+      // There is no distinct "Replace" button (#1431). The panel has ONE submit
+      // control, `provider-save-button`, whose label is picked at render time:
+      // `Retry save` after a failed validation, `Replace` when the panel
+      // considers the provider already configured, `Save` otherwise. That last
+      // state is not hypothetical — `isAlreadyConfigured` is derived from the
+      // credential variables, so the label reads `Save` until
+      // `GET /api/v1/variables/` resolves, while the models badge and the key
+      // input are ALREADY rendered. Locating by role+name matched nothing for
+      // the full 10 s in that window and reported `element(s) not found`
+      // instead of the label it actually found (daily 2026-08-12; reproduced
+      // locally by delaying that request: `Save` for 9 s, then `Replace`).
+      const saveButton = page.getByTestId("provider-save-button");
       const keyInput = page.getByTestId("provider-variable-input-OPENAI_API_KEY");
 
       await test.step("configured state: models badge, key input, Replace disabled", async () => {
@@ -89,9 +100,28 @@ test.describe("Model Provider API Key Management", () => {
           { timeout: 10000 },
         );
         await expect(keyInput).toBeVisible({ timeout: 10000 });
+        await expect(saveButton).toBeVisible({ timeout: 10000 });
+
+        // Settle the panel first: while `loading`, the button keeps its
+        // accessible name but renders it twice (a width-reserving copy plus an
+        // `sr-only` one) and is blocked via `aria-disabled`, not `disabled`.
+        await expect(saveButton).not.toHaveAttribute("aria-busy", "true", {
+          timeout: 15000,
+        });
+        // The premise of this test: a configured provider offers REPLACEMENT of
+        // the stored key, not raw editing. Asserted as a property of the
+        // located button, so `Save` (variables not loaded) and `Retry save`
+        // (previous validation failed) fail HERE, naming what was found.
+        await expect(saveButton).toHaveAccessibleName("Replace", {
+          timeout: 15000,
+        });
+
         // Replace is the SUBMIT of a key replacement — with nothing typed it
-        // must be disabled (nothing to replace with).
-        await expect(replaceButton).toBeDisabled({ timeout: 10000 });
+        // must be disabled (nothing to replace with). Assert the NATIVE
+        // mechanism: `toBeDisabled()` alone is also satisfied by the
+        // `aria-disabled` a mid-request button carries, which would let a
+        // permanently-busy panel read as a correctly-guarded one.
+        await expect(saveButton).toHaveJSProperty("disabled", true);
       });
 
       await test.step("typing a value arms Replace; clearing it disarms again", async () => {
@@ -99,10 +129,14 @@ test.describe("Model Provider API Key Management", () => {
         // this test never does (a destructive re-add poisons the backend's
         // credential cache; see the header comment).
         await keyInput.fill("sk-draft-never-submitted");
-        await expect(replaceButton).toBeEnabled({ timeout: 10000 });
+        await expect(saveButton).toHaveJSProperty("disabled", false);
+        await expect(saveButton).toBeEnabled({ timeout: 10000 });
+        // Still the replacement surface — arming it must not have flipped the
+        // panel into the unconfigured (`Save`) or failed (`Retry save`) state.
+        await expect(saveButton).toHaveAccessibleName("Replace");
 
         await keyInput.fill("");
-        await expect(replaceButton).toBeDisabled({ timeout: 10000 });
+        await expect(saveButton).toHaveJSProperty("disabled", true);
       });
     },
   );


### PR DESCRIPTION
**Fixes #1431.** Closes #1431

## Problem

`model-provider-api-key.spec.ts:94` located the key-replacement submit with
`getByRole("button", { name: "Replace", exact: true })`. It matched **nothing**
for the full 10 s on the 2026-08-12 daily ([run 31581590030](https://github.com/oriontech-me/langflow-e2e/actions/runs/31581590030), green — 493 passed, 6 flaky),
while the two assertions ahead of it in the same step passed: the provider row
read `N models` and `provider-variable-input-OPENAI_API_KEY` was visible.

There is no distinct "Replace" button. `ProviderConfigurationForm.tsx` renders
**one** control, `provider-save-button`, whose label is picked at render time:
`Retry save` after a failed validation, `Replace` when `isAlreadyConfigured`,
`Save` otherwise.

**The issue's stated mechanism is refuted, and the real one is worse.** The
issue attributed the miss to `button.tsx` swapping the children for a spinner
while `loading`; upstream #13999 (2026-07-22, on `release-1.12.0` — the line the
nightly is cut from) keeps the accessible name in an `sr-only` span, so a
loading button is still findable by name. What actually breaks is that
`isAlreadyConfigured` is derived from the credential variables, so the label
reads **`Save` until `GET /api/v1/variables/` resolves** — a window in which the
badge and the key input are *already* rendered. Reproduced live on
`1.12.0.dev24` by delaying that request:

```
t+0ms    text="Save"     roleReplaceCount=0  disabled=true  aria-busy=null
...
t+8500ms text="Save"     roleReplaceCount=0  disabled=true  aria-busy=null
t+9000ms text="Replace"  roleReplaceCount=1  disabled=true  aria-busy=null
```

That reproduces all three of the daily's observations, with no spinner involved.

## Fix

- Locate the control by **`provider-save-button`**; the accessible name is no
  longer used to *find* it.
- Assert the `Replace` label as a **property of the located button** — the
  test's premise (a configured provider offers replacement, not raw editing) is
  preserved and now *strengthened*: `Save` and `Retry save` fail **here**,
  naming what was found, where the old locator collapsed all three states plus
  the loading window into `element(s) not found`.
- Assert the **native** disabled mechanism (`toHaveJSProperty("disabled", …)`).
  `toBeDisabled()` alone is also satisfied by the `aria-disabled` that
  `button.tsx` sets while `loading` (it deliberately keeps the control focusable
  and sets no native `disabled`), which would let a permanently-busy panel read
  as a correctly-guarded one.
- Keep an `aria-busy` settle wait before the label assertion. It was not
  exercised in the reproduction — it is a guard sourced from `button.tsx` and
  from the busy-`Save` contention already handled in `collect-models` (#1355).

**Rejected:** widening the locator to a name regex (`/Replace|Save/`) — it would
have turned the very state this test exists to distinguish into a pass.

## Scope note

Zero writes, as before — nothing is ever submitted. Tests 1 and 2 are untouched.
The typing/clearing step keeps its behaviour and gains a label re-check so
arming the button cannot silently flip the panel into another state. `@stable`
retained (first occurrence, and the defect is ours).

Out of scope, found in the sweep: the same name-based fragility exists in
`tests/helpers/provider-setup/setup-language-model-openai.ts:151-152`,
`tests/helpers/provider-setup/collect-models.ts:1047` and
`model-provider-modal-actions.spec.ts:65`. One issue per branch — worth a
follow-up.

## Validation (nightly 1.12.0.dev24, `--retries=0`)

- typecheck ✅ · eslint ✅ (0 errors on the touched file; 2 pre-existing
  warnings) · QA-CHECKLIST coverage guard ✅
- **4 clean runs**, no flake: 10.3 s / 9.3 s / 9.4 s, plus one run **immediately
  after `collect-models` reconfigured providers** (11.0 s) — deliverable 4 of
  the issue. Final post-revert run: 3 passed (10.2 s).
- **Adversarial**: the fixed sequence runs *inside* both bad windows and passes
  — `variables` delayed 12 s (old locator = 0 matches, label `Save`) and
  `models` delayed 12 s.
- **force-fail ✅ — 4 executed mutations, all red, revert verified (md5 + 0
  markers)**:
  - break both listing testids → 2 failed / 1 passed, `element(s) not found`
  - expect label `Save` → 1 failed, `Expected: "Save" / Received: "Replace"`
  - empty state `disabled: false` → 1 failed, `Expected: false / Received: true`
  - armed state `disabled: true` → 1 failed, `Expected: true / Received: false`
- zero `🚨 Backend Error` ✅
- `--trace=on` ⚠️ **not run** — known local hang on UI specs; step verification
  came from the `--retries=0` bursts, the force-fails and the live scouts.
- Flow cleanup: this spec creates no flows; instance orphan check clean (27
  flows, all starter templates plus one `Simple Agent` predating the session).

## Docs

`docs/core-functionality/model-provider/provider-management.md` updated first
(spec-first): its item 3 still described a `Replace → input → Cancel` flow that
no longer exists, and it now records the one-button/three-label contract, the
`Save`-while-variables-pending window, and the two disabled mechanisms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
