### PR TITLE
test(core-components): quarantine the custom-component code-button test (#1365)

### DIFF
--- a/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
+++ b/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
@@ -39,9 +39,22 @@ test.afterEach(async ({ request }) => {
   }
 });
 
-test(
+// Quarantined at the triage of #1458 as prevention: recurrent flake, 3× under the
+// same signature (dailies 2026-07-15, 2026-08-12, 2026-08-14). `code-button-modal`
+// is ABSENT — `element(s) not found`, not late-and-invisible — at the 10 s mark
+// after the custom component is added, and it recovered on the next attempt every
+// time. Same locator and same area as `full-custom-component.spec.ts:66`, so it is
+// tracked there rather than as its own cause.
+//
+// `test.fixme` accompanies the tag removal on purpose: dropping `@stable` alone
+// only stops the daily, while the PR impacted-specs gate selects by file diff and
+// would keep running this red (#871).
+//
+// Lifting this — remove `test.fixme` AND restore `@stable`, re-validated per
+// CONTRIBUTING.md — is a deliverable of #1365.
+test.fixme(
   "custom component code button should be pink when adding custom component",
-  { tag: ["@release", "@components", "@stable"] },
+  { tag: ["@release", "@components"] },
 
   async ({ page }) => {
     trackCreatedFlows(page);


### PR DESCRIPTION
Quarantine owed by the triage of #1458 — the one code change that triage required, and the reason that umbrella was left open.

## What

`tests/tests-automations/regression/core-components/customComponentAdd.spec.ts:42` ("custom component code button should be pink when adding custom component") — `@stable` removed **and** the test wrapped as `test.fixme`.

## Why

Recurrent flake, **3× under the same error signature** (`Error: expect(locator).toBeVisible() failed`) on the dailies of 2026-07-15, 2026-08-12 and 2026-08-14 — `actionable: true` from the triage dataset, which is the criterion in `CONTRIBUTING.md` for quarantining as prevention.

The call log adds a detail the earlier occurrences did not record explicitly: the wait fails with `Error: element(s) not found`, so `code-button-modal` is **absent** at the 10 s mark, not late-and-invisible. It recovered on the next attempt every time.

Two things about the 2026-08-14 occurrence weaken the load confound recorded on #1365, which is worth carrying over: the mass-failure guard did **not** trip (4 hard failures, `guard_tripped: false`), and the run's own liveness recorder measured **0 outages** on the shard this ran on — the only outages were 3 × 8 s on shard 4, whose single overlapping spec was `openai-provider.spec.ts`.

## Why both edits

Dropping `@stable` alone only stops the daily. The PR impacted-specs gate selects specs by **file diff**, not by tag (#871), so this would keep going red there. `test.fixme` is what skips it in every context — daily, PR gate and full suite.

## Tracked on #1365, not as a new cause

Same wait locator (`getByTestId('code-button-modal').last()`), same feature area (adding a custom component) and same signature as `full-custom-component.spec.ts:66`, which #1365 already covers and which was already quarantined. Details are in the enrich comment on that issue. Lifting this quarantine — un-`fixme` plus restoring `@stable`, re-validated per `CONTRIBUTING.md` — is a deliverable there.

## Checks

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run check:checklist-coverage` — passes; the Part II bullet already references this spec, so no checklist edit is owed
- `npm run check:checklist-guard` — no generated block touched

No spec doc change: a quarantine is temporary and tracked by issue, per the PR review checklist.

Refs #1458, #1365. Deliberately no closing keyword — #1365 closes when the flake is fixed and the quarantine is lifted, not here.