### PR TITLE
fix(llm-agents): wake the model-toggle spec and make its removal assert able to fail (#1464)

### DIFF
--- a/docs/core-functionality/llm-agents/model-provider-model-toggle.md
+++ b/docs/core-functionality/llm-agents/model-provider-model-toggle.md
@@ -1,6 +1,6 @@
 # Model Provider Model Toggle
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x (measured on `1.12.0.dev30`)
 
 ---
 
@@ -40,28 +40,84 @@ Both tests resolve a single provider — `MODEL_TEST_PROVIDER` when its env keys
 ### Test 2 — disabling a model removes it from a component dropdown
 
 1. `SimpleAgentTemplatePage.load({ provider })` — same baseline (all models enabled, a model selected on the Agent). Capture the flow URL.
-2. Open the Agent's `model_model` picker and collect the option names
-   (`[data-testid$="-option"]`). **The dropdown mixes models from every
-   configured provider** (#597 — with Google configured by sibling specs it
-   listed `gemini-3.5-flash` first while the test's provider was OpenAI), so
-   the options alone cannot pick the target.
-3. In **Settings → Model Providers**, open the test's provider and read the
-   attached `llm-toggle-<model>` testids — the provider's own model set.
-   Pick the target as the first dropdown option that is **in that set** and
-   is **not** the currently selected model (avoids entangling with
-   selection-reset logic). Skip if the intersection is empty. Then disable
-   the target (immediate + persisted, as in Test 1).
-4. Return to the flow (`page.goto(flowUrl)`), open the `model_model` picker, and assert the target model option has count `0` (anchored exact-match regex so substrings like `gpt-4o` vs `gpt-4o-mini` don't collide).
-5. Re-enable the target model in Settings, return to the flow, and assert the option reappears (count `1`).
+2. Open the Agent's `model_model` picker and enumerate every option through
+   `enumerateModelOptions()` (`tests/helpers/provider-setup/model-option.ts`),
+   which reads each option's **identity** — `data-value` (`${provider}::${model}`)
+   with `data-testid` (`${provider}-${model}-option`) as the fallback. A picker
+   that offers **zero options of the test's own provider** fails here — scoped to
+   that provider on purpose, because an all-provider count passes on Anthropic's and
+   Google's options while the one under test is absent, and the run then dies further
+   down on an unattributed toggle timeout (three drained-key incidents are on record:
+   #772/#1029/#1169). It proves nothing about removal and may never become a skip
+   (#1461). **The dropdown mixes models from every configured provider** (#597 — with
+   Google configured by sibling specs it listed `gemini-3.5-flash` first while the
+   test's provider was OpenAI), so the options alone cannot pick the target.
+3. In **Settings → Model Providers**, open the test's provider and read its
+   `llm-toggle-<model>` ids via `enumerateEnabledModels()` — every toggle the panel
+   renders, in the **bare** ids the picker's testid does not use. (The helper's name
+   is narrower than its behavior: it returns all of them regardless of
+   `aria-checked`, deprecated rows included, so a count taken from it is never a
+   count of *enabled* models.) Pick the target as the first option that **belongs to
+   this provider** (`option.provider`, not the model id alone — see the note below),
+   is **in that toggle set**, is **not deprecated** (its row lives inside the
+   collapsed `*-deprecated-disclosure`, so its toggle would never become visible) and
+   is **not** the currently selected model (avoids entangling with selection-reset
+   logic). The target's identity is then asserted to exist at all: one carrying
+   neither `data-value` nor `data-testid` matches no option, which would make every
+   removal verdict below vacuous. A provider with **no comparable model** is a
+   **failure**, not a skip — not because the sources must agree (the picker is a
+   *filtered* subset: the Agent declares a `tool_calling` filter and only enabled
+   models are offered) but because zero comparable models means the behavior was
+   never exercised, and that must not read as coverage. The only skip left is the
+   degenerate case where the provider offers exactly one non-deprecated model and
+   it is the selected one, and its reason carries the counts. Then disable the
+   target (immediate + persisted, as in Test 1).
+4. Return to the flow (`page.goto(flowUrl)`), open the `model_model` picker, and
+   assert **by identity** that no option matches the target's `data-value` /
+   `data-testid`. Two guards make that zero mean removal rather than nothing: the
+   picker must still be **populated**, and the provider's **other** models must
+   still resolve by identity. Without them a zero is also what an empty or
+   unparsable list produces (#1012). Both figures come from the **same** read as the
+   zero, and the populated check runs **before** the poll — `enumerateModelOptions`
+   swallows its own wait, so a picker that never opens would otherwise burn the whole
+   poll budget in one predicate call and abort with no cause named.
+5. Re-enable the target model in Settings, return to the flow, and assert the
+   option reappears — again by identity, count `1`, behind the same populated guard
+   so a popover that never opened is not reported as "re-enabling did not work".
 
 ---
 
-## Validation criteria *(required)*
+## Validation criterion *(required)*
 
 - Toggling a model flips `aria-checked` immediately (optimistic update).
 - A `POST /api/v1/models/enabled_models` is sent after the debounce; reopening Model Providers reflects the persisted state.
 - A disabled model disappears from the Agent's `model_model` dropdown; re-enabling restores it.
+- Every dropdown verdict is reached from the option's **identity**, never its text, and a
+  negative verdict is only accepted from a picker that is populated and still parsable —
+  so "the model is gone" can fail, and cannot be satisfied by an empty or renamed list.
 - The baseline is restored at the end of each test (model left enabled) so sibling specs are unaffected.
+
+---
+
+## Account-global state cleanup *(required)*
+
+Test 2 disables a model in Settings, which is **account-wide** — not per-flow and not
+per-worker. Until #1464 that mutation was unreachable (the provider-prefixed model name
+made the test skip before the disable), so no failure-path restore existed; waking the
+test makes one mandatory. The spec arms `disabledModel` the moment the toggle goes off,
+disarms it when the test re-enables the model itself, and a `test.afterEach` restores
+anything still armed through `POST /api/v1/models/enabled_models`
+(`[{provider, model_id, enabled: true, model_type: "llm"}]`) — over the **API**, because
+after a mid-test failure the page can be anywhere and a restore needing Settings to
+render is one that fails exactly when it is needed. A failed restore is **logged loudly**
+and never swallowed: leaving it silent would hand every later spec a disabled model with
+nothing in the log naming why (#1012). Relying on a sibling's `setup-*` enable-all pass
+is not sufficient — it repairs only when a later spec configures the **same** provider in
+the same lane, which the daily's weekday provider rotation does not guarantee, and
+`setup-language-model-openai.ts` enables a single model and repairs nothing.
+
+Behavioral force-fail contract: leave the model disabled with the restore no-op'd, and a
+sibling spec pinning that model skips or fails.
 
 ---
 
@@ -82,7 +138,9 @@ flow count grows.
 - `src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx` and `pages/SettingsPage/pages/ModelProvidersPage/index.tsx` — host the model selection panel and the `provider-item-...` / `model-provider-selection` testids.
 - `src/frontend/src/modals/modelProviderModal/hooks/useModelToggleQueue.ts` — the optimistic queue + ~1s debounced `POST .../enabled_models` write under test. Changing the endpoint or debounce affects the persistence wait.
 - `src/frontend/src/hooks/use-refresh-model-inputs.ts` — refreshes component model dropdowns when toggles change (the propagation behavior in Test 2).
-- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/` — renders the Agent's `model_model` trigger, `value-dropdown-model_model` value span, and the `-option` dropdown entries.
+- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/` — renders the Agent's `model_model` trigger, `value-dropdown-model_model` value span, and the `-option` dropdown entries. `components/ModelList.tsx` owns `getModelOptionTestId(provider, modelName)` = `${provider}-${modelName}-option` and the cmdk `value` = `${provider}::${modelName}` that surfaces as `data-value` — the two attributes this spec resolves a model by.
+- `tests/helpers/provider-setup/model-option.ts` — the shared identity reader (#1463): `enumerateModelOptions()`, `enumerateEnabledModels()`, `ModelOption`, plus `censusForTarget()` / `hasOptionIdentity()` (#1464). Test 2 matches options exclusively through it; the classification is pure and unit-tested in `model-option.test.ts`, because the branch that must not regress ("a `target: 0` verdict counts only with `total > 0` and `providerOthers > 0`") is otherwise reachable only from a live run.
+- `tests/helpers/provider-setup/provider-config.ts` — `langflowProviderName()` supplies the provider as Langflow spells it (`OpenAI`, `Google Generative AI`), which is what the picker groups options by and what the restore payload sends.
 - `tests/helpers/provider-setup/` and `data/models.json` — provider setup and model source of truth (populated by `collect-models`).
 
 ---
@@ -100,7 +158,11 @@ flow count grows.
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`.
 - At least one provider has its env keys set (e.g. `OPENAI_API_KEY`). A real API key is required to configure the provider so models are listed, but no LLM call is made.
-- Run with `--workers=1`: `SimpleAgentTemplatePage.load()` deletes all flows before loading the template, so parallel agent specs would wipe each other's flows. The spec also sets file-level serial mode.
+- Run with `--workers=1`: named template loads collide under parallelism, and Test 2's
+  toggle is **account-global** state that a concurrent provider setup would fight over.
+  The spec also sets file-level serial mode. (`SimpleAgentTemplatePage.load()` does
+  **not** delete flows — the cross-worker wipe was removed in #553; this precondition
+  claimed the opposite until #1464.)
 
 ---
 
@@ -109,3 +171,21 @@ flow count grows.
 - Models are only listed once the provider has an API key configured — the spec cannot run standalone without provider setup.
 - The `model-search-input` filter is used before reading a toggle so the target row is always rendered on-screen, regardless of how many models the provider exposes.
 - The Settings page mounts `ModelProvidersContent` without `onFlushRef`, so persistence depends on the ~1s debounce; the test waits for the `POST` response rather than a fixed timeout.
+- **Why Test 2 resolves a model by identity and not by name or text (#1464).** The two
+  surfaces spell the same model differently, and both spellings were measured on
+  `1.12.0.dev30`:
+
+  | Surface | Attribute | Measured value |
+  |---|---|---|
+  | Agent picker option | `data-testid` | `Anthropic-claude-opus-5-option` |
+  | Agent picker option | `data-value` | `Anthropic::claude-opus-5` |
+  | Agent picker option | `textContent` | `claude-opus-51 of 69` |
+  | Provider panel toggle | `data-testid` | `llm-toggle-gpt-5.6-sol` |
+
+  Stripping `-option` therefore yields a **provider-prefixed** name that can never
+  intersect the panel's bare ids, which made Test 2 skip on every run while counting as
+  `@stable` coverage. And the option's text carries an `sr-only` position counter glued
+  to the name with no separator (`claude-opus-5` + `1 of 69`, from `1.12.0.dev26`), so
+  the anchored `^model$` matchers the removal and re-enable asserts used to run matched
+  nothing — `toHaveCount(0)` passed whether or not the model had been removed. Both are
+  closed by reading `data-value` / `data-testid` through `model-option.ts`.

--- a/tests/helpers/provider-setup/model-option.test.ts
+++ b/tests/helpers/provider-setup/model-option.test.ts
@@ -24,7 +24,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  censusForTarget,
   enumerateModelOptions,
+  hasOptionIdentity,
   nearestModels,
   resolveModelOption,
   toModelOption,
@@ -198,6 +200,98 @@ test("nearestModels surfaces the rename candidates first", () => {
   const nearest = nearestModels("claude-haiku-3-5", DEV26_PICKER);
   assert.equal(nearest[0], "claude-haiku-4-5");
   assert.ok(!nearest.includes("gpt-4o-mini-search-preview"));
+});
+
+// ─── censusForTarget / hasOptionIdentity (#1464) ──────────────────────────────
+//
+// These pin the OTHER direction of the same property: not "can a model the picker
+// offers resolve to a skip", but "can a model the picker still offers be reported
+// as GONE". `model-provider-model-toggle.spec.ts` asserted a removal by matching the
+// option's TEXT with `hasText: /^model$/`, which the dev26 counter had already
+// defeated — so `toHaveCount(0)` passed whether or not the model was removed, for
+// as long as the spec existed. It never noticed because a second defect (the model
+// name derived from a provider-prefixed testid) skipped the test before it ran.
+//
+// So the property is: a `target: 0` verdict is trustworthy ONLY together with
+// `total > 0` and `providerOthers > 0`. Both zero-states below were reached by
+// executed mutation during review, not imagined.
+
+const OPENAI_MODELS = new Set(["gpt-4o-mini", "gpt-4o-mini-search-preview"]);
+
+test("censusForTarget finds the target by data-value and counts the provider's others", () => {
+  const target = option("OpenAI", "gpt-4o-mini", "40 of 90");
+  const census = censusForTarget(DEV26_PICKER, target, OPENAI_MODELS);
+  assert.equal(census.total, 5);
+  assert.equal(census.target, 1);
+  assert.equal(census.providerOthers, 1);
+  assert.deepEqual(census.labels[0], "claude-opus-5");
+});
+
+test("censusForTarget reports removal as target 0 while the provider's others survive", () => {
+  const target = option("OpenAI", "gpt-4o-mini", "40 of 90");
+  const remaining = DEV26_PICKER.filter((o) => o.model !== "gpt-4o-mini");
+  const census = censusForTarget(remaining, target, OPENAI_MODELS);
+  assert.equal(census.target, 0);
+  assert.equal(census.total, 4);
+  // The half that makes the zero mean anything.
+  assert.equal(census.providerOthers, 1);
+});
+
+test("an EMPTY picker yields target 0 — indistinguishable from removal without total", () => {
+  const census = censusForTarget([], option("OpenAI", "gpt-4o-mini"), OPENAI_MODELS);
+  assert.equal(census.target, 0);
+  assert.equal(census.total, 0);
+  assert.equal(census.providerOthers, 0);
+});
+
+test("a picker whose identities stopped parsing yields target 0 with providerOthers 0", () => {
+  // Exactly the review mutation: the options are still rendered and still readable
+  // by a human, but neither attribute resolves any more.
+  const unparsable = DEV26_PICKER.map((o) => ({
+    ...o,
+    testId: "",
+    value: "",
+    model: null,
+  }));
+  const census = censusForTarget(
+    unparsable,
+    option("OpenAI", "gpt-4o-mini"),
+    OPENAI_MODELS,
+  );
+  assert.equal(census.target, 0);
+  assert.ok(census.total > 0, "the list is populated — only the identity broke");
+  assert.equal(census.providerOthers, 0, "so the zero is not attributable to a toggle");
+});
+
+test("censusForTarget falls back to the testid when data-value is gone", () => {
+  const withoutValue = DEV26_PICKER.map((o) => ({ ...o, value: "" }));
+  const target = { testId: "OpenAI-gpt-4o-mini-option", value: "" };
+  assert.equal(censusForTarget(withoutValue, target, OPENAI_MODELS).target, 1);
+});
+
+test("censusForTarget does not confuse two providers sharing a model id", () => {
+  // The #597 collision the spec's target selection has to exclude: a sibling spec
+  // enables `OpenAI Compatible::gpt-4o-mini`, whose bare id is also in the OpenAI
+  // panel's toggle list. Identity keeps them apart.
+  const mixed = [...DEV26_PICKER, option("OpenAI Compatible", "gpt-4o-mini", "91 of 91")];
+  const target = option("OpenAI", "gpt-4o-mini", "40 of 90");
+  assert.equal(censusForTarget(mixed, target, OPENAI_MODELS).target, 1);
+});
+
+test("a target with NEITHER attribute matches nothing, so its census is vacuous", () => {
+  const blank = { testId: "", value: "" };
+  assert.equal(hasOptionIdentity(blank), false);
+  const census = censusForTarget(DEV26_PICKER, blank, OPENAI_MODELS);
+  // Zero targets over a healthy, populated, parsable picker — the trap a caller
+  // must refuse BEFORE polling, since both guards pass here.
+  assert.equal(census.target, 0);
+  assert.ok(census.total > 0);
+  assert.ok(census.providerOthers > 0);
+});
+
+test("hasOptionIdentity accepts an option carrying either attribute alone", () => {
+  assert.equal(hasOptionIdentity({ testId: "OpenAI-gpt-4o-option", value: "" }), true);
+  assert.equal(hasOptionIdentity({ testId: "", value: "OpenAI::gpt-4o" }), true);
 });
 
 // The `sr-only`-stripping half runs INSIDE the page (`Locator.evaluateAll`), so it

--- a/tests/helpers/provider-setup/model-option.test.ts
+++ b/tests/helpers/provider-setup/model-option.test.ts
@@ -25,7 +25,6 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   censusForTarget,
-  enumerateModelOptions,
   hasOptionIdentity,
   nearestModels,
   resolveModelOption,

--- a/tests/helpers/provider-setup/model-option.ts
+++ b/tests/helpers/provider-setup/model-option.ts
@@ -267,7 +267,83 @@ export async function readModelOptions(options: Locator): Promise<ModelOption[]>
   return raw.map(toModelOption);
 }
 
-/** Model ids of the provider panel's toggles — the second source of truth. */
+/**
+ * Whether an option can be matched against at all.
+ *
+ * A target carrying neither attribute matches NOTHING, so every "it is no longer
+ * offered" verdict about it is vacuous. That state is not hypothetical: reviewing
+ * #1464 reproduced it by blanking both attributes on a target whose model HAD been
+ * disabled, and the removal step passed — the run only reddened 25 s later, at the
+ * re-enable, blaming the product for what was a suite defect.
+ */
+export function hasOptionIdentity(
+  option: Pick<ModelOption, "testId" | "value">,
+): boolean {
+  return option.value !== "" || option.testId !== "";
+}
+
+/** What one read of the picker establishes about a single target option. */
+export type PickerCensus = {
+  /** Options offered, every provider included. */
+  total: number;
+  /** Options whose IDENTITY is the target's — 0 or 1 in a healthy picker. */
+  target: number;
+  /** OTHER models of the caller's provider that still resolve by identity. */
+  providerOthers: number;
+  /** What a user would read, for the failure message. */
+  labels: string[];
+};
+
+/**
+ * Counts what an enumerated picker establishes about one target option.
+ *
+ * Pure for the same reason `resolveModelOption` is: the property that must never
+ * regress is that a NEGATIVE verdict about one option can only be reached from a
+ * picker that was populated and is still parsable — and a unit test can pin that
+ * where a live spec cannot reproduce a markup change on demand. `target: 0` alone
+ * is also exactly what an empty list and a renamed attribute produce, so a caller
+ * asserting it without `total` and `providerOthers` is asserting nothing
+ * (#1012/#1461). Matching is on `data-value` then `data-testid`; the option's text
+ * is never consulted, because the `sr-only` position counter added on
+ * 1.12.0.dev26 renders inside it with no separator ("claude-opus-5" + "1 of 69").
+ *
+ * `providerOthers` keys on the model ID rather than the provider label on purpose:
+ * it answers "does this provider's catalog still resolve at all", which is the
+ * question that separates a model the product removed from a reader we broke.
+ */
+export function censusForTarget(
+  options: ModelOption[],
+  target: Pick<ModelOption, "testId" | "value">,
+  providerModels: ReadonlySet<string>,
+): PickerCensus {
+  const isTarget = (option: ModelOption): boolean =>
+    (target.value !== "" && option.value === target.value) ||
+    (target.testId !== "" && option.testId === target.testId);
+
+  return {
+    total: options.length,
+    target: options.filter(isTarget).length,
+    providerOthers: options.filter(
+      (option) =>
+        !isTarget(option) &&
+        option.model !== null &&
+        providerModels.has(option.model),
+    ).length,
+    labels: options.map((option) => option.visibleLabel),
+  };
+}
+
+/**
+ * Model ids of the provider panel's toggles — the second source of truth.
+ *
+ * The name is narrower than the behavior and callers must not over-trust it: this
+ * returns EVERY rendered `llm-toggle-*` id regardless of `aria-checked`, including
+ * the rows inside the collapsed `llm-deprecated-disclosure` (measured on
+ * 1.12.0.dev30: 49 ids for OpenAI, 41 checked and 8 not, the 8 being exactly the
+ * deprecated ones). So it answers "which models does this provider LIST", not
+ * "which are enabled" — which is what its callers want, and why the behavior is
+ * left alone; a count taken from it is never a count of enabled models.
+ */
 export async function enumerateEnabledModels(page: Page): Promise<string[]> {
   const ids = await page
     .locator('[data-testid^="llm-toggle-"]')

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
@@ -97,30 +97,48 @@ let disabledModel: string | null = null;
 // model-provider/openai-compatible-provider-setup.spec.ts.
 test.afterEach(async ({ request }) => {
   const model = disabledModel;
-  disabledModel = null;
-  if (!model || !provider) return;
-
-  const bearer = await getAuthToken(request);
-  const res = await request.post(ENABLED_MODELS_ENDPOINT, {
-    headers: { Authorization: bearer, "Content-Type": "application/json" },
-    data: [
-      {
-        provider: providerLabel,
-        model_id: model,
-        enabled: true,
-        model_type: "llm",
-      },
-    ],
-  });
-  // Loud, never swallowed: a silent failure here hands every later spec a disabled
-  // model with nothing in the log naming why (#1012).
-  if (res.status() !== 200) {
-    console.log(
-      `⚠️  could not restore "${model}" for ${providerLabel} — POST ` +
-        `${ENABLED_MODELS_ENDPOINT} -> ${res.status()} ` +
-        `${(await res.text()).slice(0, 200)}. Later specs pinning it may skip or fail.`,
-    );
+  if (!model || !provider) {
+    disabledModel = null;
+    return;
   }
+
+  // Retried HERE rather than deferred to a later test's hook. Test 2 is the only
+  // test that arms this flag and it is the LAST test in a serial file, so "the next
+  // afterEach will retry" describes a hook that never runs — the transient 5xx or
+  // transport throw has to be survived on the spot or not at all.
+  let lastOutcome = "";
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const bearer = await getAuthToken(request);
+      const res = await request.post(ENABLED_MODELS_ENDPOINT, {
+        headers: { Authorization: bearer, "Content-Type": "application/json" },
+        data: [
+          {
+            provider: providerLabel,
+            model_id: model,
+            enabled: true,
+            model_type: "llm",
+          },
+        ],
+      });
+      if (res.status() === 200) {
+        disabledModel = null;
+        return;
+      }
+      lastOutcome = `${res.status()} ${(await res.text()).slice(0, 200)}`;
+    } catch (error) {
+      lastOutcome = `threw: ${(error as Error)?.message ?? String(error)}`;
+    }
+  }
+
+  // Left ARMED deliberately. Nothing in this file will act on it today, but a test
+  // added after Test 2 would restore it in its own teardown, and an armed flag costs
+  // nothing when nothing follows. Loud, never swallowed: a silent failure hands every
+  // later spec a disabled model with nothing in the log naming why (#1012).
+  console.log(
+    `⚠️  could not restore "${model}" for ${providerLabel} after 3 attempts — POST ` +
+      `${ENABLED_MODELS_ENDPOINT} -> ${lastOutcome}. Later specs pinning it may skip or fail.`,
+  );
 });
 
 // Load the Simple Agent template with the configured provider. This configures

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
@@ -7,10 +7,19 @@ import { navigateSettingsPages } from "../../../../helpers/ui/go-to-settings";
 import {
   hasProviderEnvKeys,
   keyedProviderNames,
+  langflowProviderName,
   missingProviderEnvKeys,
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
+import {
+  censusForTarget,
+  enumerateEnabledModels,
+  enumerateModelOptions,
+  hasOptionIdentity,
+  type ModelOption,
+  type PickerCensus,
+} from "../../../../helpers/provider-setup/model-option";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
@@ -47,6 +56,12 @@ const providerItemTestId = provider
   ? providerConfigMap[provider].providerTestId
   : "";
 
+// The provider as LANGFLOW spells it ("OpenAI", "Google Generative AI") — the same
+// string the picker groups its options by (`ModelList` renders
+// `data-value="${provider}::${model}"` and the panel `provider-item-${provider}`,
+// both from the models API). Derived, never a second table (#1043/#1184).
+const providerLabel = provider ? langflowProviderName(provider) : "";
+
 const ENABLED_MODELS_ENDPOINT = "/api/v1/models/enabled_models";
 
 // SimpleAgentTemplatePage.load() does NO cleanup (post-#553 contract) and the
@@ -60,6 +75,51 @@ test.afterEach(async ({ request }) => {
   const bearer = await getAuthToken(request);
   for (const id of createdFlowIds.splice(0)) {
     await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(() => {});
+  }
+});
+
+// Model set to DISABLED by the test body and not yet restored by it.
+//
+// Test 2 mutates ACCOUNT-GLOBAL state, and until #1464 that mutation was
+// unreachable — the provider-prefixed model name made the test skip before the
+// disable — so no failure-path restore ever existed. Waking the test makes one
+// mandatory: a failure between the disable and the re-enable would otherwise leave
+// the model off for every later spec. The sibling setups do re-enable everything
+// (`[data-testid^="llm-toggle"]:visible` in setup-openai/anthropic/google), but only
+// when a later spec configures the SAME provider in the same lane, which the daily's
+// weekday provider rotation does not guarantee — and
+// `setup-language-model-openai.ts` enables one model and repairs nothing.
+let disabledModel: string | null = null;
+
+// Restored over the API, not the UI: after a mid-test failure the page can be
+// anywhere, and a restore that needs Settings to render is a restore that fails
+// exactly when it is needed. Payload shape shared with
+// model-provider/openai-compatible-provider-setup.spec.ts.
+test.afterEach(async ({ request }) => {
+  const model = disabledModel;
+  disabledModel = null;
+  if (!model || !provider) return;
+
+  const bearer = await getAuthToken(request);
+  const res = await request.post(ENABLED_MODELS_ENDPOINT, {
+    headers: { Authorization: bearer, "Content-Type": "application/json" },
+    data: [
+      {
+        provider: providerLabel,
+        model_id: model,
+        enabled: true,
+        model_type: "llm",
+      },
+    ],
+  });
+  // Loud, never swallowed: a silent failure here hands every later spec a disabled
+  // model with nothing in the log naming why (#1012).
+  if (res.status() !== 200) {
+    console.log(
+      `⚠️  could not restore "${model}" for ${providerLabel} — POST ` +
+        `${ENABLED_MODELS_ENDPOINT} -> ${res.status()} ` +
+        `${(await res.text()).slice(0, 200)}. Later specs pinning it may skip or fail.`,
+    );
   }
 });
 
@@ -142,6 +202,29 @@ async function setToggle(
   await save;
 }
 
+// Reads the OPEN model picker and counts what it establishes about the target.
+//
+// The classification is `censusForTarget` — pure, in the shared helper, and unit
+// tested there, because the branch that must never regress ("a `target: 0` verdict
+// is trustworthy ONLY with `total > 0` and `providerOthers > 0`") is otherwise
+// reachable only from a live run of a spec that mutates global state.
+//
+// `timeout` matters and is the caller's business: `enumerateModelOptions` waits for
+// the first option and SWALLOWS that timeout, so a long budget inside a poll
+// predicate lets one call consume the whole poll deadline (#1464 review).
+async function readPickerCensus(
+  page: Page,
+  target: ModelOption,
+  providerModels: Set<string>,
+  timeout: number,
+): Promise<PickerCensus> {
+  return censusForTarget(
+    await enumerateModelOptions(page, timeout),
+    target,
+    providerModels,
+  );
+}
+
 // Named template loads collide under parallelism — this file is serial and
 // the folder is run with --workers=1 (agent-family convention).
 test.describe.configure({ mode: "serial" });
@@ -202,36 +285,47 @@ test.describe("Model Provider Model Toggle", () => {
 
       const modelTrigger = page.getByTestId("model_model");
       const modelValue = page.getByTestId("value-dropdown-model_model");
-      const optionLocator = '[data-testid$="-option"]';
 
       let flowUrl = "";
-      let targetModel = "";
-      let dropdownModels: string[] = [];
+      let dropdownOptions: ModelOption[] = [];
       let dropdownSelected = "";
+      let providerModels = new Set<string>();
+      let target: ModelOption;
+      let targetModel = "";
 
       await test.step("load Agent with configured provider and capture model options", async () => {
         await loadAgentWithProvider(page);
         await expect(modelTrigger).toBeVisible({ timeout: 30000 });
         flowUrl = page.url();
 
-        const selectedModel = (await modelValue.innerText()).trim();
+        dropdownSelected = (await modelValue.innerText()).trim();
         await modelTrigger.click();
-        const options = page.locator(optionLocator);
-        await options.first().waitFor({ state: "visible", timeout: 10000 });
-        // Derive model names from the `${name}-option` testid rather than the
-        // option's innerText — deprecated options also render a "Deprecated"
-        // badge, so innerText would yield a malformed name. This mirrors how
-        // Test 1 reads the model name from the toggle's testid.
-        const names = (
-          await options.evaluateAll((els) =>
-            els.map(
-              (el) =>
-                el.getAttribute("data-testid")?.replace(/-option$/, "") ?? "",
-            ),
-          )
-        ).filter((n) => n.length > 0);
-        dropdownModels = names;
-        dropdownSelected = selectedModel;
+        // Read every option through the shared identity reader (#1463) rather
+        // than deriving a name from the raw testid. The picker's testid is
+        // `${provider}-${model}-option` (ModelList.getModelOptionTestId), so the
+        // `-option`-suffix strip this used to run yielded "OpenAI-gpt-4.1" and
+        // could never intersect the provider panel's bare `llm-toggle-gpt-4.1` —
+        // the skip that made this test pass without ever running (#1464).
+        dropdownOptions = await enumerateModelOptions(page);
+        const seenProviders = [
+          ...new Set(dropdownOptions.map((o) => o.provider ?? "(unparsed)")),
+        ].join(", ");
+        // Scoped to THIS provider, not to the picker as a whole. An all-provider
+        // count passes on Anthropic's and Google's options while the test's own
+        // provider is absent, and the run then dies further down on a toggle
+        // `waitFor` timeout that names no cause — the misattribution a repo with
+        // three recorded drained-key incidents cannot afford (#772/#1029/#1169).
+        const ownOptions = dropdownOptions.filter(
+          (option) => option.provider === providerLabel,
+        );
+        expect(
+          ownOptions.length,
+          `the Agent's model picker offers no ${providerLabel} option, so nothing about ` +
+            `removal can be proven — ${dropdownOptions.length} option(s) enumerated across ` +
+            `[${seenProviders}]. Either the provider was not configured (a rejected or ` +
+            `drained key leaves the credential unsaved) or its list never loaded. Reported ` +
+            `as a FAILURE, not a skip: zero observations prove nothing (#1461)`,
+        ).toBeGreaterThan(0);
         await page.keyboard.press("Escape");
       });
 
@@ -249,44 +343,137 @@ test.describe("Model Provider Model Toggle", () => {
           .locator('[data-testid^="llm-toggle-"]')
           .first()
           .waitFor({ state: "attached", timeout: 10000 });
-        const providerModels = new Set(
-          (
-            await page
-              .locator('[data-testid^="llm-toggle-"]')
-              .evaluateAll((els) =>
-                els.map(
-                  (el) =>
-                    el.getAttribute("data-testid")?.replace(/^llm-toggle-/, "") ??
-                    "",
-                ),
-              )
-          ).filter((n) => n.length > 0),
+        providerModels = new Set(await enumerateEnabledModels(page));
+        const ownOptions = dropdownOptions.filter(
+          (option) => option.provider === providerLabel,
         );
-        targetModel =
-          dropdownModels.find(
-            (n) => providerModels.has(n) && n !== dropdownSelected,
-          ) ?? "";
+        // `option.provider === providerLabel` is load-bearing, not decoration. The
+        // panel's toggles are BARE model ids, so an id-only intersection also
+        // matches an option belonging to a DIFFERENT provider that happens to ship
+        // the same id — and that is a configured state in this suite, not a
+        // hypothetical: `model-provider/openai-compatible-provider-setup.spec.ts`
+        // deliberately enables `OpenAI Compatible::gpt-4o-mini` over the API so its
+        // option renders, and the Azure sibling seeds `gpt-4o`/`gpt-4o-mini`/
+        // `gpt-4.1` — both `@stable`, same account, `workers: 2`. Without the
+        // provider clause the foreign option can become the target, the toggle then
+        // gets flipped in the WRONG panel, the removal poll never sees its option
+        // leave, and OpenAI's `gpt-4o-mini` is left disabled account-wide.
+        //
+        // Deprecated models are excluded, not because they cannot be toggled but
+        // because their row lives inside the collapsed `*-deprecated-disclosure`
+        // section: `toggleForModel` waits for a VISIBLE toggle and would time out
+        // on a cause that has nothing to do with the behavior under test.
+        const providerOptions = ownOptions.filter(
+          (option) =>
+            option.model !== null &&
+            providerModels.has(option.model) &&
+            !option.deprecated,
+        );
+        // Loud rather than skipped, but claiming LESS than it used to. The picker is
+        // a FILTERED subset of the panel by design — the Agent declares a
+        // `tool_calling` filter and only enabled models are offered — so an empty
+        // intersection is not necessarily a defect, and the message no longer says it
+        // is. What justifies failing is narrower and holds regardless of the cause:
+        // zero comparable models means the behavior was never exercised, and a test
+        // that exercised nothing must not read as coverage (#1461/#1012).
+        expect(
+          providerOptions.length,
+          `none of the ${ownOptions.length} ${providerLabel} option(s) the picker offers is a ` +
+            `non-deprecated model the provider panel also lists (${providerModels.size} ` +
+            `llm-toggle-* rendered, every state and deprecated rows included), so there is ` +
+            `nothing whose removal this test could observe. The picker is a filtered subset ` +
+            `of the panel, so this is not necessarily a defect — it fails rather than skips ` +
+            `because a test that exercised nothing must not count as coverage`,
+        ).toBeGreaterThan(0);
+
+        const candidates = providerOptions.filter(
+          (option) => option.model !== dropdownSelected,
+        );
+        // The one legitimately untestable state, and it is degenerate: the
+        // provider offers a single non-deprecated model and it is the one the
+        // Agent has selected. The reason names the counts so it cannot be read
+        // as the blanket skip it replaces.
         test.skip(
-          targetModel.length === 0,
-          "No non-selected dropdown option belongs to the test's provider — cannot test removal.",
+          candidates.length === 0,
+          `${providerLabel} offers exactly ${providerOptions.length} non-deprecated model(s) in ` +
+            `the picker and the only one is the selected "${dropdownSelected}" — removing the ` +
+            `active selection would entangle this test with selection-reset logic.`,
         );
+        target = candidates[0];
+        targetModel = target.model ?? "";
+        // Refused HERE, before anything is polled against it: a target carrying
+        // neither `data-value` nor `data-testid` matches no option at all, so every
+        // later "it is no longer offered" verdict about it is vacuous. Review
+        // reproduced exactly that by blanking both attributes — the removal step
+        // PASSED, and the run only reddened 25 s later at the re-enable, blaming the
+        // product for a suite defect.
+        expect(
+          hasOptionIdentity(target),
+          `the target option carries neither data-value nor data-testid (visible label ` +
+            `"${target.visibleLabel}"), so nothing can be matched against it and every ` +
+            `removal verdict below would be vacuous`,
+        ).toBe(true);
+        expect(
+          targetModel.length,
+          `the target option resolved no model id (testid "${target.testId}", ` +
+            `data-value "${target.value}")`,
+        ).toBeGreaterThan(0);
+
         const toggle = await toggleForModel(page, targetModel);
         await setToggle(page, toggle, false);
+        // Armed for the failure-path restore in afterEach; disarmed by the re-enable
+        // step below when the test completes normally.
+        disabledModel = targetModel;
       });
 
       await test.step("target model no longer appears in the component dropdown", async () => {
         await page.goto(flowUrl);
         await expect(modelTrigger).toBeVisible({ timeout: 30000 });
         await modelTrigger.click();
-        await page
-          .locator(optionLocator)
-          .first()
-          .waitFor({ state: "visible", timeout: 10000 });
-        await expect(
-          page.locator(optionLocator, {
-            hasText: new RegExp(`^${escapeRegExp(targetModel)}$`),
-          }),
-        ).toHaveCount(0);
+
+        // Asserted BEFORE the poll, and that order is the whole point.
+        // `enumerateModelOptions` waits for the first option and swallows its own
+        // timeout, so with the same budget on both, ONE predicate call consumes the
+        // poll's entire deadline and `expect.poll` aborts as "Timeout 10000ms
+        // exceeded while waiting on the predicate" — no Expected/Received, no cause.
+        // Review proved this by removing the click above: the guard below never ran.
+        const opened = await readPickerCensus(page, target, providerModels, 10000);
+        expect(
+          opened.total,
+          `the Agent's model picker rendered ZERO options — it did not open, or the ` +
+            `catalog is empty; either way it proves nothing about "${targetModel}"`,
+        ).toBeGreaterThan(0);
+
+        // ONE read decides all three figures. Polling `target` and re-reading for the
+        // guards let a transient empty read satisfy the poll while a later populated
+        // read — still containing the target — satisfied the guards, so the step could
+        // go green with the model still offered. `census` therefore holds exactly the
+        // read that satisfied the matcher, and a short inner timeout keeps each
+        // iteration cheap.
+        let census = opened;
+        await expect
+          .poll(
+            async () => {
+              census = await readPickerCensus(page, target, providerModels, 2000);
+              return census.target;
+            },
+            { timeout: 10000 },
+          )
+          .toBe(0);
+
+        // That zero is evidence of removal only if the picker was populated and this
+        // provider's OTHER models still resolve by identity (#1012).
+        expect(
+          census.total,
+          `"${targetModel}" is absent from a picker that rendered ZERO options — ` +
+            `that proves nothing about the toggle`,
+        ).toBeGreaterThan(0);
+        expect(
+          census.providerOthers,
+          `"${targetModel}" is absent, but so is every OTHER model of ${providerLabel} — ` +
+            `the ${census.total} option(s) offered are [${census.labels.join(", ")}], so the ` +
+            `absence is not attributable to the toggle`,
+        ).toBeGreaterThan(0);
         await page.keyboard.press("Escape");
       });
 
@@ -294,23 +481,31 @@ test.describe("Model Provider Model Toggle", () => {
         await openProviderModelList(page);
         const toggle = await toggleForModel(page, targetModel);
         await setToggle(page, toggle, true);
+        // Restored by the test itself — the afterEach net is no longer needed.
+        disabledModel = null;
 
         await page.goto(flowUrl);
         await expect(modelTrigger).toBeVisible({ timeout: 30000 });
         await modelTrigger.click();
-        await expect(
-          page.locator(optionLocator, {
-            hasText: new RegExp(`^${escapeRegExp(targetModel)}$`),
-          }),
-        ).toHaveCount(1, { timeout: 10000 });
+        // Same pre-poll guard as the removal step. This step cannot go vacuously
+        // green (an empty picker never yields `target: 1`), but without the guard a
+        // popover that never opened fails here as "expected 1, received 0" — which
+        // reads as a product claim that re-enabling did not work.
+        const opened = await readPickerCensus(page, target, providerModels, 10000);
+        expect(
+          opened.total,
+          `the Agent's model picker rendered ZERO options after re-enabling ` +
+            `"${targetModel}" — it did not open, or the catalog is empty`,
+        ).toBeGreaterThan(0);
+        await expect
+          .poll(
+            async () =>
+              (await readPickerCensus(page, target, providerModels, 2000)).target,
+            { timeout: 15000 },
+          )
+          .toBe(1);
         await page.keyboard.press("Escape");
       });
     },
   );
 });
-
-// Escape a model name for safe use inside an anchored RegExp (model ids can
-// contain regex metacharacters such as "." in "gpt-4.1").
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}


### PR DESCRIPTION
**Closes #1464.**

## Problem

`model-provider-model-toggle.spec.ts` Test 2 is `@stable` and **had never run**. Not a failure — a test passing by never executing, counted as coverage in every generated total. Two defects, stacked, both measured live on `1.12.0.dev30`:

**1 — the permanent skip.** The spec derived the model name from the picker's testid with `replace(/-option$/, "")`. That testid is `${provider}-${model}-option` (`ModelList.getModelOptionTestId`), so it yielded `Anthropic-claude-opus-5`, while the provider panel's toggles yield the bare `claude-opus-5`. The intersection was empty on every run and `test.skip` fired before anything was exercised — including the 2026-08-14 daily ([run 31786538844](https://github.com/oriontech-me/langflow-e2e/actions/runs/31786538844)).

**2 — the vacuous assert behind it.** The removal assertion matched the option's **text** with `hasText: /^model$/`. Since `1.12.0.dev26` each option renders an `sr-only` "N of M" counter glued to the name with no separator — measured `"claude-opus-51 of 69"` — so `toHaveCount(0)` passed whether or not the model had been removed. Same shape in the re-enable step. This is #1459's mechanism reaching a second surface.

The four spellings, measured:

| Surface | Attribute | Value |
|---|---|---|
| picker option | `data-testid` | `Anthropic-claude-opus-5-option` |
| picker option | `data-value` | `Anthropic::claude-opus-5` |
| picker option | `textContent` | `claude-opus-51 of 69` |
| provider panel toggle | `data-testid` | `llm-toggle-gpt-5.6-sol` |

## Product finding

**The product is correct — both defects were ours.** With the assertions executing for the first time: 69 options, disable `gpt-5.6-sol`, 68 remain with only that one gone and every other OpenAI model intact; re-enabling restores it. No backend errors across 5 clean runs.

## Fix

Options are resolved through `tests/helpers/provider-setup/model-option.ts` (`data-value`, `data-testid` as fallback) — never text. Waking the test made several things mandatory that the skip had been hiding:

- **The target is matched on `option.provider` too**, not on the bare model id alone. A shared id is a *configured* state in this suite, not a hypothesis: `openai-compatible-provider-setup.spec.ts` enables `OpenAI Compatible::gpt-4o-mini` over the API precisely so its option renders, and the Azure sibling seeds `gpt-4o`/`gpt-4o-mini`/`gpt-4.1` — both `@stable`, same account, `workers: 2`. Without the clause the foreign option can become the target, the toggle is flipped in the **wrong panel**, and OpenAI's `gpt-4o-mini` is left disabled account-wide.
- **A failure-path restore.** The disable mutates account-global state and was previously unreachable (the skip fired first), so no restore existed. Done over the API — after a mid-test failure the page can be anywhere, and a restore needing Settings to render fails exactly when it is needed. A failed restore is logged loudly, never swallowed.
- **The populated guard runs before the poll.** `enumerateModelOptions` waits for the first option and swallows that timeout, so with the same budget on both, one predicate call consumed the poll's whole deadline and it aborted as `Timeout 10000ms exceeded while waiting on the predicate` — no cause named.
- **One read decides all three figures.** Polling `target` and re-reading for the guards let a transient empty read satisfy the poll while a later populated read, still containing the target, satisfied the guards.
- **The target's identity is asserted to exist** before anything is polled against it — a target with neither attribute matches no option, making every removal verdict vacuous.

The pure classification (`censusForTarget`, `hasOptionIdentity`) lives in `model-option.ts` with 8 unit tests, for the reason `resolveModelOption`'s own docstring gives: a unit test can pin the branch where a live spec cannot reproduce a markup change on demand. **Additive only — no existing export changes.**

**Rejected alternatives.** Keeping the blanket `test.skip` when no comparable model is found: that is what hid this defect for its whole life (#1461). Asserting "the two sources disagree ⇒ defect": refuted — the picker is a *filtered* subset (`passesModelFilters`, the Agent declares a `tool_calling` filter), so an empty intersection is not necessarily a defect. It still **fails** rather than skips, on the narrower ground that zero comparable models means the behavior was never exercised, and that must not read as coverage.

## Scope note

Test 1 is unchanged in behavior and its tags are untouched. The only surviving `test.skip` in Test 2 is the degenerate case (the provider offers a single non-deprecated model and it is the selected one) and its reason carries the counts. The step-1 guard is now scoped to the test's own provider, so a drained key for *this* provider while another is configured fails with the cause named instead of dying later on an unattributed toggle timeout (#772, #1029, #1169). Flow cleanup is untouched. `QA-CHECKLIST.md` needs no edit — both Part II bullets already exist and remain accurate.

## Validation (nightly `1.12.0.dev30`, `--retries=0`, `--workers=1`)

- typecheck ✅ · eslint 0 errors ✅ · `npm run test:units` 684 pass / 0 fail ✅ · both QA-CHECKLIST guards ✅
- **5 clean runs**, 2 passed each, 38.9–40.2s, no flake ✅
- zero `🚨 Backend Error` ✅ · zero restore warnings ✅ · **0 orphan flows** after a clean run ✅
- `--trace=on` ❌ **not run** — Simple Agent template family hangs indefinitely under tracing (#490/#518). Covered instead by the `--retries=0` runs, a live DOM scout, and the force-fails below.

**Force-fails — executed, isolated with `--grep`, all reverted (`git diff | grep -c FF-MUTATION` → 0):**

| Mutation | Result |
|---|---|
| toggle left **enabled** (the one this issue names) | removal poll red, `Expected 0 / Received 1` — the old code passed here |
| toggle left **disabled** at re-enable | red, `Expected 1` |
| option identity stops parsing, picker full | red on the `providerOthers` guard, naming the 68 options |
| Test 1 `setToggle` no-op | red, `aria-checked` `Expected "false" / Received "true"` |
| picker never opens | red **naming the cause** (`rendered ZERO options — it did not open`); before the fix, a mute poll timeout |
| target identity blanked | red **at selection**; before the fix, the removal step *passed* and the run reddened 25s later at the re-enable, blaming the product |
| provider clause, A/B | foreign Anthropic id injected into the panel set: **with** the clause green (ignored), **without** it the target becomes the Anthropic option and the spec looks for `llm-toggle-claude-opus-5` in the **OpenAI** panel → timeout |
| restore no-op'd | `gpt-5.6-sol` left `false` (real leak); with the restore, `true` after a run that failed *after* disabling it |

Two of these — the picker-never-opens and blank-identity cases — were found by adversarial review *after* the first round, and each showed a guard I had reported as verified was not: the first force-fail I wrote for the empty-picker guard mutated the read to return instantly, which bypassed the timing that made the guard unreachable in the real state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
