### PR TITLE
fix(llm-agents): assert the model picker is usable, not pre-filled (#1445)

### DIFF
--- a/docs/core-functionality/llm-agents/modelInputComponent.md
+++ b/docs/core-functionality/llm-agents/modelInputComponent.md
@@ -1,0 +1,214 @@
+# Model Input component — the Language Model node's model picker
+
+**Last validated:** Langflow 1.12.x (measured on `1.12.0.dev25`)
+
+---
+
+## What this test validates *(required)*
+
+Covers the **Model Input** selector rendered by the canonical `models_and_agents`
+**Language Model** component (QA-CHECKLIST §7.5 *Model Input component*) — the
+unified model picker that replaced the per-provider inline fields in 1.11. Four
+behaviours, all pure UI/state (no LLM call is made, no flow is run):
+
+1. A freshly added Language Model node renders the picker trigger `model_model`.
+2. Opening the picker lists more than one model option.
+3. The open picker exposes the **Manage Model Providers** entry — the only route
+   from the node to the global credential surface since credentials stopped being
+   node-level fields.
+4. **The trigger reflects the model the user selects** — the picker is not merely
+   present, it is *usable*: the trigger goes from the `"Select a model"`
+   placeholder to exactly the model name that was clicked.
+
+### The premise behind behaviour 4 changed in 1.12 — this is the current one
+
+Until 1.12 this test asserted the opposite of what it asserts now. A freshly
+added node used to come up with a model **pre-selected**, because both the
+frontend and the backend filled an empty `model` field with `options[0]` — the
+first default-enabled model of the first *enabled* provider. The assertion was
+"the trigger is not a `Select…` placeholder", and it never selected anything.
+
+Upstream [langflow#14505](https://github.com/langflow-ai/langflow/pull/14505) —
+*"fix: stop pre-selecting an unconfigured model"*, merged **2026-08-12** into
+`release-1.12.0` — removed that fill deliberately, on both sides:
+
+- **frontend** — `hooks/useAutoSelectModel.ts` now replaces only a *stale*
+  selection (provider disconnected, model deactivated); an empty field is left
+  empty. `helpers/derive-selected-model.ts` renders the placeholder instead of
+  `flatOptions[0]`.
+- **backend** — `unified_models/build_config.py` gates the `options[0]` fallback
+  behind `user_triggered = field_name is not None`, i.e. a bare initial load no
+  longer fills. The inline comment names the ticket (LE-2168) and the reason: a
+  provider counts as *enabled* purely because a credential exists
+  (`skip_validation=True`), and env-harvested keys therefore made the node
+  advertise a provider the user never set up.
+
+That PR's own verification reads: *"After the fix, a freshly added Language Model
+node shows **Select a model**; the dropdown still lists every model and a manual
+pick persists."* It also inverted four of its own assertions for the same reason
+and states *"the Playwright E2E suite was not run"* — which is why this suite
+reddened the next morning (issue #1445, daily run 31685261355).
+
+So behaviour 4 now encodes both halves of the current contract, in one causal
+test: the fresh node **must** show the placeholder (which pins the LE-2168 fix
+against a silent return of the auto-fill), and after a pick the trigger **must**
+show that exact model name. This is strictly stronger than the pre-1.12
+assertion, which only demanded "not the placeholder" and could be satisfied by
+any accidental value.
+
+**What is deliberately *not* asserted here:** the preserved
+`__default_language_model__` auto-selection path. Measured on `1.12.0.dev25`,
+setting that variable via `POST /api/v1/models/default_model` does **not** change
+the trigger on a freshly dropped node — the stored default acts only through a
+backend `update_build_config` round-trip, not through the frontend's mount-time
+render. Covering it would require a different entry point and belongs in its own
+spec.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@components` `@workspace` `@model-provider`
+
+All four tests carry the same set. `@model-provider` is load-bearing beyond
+categorisation: `scripts/provider-dependent-specs.mjs` reads it to force the
+`Collect models` sweep for this file on the PR lane, which is what satisfies the
+provider prerequisite below.
+
+---
+
+## Step-by-step *(required)*
+
+Every test starts from the same entry point (`addLanguageModelNode`):
+
+1. `awaitBootstrapTest(page)` → click `blank-flow` → wait for `/flow/{id}`.
+2. Wait for `sidebar-search-input` through `waitForAttributedSelector` with
+   `surface: "component-sidebar"` — the component sidebar, not the model
+   selector, is what times out when Langflow stalls, and the barrier attributes
+   the failure instead of blaming the assertion the test is named for.
+3. `addComponentFromSidebar(page, "language model", "add-component-button-language-model")`
+   — returns only once a node landed, repairing one swallowed click (#1304).
+4. Assert `[data-testid^="rf__node-"]` is **visible**.
+
+Then, per test:
+
+**4.1 — the Language Model node renders its model selector**
+
+5. Assert `model_model` is visible on the node.
+
+**4.2 — opening the model dropdown lists model options**
+
+5. Click `model_model`.
+6. Assert the first `[data-testid$="-option"]` is visible and the option count is
+   greater than 1.
+
+**4.3 — the model dropdown exposes the Manage Model Providers entry**
+
+5. Click `model_model`.
+6. Assert `manage-model-providers` is visible.
+
+**4.4 — the trigger shows the model the user selects**
+
+5. Read `model_model` and assert it is the placeholder — matches
+   `/^select a model$/i`. This is the post-#14505 initial state.
+6. Click `model_model` to open the picker.
+7. Wait for the first `[data-testid$="-option"]`, read **its own label** (the
+   option's inner text is the bare model name) and its `data-testid` — the
+   option testid shape is `{Provider}-{model}-option`, e.g.
+   `Anthropic-claude-opus-5-option` (frontend `ModelList.getModelOptionTestId`).
+   The model is never hardcoded: whichever option the catalog puts first is the
+   one used, so the test is provider-agnostic and survives model retirement.
+8. Click that option.
+9. Assert `model_model` now reads **exactly** the label captured in step 7, and
+   no longer matches the placeholder.
+
+Cleanup (all tests): flows created through the UI are tracked from `beforeEach`
+by `trackCreatedFlows` and deleted id-scoped in `afterEach`. This entry point
+creates **two** flows — `awaitBootstrapTest` → `openNewFlowTemplatesModal` clicks
+"New Flow", which creates a flow of its own before the modal opens (#1002) —
+which is why the tracker is armed before the test body and a local
+`waitForResponse` is not enough (#1265). Never `cleanAllFlows`: parallel workers
+own their own flows.
+
+---
+
+## Validation criterion *(required)*
+
+- **4.1** — `model_model` is visible on the freshly added node.
+- **4.2** — at least two `[data-testid$="-option"]` entries render in the open
+  picker.
+- **4.3** — `manage-model-providers` is visible in the open picker.
+- **4.4** — the trigger reads `Select a model` before the pick, and after
+  clicking the first option it reads exactly that option's model label (e.g.
+  `claude-opus-5`), with the placeholder gone. The label comes from the DOM, not
+  from a constant, so a catalog reorder or a retired model cannot make this test
+  wrong.
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/`
+  — renders the `model_model` trigger, the `value-dropdown-model_model` value
+  span, the `{Provider}-{model}-option` entries and the `manage-model-providers`
+  footer entry. Renaming these `data-testid` attributes breaks every test here.
+- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx`
+  — derives the displayed label; the `Select a model` placeholder string is
+  test 4.4's initial-state anchor.
+- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelList.tsx`
+  — `getModelOptionTestId` defines the `{Provider}-{model}-option` shape the test
+  reads the picked label from.
+- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/useAutoSelectModel.ts`
+  and `helpers/derive-selected-model.ts` — the two halves of the #14505 change.
+  Restoring the empty-field auto-fill in either would flip test 4.4's first
+  assertion; that is the regression this test now guards.
+- `src/lfx/src/lfx/base/models/unified_models/build_config.py` — the backend half
+  (`user_triggered = field_name is not None`, LE-2168). Defence in depth for
+  API-driven flows; the same guard.
+- `tests/helpers/provider-setup/` + `data/models.json` / `providers.json` —
+  produced by `tests/collect-models.spec.ts`; what puts a credential on the
+  instance so the picker renders at all.
+
+---
+
+## Preconditions *(optional)*
+
+**Provider credential prerequisite — the whole file needs it.** At least one
+provider **credential** must be configured in Langflow. With none, the node still
+mounts but its Language Model field renders a **"Setup Provider"** CTA behind
+`parameter-permission-gate` and `model_model` is absent entirely, so all four
+tests fail on an observable unrelated to what they assert (#1265, measured on
+`1.12.0.dev17`).
+
+It is the *credential* that matters, not a funded key: the 2026-08-13 validation
+ran with a drained `openai` (no credits) alongside an active anthropic and
+google, and the catalog still offered 89 models across all three providers.
+That is also the control that rules the key out as a cause of the #1445 failure —
+`options[0]` was `claude-opus-5` from the **active** Anthropic, so there was a
+healthy model to pre-select and it was still not pre-selected.
+
+Nothing to wire up in CI (`@model-provider` forces the sweep, and the daily
+always runs it), but **locally run `npx playwright test tests/collect-models.spec.ts`
+first** or the failures look like a model-selector regression.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Persistence of the pick across a reload / re-open of the flow (upstream #14505
+  claims *"a manual pick persists"*; this test asserts the trigger, not the
+  saved flow).
+- The `__default_language_model__` auto-selection path — see the note under
+  *What this test validates*.
+- Running a flow with the selected model (covered by the agent and
+  provider-execution specs).
+- Provider credential configuration itself (covered by the provider-management
+  specs under `core-functionality/model-provider/`).
+
+---
+
+## Change log
+
+| Date | Langflow | Change |
+|---|---|---|
+| 2026-08-13 | `1.12.0.dev25` | Spec doc created (the file had none). Behaviour 4 rewritten: the pre-selected-default premise expired with upstream [#14505](https://github.com/langflow-ai/langflow/pull/14505); the test now asserts placeholder → pick → exact model name. Issue #1445, from daily triage #1444. |

--- a/docs/core-functionality/llm-agents/modelInputComponent.md
+++ b/docs/core-functionality/llm-agents/modelInputComponent.md
@@ -158,13 +158,26 @@ own their own flows.
 - `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelList.tsx`
   — `getModelOptionTestId` defines the `{Provider}-{model}-option` shape the test
   reads the picked label from.
-- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/useAutoSelectModel.ts`
-  and `helpers/derive-selected-model.ts` — the two halves of the #14505 change.
-  Restoring the empty-field auto-fill in either would flip test 4.4's first
-  assertion; that is the regression this test now guards.
+- The two frontend halves of the #14505 change — `useAutoSelectModel.ts` (under
+  the component's `hooks/`) and `derive-selected-model.ts` (under its
+  `helpers/`). Restoring the empty-field auto-fill in either would flip test
+  4.4's first assertion; that is the regression this test now guards. **They are
+  deliberately named here as bare filenames rather than as full upstream
+  dependency paths, because they do not resolve on upstream `main`** — measured
+  2026-08-13, they exist only on
+  `origin/release-1.12.0`, together with `build-grouped-options.ts` and
+  `useRefreshAfterProviderClose.ts`, while `main`'s `hooks/` holds only
+  `useModelConnectionLogic.ts` and its `helpers/` only `model-option-identity.ts`
+  and `recover-model-option.ts`. The release line is the one the nightly is cut
+  from and the one this spec is validated against — the same ref distinction
+  `CLAUDE.md` records for the component-distribution measurements. Citing them as
+  dependency paths would fail `watch-upstream-areas.mjs --mode=check-docs`, which
+  resolves against `main`, and the honest fact is that the refactor has not been
+  merged back rather than that the files are missing.
 - `src/lfx/src/lfx/base/models/unified_models/build_config.py` — the backend half
   (`user_triggered = field_name is not None`, LE-2168). Defence in depth for
-  API-driven flows; the same guard.
+  API-driven flows; the same guard. Unlike the two frontend files, this one is
+  present on both refs.
 - `tests/helpers/provider-setup/` + `data/models.json` / `providers.json` —
   produced by `tests/collect-models.spec.ts`; what puts a credential on the
   instance so the picker renders at all.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
@@ -138,28 +138,44 @@ test.describe("ModelInputComponent", () => {
   );
 
   test(
-    "the trigger shows the selected model name",
-    // Quarantine lifted in #1304 after the mechanism was found, and it is not in
-    // this test — nor in this file. The 2026-08-05 hard failure (run 30997773754,
-    // all 3 attempts) was the SHARED sidebar add dropping its click: Langflow
-    // accepts the click on `add-component-button-language-model`, never registers
-    // the add, and no node reaches the canvas. Measured 4/20 by an instrumented
-    // scout on 1.12.0.dev17, with an identical second click repairing all 4 —
-    // which is why `addComponentFromSidebar` now verifies the node landed and
-    // re-issues once, and why nothing here needed a longer timeout (this test
-    // already waited 15 s and lost 3/3).
+    "the trigger shows the model the user selects",
+    // Renamed in #1445 because the old title ("the trigger shows the SELECTED
+    // model name") promised a selection this test never made: it read the
+    // trigger of a freshly added node and asserted only that the text was not a
+    // "Select…" placeholder. That passed on a pre-fill nobody asked for, and it
+    // is now a selection the test performs itself.
     //
-    // Provider-credential churn was the standing hypothesis and is REFUTED: the
-    // drop reproduces solo with no neighbour at all (2 of 11 runs pre-fix), and
-    // the same class hit `core-components/edit-name-description-node.spec.ts:42`
-    // on that daily with no provider-mutating spec running. What the daily added
-    // was a degraded window — `stop-building.spec.ts:24` and
-    // `langflowShortcuts.spec.ts:47` failed on the same shard within 100 s with
-    // the same mechanism under different messages — which raised the per-add drop
-    // probability enough to cost all three attempts. #1265 stays separate: its
-    // observable is the sidebar never opening, upstream of any add.
+    // The premise it used to encode — "the catalog pre-selects a default model"
+    // — EXPIRED with upstream langflow#14505 ("fix: stop pre-selecting an
+    // unconfigured model", merged 2026-08-12 into release-1.12.0), which removed
+    // the empty-field fallback to `options[0]` on both sides: the frontend
+    // (`useAutoSelectModel.ts` now replaces only a STALE selection;
+    // `derive-selected-model.ts` renders the placeholder instead of
+    // `flatOptions[0]`) and the backend (`unified_models/build_config.py` gates
+    // that fallback behind `user_triggered = field_name is not None`, citing
+    // LE-2168). The reason is that a provider counts as enabled purely because a
+    // credential exists, so an env-harvested key made the node advertise a
+    // provider the user never set up. That PR's own verification says a freshly
+    // added Language Model node now shows "Select a model" — and it inverted
+    // four of its own assertions for the same reason while stating the Playwright
+    // E2E suite was not run, which is why this file reddened the next morning
+    // (daily run 31685261355, 3/3 attempts; reproduced 5/5 locally on
+    // 1.12.0.dev25). NOT langflow#14465, the lead the issue carried: that one
+    // only stopped substituting an EXPLICITLY CLEARED selection and left the
+    // initial-load default intact.
+    //
+    // Neither the failing daily nor the local repro was a provider artefact —
+    // the catalog offered 89 models across three providers and `options[0]` was
+    // `claude-opus-5` from the ACTIVE Anthropic, so there was a healthy model to
+    // pre-select and it was still not pre-selected (OpenAI's key was drained on
+    // both, see #1442/#1443).
+    //
+    // The earlier quarantine (#1304) was a different mechanism and is not in this
+    // test nor in this file: the SHARED sidebar add dropped its click (4/20 on
+    // 1.12.0.dev17), which `addComponentFromSidebar` now verifies and repairs.
     {
       tag: [
+        "@stable",
         "@release",
         "@components",
         "@workspace",
@@ -168,15 +184,32 @@ test.describe("ModelInputComponent", () => {
     },
     async ({ page }) => {
       await addLanguageModelNode(page);
+      const trigger = page.getByTestId("model_model");
 
-      // The catalog pre-selects a default model, so the trigger must show a
-      // concrete model name, not a "Select…" placeholder. NOT key-independent,
-      // as this comment used to claim: with no provider credential at all the
-      // trigger is a "Setup Provider" CTA and `model_model` is absent — see the
-      // provider prerequisite at the top of the file (#1265).
-      const text = (await page.getByTestId("model_model").textContent())?.trim() ?? "";
-      expect(text.length).toBeGreaterThan(0);
-      expect(text).not.toMatch(/select a model/i);
+      // Post-#14505 initial state. Asserted, not tolerated: a silent return of
+      // the auto-fill is exactly the regression LE-2168 fixed, and only this
+      // half of the test can catch it.
+      await expect(trigger).toHaveText(/^select a model$/i, { timeout: 10000 });
+
+      await trigger.click();
+
+      // Each option carries `data-testid="{Provider}-{model}-option"` (frontend
+      // `ModelList.getModelOptionTestId`) and its inner text is the bare model
+      // name. The expected label is read FROM THE DOM rather than hardcoded, so
+      // a catalog reorder or a retired model id cannot make this test wrong —
+      // whichever model the instance offers first is the one selected.
+      const firstOption = page.locator('[data-testid$="-option"]').first();
+      await expect(firstOption).toBeVisible({ timeout: 15000 });
+      const modelLabel = (await firstOption.innerText()).trim();
+      expect(modelLabel.length).toBeGreaterThan(0);
+      expect(modelLabel).not.toMatch(/select a model/i);
+
+      await firstOption.click();
+
+      // Exact equality, which subsumes "the placeholder is gone" — the old
+      // assertion only demanded the text differ from the placeholder and would
+      // have accepted any value the picker happened to hold.
+      await expect(trigger).toHaveText(modelLabel, { timeout: 10000 });
     },
   );
 });


### PR DESCRIPTION
**Closes #1445.** Spun out of daily-failure triage #1444 (run [31685261355](https://github.com/oriontech-me/langflow-e2e/actions/runs/31685261355), 2026-08-13).

## Problem

`modelInputComponent.spec.ts:140` ("the trigger shows the selected model name") hard-failed on **all 3 attempts** — deterministic, not a flake that ran out of retries. A freshly added **Language Model** node rendered its model trigger as the placeholder `"Select a model"`, while the test asserted the trigger showed a concrete model name.

**Verdict: `product-changed` — the test's premise expired, the product did not regress.**

Upstream [langflow#14505](https://github.com/langflow-ai/langflow/pull/14505) — *"fix: stop pre-selecting an unconfigured model"* — merged **2026-08-12T16:55Z** into `release-1.12.0`, the day before this daily. It removed the empty-field fallback to `options[0]` deliberately, on both sides:

- **frontend** — `useAutoSelectModel.ts` now replaces only a *stale* selection; `derive-selected-model.ts` renders the placeholder instead of `flatOptions[0]`.
- **backend** — `unified_models/build_config.py` gates the fallback behind `user_triggered = field_name is not None`, with an inline comment naming LE-2168.

Its own verification section reads: *"After the fix, a freshly added Language Model node shows **Select a model**; the dropdown still lists every model and a manual pick persists."* It lists **four of its own assertions that it inverted** for the same reason, and states *"the full backend suite and the Playwright E2E suite were not run"* — which is why this suite reddened the next morning.

**Not `langflow#14465`**, the lead the issue carried. Right family, wrong PR: #14465 only stopped substituting an **explicitly cleared** selection and left the initial-load default intact.

### Evidence (measured on `1.12.0.dev25`, not assumed)

| Control | Result |
|---|---|
| Pre-fix baseline (unmodified spec, `--retries=0`) | **5/5 failed (100%)**, 0 voided — matches the daily's 3/3 |
| `docs/upstream-bugs/scripts/probe-2156-model-input-fill.py` | `options=89`, providers `[Anthropic, OpenAI, Google Generative AI]`, `options[0] = claude-opus-5 @ Anthropic` |
| Provider-mix control (issue directive 4) | **Rules the drained OpenAI key out**: `options[0]` belonged to the **active** Anthropic, so there was a healthy model to pre-select and it was still not pre-selected |
| Container source | `lfx/base/models/unified_models/build_config.py:437` — the `user_triggered` guard, comment citing LE-2168 |
| A/B on the one path upstream says it preserved | `__default_language_model__ = claude-haiku-4-5@Anthropic` via `POST /api/v1/models/default_model` → trigger **still** reads `Select a model`; the stored default acts only through an `update_build_config` round-trip, not the frontend's mount-time render. Reverted to `null` after |
| Blast radius | Bounded to this one test. `agent-model-connection-isolation.spec.ts:153` also compares against `"Select a model"` but its helper selects a concrete model first (green on the daily and locally); `memory-base-panel.spec.ts` already treats `Select a model` as *unset*. The three sibling tests in this file passed throughout |

## Fix

Test 4 rewritten **causally** and renamed to *"the trigger shows the model the user selects"* — the old title promised a selection the test never made:

1. assert the freshly added node's trigger matches `/^select a model$/i` — the post-#14505 initial state, which **pins the LE-2168 fix against a silent return of the auto-fill**;
2. open the picker, read the **first option's own label from the DOM** (`{Provider}-{model}-option`, e.g. `Anthropic-claude-opus-5-option`, inner text `claude-opus-5`) and click it;
3. assert the trigger reads **exactly** that label.

Strictly stronger than what it replaces: the old assertion only demanded the text differ from the placeholder and would have accepted any value the picker happened to hold. The expected model is never hardcoded, so a catalog reorder or a retired model id cannot make this test wrong.

`@stable` restored (auto-removed by triage commit `1bb9425`).

Adds `docs/core-functionality/llm-agents/modelInputComponent.md` — **this spec never had a mirrored doc**; it covers all four tests, records the new premise with the upstream reference, and states the provider-credential prerequisite.

### Rejected alternatives

- **Inverting the assertion only** (fresh node must show the placeholder) — minimal diff, but the test would stop covering the picker's actual capability and the title would keep lying.
- **Dropping the placeholder assertion** and only testing the pick — leaves the new upstream behaviour unguarded; a returning auto-fill would pass unnoticed.
- **`waitForLoadState("networkidle")` before the create POST** (the #464 remedy for the ambient 500 below) — **tried and measured worse**, 4 and 2 occurrences against a baseline of 1, so it was reverted. No wait, retry or catch was added to this spec.

## Scope note

`addLanguageModelNode` and the three sibling tests are **unchanged**, as is the `trackCreatedFlows` cleanup wiring. No assertion anywhere was weakened, no timeout raised, no selector loosened.

`QA-CHECKLIST.md` is deliberately untouched: the per-test bullets sit **below** the `## Coverage Summary` anchor (the auto-generated `Phase 0` block, which regenerates on merge once `@stable` is back), and the manual Part II bullet that `check:checklist-coverage` requires already exists and references this file.

## Validation (nightly `1.12.0.dev25`, `--workers=1 --retries=0`)

- typecheck ✅ (`tsc --noEmit`, 0 errors) · eslint ✅ (0 errors; the single `no-explicit-any` warning on line 47 pre-exists on `main` and is untouched)
- **3/3 clean runs**, `expected=4 unexpected=0 flaky=0` each, no flake
- **force-fail 5/5** — every `test()` in the file, plus a second mutation on the rewritten test so **both** of its new halves are proven live:
  - `model_model_ff` instead of `model_model` → failed as expected
  - option count `> 99999` instead of `> 1` → failed as expected
  - `manage-model-providers-ff` instead of `manage-model-providers` → failed as expected
  - trigger expected as `${label}-ff` → failed as expected (the post-selection assert really compares against the option that was clicked)
  - initial state expected as `select a model-ff` → failed as expected (the placeholder assert is live, so a returning auto-fill would be caught)
  - all mutations reverted, no `FF-MUTATION` marker in the diff, final green run ✅
- flow cleanup ✅ — `GET /api/v1/flows/` reads **0 flows** after every run

### Backend-error log — declared, not ignored

Runs log `🚨 Backend Error: 500 … /api/v1/flows/`. It is **pre-existing on unmodified `main` at 100%**: 4/4 full-file runs on a stashed working tree logged it (3, 1, 1, 1 occurrences), and 2/2 more after restarting the instance on a fresh DB.

Mechanism, read from the container log rather than guessed:

```
ERROR  Error deleting multiple flows                     flows.py:993
OperationalError: (sqlite3.OperationalError) database is locked
```

A request-level scout identified the issuer as the **frontend's own transient-flow sweep** (`DELETE /api/v1/flows/`, single-id body, one per test) racing this file's flow writes on SQLite. Same upstream weakness the repo already documents for `core-components/webhook-component-regression.spec.ts` (#464), `core-functionality/project-management/folder-drag-drop-flow.spec.ts` and `api/flows/api-folders-crud.spec.ts` (#965/LE-2020 — upstream wrapped the **folder** endpoint in `services/database/lock_retry.py` but not the bulk-flow delete). Log-only: it never fails a test and leaks no flow.

## Issue lifecycle

#1445's deliverable *"if the root cause is a product regression, this issue stays open until the upstream fix lands"* does **not** apply — the behaviour is intentional upstream and documented as such in langflow#14505, so there is no upstream fix to wait for. The issue closes with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
