### PR TITLE
fix(llm-agents): name the canvas seam, and stop selecting a sticky note (#1469)

### DIFF
--- a/docs/core-functionality/llm-agents/language-model-regression.md
+++ b/docs/core-functionality/llm-agents/language-model-regression.md
@@ -1,6 +1,6 @@
 # Language Model Component Regression
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.12.x (dev30)
 
 ---
 
@@ -16,7 +16,7 @@ management dialog opens from the node.
 | `language model must respond with OpenAI provider` | Component configured with OpenAI builds (`built successfully`) and the Playground answers `2+2` with `4` |
 | `language model must respond with Google provider` | Same journey with Google: build completes and the Playground returns a non-empty reply |
 | `language model provider switch from OpenAI to Google must persist` | After OpenAI → Google setup, the node's `model_model` trigger shows a Gemini model |
-| `model provider dialog opens from the Language Model node` | The node's model dropdown opens `manage-model-providers` and lists `provider-item-OpenAI` |
+| `model provider dialog opens from the Language Model node` | Selecting the **Language Model component node** (the `genericNode` carrying `title-Language Model`, never the README sticky note) opens `manage-model-providers` from its model dropdown, and the dialog lists `provider-item-OpenAI` |
 
 ---
 
@@ -36,6 +36,13 @@ see Notes).
 PR #775 — the key had no quota, not the test — and **restored in #992** once
 the quota was confirmed back (live HTTP 200 completion on `gpt-4o-mini`) and
 the test ran clean at `--retries=0`.
+
+`@stable` was removed from the **dialog** test by the 2026-08-17 daily's
+auto-removal (run 32011412906, commit `14a77eb`) and is **restored by the
+#1469 fix**. The removal was collateral of a backend the shard could not
+reach, but `page.waitForSelector: Timeout` is deliberately not an exempting
+signature — which is the whole reason the fix is an *attribution* one (see
+Notes, #1469).
 
 `@stable` was removed from the **Google** test again by the 2026-08-04 daily's
 auto-removal (run 30901311395) and is **restored by the #1262 fix**. The
@@ -71,6 +78,13 @@ timeout it probes `GET /api/v1/version` and says whether the backend answered,
 so an unreachable backend can no longer be reported as "`mainpage_title` never
 rendered".
 
+`openBasicPrompting()` no longer returns on `page.waitForURL` alone (#1469):
+after the flow URL is reached it holds a **canvas-mount barrier** — the canvas
+controls bar, then at least one rendered `.react-flow__node` — through
+`waitForAttributedSelector` with the `flow-canvas` surface. A canvas that never
+mounts therefore fails at a named seam that says whether Langflow answered,
+instead of inside whichever assertion each test happens to run first.
+
 **OpenAI test:** `initialGPTsetup` — which pins a deterministic GPT model
 from `models.json` via `resolveGptModel()` (#606; UI preference-ranking is
 the fallback when `models.json` is absent or the pinned model left the
@@ -96,9 +110,13 @@ output` badge (60s, #750 — replaces the transient `built successfully` toast)
 **Switch test:** `initialGPTsetup` + `setupGoogle` → save settle → the
 page-level `model_model` trigger shows `/gemini/i`.
 
-**Dialog test:** select the Language Model node → `hideInspectorPanel` →
-open `model_model` → `manage-model-providers` → `provider-item-OpenAI`
-visible → Escape.
+**Dialog test:** select the Language Model **component** node —
+`.react-flow__node:has([data-testid="title-Language Model"])`, the only node
+carrying that title testid — → `hideInspectorPanel` → open `model_model` →
+`manage-model-providers` → `provider-item-OpenAI` visible → Escape. The node
+is NOT resolved by `.filter({ hasText: "Language Model" })`: the template's
+README sticky note contains "Large **Language Model** (LLM)", so that filter
+matches two nodes and `.first()` picks the note (#1469).
 
 ---
 
@@ -108,6 +126,18 @@ visible → Escape.
   `node_duration_` badge within 60s (OpenAI test still uses the `built
   successfully` toast — #750 hardened only the flaking Google test); the
   Playground reply is the end-to-end proof the selected provider executed.
+- **Dialog test:** the node the test selects is the Language Model
+  **component** — proven by the node it clicks carrying
+  `data-testid="title-Language Model"`, which the README sticky note does not —
+  and the dialog reached from its `model_model` trigger lists
+  `provider-item-OpenAI`.
+- **Fix #1469 exit criterion:** (a) `openBasicPrompting()` fails at a named,
+  attributed canvas seam when the canvas does not mount — the message says
+  whether Langflow answered `GET /api/v1/version`, so this collateral is
+  classifiable instead of reading as a bare `page.waitForSelector: Timeout`;
+  (b) the dialog test resolves the component node unambiguously (one match,
+  never the sticky note); (c) the test proves N clean `--retries=0` runs on the
+  current nightly before `@stable` is restored on the `test()` call.
 - **Fix #1262 exit criterion:** the recorded page-entry signature is
   attributed (backend-reachability probed at the barrier), the Google test's
   own recurrent observable is addressed at its cause (the provider-panel
@@ -123,8 +153,11 @@ visible → Escape.
 
 ## External dependencies *(required)*
 
-- Basic Prompting starter template (Language Model node, `model_model`
-  trigger, `button_run_chat output`).
+- Basic Prompting starter template (Language Model node — `genericNode`
+  carrying `title-Language Model` — `model_model` trigger,
+  `button_run_chat output`, `canvas_controls_dropdown`). The template also
+  ships two sticky notes; the README one contains the words "Language Model"
+  and must not be mistaken for the component (#1469).
 - `setup-google.ts` / `initialGPTsetup` helpers — **model choice happens
   here**: `setupGoogle(page)` with no argument selects the FIRST Gemini
   option in the dropdown, so the Google catalog's ordering directly affects
@@ -218,6 +251,42 @@ visible → Escape.
     signals to a 5s deadline and treats a **non-empty (masked) key field** as
     configured on its own — a masked value can never be one this helper typed,
     so it cannot skip a setup that was genuinely needed.
+- **#1469 root cause (2026-08-17):** the dialog test hard-failed on all three
+  attempts of run 32011412906 (shard 2) before reaching anything it is about,
+  each attempt dying on a different canvas observable. Findings:
+  - **The gunicorn wedge is ruled OUT for the attempt window.** The shard's
+    Langflow logged exactly two `WORKER TIMEOUT` — `(pid:31)` at 08:46:09 and
+    `(pid:341)` at 08:51:27, both SIGKILLed — and **both precede attempt 0**
+    (08:55:08). Nothing in 08:55:08→09:01:45.
+  - **The backend was nevertheless unreachable, by event-loop blocking rather
+    than by a worker restart.** Shard 2's `backend-liveness.jsonl` fails 5/43
+    (12 %), 16/46 (35 %) and 33/57 (58 %) of probes across the three attempts,
+    in contiguous runs of 45 s, 66 s and 60 s — long enough to burn a 30 s
+    budget, short enough never to reach gunicorn's 300 s timeout. Concurrent on
+    the same single-worker backend: `memory-history-regression`'s "session
+    isolation" test, itself failing, running 08:55:21→09:00:26 and again
+    09:00:27→09:01:21. Verdict for all three attempts: **environment**
+    (#1077's lever), not a product regression.
+  - **Attempt 0 needs no product regression either.** Its shape — canvas
+    controls rendered, zero nodes — is reproducible on demand on 1.12.0.dev30
+    by failing the canvas's backend GETs (`page.route` abort: controls visible,
+    `.react-flow__node` count 0). On a quiet instance the same sequence renders
+    the controls in 64–824 ms and the Language Model node in 353–826 ms, 5 runs
+    of 5, so the 15 s budget was never tight. The template's node also still
+    carries `display_name: "Language Model"` on dev30 (`GET
+    /api/v1/flows/basic_examples/`), so the absence is not a rename.
+  - **Two real test defects surfaced by the investigation, and they are what
+    the fix addresses.** (1) `.react-flow__node` filtered on `hasText:
+    "Language Model"` matches **two** nodes, because the template's README
+    sticky note reads "Large Language Model (LLM)"; the note precedes the
+    component in DOM order, so `.first()` selected the note — the test named
+    after selecting the node never selected it (it still passed, because the
+    following `model_model` locator is page-level). (2) `openBasicPrompting()`
+    returned on `waitForURL` alone, so a canvas that never mounts failed at
+    whichever observable each test happens to wait on first, with no
+    attribution — which is how a `@release` test lost `@stable` to a backend
+    outage. Both fixed here; the second reuses `waitForAttributedSelector`
+    (#1265) rather than a new mechanism.
 - **Page-entry attribution (#1262, suite-wide):** the shared barrier now lives
   in `helpers/other/page-entry-barrier.ts` and is used by `awaitBootstrapTest`,
   `MainPage.waitForLoad`, `loadTemplateByName` and

--- a/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { waitForAttributedSelector } from "../../../../helpers/other/page-entry-barrier";
 import { initialGPTsetup } from "../../../../helpers/other/initialGPTsetup";
 import { setupGoogle } from "../../../../helpers/provider-setup/setup-google";
 import { resolveGeminiModel } from "../../../../helpers/provider-setup/resolve-gemini-model";
@@ -58,6 +59,35 @@ test.describe("Language Model Component Regression", () => {
     await page.waitForURL(/\/flow\/[^/?#]+/, { timeout: 30000 });
     const flowId = await flowCreated;
     if (flowId) createdFlowIds.push(flowId);
+
+    // The canvas-mount barrier (#1469). `waitForURL` only proves the route
+    // changed — the canvas fetches and renders AFTER it, so returning here left
+    // every test to trip over whichever canvas observable it happened to wait on
+    // first, with no attribution. On the 2026-08-17 daily (run 32011412906,
+    // shard 2) that cost this file's `@release` dialog test its `@stable`: its
+    // three attempts died on `.react-flow__node` filtered on Language Model,
+    // then twice on `canvas_controls_dropdown`, while shard 2's own
+    // backend-liveness lost 12% / 35% / 58% of its probes in contiguous 45-66s
+    // stretches. Both shapes are reproducible on demand by failing the canvas's
+    // backend GETs (measured on 1.12.0.dev30), so they say "the backend was
+    // gone", not "the canvas regressed" — but `page.waitForSelector: Timeout`
+    // cannot say which, and it is deliberately NOT an exempting infra signature.
+    //
+    // So wait here, once, through the attributed barrier (#1262/#1265): on
+    // timeout it probes `GET /api/v1/version` and reports whether Langflow
+    // answered, which is what makes this class of collateral classifiable.
+    // Budgets are exactly the ones the dialog test already spent (30s + 15s) —
+    // nothing is inflated, and on a healthy instance both resolve in under a
+    // second (64-824ms and 353-826ms over 5 runs of 5 on 1.12.0.dev30).
+    await waitForAttributedSelector(
+      page,
+      '[data-testid="canvas_controls_dropdown"]',
+      30000,
+      { surface: "flow-canvas" },
+    );
+    await waitForAttributedSelector(page, ".react-flow__node", 15000, {
+      surface: "flow-canvas-nodes",
+    });
   };
 
   test.afterEach(async ({ request }) => {
@@ -239,18 +269,34 @@ test.describe("Language Model Component Regression", () => {
 
   test(
     "model provider dialog opens from the Language Model node",
-    { tag: ["@release", "@components", "@workspace", "@model-provider"] },
+    {
+      tag: [
+        "@stable",
+        "@release",
+        "@components",
+        "@workspace",
+        "@model-provider",
+      ],
+    },
     async ({ page }) => {
+      // openBasicPrompting now holds the canvas-mount barrier itself, so the
+      // canvas_controls_dropdown wait that used to open this test is gone —
+      // it was the same wait, one caller up (#1469).
       await openBasicPrompting(page);
 
-      await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-        timeout: 30000,
-      });
-
-      const languageModelNode = page
-        .locator(".react-flow__node")
-        .filter({ hasText: "Language Model" })
-        .first();
+      // Resolve the node by the title testid the COMPONENT carries, never by
+      // text (#1469). `.filter({ hasText: "Language Model" })` matched TWO
+      // nodes: the template's README sticky note reads "Large Language Model
+      // (LLM)", and it precedes the component in DOM order — so `.first()`
+      // selected the note and this test never touched the node it is named
+      // after. It still passed, because the `model_model` locator below is
+      // page-level; a false negative that no green run could reveal. The count
+      // assert pins the disambiguation: if a future template adds a second node
+      // carrying this title, the test says so instead of silently picking one.
+      const languageModelNode = page.locator(
+        '.react-flow__node:has([data-testid="title-Language Model"])',
+      );
+      await expect(languageModelNode).toHaveCount(1, { timeout: 15000 });
       await expect(languageModelNode).toBeVisible({ timeout: 15000 });
       await languageModelNode.click();
 


### PR DESCRIPTION
Closes #1469.

## Problem

The 2026-08-17 daily ([run 32011412906](https://github.com/oriontech-me/langflow-e2e/actions/runs/32011412906), shard 2) hard-failed `model provider dialog opens from the Language Model node` on all three attempts, each **before** reaching anything the test is about, and each on a different canvas observable — `.react-flow__node` filtered on `Language Model` (15 s), then `canvas_controls_dropdown` twice (30 s). `page.waitForSelector: Timeout` is not an exempting infra signature, so the workflow auto-removed `@stable` in `14a77eb`, leaving an `@release` test monitored by nothing.

**The gunicorn wedge is ruled OUT for the attempt window.** The shard's Langflow logged exactly two:

```
2026-08-17T08:46:09.316169Z [critical] WORKER TIMEOUT (pid:31)   [gunicorn.error]
2026-08-17T08:46:10.381529Z [error]    Worker (pid:31) was sent SIGKILL!
2026-08-17T08:51:27.496766Z [critical] WORKER TIMEOUT (pid:341)  [gunicorn.error]
2026-08-17T08:51:28.571069Z [error]    Worker (pid:341) was sent SIGKILL!
```

Both precede attempt 0 (08:55:08). Nothing in 08:55:08 → 09:01:45.

**The backend was unreachable anyway, by event-loop blocking rather than a worker restart.** Shard 2's `backend-liveness.jsonl` fails 5/43 (12 %), 16/46 (35 %) and 33/57 (58 %) of probes across attempts 0/1/2, in contiguous runs of 45 s, 66 s and 60 s — long enough to burn a 30 s budget, short enough never to reach gunicorn's 300 s timeout. Concurrent on the same single-worker backend: `memory-history-regression`'s session-isolation test, itself failing, 08:55:21→09:00:26 and again 09:00:27→09:01:21.

**Attempt 0 is answered separately, as the issue asked, and needs no product regression.** Its shape — controls rendered, zero nodes — reproduces on demand on `1.12.0.dev30` by aborting the canvas's `/api/v1/` GETs; aborting the flow's own GET reproduces attempts 1–2 (no controls at all). The template's node still carries `display_name: "Language Model"` (`GET /api/v1/flows/basic_examples/`), so the absence is not a rename. On a quiet instance the same sequence renders the controls in 64–824 ms and the node in 353–826 ms (5 runs of 5), and the test is **0/10** at `--retries=0`, so the budgets were never tight.

Verdict: **transient-saturation** for the three attempts (#1077's lever), plus one genuine test defect found on the way.

> Baseline honesty: a first `repro-run` measured 10/10 failed and was **invalid** — the local instance had no provider imported as a Langflow global variable (the preflight said so) and the test died on a missing `model_model`, which is not the daily's signature. After `collect-models` the honest baseline is 0/10.

## Fix

Two test-side defects made that collateral cost more than it should have.

**1. The seam.** `openBasicPrompting()` returned as soon as `page.waitForURL` matched, so a canvas that never mounts failed at whichever observable each test happens to wait on first, with no attribution. It now holds the canvas through `waitForAttributedSelector` (#1262/#1265), surfaces `flow-canvas` / `flow-canvas-nodes`, **at the same budgets the dialog test already spent (30 s + 15 s)**. Measured with the container paused:

```
[backend-unreachable] flow-canvas barrier "[data-testid="canvas_controls_dropdown"]" did not render
within 5000ms — and the backend did not answer GET /api/v1/version within 5003ms
(http://localhost:7861/api/v1/version): apiRequestContext.get: Timeout 5000ms exceeded..
Langflow was unreachable or restarting, so this is NOT an entry-point regression in the app.
```

Against the real classifier (`scripts/lib/infra-signatures.ts`):

```
attributed   → {"id":"api-request-timeout","why":"a direct REST call to the backend never answered"}
bare (today) → null
```

That `null` is what removed `@stable` in `14a77eb`. This is the whole deliverable: the next window of this class is classifiable instead of costing a `@release` test its monitoring.

**2. The locator selected a sticky note.** `.filter({ hasText: "Language Model" })` matches **two** nodes — the template's README note reads "Large **Language Model** (LLM)" and precedes the component in DOM order, so `.first()` picked the note (`undefined-9rOWY`, `react-flow__node-noteNode`). The test named after selecting the node never selected it, and still passed, because the `model_model` locator below it is page-level: a false negative no green run could reveal. It now resolves `.react-flow__node:has([data-testid="title-Language Model"])`, pinned with `toHaveCount(1)`.

`@stable` restored on the test.

**Rejected alternatives:** inflating the 15 s/30 s budgets (the canvas renders in under a second when the backend is up — the budget was never the problem); adding a retry or `catch` around the canvas wait (it would hide exactly the state this issue exists to name); a new shared canvas-readiness helper (the issue scopes the decision to this file's tests, and `waitForAttributedSelector` already is the mechanism).

## Scope note

No budget inflated, no assertion weakened, no retry/catch/wait added. The four tests' contracts are unchanged; the dialog test gains one assertion (`toHaveCount(1)`) rather than losing any.

**A symptom this PR does NOT fix:** the file's Google test (`language model must respond with Google provider`, line 137) is also missing `@stable`, removed by `f6f4c39` from daily 31786538844 — that row belongs to **#1459**, which closed without restoring the tag. Out of scope here; flagged so this PR is not read as having closed it.

**Cleanup audit** (`GET /api/v1/flows/?get_all=true`): the spec's id-scoped `afterEach` works; 0 orphans left on the instance. Two orphans across ~9 helper invocations were purged by hand and traced to `awaitBootstrapTest` creating a `New Flow` before the capture listener exists — shared by ~100 specs, so tracked separately rather than folded in here.

## Validation (nightly 1.12.0.dev30, `--retries=0 --workers=1`)

- typecheck ✅ (`tsc --noEmit`, 0) · eslint ✅ (0 errors)
- 3 clean burst runs, `expected=2 unexpected=0 flaky=0` ✅ · zero `🚨 Backend Error` ✅
- final green run after every force-fail revert ✅
- force-fail, 5 mutations, all reverted (no `FF-MUTATION` marker remains):
  - `title-Language Model` → `title-Language ModelX` → failed ✅
  - `provider-item-OpenAI` → `provider-item-OpenAIX` → failed ✅
  - Google widget gate `/gemini/i` → `/gemini-not-a-model/i` → failed ✅
  - shared canvas barrier `canvas_controls_dropdown` → `…X`, for the OpenAI test → failed ✅
  - same mutation for the switch test → failed ✅
- The two OpenAI-gated tests `test.skip` locally (the local key is out of credit: `GET /v1/models` 200, completion `429 credit_balance_exhausted`), so their force-fail ran under `IGNORE_PROVIDER_HEALTH=1` with the mutation firing in `openBasicPrompting`, before any provider call. Stated rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
