### PR TITLE
fix(provider-setup): match a model option by identity, and prove the absence before skipping (#1459) (#1461)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,6 +257,22 @@ for (const { label, options, skipReason } of targets) {
 }
 ```
 
+**Skip on that prefix and on nothing else.** `MODEL_NOT_AVAILABLE` is raised only
+for an absence the helper **established** — it enumerated the open picker, the
+model was not among the options, and the provider panel's `llm-toggle-*` list did
+not carry it either — and the message reports what it saw (option count,
+per-provider breakdown, nearest offered ids). Two sibling prefixes must never be
+caught: a model the picker IS offering that the suite cannot select, and an empty
+picker, both raise `MODEL_PICKER_DEFECT` and must fail the test.
+
+That split is the fix for #1461: the old guard inferred "model may not be
+supported" from one anchored text matcher returning nothing, so when 1.12.0.dev26
+added a `sr-only` "N of M" counter inside every option (#1459), ~30 `@stable`
+tests skipped green in a single daily and the only trace was the run's skip total
+(35 against a 4–15 baseline). Resolve a model through
+`tests/helpers/provider-setup/model-option.ts`, which matches the option's
+identity (`data-value` / `data-testid`) — never its rendered text.
+
 ### Running agent tests
 
 This is the most important step — and the most overlooked.

--- a/docs/core-functionality/model-provider/anthropic-provider.md
+++ b/docs/core-functionality/model-provider/anthropic-provider.md
@@ -201,6 +201,20 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
   need configure + select + switch. A dedicated `anthropic-provider.spec.ts`
   under `model-provider/` follows the family precedent (§7.2/§7.4/§7.6 all
   chose dedicated specs) and gives §7.3 a provider-centric home.
+- **How a model option is matched (#1459/#1461, 1.12.0.dev26):** Test 3's switch
+  and the shared `provider-setup` helpers resolve a model by the option's
+  **identity** — `data-value` (`${provider}::${model}`), falling back to
+  `data-testid` (`${provider}-${model}-option`) — through
+  `tests/helpers/provider-setup/model-option.ts`. Never by the option's text:
+  dev26 added a `sr-only` position counter inside every option
+  (`modelInput.optionPosition` → `"9 of 90"`), so `textContent` is
+  `"claude-haiku-4-5\n9 of 90"` and an anchored `^model$` matcher resolves
+  nothing. When it does not resolve, the failure mode is now split: an absence
+  the helper **established** (picker enumerated, model in neither the options
+  nor the provider panel's `llm-toggle-*` list) raises `MODEL_NOT_AVAILABLE`
+  and skips, carrying the option count, the per-provider breakdown and the
+  nearest offered ids; a model the picker IS offering, or an empty picker,
+  raises `MODEL_PICKER_DEFECT` and **fails** — no spec may skip on it.
 - **Model resolution from `models.json`:** Haiku/Sonnet/Opus are resolved by
   family regex from the collected catalog (preferring current, non-deprecated
   names, e.g. `claude-haiku-4-5`, `claude-sonnet-5`, `claude-opus-4-8`), so

--- a/tests/helpers/provider-setup/model-option.test.ts
+++ b/tests/helpers/provider-setup/model-option.test.ts
@@ -1,0 +1,208 @@
+// Unit tests for the model-picker resolver (issues #1459 and #1461).
+// Run with: npm run test:units
+//
+// What rides on this function is a verdict, not a selector. Until #1459 the three
+// provider-setup helpers resolved a pinned model with
+// `hasText: new RegExp("^" + model + "$")`, and on 1.12.0.dev26 the picker began
+// rendering a per-option `sr-only` position counter INSIDE the option:
+//
+//   <div data-testid="Google Generative AI-gemini-flash-latest-option" ...>
+//     <div class="truncate text-[13px]">gemini-flash-latest</div>
+//     <span class="sr-only">22 of 90</span>
+//   </div>
+//
+// The counter is invisible to a user but part of textContent, so `^model$` matched
+// nothing — and the helper reported that single negative observation as
+// `MODEL_NOT_AVAILABLE: … model may not be supported`, which every caller turns
+// into `test.skip`. One daily (run 31786538844) lost ~30 `@stable` tests that way,
+// with 35 skips against a 4–15 baseline as the only trace.
+//
+// So the property under test is NOT "the matcher works". It is: a model the picker
+// actually offers can only ever resolve to a LOUD failure — never to the skip
+// prefix. The fixtures below therefore carry the real dev26 markup, counter
+// included.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  enumerateModelOptions,
+  nearestModels,
+  resolveModelOption,
+  toModelOption,
+  type ModelOption,
+  type RawModelOption,
+} from "./model-option";
+
+/** Verbatim shape of a dev26 option, counter included. */
+function raw(provider: string, model: string, position: string, deprecated = false): RawModelOption {
+  return {
+    testId: `${provider}-${model}-option`,
+    value: `${provider}::${model}`,
+    visibleLabel: model,
+    rawText: `${model}\n${position}${deprecated ? "\nDeprecated" : ""}`,
+    deprecated,
+  };
+}
+
+function option(provider: string, model: string, position = "1 of 1"): ModelOption {
+  return toModelOption(raw(provider, model, position));
+}
+
+const DEV26_PICKER: ModelOption[] = [
+  option("Anthropic", "claude-opus-5", "1 of 90"),
+  option("Anthropic", "claude-haiku-4-5", "9 of 90"),
+  option("Google Generative AI", "gemini-flash-latest", "22 of 90"),
+  option("OpenAI", "gpt-4o-mini", "40 of 90"),
+  option("OpenAI", "gpt-4o-mini-search-preview", "41 of 90"),
+];
+
+test("toModelOption reads the identity from data-value, not from the text", () => {
+  const parsed = toModelOption(raw("Google Generative AI", "gemini-flash-latest", "22 of 90"));
+  assert.equal(parsed.provider, "Google Generative AI");
+  assert.equal(parsed.model, "gemini-flash-latest");
+  // The counter survives in rawText: it is evidence for the message, never a match key.
+  assert.equal(parsed.rawText, "gemini-flash-latest\n22 of 90");
+  assert.equal(parsed.visibleLabel, "gemini-flash-latest");
+});
+
+test("toModelOption falls back to the testid when data-value is gone", () => {
+  const parsed = toModelOption({
+    testId: "Anthropic-claude-haiku-4-5-option",
+    value: "",
+    visibleLabel: "claude-haiku-4-5",
+    rawText: "claude-haiku-4-5\n9 of 90",
+    deprecated: false,
+  });
+  assert.equal(parsed.provider, "Anthropic");
+  assert.equal(parsed.model, "claude-haiku-4-5");
+});
+
+test("toModelOption keeps a model id containing '::' intact", () => {
+  const parsed = toModelOption({
+    testId: "Ollama-llama3.2:1b-option",
+    value: "Ollama::llama3.2:1b",
+    visibleLabel: "llama3.2:1b",
+    rawText: "llama3.2:1b\n3 of 4",
+    deprecated: false,
+  });
+  assert.equal(parsed.model, "llama3.2:1b");
+});
+
+// The regression the whole file exists for.
+test("the dev26 counter no longer defeats the match", () => {
+  for (const model of ["claude-haiku-4-5", "gemini-flash-latest", "gpt-4o-mini"]) {
+    const verdict = resolveModelOption(model, DEV26_PICKER);
+    assert.equal(verdict.kind, "match", `${model} must resolve on a dev26 picker`);
+    if (verdict.kind === "match") assert.equal(verdict.option.model, model);
+  }
+});
+
+test("a longer model id is not matched by its prefix", () => {
+  const verdict = resolveModelOption("gpt-4o-mini", DEV26_PICKER);
+  assert.equal(verdict.kind, "match");
+  if (verdict.kind === "match") {
+    assert.equal(verdict.option.testId, "OpenAI-gpt-4o-mini-option");
+  }
+});
+
+test("an identity attribute that drifts FAILS loudly instead of skipping", () => {
+  // The #1459 break one layer deeper: the option is right there, labelled exactly
+  // as the test pinned it, but `data-value` now spells the id differently. The
+  // suite cannot establish an absence against its own evidence, so this is a
+  // failure — the outcome the old guard turned into `test.skip`.
+  const drifted: ModelOption = toModelOption({
+    testId: "Anthropic-claude-haiku-4-5-option",
+    value: "Anthropic::claude-haiku-4.5",
+    visibleLabel: "claude-haiku-4-5",
+    rawText: "claude-haiku-4-5\n9 of 90",
+    deprecated: false,
+  });
+  const verdict = resolveModelOption("claude-haiku-4-5", [drifted]);
+  assert.equal(verdict.kind, "unmatchable");
+  assert.ok(!verdict.message.startsWith("MODEL_NOT_AVAILABLE"), "must not carry the skip prefix");
+  assert.match(verdict.message, /IS offered by the model picker/);
+  assert.match(verdict.message, /visible label "claude-haiku-4-5"/);
+});
+
+test("a display label is a usable identity when the attributes are gone", () => {
+  // The complement of the test above, and the reason absence stays rare: with no
+  // parseable attribute left, the visible label still identifies the option and
+  // the testid still clicks it. Matching here is correct — failing loudly on a
+  // selectable model would be its own coverage loss.
+  const labelOnly = toModelOption({
+    testId: "model-option-9",
+    value: "",
+    visibleLabel: "claude-haiku-4-5",
+    rawText: "claude-haiku-4-5\n9 of 90",
+    deprecated: false,
+  });
+  const verdict = resolveModelOption("claude-haiku-4-5", [labelOnly]);
+  assert.equal(verdict.kind, "match");
+});
+
+test("a provider name carrying spaces still parses from the testid alone", () => {
+  const verdict = resolveModelOption("gemini-flash-latest", [
+    toModelOption({
+      testId: "Google Generative AI-gemini-flash-latest-option",
+      value: "",
+      visibleLabel: "gemini-flash-latest",
+      rawText: "gemini-flash-latest\n22 of 90",
+      deprecated: false,
+    }),
+  ]);
+  assert.equal(verdict.kind, "match");
+  if (verdict.kind === "match") assert.equal(verdict.option.provider, "Google Generative AI");
+});
+
+test("a model enabled in the provider panel but missing from the picker FAILS loudly", () => {
+  const verdict = resolveModelOption("claude-haiku-4-5", [option("OpenAI", "gpt-4o-mini")], {
+    enabledModels: ["claude-opus-5", "claude-haiku-4-5"],
+    providerLabel: "Anthropic",
+  });
+  assert.equal(verdict.kind, "unmatchable");
+  assert.ok(!verdict.message.startsWith("MODEL_NOT_AVAILABLE"));
+  assert.match(verdict.message, /llm-toggle-claude-haiku-4-5/);
+  assert.match(verdict.message, /1 option\(s\) enumerated/);
+});
+
+test("an EMPTY picker proves nothing and FAILS loudly", () => {
+  const verdict = resolveModelOption("claude-haiku-4-5", [], { providerLabel: "Anthropic" });
+  assert.equal(verdict.kind, "empty");
+  assert.ok(!verdict.message.startsWith("MODEL_NOT_AVAILABLE"));
+  assert.match(verdict.message, /ZERO options/);
+});
+
+test("an established absence skips, and the message carries what was seen", () => {
+  const verdict = resolveModelOption("claude-haiku-3-5", DEV26_PICKER, {
+    enabledModels: ["claude-opus-5", "claude-haiku-4-5"],
+    providerLabel: "Anthropic",
+  });
+  assert.equal(verdict.kind, "absent");
+  assert.ok(verdict.message.startsWith("MODEL_NOT_AVAILABLE: "), "callers key on this prefix");
+  // Evidence, not inference: how many options, from which providers, and what was
+  // offered instead. The pre-#1461 message asserted "model may not be supported"
+  // and named nothing it had checked.
+  assert.match(verdict.message, /5 enumerated option\(s\)/);
+  assert.match(verdict.message, /Anthropic: 2/);
+  assert.match(verdict.message, /2 provider toggle\(s\) observed/);
+  assert.match(verdict.message, /Nearest offered: claude-haiku-4-5/);
+  assert.ok(!/may not be supported/.test(verdict.message));
+});
+
+test("unobserved toggles are reported as unobserved, never as a negative", () => {
+  const verdict = resolveModelOption("claude-haiku-3-5", DEV26_PICKER);
+  assert.equal(verdict.kind, "absent");
+  assert.match(verdict.message, /provider toggles were not observed/);
+});
+
+test("nearestModels surfaces the rename candidates first", () => {
+  const nearest = nearestModels("claude-haiku-3-5", DEV26_PICKER);
+  assert.equal(nearest[0], "claude-haiku-4-5");
+  assert.ok(!nearest.includes("gpt-4o-mini-search-preview"));
+});
+
+// The `sr-only`-stripping half runs INSIDE the page (`Locator.evaluateAll`), so it
+// has no unit coverage here on purpose — replaying it against a hand-parsed string
+// would test the stand-in, not the shipped callback (#1017). Its live coverage is
+// the provider specs, whose pinned model only resolves when the strip works, plus
+// the force-fail that reverts it. What this file pins is the half a live spec
+// cannot reproduce on demand: the verdict.

--- a/tests/helpers/provider-setup/model-option.ts
+++ b/tests/helpers/provider-setup/model-option.ts
@@ -1,0 +1,335 @@
+import type { Locator, Page } from "@playwright/test";
+
+/**
+ * One entry of the unified ModelInput picker, read straight from the DOM.
+ *
+ * The frontend renders each option as
+ *
+ *   <div data-testid="${provider}-${model}-option" data-value="${provider}::${model}">
+ *     <svg/>                                     <- provider icon
+ *     <div class="truncate text-[13px]">${model}</div>
+ *     <span class="sr-only">${index} of ${total}</span>   <- 1.12.0.dev26+
+ *     <span data-testid="${model}-deprecated-badge">Deprecated</span>  <- optional
+ *     <svg/>                                     <- selected check
+ *   </div>
+ *
+ * so the option's *text* carries more than the model name, while `data-value`
+ * and `data-testid` carry the identity. Everything below reads the identity and
+ * treats the text as evidence only — the inverse of what the helpers did until
+ * #1459, where the `sr-only` position counter (added on dev26) silently defeated
+ * every `^model$` matcher.
+ */
+export type RawModelOption = {
+  /** `${provider}-${model}-option`, or "" when the attribute is gone. */
+  testId: string;
+  /** cmdk value, `${provider}::${model}` — the unambiguous identity. */
+  value: string;
+  /** Option text with `sr-only` and badge nodes removed: what a user reads. */
+  visibleLabel: string;
+  /** Full `textContent`, counter included — reported as evidence, never matched. */
+  rawText: string;
+  deprecated: boolean;
+};
+
+export type ModelOption = RawModelOption & {
+  /** Provider as the picker groups it ("Anthropic", "Google Generative AI"). */
+  provider: string | null;
+  /** Model id as the backend knows it ("claude-haiku-4-5"). */
+  model: string | null;
+};
+
+/**
+ * The verdict of looking for a pinned model in an open picker.
+ *
+ * `absent` is the ONLY outcome that may become a `test.skip`, and it is reached
+ * only when the picker was populated and neither it nor the provider panel
+ * knows the model. Every other outcome is loud: #1461 was filed because a single
+ * negative observation (one anchored matcher returning nothing) was reported as
+ * "model may not be supported" and skipped ~30 `@stable` tests in one daily.
+ */
+export type ModelOptionVerdict =
+  | { kind: "match"; option: ModelOption }
+  | { kind: "unmatchable"; message: string; evidence: string[] }
+  | { kind: "empty"; message: string }
+  | { kind: "absent"; message: string };
+
+export type ResolveContext = {
+  /**
+   * Model ids observed as `llm-toggle-<model>` in the provider panel, when the
+   * caller enabled them. The second independent source the picker can be
+   * contradicted by: a model enabled there but missing here is not an absence.
+   * `undefined` means "not observed" and is reported as such — an unobserved
+   * source must never read as a negative one (#1012).
+   */
+  enabledModels?: string[];
+  /** Provider the caller is configuring, for the message only. */
+  providerLabel?: string;
+};
+
+const MODEL_NOT_AVAILABLE = "MODEL_NOT_AVAILABLE";
+/**
+ * Deliberately NOT prefixed `MODEL_NOT_AVAILABLE`: every caller turns that
+ * prefix into `test.skip`, so a suite-side defect carrying it would be silent.
+ */
+const MODEL_PICKER_DEFECT = "MODEL_PICKER_DEFECT";
+
+/** Derives the model identity from the attributes, text last. */
+export function toModelOption(raw: RawModelOption): ModelOption {
+  const [valueProvider, ...valueRest] = raw.value.split("::");
+  if (raw.value.includes("::") && valueRest.join("::").trim()) {
+    return { ...raw, provider: valueProvider, model: valueRest.join("::") };
+  }
+
+  // No `data-value`: fall back to the testid. Both provider and model may carry
+  // "-", so the split is anchored on the "-option" suffix and the *first*
+  // separator only — good enough for evidence, and never used when data-value
+  // is present.
+  const withoutSuffix = raw.testId.replace(/-option$/, "");
+  const firstDash = withoutSuffix.indexOf("-");
+  if (raw.testId.endsWith("-option") && firstDash > 0) {
+    return {
+      ...raw,
+      provider: withoutSuffix.slice(0, firstDash),
+      model: withoutSuffix.slice(firstDash + 1),
+    };
+  }
+
+  // Neither attribute is usable — the visible label is all that is left, and it
+  // is reported as such rather than trusted as an identity.
+  return { ...raw, provider: null, model: raw.visibleLabel || null };
+}
+
+function providerCounts(options: ModelOption[]): string {
+  const counts = new Map<string, number>();
+  for (const option of options) {
+    const key = option.provider ?? "(unknown provider)";
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([provider, n]) => `${provider}: ${n}`).join(", ");
+}
+
+/**
+ * Models whose id is close enough that a human reading the failure can tell a
+ * rename from a retirement — the picker's own answer to "did you mean…".
+ */
+export function nearestModels(requested: string, options: ModelOption[], limit = 5): string[] {
+  const wanted = requested.toLowerCase();
+  const stem = wanted.split(/[-.:]/)[0] ?? wanted;
+  const scored = options
+    .map((option) => option.model ?? option.visibleLabel)
+    .filter((model): model is string => Boolean(model))
+    .map((model) => {
+      const lower = model.toLowerCase();
+      let score = 0;
+      if (lower === wanted) score = 100;
+      else if (lower.includes(wanted) || wanted.includes(lower)) score = 90;
+      else if (stem && lower.startsWith(stem)) score = 50 + sharedPrefix(lower, wanted);
+      else score = sharedPrefix(lower, wanted);
+      return { model, score };
+    })
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.model.localeCompare(b.model));
+
+  return scored.slice(0, limit).map((entry) => entry.model);
+}
+
+function sharedPrefix(a: string, b: string): number {
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return i;
+}
+
+/**
+ * Decides what an open picker actually proves about a pinned model.
+ *
+ * Pure on purpose: the branch that must never regress is "a model the picker
+ * offers can only ever resolve to a LOUD failure", and a unit test can pin that
+ * where a live spec cannot reproduce a markup change on demand.
+ */
+export function resolveModelOption(
+  requested: string,
+  options: ModelOption[],
+  context: ResolveContext = {},
+): ModelOptionVerdict {
+  const provider = context.providerLabel ? ` for ${context.providerLabel}` : "";
+
+  if (options.length === 0) {
+    return {
+      kind: "empty",
+      message:
+        `${MODEL_PICKER_DEFECT}: the model picker rendered ZERO options${provider}, so it ` +
+        `proves nothing about "${requested}". An empty picker means no provider is ` +
+        `configured (a rejected or drained API key leaves the credential unsaved) or the ` +
+        `list never loaded — not that the model is unsupported. Reported as a FAILURE, ` +
+        `not a skip: an unevaluated test is unknown, not clean (#1012/#1461).`,
+    };
+  }
+
+  const exact = options.find((option) => option.model === requested);
+  if (exact) return { kind: "match", option: exact };
+
+  // The model is in the picker but its identity did not parse — the exact shape
+  // of the #1459 break, one markup change later. Absence is contradicted by the
+  // picker itself, so this can never be a skip.
+  const evidence: string[] = [];
+  for (const option of options) {
+    if (option.visibleLabel === requested) {
+      evidence.push(`visible label "${option.visibleLabel}" (testid "${option.testId}")`);
+    } else if (option.testId.endsWith(`-${requested}-option`)) {
+      evidence.push(`testid "${option.testId}"`);
+    } else if (option.rawText.split("\n")[0]?.trim() === requested) {
+      evidence.push(`option text "${option.rawText.replace(/\n/g, "\\n")}"`);
+    }
+  }
+
+  if (evidence.length > 0) {
+    return {
+      kind: "unmatchable",
+      evidence,
+      message:
+        `${MODEL_PICKER_DEFECT}: "${requested}" IS offered by the model picker${provider} ` +
+        `but this suite could not select it — ${evidence.join("; ")}. ` +
+        `The model identity (data-value / data-testid) no longer resolves to the id the ` +
+        `test pinned, which is a suite defect, not a missing model. Reported as a FAILURE ` +
+        `so it cannot become a silent skip (#1461).`,
+    };
+  }
+
+  const enabled = context.enabledModels;
+  if (enabled?.includes(requested)) {
+    return {
+      kind: "unmatchable",
+      evidence: [`llm-toggle-${requested} in the provider panel`],
+      message:
+        `${MODEL_PICKER_DEFECT}: "${requested}" is ENABLED in the provider panel ` +
+        `(llm-toggle-${requested})${provider} but the model picker does not offer it — ` +
+        `${options.length} option(s) enumerated (${providerCounts(options)}). ` +
+        `The two sources disagree, so the model is not absent: either the picker did not ` +
+        `refresh after the panel closed, or the option list is filtered. Reported as a ` +
+        `FAILURE, not a skip (#1461).`,
+    };
+  }
+
+  const nearest = nearestModels(requested, options);
+  const toggleEvidence =
+    enabled === undefined
+      ? "provider toggles were not observed on this path"
+      : `${enabled.length} provider toggle(s) observed, none of them "${requested}"`;
+
+  return {
+    kind: "absent",
+    message:
+      `${MODEL_NOT_AVAILABLE}: "${requested}" is not offered${provider} — established from ` +
+      `${options.length} enumerated option(s) (${providerCounts(options)}) and ` +
+      `${toggleEvidence}. ` +
+      (nearest.length > 0 ? `Nearest offered: ${nearest.join(", ")}. ` : "") +
+      `The model was retired from the catalog or is not enabled for this account.`,
+  };
+}
+
+/**
+ * Reads every option of the OPEN model picker.
+ *
+ * `sr-only` and badge nodes are stripped inside the page so `visibleLabel` is
+ * what a user reads, while `rawText` keeps the polluted string for the failure
+ * message — the picker's own answer to "what did you actually see".
+ */
+export async function enumerateModelOptions(
+  page: Page,
+  timeout = 10000,
+): Promise<ModelOption[]> {
+  const options = page.locator('[data-testid$="-option"]');
+  await options.first().waitFor({ state: "visible", timeout }).catch(() => {});
+  return readModelOptions(options);
+}
+
+/**
+ * The same read over a caller-scoped locator — for pickers that are filtered to
+ * one provider (`setup-ollama`) and must not wait on the shared selector.
+ */
+export async function readModelOptions(options: Locator): Promise<ModelOption[]> {
+  const raw = await options.evaluateAll((els) =>
+    els.map((el) => {
+      const clone = el.cloneNode(true) as HTMLElement;
+      clone
+        .querySelectorAll('.sr-only, [data-testid$="-deprecated-badge"]')
+        .forEach((node) => node.remove());
+      return {
+        testId: el.getAttribute("data-testid") ?? "",
+        value: el.getAttribute("data-value") ?? "",
+        visibleLabel: (clone.textContent ?? "").trim(),
+        rawText: (el.textContent ?? "").trim(),
+        deprecated: el.querySelector('[data-testid$="-deprecated-badge"]') !== null,
+      };
+    }),
+  );
+
+  return raw.map(toModelOption);
+}
+
+/** Model ids of the provider panel's toggles — the second source of truth. */
+export async function enumerateEnabledModels(page: Page): Promise<string[]> {
+  const ids = await page
+    .locator('[data-testid^="llm-toggle-"]')
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-testid") ?? ""));
+  return ids.map((id) => id.replace(/^llm-toggle-/, "")).filter(Boolean);
+}
+
+/**
+ * Clicks an enumerated option by identity.
+ *
+ * Prefers the testid and falls back to the cmdk value, so a build that drops one
+ * attribute is still selectable instead of degrading into a false absence.
+ */
+export async function clickModelOption(page: Page, option: ModelOption): Promise<void> {
+  const locator = option.testId
+    ? page.getByTestId(option.testId)
+    : page.locator(`[data-testid$="-option"][data-value="${option.value.replace(/"/g, '\\"')}"]`);
+  await locator.first().click();
+}
+
+export type PinnedSelection =
+  | { status: "selected"; model: string }
+  | { status: "absent"; message: string };
+
+/**
+ * Selects a pinned model in the OPEN picker, or reports what the picker proved.
+ *
+ * Loud verdicts (`empty`, `unmatchable`) always throw: they are the suite's own
+ * defects and must never reach a caller that would skip on them. Only an
+ * *established* absence is handed back, and even then the caller decides —
+ * `absentBehavior: "return"` exists for `setup-openai`'s `fallbackToRanking`
+ * consumers (#606), which must degrade rather than fail on a stale pin.
+ */
+export async function selectPinnedModelOption(
+  page: Page,
+  opts: {
+    requested: string;
+    enabledModels?: string[];
+    providerLabel?: string;
+    absentBehavior?: "throw" | "return";
+    timeout?: number;
+  },
+): Promise<PinnedSelection> {
+  const options = await enumerateModelOptions(page, opts.timeout ?? 10000);
+  const verdict = resolveModelOption(opts.requested, options, {
+    enabledModels: opts.enabledModels,
+    providerLabel: opts.providerLabel,
+  });
+
+  if (verdict.kind === "match") {
+    await clickModelOption(page, verdict.option);
+    return { status: "selected", model: verdict.option.model ?? opts.requested };
+  }
+
+  await page.keyboard.press("Escape");
+
+  if (verdict.kind === "absent") {
+    if ((opts.absentBehavior ?? "throw") === "return") {
+      return { status: "absent", message: verdict.message };
+    }
+    throw new Error(verdict.message);
+  }
+
+  throw new Error(verdict.message);
+}

--- a/tests/helpers/provider-setup/setup-anthropic.ts
+++ b/tests/helpers/provider-setup/setup-anthropic.ts
@@ -1,5 +1,11 @@
 import type { Page } from "@playwright/test";
 import { hideInspectorPanel } from "../ui/hide-inspector-panel";
+import {
+  clickModelOption,
+  enumerateEnabledModels,
+  enumerateModelOptions,
+  selectPinnedModelOption,
+} from "./model-option";
 
 export async function setupAnthropic(
   page: Page,
@@ -77,6 +83,11 @@ export async function setupAnthropic(
     }
   }
 
+  // Read the panel's toggles BEFORE closing it: they are the second, independent
+  // source for "this model exists and is enabled", and a picker miss that this
+  // list contradicts is not an absence (#1461).
+  const enabledModels = await enumerateEnabledModels(page);
+
   // Step 6: Close the provider management panel
   await page.getByRole("button", { name: "Close" }).click();
 
@@ -84,15 +95,26 @@ export async function setupAnthropic(
   await hideInspectorPanel(page);
   await page.getByTestId("model_model").click();
   if (modelTestId) {
-    const modelOption = page.locator('[data-testid$="-option"]', { hasText: new RegExp(`^${modelTestId}$`) });
-    const isAvailable = await modelOption.isVisible({ timeout: 10000 }).catch(() => false);
-    if (!isAvailable) {
-      await page.keyboard.press("Escape");
-      throw new Error(`MODEL_NOT_AVAILABLE: "${modelTestId}" not found in dropdown — model may not be supported.`);
-    }
-    await modelOption.click();
+    // Resolved by option IDENTITY (data-value / data-testid), never by the option's
+    // text: 1.12.0.dev26 renders a `sr-only` "N of M" counter inside each option, so
+    // the anchored `^model$` text matcher this used to run matched nothing and the
+    // helper reported a model it could not match as one that does not exist (#1459).
+    await selectPinnedModelOption(page, {
+      requested: modelTestId,
+      enabledModels,
+      providerLabel: "Anthropic",
+    });
   } else {
-    await page.locator('[data-testid$="-option"]', { hasText: "claude" }).first().waitFor({ state: "visible", timeout: 10000 });
-    await page.locator('[data-testid$="-option"]', { hasText: "claude" }).first().click();
+    const options = await enumerateModelOptions(page);
+    const claude = options.find((option) => (option.model ?? "").includes("claude"));
+    if (!claude) {
+      await page.keyboard.press("Escape");
+      throw new Error(
+        `MODEL_NOT_AVAILABLE: the model picker offers no Anthropic model — ` +
+          `${options.length} option(s) enumerated: ` +
+          `${options.map((option) => option.model ?? option.visibleLabel).join(", ") || "(none)"}.`,
+      );
+    }
+    await clickModelOption(page, claude);
   }
 }

--- a/tests/helpers/provider-setup/setup-google.ts
+++ b/tests/helpers/provider-setup/setup-google.ts
@@ -1,5 +1,11 @@
 import type { Page } from "@playwright/test";
 import { hideInspectorPanel } from "../ui/hide-inspector-panel";
+import {
+  clickModelOption,
+  enumerateEnabledModels,
+  enumerateModelOptions,
+  selectPinnedModelOption,
+} from "./model-option";
 import { providerAlreadyConfigured } from "./provider-config-state";
 
 export async function setupGoogle(
@@ -111,6 +117,11 @@ export async function setupGoogle(
     }
   }
 
+  // Read the panel's toggles BEFORE closing it: they are the second, independent
+  // source for "this model exists and is enabled", and a picker miss that this
+  // list contradicts is not an absence (#1461).
+  const enabledModels = await enumerateEnabledModels(page);
+
   // Step 6: Close the provider management panel
   await page.getByRole("button", { name: "Close" }).click();
 
@@ -118,15 +129,27 @@ export async function setupGoogle(
   await hideInspectorPanel(page);
   await page.getByTestId("model_model").click();
   if (modelTestId) {
-    const modelOption = page.locator('[data-testid$="-option"]', { hasText: new RegExp(`^${modelTestId}$`) });
-    const isAvailable = await modelOption.isVisible({ timeout: 10000 }).catch(() => false);
-    if (!isAvailable) {
-      await page.keyboard.press("Escape");
-      throw new Error(`MODEL_NOT_AVAILABLE: "${modelTestId}" not found in dropdown — model may not be supported.`);
-    }
-    await modelOption.click();
+    // Resolved by option IDENTITY (data-value / data-testid), never by the option's
+    // text: 1.12.0.dev26 renders a `sr-only` "N of M" counter inside each option, so
+    // the anchored `^model$` text matcher this used to run matched nothing — the
+    // hard failure of `language-model-regression.spec.ts` on the 2026-08-14 daily,
+    // whose trace shows the model present at option 22 of 90 (#1459).
+    await selectPinnedModelOption(page, {
+      requested: modelTestId,
+      enabledModels,
+      providerLabel: "Google Generative AI",
+    });
   } else {
-    await page.locator('[data-testid$="-option"]', { hasText: "gemini" }).first().waitFor({ state: "visible", timeout: 10000 });
-    await page.locator('[data-testid$="-option"]', { hasText: "gemini" }).first().click();
+    const options = await enumerateModelOptions(page);
+    const gemini = options.find((option) => (option.model ?? "").includes("gemini"));
+    if (!gemini) {
+      await page.keyboard.press("Escape");
+      throw new Error(
+        `MODEL_NOT_AVAILABLE: the model picker offers no Google model — ` +
+          `${options.length} option(s) enumerated: ` +
+          `${options.map((option) => option.model ?? option.visibleLabel).join(", ") || "(none)"}.`,
+      );
+    }
+    await clickModelOption(page, gemini);
   }
 }

--- a/tests/helpers/provider-setup/setup-language-model-openai.ts
+++ b/tests/helpers/provider-setup/setup-language-model-openai.ts
@@ -1,4 +1,5 @@
 import { type Locator, type Page, expect } from "@playwright/test";
+import { enumerateModelOptions } from "./model-option";
 
 // Cheap, fast chat models in priority order. `gpt-4o-mini` is kept first so older
 // Langflow builds still match; the `gpt-5.x` entries cover newer builds (1.11.0+)
@@ -27,10 +28,6 @@ const NON_CHAT_MODEL = /image|embedding|audio|tts|realtime|whisper|dall-?e|moder
 // slow/empty reasoning response reintroduces the 120s timeout and masks assertions.
 const AVOID_MODEL = /(^|[-\s])(pro|o1|o3|o4)([-\s]|$)|codex|deep-research|search-preview/i;
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 // Selects a usable OpenAI chat model from the already-open `model_model` dropdown.
 // Resolution order: MODEL_TEST_ID env override → first available preferred model →
 // first option that is neither a non-chat nor an avoided (pro/reasoning) model.
@@ -38,11 +35,14 @@ function escapeRegExp(value: string): string {
 // actually reflects the choice — a silently-intercepted click (the api_key popover can
 // steal the click) would otherwise leave the node on its default (`gpt-5.5-pro`).
 async function selectPreferredChatModel(page: Page): Promise<void> {
-  const options = page.locator('[data-testid$="-option"]');
-  await options.first().waitFor({ state: "visible", timeout: 15000 });
-
-  const labels = (await options.allInnerTexts())
-    .map((label) => label.trim())
+  // Read the options by IDENTITY (data-value / data-testid), not by their rendered
+  // text: since 1.12.0.dev26 each option carries a `sr-only` "N of M" counter, so
+  // `allInnerTexts()` returned "claude-opus-5\n1 of 69" and the anchored click below
+  // could never resolve — the 20s timeout of `memory-history-regression.spec.ts` on
+  // the 2026-08-14 daily (#1459).
+  const entries = await enumerateModelOptions(page, 15000);
+  const labels = entries
+    .map((option) => (option.model ?? option.visibleLabel).trim())
     .filter(Boolean);
 
   const envModel = process.env.MODEL_TEST_ID?.trim();
@@ -55,14 +55,13 @@ async function selectPreferredChatModel(page: Page): Promise<void> {
     // that fallback used to hand back a non-OpenAI model from a helper named
     // `...OpenAI` whenever PREFERRED_CHAT_MODELS drifted behind the build's
     // curated list (issue #961).
-    // A multi-line label carries a badge rendered inside the option (e.g.
-    // "Deprecated"): skip it. Unlike the exact-match PREFERRED lookup above,
-    // this pattern-based branch would otherwise put the badge text into
-    // `chosen` and break the trigger assertion below — and a deprecated model
-    // is not what a regression run wants either.
+    // A deprecated model is not what a regression run wants: it used to be excluded
+    // by rejecting a multi-line label (the badge renders inside the option), a test
+    // that dev26's counter made true for EVERY option. The badge is now read from
+    // the DOM instead, so the exclusion states what it means.
     labels.find(
-      (label) =>
-        !label.includes("\n") &&
+      (label, index) =>
+        !entries[index].deprecated &&
         /^gpt-/i.test(label) &&
         !NON_CHAT_MODEL.test(label) &&
         !AVOID_MODEL.test(label),
@@ -72,14 +71,23 @@ async function selectPreferredChatModel(page: Page): Promise<void> {
   if (!chosen) {
     await page.keyboard.press("Escape");
     throw new Error(
-      `No usable OpenAI chat model found in the model dropdown. Options: ${labels.join(", ")}`,
+      `No usable OpenAI chat model found in the model dropdown. ` +
+        `${entries.length} option(s) enumerated: ${labels.join(", ") || "(none)"}`,
     );
   }
 
-  await options
-    .filter({ hasText: new RegExp(`^${escapeRegExp(chosen)}$`) })
-    .first()
-    .click();
+  const chosenEntry = entries.find(
+    (option, index) => labels[index] === chosen && Boolean(option.testId),
+  );
+  if (!chosenEntry) {
+    await page.keyboard.press("Escape");
+    throw new Error(
+      `MODEL_PICKER_DEFECT: "${chosen}" was ranked from the picker's own options but no ` +
+        `option carries a usable testid to click. Reported as a FAILURE so a picker the ` +
+        `suite cannot drive never resolves into a silent default (#1461).`,
+    );
+  }
+  await page.getByTestId(chosenEntry.testId).click();
 
   await expect(page.getByTestId("model_model")).toContainText(chosen, { timeout: 10000 });
 }
@@ -244,19 +252,13 @@ async function optionAppeared(option: Locator): Promise<boolean> {
 // list: a saturated runner that takes >5s to populate it must be waited out, not
 // mistaken for "OpenAI is missing" (which would trigger a pointless panel detour).
 async function isOpenAIOffered(page: Page): Promise<boolean> {
-  const options = page.locator('[data-testid$="-option"]');
-  await options
-    .first()
-    .waitFor({ state: "visible", timeout: 15000 })
-    .catch(() => {});
+  const entries = await enumerateModelOptions(page, 15000);
+  if (entries.some((option) => /^openai$/i.test(option.provider ?? ""))) return true;
+  if (entries.some((option) => /^openai-/i.test(option.testId))) return true;
 
-  const testIds = await options.evaluateAll((els) =>
-    els.map((el) => el.getAttribute("data-testid") ?? ""),
-  );
-  if (testIds.some((id) => /^openai-/i.test(id))) return true;
-
-  const labels = await options.allInnerTexts();
-  return labels.some((label) => /^gpt-/i.test(label.trim()));
+  // Label fallback, read from the option's identity rather than its text: the
+  // rendered text carries the dev26 position counter (#1459).
+  return entries.some((option) => /^gpt-/i.test((option.model ?? option.visibleLabel).trim()));
 }
 
 // Opens the model dropdown's "Manage Model Providers" panel, configures the

--- a/tests/helpers/provider-setup/setup-ollama.ts
+++ b/tests/helpers/provider-setup/setup-ollama.ts
@@ -1,9 +1,26 @@
 import type { Page } from "@playwright/test";
 import { hideInspectorPanel } from "../ui/hide-inspector-panel";
 import { providerConfigMap } from "./provider-config";
+import { readModelOptions } from "./model-option";
 import { ollamaBaseUrlFromLangflow } from "./ollama-endpoint";
 
 const OLLAMA = providerConfigMap.ollama;
+
+/**
+ * The Ollama tags the picker currently offers, read from each option's identity.
+ *
+ * This list is EVIDENCE in the failure messages below, and reading it as text was
+ * wrong for the same reason the keyed helpers' matchers were (#1459): since
+ * 1.12.0.dev26 every option's text ends with a `sr-only` "N of M" counter, so the
+ * message would have offered `llama3.2:1b\n3 of 4` as the tag to pull. The
+ * selection itself was never affected — it has always matched by testid.
+ */
+async function readOfferedOllamaModels(page: Page): Promise<string[]> {
+  const options = await readModelOptions(
+    page.locator('[data-testid^="Ollama-"][data-testid$="-option"]'),
+  ).catch(() => []);
+  return options.map((option) => option.model ?? option.visibleLabel).filter(Boolean);
+}
 
 /**
  * Point the Agent node at a model served by the LOCAL Ollama instance (#1187).
@@ -218,10 +235,7 @@ export async function setupOllama(page: Page, modelTestId?: string): Promise<voi
   let isAvailable = await option.isVisible({ timeout: 10000 }).catch(() => false);
   let offered = isAvailable
     ? []
-    : await page
-        .locator('[data-testid^="Ollama-"][data-testid$="-option"]')
-        .allTextContents()
-        .catch(() => [] as string[]);
+    : await readOfferedOllamaModels(page);
 
   // One re-read before deciding, and ONLY when the list came back empty. The
   // dropdown's options are fetched, so "no options yet" and "no options at all"
@@ -238,12 +252,7 @@ export async function setupOllama(page: Page, modelTestId?: string): Promise<voi
     await hideInspectorPanel(page);
     await page.getByTestId("model_model").click().catch(() => {});
     isAvailable = await option.isVisible({ timeout: 15000 }).catch(() => false);
-    offered = isAvailable
-      ? []
-      : await page
-          .locator('[data-testid^="Ollama-"][data-testid$="-option"]')
-          .allTextContents()
-          .catch(() => [] as string[]);
+    offered = isAvailable ? [] : await readOfferedOllamaModels(page);
   }
 
   if (!isAvailable) {

--- a/tests/helpers/provider-setup/setup-openai.ts
+++ b/tests/helpers/provider-setup/setup-openai.ts
@@ -1,5 +1,11 @@
 import type { Page } from "@playwright/test";
 import { hideInspectorPanel } from "../ui/hide-inspector-panel";
+import {
+  clickModelOption,
+  enumerateEnabledModels,
+  enumerateModelOptions,
+  selectPinnedModelOption,
+} from "./model-option";
 
 export async function setupOpenAI(
   page: Page,
@@ -89,6 +95,11 @@ export async function setupOpenAI(
     }
   }
 
+  // Read the panel's toggles BEFORE closing it: they are the second, independent
+  // source for "this model exists and is enabled", and a picker miss that this
+  // list contradicts is not an absence (#1461).
+  const enabledModels = await enumerateEnabledModels(page);
+
   // Step 6: Close the provider management panel
   await page.getByRole("button", { name: "Close" }).click();
 
@@ -104,18 +115,30 @@ export async function setupOpenAI(
   await modelTrigger.click();
   let pickByRanking = !modelTestId;
   if (modelTestId) {
-    const modelOption = page.locator('[data-testid$="-option"]', { hasText: new RegExp(`^${modelTestId}$`) });
-    const isAvailable = await modelOption.isVisible({ timeout: 10000 }).catch(() => false);
-    if (isAvailable) {
-      await modelOption.click();
-    } else if (opts?.fallbackToRanking) {
+    // Resolved by option IDENTITY (data-value / data-testid), never by the option's
+    // text: 1.12.0.dev26 renders a `sr-only` "N of M" counter inside each option, so
+    // the anchored `^model$` text matcher this used to run matched nothing (#1459).
+    //
+    // `fallbackToRanking` degrades on an ESTABLISHED absence only — a stale pin from
+    // models.json is what #606 asked it to survive. A picker that is empty, or that
+    // offers the model without letting the suite select it, throws through this call:
+    // degrading there would hide a suite defect behind a healthy-looking run (#1461).
+    const selection = await selectPinnedModelOption(page, {
+      requested: modelTestId,
+      enabledModels,
+      providerLabel: "OpenAI",
+      absentBehavior: opts?.fallbackToRanking ? "return" : "throw",
+    });
+    if (selection.status === "absent") {
       console.log(
-        `pinned model "${modelTestId}" not in the live dropdown — falling back to UI preference-ranking (#606)`,
+        `pinned model "${modelTestId}" is not offered by the live dropdown — falling back to ` +
+          `UI preference-ranking (#606). ${selection.message}`,
       );
       pickByRanking = true;
-    } else {
-      await page.keyboard.press("Escape");
-      throw new Error(`MODEL_NOT_AVAILABLE: "${modelTestId}" not found in dropdown — model may not be supported.`);
+      // The Escape that reported the absence closed the dropdown; reopen it for the
+      // ranking pass below.
+      await modelTrigger.waitFor({ state: "visible", timeout: 15000 });
+      await modelTrigger.click();
     }
   }
   if (pickByRanking) {
@@ -127,15 +150,22 @@ export async function setupOpenAI(
     // vision-capable — callers like the agent image test rely on that — while
     // surviving model-family churn and skipping the slow/expensive
     // "pro"/reasoning models that tend to top the dropdown.
-    const options = page.locator('[data-testid$="-option"]');
-    await options.first().waitFor({ state: "visible", timeout: 10000 });
-    const count = await options.count();
-    // Lower-case each label so matching is case-insensitive: textContent may
-    // carry display casing (e.g. "GPT-4o Mini") that plain includes() would miss.
-    const labels: string[] = [];
-    for (let i = 0; i < count; i++) {
-      labels.push(((await options.nth(i).textContent()) ?? "").trim().toLowerCase());
+    // Ranked over the option IDENTITY, not its rendered text: since dev26 the text
+    // carries a `sr-only` "N of M" counter, so `textContent` is no longer the model
+    // name (#1459). Lower-cased so matching survives display casing.
+    const optionEntries = await enumerateModelOptions(page);
+    if (optionEntries.length === 0) {
+      await page.keyboard.press("Escape");
+      throw new Error(
+        "MODEL_PICKER_DEFECT: the model picker rendered ZERO options after configuring " +
+          "OpenAI, so no model could be ranked. An empty picker means the credential was " +
+          "not saved (a rejected or drained key) or the list never loaded — reported as a " +
+          "FAILURE, not a silent default (#1461).",
+      );
     }
+    const labels = optionEntries.map((option) =>
+      (option.model ?? option.visibleLabel).trim().toLowerCase(),
+    );
 
     // Reject families that are NOT general-purpose vision chat models: reasoning
     // (o1/o3/o4…), audio/realtime/tts/transcribe, search-preview and nano
@@ -164,6 +194,6 @@ export async function setupOpenAI(
     }
     if (chosenIndex === -1) chosenIndex = 0; // no preferred match — first available
 
-    await options.nth(chosenIndex).click();
+    await clickModelOption(page, optionEntries[chosenIndex]);
   }
 }

--- a/tests/tests-automations/regression/core-functionality/llm-agents/CLAUDE.md
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/CLAUDE.md
@@ -71,6 +71,24 @@ try {
 }
 ```
 
+**Catch that prefix and nothing else.** `MODEL_NOT_AVAILABLE` now means an
+absence the helper *established*: it enumerated the picker, the model was not
+among the options, and the provider panel did not list it either — the message
+carries the option count, the per-provider breakdown and the nearest offered
+ids. A model the picker IS offering but the suite cannot select raises
+`MODEL_PICKER_DEFECT` instead, which no spec may skip on: that is our defect,
+and it must fail. An **empty** picker raises it too — zero options prove nothing
+about a model, so they can never justify a skip (#1461).
+
+Why the split exists: until #1459 the three provider helpers resolved a pinned
+model with `hasText: /^model$/`, and 1.12.0.dev26 added a `sr-only` "N of M"
+counter inside every option. The matcher stopped matching, the guard reported
+"model may not be supported", and one daily lost ~30 `@stable` tests to
+`test.skip` — with the run's skip total (35 against a 4–15 baseline) as the only
+trace. Resolve a model through
+`tests/helpers/provider-setup/model-option.ts` (identity from `data-value` /
+`data-testid`), never through the option's rendered text.
+
 ### 5. Run with --workers=1
 
 ```bash

--- a/tests/tests-automations/regression/core-functionality/model-provider/anthropic-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/anthropic-provider.spec.ts
@@ -13,6 +13,7 @@ import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
 } from "../../../../helpers/provider-setup";
+import { selectPinnedModelOption } from "../../../../helpers/provider-setup/model-option";
 import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 /**
@@ -163,11 +164,12 @@ async function runPlaygroundSentinel(page: Page, token: string): Promise<void> {
 async function switchModel(page: Page, model: string): Promise<void> {
   await hideInspectorPanel(page);
   await page.getByTestId("model_model").click();
-  const option = page.locator('[data-testid$="-option"]', {
-    hasText: new RegExp(`^${model}$`),
-  });
-  await option.waitFor({ state: "visible", timeout: 10000 });
-  await option.click();
+  // Matched on the option's IDENTITY, not its text: since 1.12.0.dev26 every option
+  // carries a `sr-only` "N of M" counter, so the anchored `^model$` text match this
+  // used to run resolved nothing and timed out on a model the picker was showing
+  // (#1459). The shared resolver also fails loudly when the model IS offered but
+  // cannot be selected, instead of reporting it as unsupported (#1461).
+  await selectPinnedModelOption(page, { requested: model, providerLabel: "Anthropic" });
   await expect(page.getByTestId("value-dropdown-model_model")).toContainText(
     model,
     { timeout: 10000 },


### PR DESCRIPTION
Closes #1461
Closes #1459

## Problem

`MODEL_NOT_AVAILABLE` asserted a cause it never checked.

On [run 31786538844](https://github.com/oriontech-me/langflow-e2e/actions/runs/31786538844) (2026-08-14, `1.12.0.dev26`) the daily reported 4 failures — and lost **~30 `@stable` tests to silent skips**, all through the same primitive. The run's skip total (35, against a 4–15 baseline since 2026-07-30) was the only trace it left, and that is the field nobody watches.

**Trigger (upstream, legitimate).** dev26 added a per-option accessibility counter to the unified ModelInput picker. Read from the frontend bundle (`index-JOT9mUHU.js`):

```jsx
<div className="truncate text-[13px]">{f.name}</div>
<span className="sr-only">{o("modelInput.optionPosition", { current: c, total: a })}</span>
```

so an option's `textContent` became `"claude-haiku-4-5\n9 of 90"`. The identity attributes are unchanged (`data-value="Provider::model"`, `data-testid="Provider-model-option"`).

**Layer 1 — the matcher (#1459).** `setup-google` / `setup-openai` / `setup-anthropic` resolved a pinned model with `locator('[data-testid$="-option"]', { hasText: new RegExp('^' + model + '$') })`, and `setup-language-model-openai` read labels with `allInnerTexts()`. All of them stopped matching.

**Layer 2 — the guard (#1461).** The miss was reported as `MODEL_NOT_AVAILABLE: "<id>" not found in dropdown — model may not be supported.` Every caller turns that prefix into `test.skip`, so a broken matcher resolved to a green run. The trace of the one call site that throws instead shows the model **present, at option 22 of 90**.

## Change

Model options are resolved through a new shared module, `tests/helpers/provider-setup/model-option.ts`, by **identity** (`data-value` → `data-testid` fallback), never by rendered text. The verdict is split so only one outcome can become a skip:

| Verdict | When | Consequence |
|---|---|---|
| `match` | identity resolves | clicks by testid (falls back to `data-value`) |
| `absent` | the picker was enumerated **and** the model is in neither the options nor the provider panel's `llm-toggle-*` list | `MODEL_NOT_AVAILABLE` → skip. The message now carries the option count, the per-provider breakdown and the nearest offered ids |
| `unmatchable` | the picker offers the model (or the panel has its toggle) but the suite cannot select it | `MODEL_PICKER_DEFECT` → **fails**. That is our defect, not a missing model |
| `empty` | zero options rendered | `MODEL_PICKER_DEFECT` → **fails**. Zero options prove nothing about a model (#1012) |

Wired into all five helpers. Notes on the two non-obvious ones:

- **`setup-openai`'s `fallbackToRanking` (#606) still degrades on a stale `models.json` pin — but only for an ESTABLISHED absence.** An empty picker, or one that offers the model without letting us select it, throws through it: degrading there would hide a suite defect behind a healthy-looking run.
- **`setup-ollama` already matched by testid**, so its selection was never affected. Only its evidence strings changed — a failure no longer offers `llama3.2:1b\n3 of 4` as the tag to pull.

One spec-local matcher of the same shape is migrated with them: `anthropic-provider.spec.ts`'s `switchModel`, which was **masked** by the skip wave (the file skipped before reaching it) and goes red the moment the helper works again.

## Validation

- **Langflow `1.12.0.dev26`** — the build the daily ran, pulled and started on port 7861. `dev25` (the local default) has no counter, which is why this only surfaced on 2026-08-14.
- `anthropic-provider.spec.ts` — **3/3 clean** at `--retries=0 --workers=1`.
- `language-model-regression.spec.ts` (the issue's hard failure) — **3/3 clean**; its Google test passes. The two OpenAI tests skip locally on a drained key.
- `npm run test:units` — **655 pass**, including 13 new ones whose fixtures carry the real dev26 markup, counter included.
- `npm run typecheck` — 0. `npm run lint` — 0 errors.

**Force-fail (executed, red observed, revert proved, final green run):**

- `Anthropic API key is configured via Settings → Model Providers` — commented out the Save click, so neither armed waiter fires → failed.
- `configured Anthropic selects a Claude model in the Agent and executes the flow` — asserted `/gemini/i` on the model trigger instead of `/claude/i` → failed.
- `switches between Claude model families (Haiku → Sonnet → Opus)` — **restored the pre-#1459 anchored text matcher**, so the dev26 counter defeats it → failed. This is the force-fail for the fix itself.
- Unit lane, 4 mutations: matching on `rawText`; renaming `MODEL_PICKER_DEFECT` to the skip prefix; degrading `empty` to `absent`; ignoring the toggle source. Each killed exactly the tests that cover it; revert → 13/13 green.

One backend error was declared ambient in the pipeline record: a `500` on `DELETE /api/v1/flows/{id}` from the spec's own id-scoped cleanup, the known local SQLite-lock class under Colima. It appeared in a run where all 3 tests passed, and not in two earlier runs of the same code; this diff touches no cleanup path, and the fixture treats HTTP errors as advisory (#1084).

## Scope — what is deliberately NOT here

- **`mcp-client-agent.spec.ts`** carries the same anchored matcher, and its fix is not in this PR because it **cannot be validated on this machine**: it dies on `GET /api/v2/mcp/servers?action_count=true` (20 s) both **with and without** this diff — baseline identical, 38.37 s vs 38.36 s, the #1266 class where that call starts every registered MCP server. Left at today's behavior (the matcher misses and the spec falls back to the shared provider setup), tracked for #1459's remaining half rather than shipped unproven.
- **`modelInputComponent.spec.ts` / `memory-base-registration.spec.ts`** — the spec-local half, owned by #1460.
- **Gating the run's skip total** (the issue's item c) — out of scope, with the reason: once the guard stops inferring absence, a silent skip is no longer this defect's channel, and a totals gate belongs to the run-integrity mechanism (`scripts/check-run-integrity.mjs`), not to a provider helper.
- **`setup-openai` / `setup-language-model-openai` have no live local coverage in this PR** — the local `OPENAI_API_KEY` is drained (`no credits remaining`), so those paths were exercised only through the unit lane here; CI covers them.

## Found on the way (not fixed here)

`model-provider-model-toggle.spec.ts` derives the model name as `testid.replace(/-option$/, "")`, which yields `Anthropic-claude-haiku-4-5` while the toggles yield `claude-haiku-4-5` — so `targetModel` is always empty and the test **skips on every run** (it is the `"No non-selected dropdown option belongs to the test's provider"` skip in the same daily). Its negative assertion is anchored on the option text too, so it would pass vacuously even if it ran. Worth its own issue: fixing it wakes an assertion that has never executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
