### PR TITLE
fix(core-components): confirm the sidebar kept the search term before waiting for its row (#1468)

### DIFF
--- a/docs/core-components/chat-input-output-component-regression.md
+++ b/docs/core-components/chat-input-output-component-regression.md
@@ -1,6 +1,6 @@
 # Chat Input / Chat Output Components — Regression
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev7`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev30`)
 
 ---
 
@@ -25,7 +25,9 @@ If any of these tests fails, one of the two endpoints of the Playground is broke
 
 `@stable` `@regression` `@components`
 
-All 6 tests carry `@stable` per the project rule "spec is born 100% @stable; tag is removed per-test only during weekly triage".
+5 of the 6 tests carry `@stable` per the project rule "spec is born 100% @stable; tag is removed per-test only during weekly triage".
+
+Test 1 is the exception: it is `test.fixme` and untagged, quarantined at the triage of daily #1417 for the swallowed sidebar **click** (the click lands and no node is placed). Lifting it is a deliverable of **#1423**, not of this spec's own work. Test 6's `@stable` was auto-removed by the daily workflow for #1468 and is restored here, re-validated on `1.12.0.dev30`.
 
 ---
 
@@ -142,4 +144,8 @@ All 6 tests carry `@stable` per the project rule "spec is born 100% @stable; tag
 
 - Test 5 deliberately validates the override through the **Playground** rather than the canvas-side output-inspection dialog, because the dialog renders a Message as plain text (no metadata fields exposed in `textContent`). The Playground's `chat-message-{sender_name}-{text}` testid is the user-visible surface where the override actually shows up.
 - Test 6 validates the defaults at the **inspector level** (the field value) rather than running the flow. The field value is the upstream of any runtime behavior — this avoids the same dialog-rendering limitation as test 5 while still catching a regression in the constants.
+- **The sidebar add is guarded on two axes, and both guards exist because a measurement demanded them (#1468).** Every add here goes through `openBlankFlowFromModal` and `fillSidebarSearch` instead of clicking `blank-flow` and filling `sidebar-search-input` inline. Measured on nightly `1.12.0.dev30` with four harnesses driving one backend — **31 failures in 348 adds (8.9 %)**, and **0 in 30** on a quiet instance, which is why none of this reproduces locally. The failures split into two modes with distinct observables:
+  - **The templates modal never closes** (9 of 21 tabulated; `role="dialog"` present, absent in all 16 measured successes; `400 POST /api/v1/flows/` in 6 of the 9 — the "flow must be unique" collision, which `mode: "serial"` cannot prevent because it is across the daily's shards, not within this file). The sidebar is then covered and the fill times out. This mode hits the guarded and unguarded fills alike, which is why it — not the remount — is the likeliest cause of test 6's hard failure on the 2026-08-17 daily.
+  - **The sidebar remounts and discards the typed term** (12 of 21, **all** of them on a fill issued with no prior wait for the input to be visible, **0** on a guarded fill). An in-page probe sampling every animation frame recorded the input node ABSENT at ~102 ms and a NEW empty one at ~156 ms. Since 1.12 a component row only exists in the DOM under a filter, so `input_output<Display Name>` never appears and the wait ends as `element(s) not found` with no add attempted.
+  Neither mode is slowness: re-typing into the remounted input recovered 0 of 4, a reload 4 of 4, and a raised timeout reaches neither. After the two guards: **0 failures in 200 adds** under the same load, including two paired rounds run in the same window as the unguarded harness (0/80 against 3/80). The reload repair inside `fillSidebarSearch` never fired in those 200 — the barrier is what carries the fix, and the repair is a fallback covered by unit tests only.
 - The original issue (#184) framed test 6 as "default sender uses authenticated username when `sender_name` is empty"; the actual upstream behavior (verified against `lfx/components/input_output/chat.py` and the upstream integration test `test_chat_input.test_default`) is that the default is the literal string `"User"`, with no username fallback. The test was reframed to match real behavior.

--- a/tests/helpers/flows/fill-sidebar-search.test.ts
+++ b/tests/helpers/flows/fill-sidebar-search.test.ts
@@ -1,0 +1,111 @@
+// Unit tests for the sidebar search barrier (issue #1468).
+// Run with: npm run test:units
+//
+// What rides on these functions: whether a sidebar that dropped the typed term is
+// REPAIRED by the one repair measured to work, and whether the two failures a
+// caller can hit stay named apart. Before this, both surfaced as the caller's own
+// `expect(input_output<Display Name>).toBeVisible()` timing out — the signature
+// #1468 was filed under, on two tests of one file, with no add ever attempted.
+//
+// Measured on nightly 1.12.0.dev30 under four-way backend contention: 23 failures
+// in 220 adds (10.5 %), against 0 in 30 on a quiet instance. An in-page probe
+// sampling the input every animation frame put the cause beyond inference — the
+// input node is ABSENT at ~100 ms and a NEW empty one is mounted at ~156 ms, so
+// the term does not fail to arrive, it is discarded with the node that held it.
+//
+// The reload repair is measured, not preferred: re-typing into the remounted
+// input recovered 0 of 4, `reload()` 4 of 4. That asymmetry is the whole reason
+// this helper exists instead of a second `fill()`, and it is why the message
+// tells the reader a longer wait cannot help.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyInfraError } from "../../../scripts/lib/infra-signatures";
+import {
+  SEARCH_VALUE_TIMEOUT_MS,
+  classifySearchOutcome,
+  droppedSearchMessage,
+  missingRowMessage,
+} from "./fill-sidebar-search";
+
+const DETAIL = {
+  term: "chat input",
+  rowTestId: "input_outputChat Input",
+  observedValue: "",
+  attempts: 2,
+  reloaded: true,
+  perAttemptMs: SEARCH_VALUE_TIMEOUT_MS,
+  rowCount: 0,
+};
+
+test("the term surviving in the input is a held search", () => {
+  assert.equal(classifySearchOutcome("chat input", "chat input"), "held");
+});
+
+test("an emptied input is a dropped search — the measured shape of #1468", () => {
+  assert.equal(classifySearchOutcome("chat input", ""), "dropped");
+});
+
+test("a vanished input is dropped, not held", () => {
+  // `readValue` reports `<gone>` when the input cannot be read at all, which is
+  // the remount's own middle state. It must never classify as held.
+  assert.equal(classifySearchOutcome("chat input", "<gone>"), "dropped");
+});
+
+test("a truncated term is dropped — a partial filter lists different rows", () => {
+  assert.equal(classifySearchOutcome("chat input", "chat inpu"), "dropped");
+});
+
+test("whitespace is not normalised away — it changes what the sidebar filters", () => {
+  assert.equal(classifySearchOutcome("chat input", " chat input"), "dropped");
+});
+
+test("the dropped-term message names the mechanism, the repair and the rate", () => {
+  const msg = droppedSearchMessage(DETAIL);
+  assert.match(msg, /dropped the search term/);
+  assert.match(msg, /sidebar-search-input/);
+  assert.match(msg, /"chat input"/);
+  assert.match(msg, /#1468/);
+  // The two numbers a reader needs to not re-run it as a flake.
+  assert.match(msg, /23 of 220/);
+  assert.match(msg, /0 of 30/);
+  assert.match(msg, /re-typing\s+recovers 0 of 4/);
+  assert.match(msg, /NOT a slow sidebar/);
+  assert.match(msg, /page reload/);
+});
+
+test("the message reports the value it actually observed, not the term", () => {
+  // A message that echoed the term back would read as though the fill worked.
+  const msg = droppedSearchMessage({ ...DETAIL, observedValue: "cha" });
+  assert.match(msg, /reads "cha"/);
+});
+
+test("a message for a run with no reload does not claim one happened", () => {
+  const msg = droppedSearchMessage({ ...DETAIL, attempts: 1, reloaded: false });
+  assert.doesNotMatch(msg, /reload/i);
+});
+
+test("a held term with no row is NOT reported as #1468", () => {
+  // Different cause, different fix: the catalog does not carry the component
+  // under that category. Borrowing #1468's explanation would send the reader to
+  // a remount that did not happen.
+  const msg = missingRowMessage(DETAIL);
+  assert.match(msg, /held the search term/);
+  assert.doesNotMatch(msg, /remount happened/);
+  assert.match(msg, /NOT issue #1468's remount/);
+  assert.match(msg, /#1040/);
+  assert.match(msg, /<category><Display Name>/);
+});
+
+test("neither message is classified as infra — a real sidebar defect must stay eligible for @stable auto-removal", () => {
+  // The #1262 rule: an infra prefix would exempt this from the daily's
+  // auto-removal, and a sidebar that drops what you type is a product defect,
+  // not a runner problem.
+  assert.equal(classifyInfraError(droppedSearchMessage(DETAIL)), null);
+  assert.equal(classifyInfraError(missingRowMessage(DETAIL)), null);
+});
+
+test("the settle budget spans the measured remount window", () => {
+  // The remount landed at 96–215 ms in every reproduction. A budget at or below
+  // that would call an inert sidebar healthy.
+  assert.ok(SEARCH_VALUE_TIMEOUT_MS > 215);
+});

--- a/tests/helpers/flows/fill-sidebar-search.ts
+++ b/tests/helpers/flows/fill-sidebar-search.ts
@@ -1,0 +1,214 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Types a term into the component sidebar's search box and does not return until
+ * the input is actually **holding** it (issue #1468).
+ *
+ * `fill()` returning is not evidence the term landed. Measured on nightly
+ * 1.12.0.dev30 with 4 harnesses driving one backend — 23 failures in 220 adds
+ * (10.5 %; 0 in 30 on a quiet instance, which is why this never reproduces
+ * locally): an in-page probe sampling the input every animation frame recorded
+ *
+ *     [ 41 ms, "",   "same"     ]   the input is there, empty
+ *     [102 ms, null, "absent"   ]   the input NODE is gone
+ *     [156 ms, "",   "remounted"]   a NEW input node, empty
+ *
+ * — the sidebar unmounts and remounts 96–215 ms after the fill and the typed
+ * term dies with the old node. Since 1.12 a component row only exists in the DOM
+ * under a filter, so the caller's `input_output<Display Name>` never appears and
+ * the wait ends as `element(s) not found` with no add ever attempted. That is the
+ * whole of #1468's signature, on both of the two tests it was filed for.
+ *
+ * **The repair is a reload, and that is measured, not chosen.** Re-typing into
+ * the remounted input recovered **0 of 4** — it accepts no value at all, for the
+ * remaining 30 s of the wait and 10 s past it. A full `reload()` recovered
+ * **4 of 4**. So the "type again" repair that fixed the swallowed *click*
+ * (#1304, `add-component-from-sidebar.ts`) does not reach this layer, and a
+ * longer timeout reaches it even less: nothing is in flight to wait for.
+ *
+ * **Waiting for the input to be VISIBLE is not the barrier**, which is why the
+ * guard already present in `chat-input-output-component-regression.spec.ts`
+ * did not help. The input is visible before the remount; the remount comes
+ * after. The only observable that distinguishes a working sidebar from an inert
+ * one is whether it keeps what you typed — so that is what this asserts.
+ *
+ * Not folded into `add-component-from-sidebar.ts`: that helper repairs a click
+ * the app dropped, one layer later, and its `issueAdd` fills the search as a
+ * step of that repair. Both belong on the path (this one first), and merging
+ * them would put a `reload()` — which discards a canvas the caller may have
+ * already built — inside a helper 34 call sites use after placing nodes.
+ */
+/**
+ * How long the term must survive to count as held. The remount was measured at
+ * 96–215 ms after the fill across every reproduction, so 1.5 s spans it with
+ * room to spare — and a healthy add never pays it, because the row appearing is
+ * itself proof the sidebar kept the term and returns early.
+ */
+export const SEARCH_VALUE_TIMEOUT_MS = 1500;
+export const SEARCH_INPUT_TIMEOUT_MS = 20000;
+export const ROW_TIMEOUT_MS = 30000;
+
+export const SEARCH_INPUT_TESTID = "sidebar-search-input";
+
+export type SearchOutcome = "held" | "dropped";
+
+/**
+ * Whether the sidebar kept the term. Trailing/leading whitespace is not
+ * normalised away: the caller's term is what filters the list, and a sidebar
+ * that trimmed it would filter differently.
+ */
+export function classifySearchOutcome(
+  term: string,
+  observedValue: string,
+): SearchOutcome {
+  return observedValue === term ? "held" : "dropped";
+}
+
+type SearchFailureDetail = {
+  term: string;
+  rowTestId: string | null;
+  observedValue: string;
+  attempts: number;
+  reloaded: boolean;
+  perAttemptMs: number;
+  rowCount: number;
+};
+
+export function droppedSearchMessage(d: SearchFailureDetail): string {
+  return (
+    `the component sidebar dropped the search term: filled ` +
+    `getByTestId("${SEARCH_INPUT_TESTID}") with "${d.term}" and the input reads ` +
+    `"${d.observedValue}" after ${d.attempts} attempt(s) of ${d.perAttemptMs}ms` +
+    `${d.reloaded ? " (including one page reload)" : ""}. ` +
+    `Issue #1468 — the sidebar unmounts and remounts 96–215 ms after the fill ` +
+    `and the typed term dies with the old node; measured 23 of 220 adds on ` +
+    `nightly 1.12.0.dev30 under four-way backend contention, 0 of 30 on a quiet ` +
+    `instance. Observed: sidebar rows matching the filter: ${d.rowCount}` +
+    `${d.rowTestId ? `; waiting for getByTestId("${d.rowTestId}")` : ""}. ` +
+    `This is NOT a slow sidebar — a longer wait cannot fix it, and re-typing ` +
+    `recovers 0 of 4 — so treat a reproducible failure here as a real defect in ` +
+    `the sidebar, not as a flake to re-run.`
+  );
+}
+
+/**
+ * A term that the sidebar kept but that produced no row is a different failure
+ * from a dropped term, and it must not borrow the other's explanation: it means
+ * the catalog does not carry that component under that category, which is
+ * `globalSetup`'s drift verdict (#1040), not #1468.
+ */
+export function missingRowMessage(d: SearchFailureDetail): string {
+  return (
+    `the sidebar held the search term "${d.term}" but no row for ` +
+    `getByTestId("${d.rowTestId}") appeared within ${ROW_TIMEOUT_MS}ms ` +
+    `(rows matching the filter: ${d.rowCount}). The typed term is in the input, ` +
+    `so this is NOT issue #1468's remount. Check the component catalog for this ` +
+    `category/display name — a reparented or removed component is reported by ` +
+    `globalSetup's drift verdict (#1040), and the testid is ` +
+    `\`<category><Display Name>\`.`
+  );
+}
+
+const readValue = async (page: Page): Promise<string> =>
+  page
+    .getByTestId(SEARCH_INPUT_TESTID)
+    .inputValue()
+    .catch(() => "<gone>");
+
+const rowsUnderFilter = async (page: Page): Promise<number> =>
+  page
+    .locator('[data-testid^="input_output"], [data-testid^="add-component-button-"]')
+    .count()
+    .catch(() => -1);
+
+const isRowVisible = async (page: Page, rowTestId: string): Promise<boolean> =>
+  page
+    .getByTestId(rowTestId)
+    .isVisible()
+    .catch(() => false);
+
+/**
+ * Fills, then watches until the term is seen to drop, the row appears, or the
+ * settle budget runs out. Polling rather than a single assert: the remount lands
+ * ~100–215 ms in, so a value read once right after the fill can be right and
+ * then wrong.
+ */
+const fillAndSettle = async (
+  page: Page,
+  term: string,
+  rowTestId?: string,
+): Promise<{ value: string; rowSeen: boolean }> => {
+  await expect(page.getByTestId(SEARCH_INPUT_TESTID)).toBeVisible({
+    timeout: SEARCH_INPUT_TIMEOUT_MS,
+  });
+  await page.getByTestId(SEARCH_INPUT_TESTID).fill(term);
+
+  const deadline = Date.now() + SEARCH_VALUE_TIMEOUT_MS;
+  let value = await readValue(page);
+  for (;;) {
+    // The row rendering IS the sidebar keeping the term, so a healthy add
+    // returns here in a few hundred ms instead of paying the settle budget.
+    if (rowTestId && (await isRowVisible(page, rowTestId))) {
+      return { value: term, rowSeen: true };
+    }
+    if (classifySearchOutcome(term, value) === "dropped") {
+      return { value, rowSeen: false };
+    }
+    if (Date.now() >= deadline) return { value, rowSeen: false };
+    await page.waitForTimeout(150);
+    value = await readValue(page);
+  }
+};
+
+/**
+ * Fills the sidebar search and — when `rowTestId` is given — waits for that
+ * component's row, so the two failures the caller could hit are named apart.
+ *
+ * @param term       text typed into `sidebar-search-input`
+ * @param rowTestId  the sidebar row to wait for, e.g. `input_outputChat Input`
+ */
+export const fillSidebarSearch = async (
+  page: Page,
+  term: string,
+  rowTestId?: string,
+) => {
+  let settled = await fillAndSettle(page, term, rowTestId);
+  let attempts = 1;
+  let reloaded = false;
+
+  if (classifySearchOutcome(term, settled.value) === "dropped") {
+    // The only repair with a measured recovery: 4 of 4, against 0 of 4 for
+    // re-typing into the inert input.
+    await page.reload();
+    reloaded = true;
+    settled = await fillAndSettle(page, term, rowTestId);
+    attempts = 2;
+  }
+  const value = settled.value;
+
+  const detail: SearchFailureDetail = {
+    term,
+    rowTestId: rowTestId ?? null,
+    observedValue: value,
+    attempts,
+    reloaded,
+    perAttemptMs: SEARCH_VALUE_TIMEOUT_MS,
+    rowCount: await rowsUnderFilter(page),
+  };
+
+  if (classifySearchOutcome(term, value) === "dropped") {
+    throw new Error(droppedSearchMessage(detail));
+  }
+  if (!rowTestId) return;
+  if (settled.rowSeen) return;
+
+  const appeared = await expect(page.getByTestId(rowTestId))
+    .toBeVisible({ timeout: ROW_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!appeared) {
+    throw new Error(
+      missingRowMessage({ ...detail, rowCount: await rowsUnderFilter(page) }),
+    );
+  }
+};

--- a/tests/helpers/flows/open-blank-flow-from-modal.test.ts
+++ b/tests/helpers/flows/open-blank-flow-from-modal.test.ts
@@ -1,0 +1,44 @@
+// Unit tests for the blank-flow modal barrier (issue #1468, second failure mode).
+// Run with: npm run test:units
+//
+// What rides on this message: a refused flow creation leaves the templates modal
+// open OVER the editor, and every spec that types next reports the covered
+// sidebar instead of the refusal. Measured on nightly 1.12.0.dev30 under
+// four-way contention — `400 POST /api/v1/flows/` in every reproduction of this
+// mode, `role="dialog"` present in all of them and absent in all 16 measured
+// successes.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyInfraError } from "../../../scripts/lib/infra-signatures";
+import {
+  MODAL_DISMISSED_TIMEOUT_MS,
+  refusedBlankFlowMessage,
+} from "./open-blank-flow-from-modal";
+
+const DETAIL = {
+  attempts: 2,
+  perAttemptMs: MODAL_DISMISSED_TIMEOUT_MS,
+  dialogCount: 1,
+};
+
+test("the message names the modal, the click and the 400 to look for", () => {
+  const msg = refusedBlankFlowMessage(DETAIL);
+  assert.match(msg, /templates modal did not close/);
+  assert.match(msg, /blank-flow/);
+  assert.match(msg, /400 POST \/api\/v1\/flows\//);
+  assert.match(msg, /flow must be unique/);
+  assert.match(msg, /#1468/);
+});
+
+test("the message says a longer wait cannot help — the modal is not slow", () => {
+  // The whole point of retrying the click instead of raising a timeout.
+  assert.match(refusedBlankFlowMessage(DETAIL), /NOT a slow modal/);
+});
+
+test("the message reports the dialog count it observed", () => {
+  assert.match(refusedBlankFlowMessage({ ...DETAIL, dialogCount: 2 }), /present: 2/);
+});
+
+test("not classified as infra — a modal that will not close is a product defect", () => {
+  assert.equal(classifyInfraError(refusedBlankFlowMessage(DETAIL)), null);
+});

--- a/tests/helpers/flows/open-blank-flow-from-modal.ts
+++ b/tests/helpers/flows/open-blank-flow-from-modal.ts
@@ -1,0 +1,87 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Clicks `blank-flow` in the new-flow templates modal and does not return until
+ * the modal is actually **gone** (issue #1468, second failure mode).
+ *
+ * The click is a flow creation, and it can be refused. Measured on nightly
+ * 1.12.0.dev30 with four harnesses driving one backend: in every reproduction of
+ * this mode the page load carried `400 POST /api/v1/flows/` — the "flow must be
+ * unique" collision this repo already knows (it is why
+ * `chat-input-output-component-regression.spec.ts` runs `mode: "serial"`) — and
+ * the modal stayed **open over the editor**. The caller then typed into a sidebar
+ * the modal was covering and `fill()` timed out at 20 s, or its row wait died as
+ * `element(s) not found`. `role="dialog"` was **1** in every such failure and
+ * **0** in all 16 measured successes, so the modal's presence is the observable
+ * that separates them.
+ *
+ * The serial mode in that file cannot prevent this: it serialises tests within
+ * one file, while the collision is across the daily's four shards, which each
+ * create a flow named "New Flow" of their own.
+ *
+ * The repair is to re-issue the click, not to wait: a refused creation is not
+ * slow, there is nothing in flight, and the modal will sit there for as long as
+ * the caller is willing to wait. One retry, then a named failure — the same
+ * doctrine as `add-component-from-sidebar.ts` (#1304).
+ *
+ * The retry is only ever issued while the modal is still up, and `blank-flow`
+ * lives inside it, so a dismissed modal is never clicked again. In the measured
+ * mode the first click created nothing (the 400), but a first click that DID
+ * create a flow and left the modal open would create a second one — which the
+ * caller's `trackCreatedFlows` deletes with the first, since it captures every
+ * `POST /api/v1/flows` → 201 rather than a single id (#1108).
+ */
+export const MODAL_DISMISSED_TIMEOUT_MS = 8000;
+
+export const BLANK_FLOW_TESTID = "blank-flow";
+
+/** The templates modal, addressed the way the repo's other modal helpers do. */
+const DIALOG_SELECTOR = '[role="dialog"]';
+
+export function refusedBlankFlowMessage(d: {
+  attempts: number;
+  perAttemptMs: number;
+  dialogCount: number;
+}): string {
+  return (
+    `the new-flow templates modal did not close after ${d.attempts} click(s) of ` +
+    `getByTestId("${BLANK_FLOW_TESTID}"), ${d.perAttemptMs}ms apart ` +
+    `(role="dialog" still present: ${d.dialogCount}). Issue #1468 — the click ` +
+    `creates a flow and the backend can refuse it with ` +
+    `400 POST /api/v1/flows/ ("flow must be unique") when parallel shards create ` +
+    `"New Flow" at the same time; the modal then stays open over the editor and ` +
+    `anything the spec types goes to a covered sidebar. Check the run's HTTP log ` +
+    `for that 400. This is NOT a slow modal — waiting longer cannot close it.`
+  );
+}
+
+const dialogCount = async (page: Page): Promise<number> =>
+  page
+    .locator(DIALOG_SELECTOR)
+    .count()
+    .catch(() => -1);
+
+const clickAndAwaitDismissal = async (page: Page): Promise<boolean> => {
+  await page.getByTestId(BLANK_FLOW_TESTID).click();
+  return expect(page.locator(DIALOG_SELECTOR))
+    .toHaveCount(0, { timeout: MODAL_DISMISSED_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+};
+
+/**
+ * Opens a blank flow from the templates modal. The caller must already have the
+ * modal open — `awaitBootstrapTest(page)` leaves it that way.
+ */
+export const openBlankFlowFromModal = async (page: Page) => {
+  if (await clickAndAwaitDismissal(page)) return;
+  if (await clickAndAwaitDismissal(page)) return;
+
+  throw new Error(
+    refusedBlankFlowMessage({
+      attempts: 2,
+      perAttemptMs: MODAL_DISMISSED_TIMEOUT_MS,
+      dialogCount: await dialogCount(page),
+    }),
+  );
+};

--- a/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
@@ -1,7 +1,10 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { fillSidebarSearch } from "../../../helpers/flows/fill-sidebar-search";
+import { openBlankFlowFromModal } from "../../../helpers/flows/open-blank-flow-from-modal";
 import { expandFocusedNode } from "../../../helpers/ui/expand-focused-node";
 import { seedAssistantDiscovered } from "../../../helpers/ui/assistant-onboarding";
 import { trackCreatedFlows } from "../../../helpers/flows/track-created-flows";
@@ -42,19 +45,16 @@ test.afterEach(async ({ request }) => {
 // in expanded (non-minimized) state.
 async function addChatInputComponent(page: Page) {
   await awaitBootstrapTest(page);
-  await page.getByTestId("blank-flow").click();
-  // Wait for the sidebar to settle before typing — filling the search input
-  // immediately after the blank-flow transition can time out while the canvas
-  // is still mounting (same guard as if-else-component-regression).
-  await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
-    timeout: 15000,
-  });
-  await page.getByTestId("sidebar-search-input").fill("chat input");
-  await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
-    timeout: 30000,
-  });
+  // Both of these replace an inline step that #1468 measured as unsafe. The
+  // click must be confirmed to have CLOSED the modal (a refused flow creation
+  // leaves it open over the editor), and the typed term must be confirmed to
+  // have STAYED in the sidebar input — waiting for that input to be merely
+  // visible, which is what stood here, is satisfied before the remount that
+  // discards the term, which is why this test's own guard never helped.
+  await openBlankFlowFromModal(page);
+  await fillSidebarSearch(page, "chat input", "input_outputChat Input");
   await page.getByTestId("input_outputChat Input").hover();
-  await page.getByTestId("add-component-button-chat-input").click();
+  await addComponentFromSidebar(page, "chat input", "add-component-button-chat-input");
   await adjustScreenView(page);
   await expect(page.getByTestId("title-Chat Input")).toBeVisible({
     timeout: 15000,
@@ -69,10 +69,11 @@ async function addChatInputComponent(page: Page) {
 async function addChatOutputToCanvas(page: Page) {
   // Zoom out so the drag target does not overlap the existing node
   await zoomOut(page, 2);
-  await page.getByTestId("sidebar-search-input").fill("chat output");
-  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
-    timeout: 30000,
-  });
+  // Same barrier as the other two adds (#1468). The drag itself keeps its
+  // explicit `targetPosition` rather than moving to `dragComponentFromSidebar`:
+  // that helper drops on the pane's centre, and this add exists to land clear of
+  // the node already on the canvas.
+  await fillSidebarSearch(page, "chat output", "input_outputChat Output");
   await page
     .getByTestId("input_outputChat Output")
     .dragTo(page.locator('//*[@id="react-flow-id"]'), {
@@ -170,13 +171,14 @@ test(
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
-    await page.getByTestId("blank-flow").click();
-    await page.getByTestId("sidebar-search-input").fill("chat output");
-    await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
-      timeout: 30000,
-    });
+    await openBlankFlowFromModal(page);
+    await fillSidebarSearch(page, "chat output", "input_outputChat Output");
     await page.getByTestId("input_outputChat Output").hover();
-    await page.getByTestId("add-component-button-chat-output").click();
+    await addComponentFromSidebar(
+      page,
+      "chat output",
+      "add-component-button-chat-output",
+    );
     await adjustScreenView(page);
 
     await expect(page.getByTestId("title-Chat Output")).toBeVisible({
@@ -320,7 +322,7 @@ test(
 
 test(
   "Chat Input/Output — default sender_name is 'User' on input and 'AI' on output",
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     // The defaults are constants in lfx/utils/constants.py:
     //   MESSAGE_SENDER_NAME_USER = "User"


### PR DESCRIPTION
**Fixes #1468.**

## Problem

Two `@stable` tests of `chat-input-output-component-regression.spec.ts` failed at the **same statement of the same interaction** on the 2026-08-17 daily (run 32011412906): the sidebar row `input_output<Display Name>` never entered the DOM, so no add was ever attempted. The test at line 321 hard-failed (its `@stable` was auto-removed in `14a77eb`); the one at line 168 flaked and recovered on its third attempt. Test 168 had also flaked on the 2026-07-23 and 08-10 dailies with a **different signature each time**, all three inside this same sidebar-add interaction.

Measured on nightly `1.12.0.dev30` with four Playwright processes driving one backend — **31 failures in 348 adds (8.9 %)**, against **0 in 30** on a quiet instance, which is why this never reproduces locally or in UI mode. `GET /api/v1/all` answered **`200` in 109–614 ms, one request per page load, in every single failure**, so the catalog is not implicated in any of the three states the issue asked to distinguish, and that is also why the liveness recorder stayed clean: nothing is wrong with the backend.

Two client-side modes, tabulated over 21 failures with full diagnostics:

| Mode | Observable | Count | `400 POST /api/v1/flows/` | Which fill it hits |
|---|---|---|---|---|
| **1 — the templates modal never closes** | `role="dialog"` present (**0** in all 16 measured successes); `fill` times out at 20 s | 9 | 6 of 9 | both (6 unguarded, 3 guarded) |
| **2 — the sidebar remounts and discards the term** | input node **absent** at ~102 ms, a **new empty** one at ~156 ms | 12 | 1 of 12 | **only** a fill with no prior visibility wait (12 vs **0**) |

Mode 2's frame-resolution trace (in-page probe, one sample per animation frame, DOM node marked to detect a remount):

```
[ 41 ms, "",   "same"     ]   the input is there, empty
[102 ms, null, "absent"   ]   the input NODE is gone
[156 ms, "",   "remounted"]   a NEW input node, empty
… 2 380 further samples: "" throughout, no other transition
```

Since 1.12 a component row only exists in the DOM under a filter, so an empty input means the row never renders. Mode 1 is a **refused flow creation** — the "flow must be unique" 400 this file's own header documents — leaving the modal over the editor; `mode: "serial"` cannot prevent it because the collision is across the daily's four shards, not within the file.

**Neither mode is slowness**, and that decides the fix: re-typing into the remounted input recovered **0 of 4**, a full `reload()` **4 of 4**, and no raised timeout reaches either. It is also why the `sidebar-search-input`-is-visible guard the test at line 321 already carried did not help — it is satisfied *before* the remount. Since mode 2 was observed **only** on unguarded fills and that test's fill is guarded, its hard failure is most consistent with **mode 1**.

Auth was raised as a hypothesis and **refuted**: `200 auto_login` + `200 whoami` + the `auto_login_lf` cookie in every failure, indistinguishable from the successes, zero 401/403 on any `/api/` route.

## Fix

Two barriers, in the "repair, don't wait" doctrine of #1304:

- **`tests/helpers/flows/open-blank-flow-from-modal.ts`** (new) — clicks `blank-flow` and returns only once the modal actually closed; one repair click; then fails naming the 400 to look for.
- **`tests/helpers/flows/fill-sidebar-search.ts`** (new) — fills, then **confirms the term is still in the input** across the measured remount window (1.5 s budget, returning early the moment the row renders, which is itself proof the term was kept); `reload` + refill as the repair; then waits for the row. A term that is **held** and still yields no row is reported as catalog drift (#1040), never as this defect.

The spec's three adds route through both, plus the existing `addComponentFromSidebar` for the click. 21 unit tests cover the classification and both messages, including a pin that **neither message is classified as infra** — a real sidebar defect must stay eligible for `@stable` auto-removal (#1262).

**Rejected alternatives, explicitly.** Raising the caller timeouts (nothing is in flight — mode 2 holds `""` for the full 30 s and 10 s past it). A second `fill()` as the repair, i.e. what fixed the swallowed *click* (0 of 4 recovery here). Folding this into `add-component-from-sidebar.ts` (its 34 call sites reach it *after* placing nodes, and a `reload()` there would discard a built canvas). Moving `addChatOutputToCanvas`'s drag to `dragComponentFromSidebar` (that helper drops on the pane centre; this add exists to land clear of the existing node).

## Scope note

No assertion changed. Every observable the six tests prove is byte-identical — titles, handles, edge count, node counts, the propagated `Input Text`, the `chat-message-QA-…` testid, the `"User"`/`"AI"` defaults. Only *how* the component gets onto the canvas changed. The `test.fixme` at line 132 is **untouched**: that is #1423's failure (the click lands and no node is placed) and lifting it is that issue's deliverable — measurement handed over there ([16/16 under load](https://github.com/oriontech-me/langflow-e2e/issues/1423#issuecomment-5318746949)), which is deliberately **not** enough to lift it without a baseline rate.

Restores `@stable` on the test at line 323, auto-removed by the daily workflow in `14a77eb`.

## Validation (nightly `1.12.0.dev30`, `--retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ 0 errors · anti-pattern checklist ✅ (29 `expect(` for 6 tests; every test reaches `awaitBootstrapTest`; serial mode present; no positional selector, no `.first()`, no `waitForTimeout` in the spec; every `.catch()` in the new helpers is on a diagnostic/poll path whose branch ends in a `throw`)
- `npm run test:units` ✅ **670/670** (21 new)
- `npm run check:checklist-coverage` ✅
- 2 clean bursts of the file: `5 passed, 1 skipped` (~31 s), plus **0 failures in 200 adds** under four-way load, including two **paired** rounds in the same window as the unguarded harness (**0/80** against **3/80**)
- Force-fail ✅ executed on all 5 running tests, isolated with `--grep` (the file is serial), diff verified free of mutation markers:
  - `FF:` test 2 — `button_run_chat output` → `…outputFFMUT` ⇒ 1 failed
  - `FF:` test 3 — `toHaveCount(2)` → `(3)` ⇒ 1 failed
  - `FF:` test 4 — `toContain(inputText)` → `+ "FFMUT"` ⇒ 1 failed
  - `FF:` test 5 — `chat-message-QA-…` → `chat-message-QAFFMUT-…` ⇒ 1 failed
  - `FF:` test 6 — `toHaveValue("AI")` → `"AIFFMUT"` ⇒ 1 failed
  - `FF:` the barriers themselves are force-failed behaviourally by the pre-fix code, which **is** the mutation: 31/348 without them, and 1/60 with only the search barrier (mode 1 returned)
- `--trace=on` ✅ ran clean on both `@stable`-relevant tests (11 s and 12 s — no sign of the known hang), steps match the trace
- Zero `🚨 Backend Error` ✅ · zero leaked flows (checked via `GET /api/v1/flows/`, the 2 orphans left behind by the killed investigation harnesses were purged id-scoped)

**Stated so it is not read as stronger than it is:** the `reload` repair inside `fillSidebarSearch` **never fired** in those 200 iterations (measured — 200/200 page loads made exactly one catalog request). The barrier is what carries the fix; the repair is a fallback covered by unit tests only.

The full verdict, with the investigation in the order #1468's directive asked for, is recorded on the issue: https://github.com/oriontech-me/langflow-e2e/issues/1468#issuecomment-5318764279
