### PR TITLE
test(llm-agents): promote the multi-tool sequence test to @stable (#1449)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -369,7 +369,7 @@
 
 #### 6.4 Tools and Integrations
 - [ ] Agent with integrated external MCP tool executes action and returns result
-- [-] Agent executes multiple tools in sequence → `llm-agents/agent-multi-tool-selection.spec.ts` (Test 3 — chained fetch→search, ordered `tool_use` assert. Both gates on record have since closed: the clean baseline of #818/#827 on 2026-07-30, and `langflow-ai/langflow#14469` — the unbounded Web Search payload that blew the context up in #1378 — by `#14489` on 2026-08-10, 17.9× smaller per call from `1.12.0.dev25`. Still `[-]` for a narrower reason: #1378's failure is OpenAI-specific (200k TPM on `gpt-4o-mini`) and there is no post-fix measurement on that provider — CI skips every OpenAI target on a drained key)
+- [x] Agent executes multiple tools in sequence → `llm-agents/agent-multi-tool-selection.spec.ts` (Test 3 — chained fetch→search, ordered `tool_use` assert; `@stable` since #1449. All three gates it carried are settled: the clean baseline of #818/#827 closed 2026-07-30, the unbounded Web Search payload `langflow-ai/langflow#14469` closed by `#14489` on 2026-08-10 — 17.9× smaller per call from `1.12.0.dev25` — and the missing OpenAI measurement, now 4 clean whole-file runs on `gpt-4o-mini` at `dev25` plus green CI runs on google and anthropic)
 - [x] Tool returns error — agent handles it and continues execution → `core-functionality/llm-agents/agent-tool-error-handling.spec.ts`
 - [x] Multiple connected tools — agent selects the correct one for each prompt → `agent-multi-tool-selection.spec.ts`
 - [x] Tool with invalid name — validation prevents execution with clear message → `core-functionality/llm-agents/agent-tool-name-validation.spec.ts`

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -96,11 +96,11 @@ review, which is why the promotion is recorded here with its evidence rather
 than as a tag flip. Validated on `1.12.0.dev25`, `--workers=1 --retries=0`,
 `gpt-4o-mini`, with `ECHO_BASE_URL` on a local go-httpbin:
 
-- **4 clean runs of the whole file, 12/12 tests**, 46–55 s per run — the first
+- **6 clean runs of the whole file, 18/18 tests**, 45–55 s per run — the first
   local validation of test 1 in this file's history, since `httpbin.org` was
   answering `503` that day (the #631 mode) and the serial describe had always
   skipped its siblings behind it.
-- Test 3 alone, measured the day before on the same image: **7/7** at
+- Test 3 alone, measured earlier the same day on the same image: **7/7** at
   `max_iterations=8` and **4/4** at the default 15.
 - Force-fail executed per test — see **Force-failure checks** below.
 

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -87,6 +87,32 @@ here). Validated on `1.11.0.dev38`: clean `--retries=0` runs via go-httpbin on
 `gpt-4o-mini` + force-fail M2. Then `@stable` restored. The search test was
 unaffected (never depended on httpbin).
 
+**Test 3 promoted to `@stable` (#1449).** It shipped without the tag under two
+gates, and by the time it was promoted **both had closed** — #827's clean
+non-guarded baseline (closed by #818 on 2026-07-30) and the unbounded Web Search
+payload (`langflow-ai/langflow#14469`, closed by `#14489` on 2026-08-10, in the
+nightly from `1.12.0.dev25`). Neither expiry was noticed until #1381 went to
+review, which is why the promotion is recorded here with its evidence rather
+than as a tag flip. Validated on `1.12.0.dev25`, `--workers=1 --retries=0`,
+`gpt-4o-mini`, with `ECHO_BASE_URL` on a local go-httpbin:
+
+- **4 clean runs of the whole file, 12/12 tests**, 46–55 s per run — the first
+  local validation of test 1 in this file's history, since `httpbin.org` was
+  answering `503` that day (the #631 mode) and the serial describe had always
+  skipped its siblings behind it.
+- Test 3 alone, measured the day before on the same image: **7/7** at
+  `max_iterations=8` and **4/4** at the default 15.
+- Force-fail executed per test — see **Force-failure checks** below.
+
+Two limits of that evidence, stated because the daily rotates providers by
+weekday (#1185) and will not always run this on OpenAI. **anthropic could not be
+measured locally** — `collect-models` reports its key `inactive` for a billing
+reason, so its targets skip. What exists for the other two is CI: #1381's lane on
+2026-08-13 ran the file on **google** and **anthropic** and passed both (its
+OpenAI targets skipped on a drained CI key, #1450) — so every provider the daily
+can pick has at least one green run of test 3 behind it, none of them on the same
+box as the others.
+
 ---
 
 ## Preconditions *(optional)*
@@ -274,24 +300,19 @@ describe with two tests:
 > turns. **Re-measure before changing the number — do not re-derive it on
 > paper.**
 >
-> **Why this test is still `[-]` and still not `@stable` — and why neither of
-> the two reasons on record still applies.** #827 gated promotion on "the clean
-> non-guarded baseline"; **#818 closed on 2026-07-30 declaring that baseline
-> achieved, twice**. #1378 then recorded #14469 as the gate; **#14489 closed
-> that one on 2026-08-10**. Both stated justifications expired without anyone
-> noticing, which is the exact failure this note was rewritten to fix — and the
-> first version of the rewrite restated the #818 gate as live, so the trap is
-> not hypothetical.
+> **Promoted to `@stable` in #1449, after the gate that outlived two others.**
+> #827 gated promotion on "the clean non-guarded baseline"; **#818 closed on
+> 2026-07-30 declaring that baseline achieved, twice**. #1378 then recorded
+> #14469 as the gate; **#14489 closed that one on 2026-08-10**. Both expired
+> without anyone noticing — and the first attempt to correct that record
+> restated the #818 gate as live, so the trap is not hypothetical. The third
+> reason was the real one and it is now measured: #1378's failure is
+> **provider-specific** (OpenAI's 200k TPM on `gpt-4o-mini`), and the missing
+> evidence was a post-#14489 run on that provider. It exists — see the Tags
+> section for the full validation set, providers included.
 >
-> The live reason is narrower and is worth stating as such: **the failure
-> #1378 recorded is provider-specific** (OpenAI's 200k TPM on `gpt-4o-mini`),
-> and there is no post-#14489 measurement on that provider. The 7/7 and 4/4
-> above are a local box; CI's run on 2026-08-13 covered google and anthropic
-> and **skipped every OpenAI target** — `provider "openai" probed "inactive"`,
-> `You have no credits remaining`. Promotion therefore waits on one clean
-> `--retries=0` measurement of test 3 on `gpt-4o-mini` against `≥ 1.12.0.dev25`,
-> not on a baseline or an upstream ticket. Tracked separately; not a side
-> effect of this fix.
+> The cap stays at 8 after promotion. Nothing above argues it is unnecessary;
+> it argues that the failure it bounds became far rarer.
 
 ---
 
@@ -374,6 +395,17 @@ tools in the wrong order, fails).
   (a cap that quietly does not apply is exactly the #1378 failure, and a
   passing run would not reveal it).
 
+  **Re-executed for the #1449 promotion** on `1.12.0.dev25`, each isolated with
+  `--grep` because the describe is `mode: "serial"` and the first failure would
+  otherwise skip its siblings: **M1** failed with *first tool called was
+  "fetch_content", expected "perform_search"*; **M3** with the mirror image;
+  **M4** with *tools out of order: ["fetch_content","perform_search"] (indices
+  [1,0])*; **M5** with `TimeoutError` on
+  `inspector-add-max_iterations_FF_MUTATION`. M4 failed on its **first**
+  attempt, against the two #1381 needed on `dev20` — where the first attempt
+  died on the context blow-up instead of on the mutation, which is the same
+  difference `#14489` makes everywhere else in this note.
+
 ---
 
 ## What this test does not cover *(optional)*
@@ -384,6 +416,20 @@ tools in the wrong order, fails).
   tools are covered by other §6.4 bullets).
 - The transient "Executed …" streaming headers — assertions target persisted
   monitor data and the final reply only.
+
+**Expected noise in the log, so a reviewer does not re-diagnose it (#1449).**
+Most runs of this file print one `🚨 Backend Error: 500 … DELETE /api/v1/flows/`
+per test, body `{"detail":"An internal error occurred while deleting flows."}`.
+That is **#1225** — `cascade_delete_flow` losing a `SQLITE_BUSY` race
+(`OperationalError: database is locked`), measured at 10–22× per `daily-stable`
+run across the whole suite and closed by decision rather than by a fix. It is
+not caused by this spec and predates the promotion; it is left as an advisory
+log entry on purpose. `page.expectKnownHttpError()` would be the natural
+mechanism and is **wrong here**: it is verified in both directions, so a
+declared defect that does not fire fails the test — and this one is
+intermittent (5 of 6 runs in one local batch, 1 of 4 in another). Declaring it
+would trade a known-noisy log for a test that goes red whenever the delete
+happens to win the race.
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -509,7 +509,7 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent runs the URL then Web Search tools in sequence for a chained prompt",
-      { tag: ["@regression", "@agents", "@playground"] },
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
       async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(


### PR DESCRIPTION
**Closes #1449.**

## Problem

Test 3 of `agent-multi-tool-selection.spec.ts` — *"agent runs the URL then Web Search tools in sequence for a chained prompt"* — shipped without `@stable` and with a `[-]` checklist bullet, under gates that had **all closed** by the time anyone looked:

| Gate on record | Status |
|---|---|
| #827 — "promote only after the clean non-guarded baseline" | **closed 2026-07-30** by #818: *"the clean, non-guarded baseline exists, twice"* |
| #1378 — `langflow-ai/langflow#14469`, the unbounded Web Search payload | **closed 2026-08-10** by `#14489`, in the nightly from `1.12.0.dev25` |
| The real one — no post-fix measurement on the provider that actually failed (OpenAI's 200k TPM on `gpt-4o-mini`) | **this PR** |

Neither of the first two expiries was noticed until #1381 went to review — and the commit written there to *remove* an expired justification restated a different one as live. That is why the promotion is recorded in the spec doc with its evidence instead of as a tag flip.

## Changes

1. `@stable` added to test 3 — the spec diff is exactly one line.
2. Spec doc: the promotion, its full validation set, what it does **not** cover, and the re-executed force-fail results.
3. `QA-CHECKLIST.md` §6.4 bullet flipped `[-]` → `[x]`.

## Covered tests

| # | Test | What it validates |
|---|---|---|
| 1 | `agent selects the URL tool for a fetch prompt` | The **persisted** `fetch_content` tool output matches `/Sample Slide Show/i` (monitor API — not the live bubble, not the model's prose, which is recitable from memory), and the **first** `tool_use` of the session is `fetch_content` |
| 2 | `agent selects the Web Search tool for a search prompt` | A non-empty final reply, and the **first** `tool_use` is `perform_search` |
| 3 | `agent runs the URL then Web Search tools in sequence` **(promoted)** | The session's **ordered** `tool_use` list contains `fetch_content` **before** `perform_search`, with `max_iterations` capped at 8 and the value verified on the field first |

Tests 1–2 were already `@stable` and are unchanged in logic. They are in scope for validation anyway: a serial describe means a change to one can silently defuse a sibling.

## A gap this closes on the way

`httpbin.org` was answering `503` (the #631 mode), so **test 1 had never been validated locally** — it failed on the third-party endpoint and the serial describe skipped tests 2–3 behind it, which is exactly what #1381 had to record as an open gap. Running against a local `go-httpbin` with `LANGFLOW_SSRF_ALLOWED_HOSTS` set — the arrangement `daily-stable.yml` already uses — validates all three locally for the first time in this file's history.

## Validation (nightly `1.12.0.dev25`, `--workers=1 --retries=0`, `MODEL_TEST_ID=gpt-4o-mini`, `ECHO_BASE_URL` → local go-httpbin)

- `npm run typecheck` ✅ · `npm run lint` ✅ 0 errors · QA-CHECKLIST guard ✅ · coverage guard ✅
- **6 clean runs of the whole file, 18/18 tests**, 45–55 s per run
- Test 3 alone, same image, measured the day before: **7/7** at `max_iterations=8`, **4/4** at the default 15
- Orphan flows: **26 → 26** (the 26 are the starter projects)

### Force-fail — executed, one per test, each isolated with `--grep`

The isolation is not incidental: the describe is `mode: "serial"`, so a single run would let the first failure skip the rest.

| Mutation | Result |
|---|---|
| **M1** — test 1 expects the sibling tool first | ✅ `first tool called was "fetch_content", expected "perform_search"; all: ["fetch_content"]` |
| **M3** — same swap in test 2 | ✅ the mirror image: `first tool called was "perform_search", expected "fetch_content"` |
| **M4** — invert test 3's sequence assert | ✅ `tools out of order: ["fetch_content","perform_search"] (indices [1,0])` — on the **first** attempt, against the two #1381 needed on `dev20`, where the first died on the context blow-up instead of on the mutation |
| **M5** — point the cap at a non-existent field id | ✅ `TimeoutError: locator.click … inspector-add-max_iterations_FF_MUTATION`, proving the cap applies rather than silently leaving the default 15 |

Revert proven: `grep FF_MUTATION` → 0 hits, and the `.spec.ts` diff against `main` is the single tag line.

### Checklist items reported as they actually went

- `--trace=on` — **skipped**, known limitation: it hangs indefinitely on specs that load the Simple Agent template (#490/#518).
- `--debug` walk — left to the reviewer; the command is in the issue thread.
- Zero `🚨 Backend Error` — **not zero**, and characterized rather than waved through. See below.

## The backend error in the log, and why it is not silenced

Most runs print one `500` per test on `DELETE /api/v1/flows/`, body `{"detail":"An internal error occurred while deleting flows."}`. That is **#1225** — `cascade_delete_flow` losing a `SQLITE_BUSY` race (`OperationalError: database is locked`) — measured at 10–22× per `daily-stable` run across the whole suite and closed by decision rather than by a fix. It predates this spec and is not caused by it.

`page.expectKnownHttpError()` is the natural mechanism and is **wrong here**: it is verified in both directions, so a declared defect that does not fire fails the test — and this one is intermittent (5 of 6 runs in one local batch, 1 of 4 in another). Declaring it would trade a noisy-but-known log line for a test that goes red whenever the delete happens to win the race. Documented in the spec doc so the next reader does not re-diagnose it.

## Limit of the evidence — stated because the daily rotates providers

`daily-stable.yml` rotates provider by weekday (#1185), so this will not always run on OpenAI. **anthropic could not be measured locally** — `collect-models` reports its key `inactive` for a billing reason, so its targets skip here. What covers the other two is CI: #1381's lane on 2026-08-13 ran this file on **google** and **anthropic** and passed both, its OpenAI targets skipping on a drained CI key (#1450). Every provider the daily can pick therefore has at least one green run of test 3 behind it, none of them on the same box as the others.

## Dependencies

An active LLM provider key, `--workers=1` (area rule for agent specs — shared instance state), and an echo endpoint for test 1's fetch: `ECHO_BASE_URL` if set, otherwise the public `httpbin.org`. No new dependency introduced.
