### PR TITLE
test(security): assert crafted payloads are validated, never executed (#1392)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -863,13 +863,18 @@
 
 #### 17.2 Code Execution Endpoints
 
-- [ ] `POST /api/v1/validate/code` rejects a payload crafted to execute on validation
+- [-] `POST /api/v1/validate/code` rejects a payload crafted to execute on validation
       (**recurring upstream defect — reported in 2023 as #696 and again in 2026 as #13336,
       three years apart on the same endpoint**, which is the strongest recurrence signal in
-      the whole bug corpus)
-- [ ] The custom-component endpoint rejects the same class of payload
-      (`langflow-ai/langflow#7900`)
-- [ ] A rejected payload leaves no partial component created
+      the whole bug corpus). "Rejects" means *refuses to execute*: a fixed instance answers
+      `200` with empty error lists, so the assertion is the absence of the side effect, never
+      a status code → security/code-execution-endpoints.spec.ts
+- [-] The custom-component endpoint rejects the same class of payload
+      (`langflow-ai/langflow#7900` — the boundary restored there is authentication; the
+      authenticated build still executes posted code by design)
+      → security/code-execution-endpoints.spec.ts
+- [-] A rejected payload leaves no partial component created
+      → security/code-execution-endpoints.spec.ts
 
 #### 17.3 Secret Exposure
 

--- a/docs/security/code-execution-endpoints.md
+++ b/docs/security/code-execution-endpoints.md
@@ -1,0 +1,281 @@
+# Code Execution Endpoints — crafted payloads are validated, never executed
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the two boundaries that keep **user-submitted Python from running on the code paths
+that only claim to *inspect* it**:
+
+- `POST /api/v1/validate/code` **statically** validates code — it parses and compiles, and never
+  executes. This is the fix for `langflow-ai/langflow#13336` (GHSA-2wcq-pvw2-xh7v, landed in
+  upstream #13696), which is the *same* defect first reported in 2023 as `#696`: `validate_code()`
+  compiled **and `exec()`'d** every module-level `ast.FunctionDef`, and Python evaluates default
+  argument expressions at definition time — so `def f(x=<anything>)` achieved arbitrary code
+  execution during "validation", without the function ever being called.
+- `POST /api/v1/custom_component` — which *does* execute posted code by design, that being the
+  custom-component feature — is reachable only by an authenticated caller. This is the fix for
+  `#7900` (GHSA-4xph-gxg8-rp48), where the route was unauthenticated and gave anonymous RCE.
+
+The same endpoint being reported in **2023 and again in 2026** is the strongest recurrence signal
+in the bug corpus, and it is the reason this spec exists: the 2026 report reproduced the 2023 PoC
+almost verbatim.
+
+### "Rejects" here means "refuses to execute", not "answers 4xx"
+
+The checklist bullet says the endpoint *rejects* the payload. Measured on the nightly, the crafted
+payload is **accepted and answered `200`** — with empty error lists, in milliseconds. That is the
+fixed behaviour: static validation of syntactically valid code succeeds, and the security property
+is the **absence of the side effect**, not a status code. A spec asserting `4xx` on
+`validate/code` would fail on a healthy instance and pass on the vulnerable one (`#696`'s PoC is
+explicit that the exploit returns `{"imports": {"errors": []}, "function": {"errors": []}}`).
+
+So the payload is crafted to make execution *observable in the response itself*:
+
+```python
+def python_function(_probe=__import__("time").sleep(8) or 1 / 0) -> str:
+    return "<sentinel>"
+```
+
+`sleep()` returns `None`, so the `or` always evaluates `1 / 0`. Evaluating that default argument
+therefore costs 8 seconds **and** raises `ZeroDivisionError`. Two independent discriminators come
+out of one request:
+
+| | pre-fix (`exec`) | fixed (`compile` only) |
+|---|---|---|
+| `function.errors` | `["division by zero"]` — the old code caught the exec exception and appended it | `[]` |
+| response time | ≥ 8 s | milliseconds |
+
+The error list is the primary discriminator; the timing is what still catches a regression that
+re-introduces `exec` but swallows the exception. `1 / 0` is **not** constant-folded at compile time
+(measured: `compile()` succeeds and the endpoint answers with no errors), and it cannot be produced
+by the imports checker, so `"division by zero"` in the response can only mean the expression ran.
+
+### The control: the same string, three destinations
+
+A clean, fast validation is only evidence if the payload is genuinely live code on this instance.
+It is proven live by sending **the same string** to the endpoint that is *supposed* to execute it.
+Measured on `1.12.0.dev30` (sleep 4 s in this table, 8 s in the spec):
+
+| request | credentials | status | time | body |
+|---|---|---|---|---|
+| `POST /api/v1/validate/code` — crafted | Bearer | `200` | 0.05 s | `{"imports":{"errors":[]},"function":{"errors":[]}}` |
+| `POST /api/v1/validate/code` — `def broken(:` | Bearer | `200` | 0.01 s | `function.errors: ["invalid syntax (<unknown>, line 1)"]` |
+| `POST /api/v1/custom_component` — crafted | Bearer | **`400`** | **4.04 s** | `Error building Component: Error creating class. ZeroDivisionError(division by zero).` |
+| `POST /api/v1/custom_component` — crafted | *none* | **`403`** | 0.01 s | `{"detail":"No authentication credentials provided"}` |
+| `POST /api/v1/validate/code` — benign | *none* | **`403`** | 0.01 s | `{"detail":"No authentication credentials provided"}` |
+
+Row 3 is the control: the identical string, sent to the build path, sleeps its full budget and
+raises. Row 1's clean, instant answer therefore cannot be explained by an inert payload, by a
+dead endpoint (row 2 still reports real syntax errors), or by the request never arriving.
+
+### Where the UI actually calls each endpoint
+
+Issue #1392 asks for the assertions to be anchored on "the custom-component code editor" as the UI
+surface that calls `validate/code`. **It is not** — measured on `1.12.0.dev30` by reading the
+frontend bundle and confirming live. The code-editor modal has two save paths and dispatches on
+whether it is editing a **component's own source** or a **`CodeInput` field**:
+
+- a node's source editor (`code-button-modal`) — on the **Custom Component** *and* on a built-in
+  node such as Chat Input — posts to `POST /api/v1/custom_component`;
+- a `CodeInput`-typed field's editor posts to `POST /api/v1/validate/code`.
+
+The whole component catalog has exactly **one** `CodeInput` field: **Python Function**'s
+`function_code` (`prototypes`, `legacy: true`, so it needs the sidebar Legacy toggle). That editor
+is therefore the only UI surface in the product that reaches `validate/code`, and it is where
+Test 1 is anchored. Anchoring Test 1 on the custom-component editor would have produced a spec
+that never touches the endpoint named in the bullet — the `#1092` failure mode, one layer up.
+
+This is also where the 4xx the issue predicts comes from, and why `page.allowHttpErrors()` is
+required: the *build* endpoint answers `400` for the crafted payload (Test 2), driven from the UI.
+
+If these tests fail: either the validation endpoint executes submitted code again (a remote code
+execution reachable by any authenticated user, `#696` / `#13336`), or the build endpoint stopped
+requiring credentials (`#7900`, anonymous RCE).
+
+---
+
+## Tags *(required)*
+
+`@api` `@regression` `@components`
+
+No **functional** tag applies: the tag table has no security area, and all three sibling specs
+under `regression/security/` carry cross-cutting tags only (`credential-secret-exposure`,
+`ssrf-url-validation`, `tweaks-injection`). `@api` marks the layer the verdict is read from (the
+two endpoints' responses); `@components` marks the surface driven to get there (the node code
+editor and the parameters-panel `CodeInput` editor), mirroring `ssrf-url-validation.spec.ts`'s
+UI test. `@regression` is what the recurrence asks for.
+
+**`@stable` is deliberately absent on the first delivery**, decided with the maintainer at SPECIFY.
+The three sibling security specs shipped `@stable` on day one, but they are pure API (no browser,
+~3 s); this one is UI-driven and adds two sidebar adds — the surface Langflow measurably drops
+clicks on (#1301/#1304) — plus ~16 s of deliberate `sleep` budget that the control spends proving
+the payload is live, for ~90 s total. It therefore takes a validation cycle in the normal lane
+before being watched by `daily-stable.yml`; the checklist bullets ship as `[-]` (automated, needs
+validation) and the promotion is a follow-up, not a spec-doc change. It is **not** `@destructive`:
+every test creates its own flow via the API and deletes it id-scoped in `afterEach`.
+
+---
+
+## Step by step *(required)*
+
+Three independent tests. Each creates its own flow through `POST /api/v1/flows/` (parallel-safe
+unique name), drives the UI at `/flow/{id}`, and deletes that id in `afterEach`. No LLM, no
+provider key.
+
+**Shared payload** — one module-level function whose default argument both sleeps and raises,
+built once with a per-run sentinel so a match can never be coincidental:
+
+```python
+def python_function(_probe=__import__("time").sleep(8) or 1 / 0) -> str:
+    return "E2E-CODEEXEC-<unique>"
+```
+
+---
+
+**Test 1 — the code editor's validation pass does not execute a crafted default-argument payload**
+*(`@api @regression @components`)*
+
+1. Create a flow via the API, `page.goto('/flow/{id}')`, wait for `sidebar-search-input`.
+2. Enable the sidebar Legacy toggle (`addLegacyComponents`) — Python Function is `legacy: true` and
+   is hidden from the sidebar without it.
+3. `addComponentFromSidebar(page, "Python Function", "add-component-button-python-function")` — the
+   shared primitive that repairs Langflow's swallowed sidebar add (#1301/#1304) — then wait for
+   `title-Python Function`.
+4. Click `codearea_code_function_code`, wait for `checkAndSaveBtn` and `.ace_editor`. Replace the
+   scaffold through ACE's own API (`window.ace.edit(...).setValue(code, -1)`; `fill()` does not
+   reach ACE) with the crafted payload.
+5. Click `checkAndSaveBtn` and capture `POST /api/v1/validate/code`.
+6. Assert on the response: status `200`; `function.errors` and `imports.errors` are both empty
+   — the `ZeroDivisionError` never happened; and the response arrived in under 4 s — the 8 s
+   `sleep` never ran either.
+7. Assert on the UI: the modal closed (`checkAndSaveBtn` hidden) — the editor treated the code as
+   valid, which is exactly what the pre-fix backend could not do, since it would have surfaced
+   `division by zero` in an error toast and kept the modal open.
+8. Assert the value persisted: poll `GET /api/v1/flows/{id}` until
+   `template.function_code.value` contains the run's sentinel. This is the control that the click
+   did something at all — a swallowed click would leave the stored code untouched and steps 6–7
+   would be vacuous.
+
+**Test 2 — the build endpoint refuses the same payload, surfaces the error, and leaves no partial
+component** *(`@api @regression @components`)*
+
+1. `page.allowHttpErrors()` — the build POST is driven into a `400` on purpose.
+2. Create a flow via the API and open it; `addCustomComponent(page)` (the shared primitive with the
+   swallowed-add repair). Wait for `title-Custom Component`.
+3. Poll `GET /api/v1/flows/{id}` until the node is persisted, and record the stored
+   `template.code.value` — the untouched scaffold.
+4. Open `code-button-modal`, replace the scaffold through ACE with **the scaffold plus the same
+   canary function**, and click Check & Save.
+5. Capture `POST /api/v1/custom_component`; assert status `400`, that the response detail names
+   `ZeroDivisionError` / `division by zero`, and that it took at least ~8 s. This is the control
+   for Test 1: the identical expression, on the endpoint that is *meant* to execute posted code,
+   both sleeps and raises.
+6. Assert the failure is **visible to the user**: the modal stayed open and the error text is
+   rendered in it — not a silent no-op.
+7. Assert **no partial component was created**: the canvas still holds exactly one node, still
+   titled `Custom Component`; and `GET /api/v1/flows/{id}` still returns the scaffold recorded in
+   step 3, with the sentinel absent from `template.code.value`.
+
+**Test 3 — both endpoints refuse an unauthenticated caller before executing anything**
+*(`@api @regression`)*
+
+Pure API, through Playwright's `request` fixture with no `Authorization` header (these calls do not
+go through the page, so they are outside the fixture's HTTP monitor and need no
+`allowHttpErrors()`).
+
+1. `POST /api/v1/validate/code` with the crafted payload and no credentials → assert `401`/`403`,
+   that the detail names the missing credentials, and that it answered in under 4 s.
+2. `POST /api/v1/custom_component` with the same payload and no credentials → the same three
+   assertions. This is `#7900`'s boundary: the payload is refused **before** the code is reached,
+   which the timing is what proves.
+3. Control, with the Bearer: `POST /api/v1/custom_component` with the **untouched scaffold** →
+   `200`. Without it, step 2's `403` is ambiguous — an instance with
+   `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false` refuses *every* caller on that route with the same
+   status (`"Custom component creation is disabled"`), which is why the detail string is asserted
+   as well as the code.
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1:** `POST /api/v1/validate/code` answers `200` with `imports.errors == []` and
+  `function.errors == []`, in under 4 s; the editor modal closes; and the sentinel is readable in
+  the saved flow's `template.function_code.value`. Any of `division by zero` in the response, an
+  error toast, or a response slower than 4 s means the default argument was evaluated.
+- **Test 2:** `POST /api/v1/custom_component` answers `400` naming `ZeroDivisionError`, after at
+  least ~8 s; the modal stays open with the error rendered; the canvas still holds exactly one
+  `Custom Component` node; and the flow's stored `template.code.value` is byte-identical to the
+  scaffold recorded before the attempt, with the sentinel absent.
+- **Test 3:** both unauthenticated calls answer `401`/`403` with a credentials-related detail, in
+  under 4 s each, while the authenticated scaffold build answers `200`.
+- Teardown leaves no flow behind:
+  `GET /api/v1/flows/?remove_example_flows=true&header_flows=true` returns the same count before
+  and after the file runs.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **`POST /api/v1/validate/prompt`** — the sibling route on the same router. It never compiled or
+  executed anything, so it is not part of this defect class.
+- **The `custom_component/update` route** (editing an already-built custom component). It shares
+  `resolve_component_code_for_action` and `Component(_code=...)` with `custom_component`, and
+  executes by the same design; the checklist bullet names the create route.
+- **Whether executing posted code on the *build* path is itself acceptable.** It is the
+  custom-component feature, gated by `LANGFLOW_ALLOW_CUSTOM_COMPONENTS` and by the catalog policy
+  (`resolve_component_code_for_action`, which can restrict it to administrators). This spec asserts
+  that path stays behind authentication, not that it stops executing.
+- **The catalog-policy gates themselves** (`disabled` / `admin_only`): both answer `403` on the
+  same routes, so a lane with custom components disabled would see Test 3's refusals for the wrong
+  reason — which is why Test 3's control and detail-string assertions exist, and why the
+  precondition below is explicit.
+- **A file-write or network canary.** The payload proves execution by time and exception, both
+  readable in the HTTP response. A file-write canary would have to be read back through
+  `docker exec`, coupling the spec to the deployment shape (the same call
+  `tweaks-injection.spec.ts` made about container logs).
+- **Every other `exec` site in Langflow** — `eval_function`, `execute_function`,
+  `prepare_global_scope` — reached from the run/build paths, which are covered by
+  `security/tweaks-injection.spec.ts` for the tweaks entry point.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL`.
+- Superuser credentials (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) for `getAuthToken`.
+- `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` on the instance. With it `false`, both routes answer
+  `403` for *every* caller, `sidebar-custom-component-button` is not rendered, and Test 2 could not
+  run at all. Every CI lane and both start scripts set it (#668/#746).
+- The **Python Function** component present in `GET /api/v1/all` (category `prototypes`,
+  `legacy: true`). It is the only `CodeInput` field in the catalog and therefore the only UI caller
+  of `validate/code`; the test fails naming it if it disappears, rather than skipping silently.
+- No provider key and no model resolution — nothing here runs a flow.
+
+---
+
+## External dependencies *(required)*
+
+- `tests/helpers/auth/get-auth-token.ts` — Bearer for the flow API and Test 3's control.
+- `tests/helpers/flows/create-flow.ts` / `delete-flow.ts` — per-test flow lifecycle (id-scoped
+  cleanup).
+- `tests/helpers/flows/add-component-from-sidebar.ts` — Test 1's add, including the swallowed-click
+  repair (#1301/#1304).
+- `tests/helpers/flows/add-custom-component.ts` — Test 2's add, same repair via
+  `addCustomComponentFromSidebar`.
+- `tests/helpers/flows/add-legacy-components.ts` — the sidebar Legacy toggle Python Function needs.
+- `tests/fixtures/fixtures.ts` — `page.allowHttpErrors()` for Test 2's deliberate `400`.
+- `src/lfx/src/lfx/custom/validate.py` — `validate_code()`: the compile-only loop that is the fix
+  being pinned, and `create_class`/`prepare_global_scope`, the `exec` the build path still uses
+  (the source of Test 2's `ZeroDivisionError`).
+- `src/backend/base/langflow/api/v1/validate.py` — `POST /validate/code`: `CurrentActiveUser`
+  (Test 3's boundary), `resolve_component_code_for_action` (the policy gate), and the
+  `CodeValidationResponse` shape (`imports` / `function`) the assertions read.
+- `src/backend/base/langflow/api/v1/endpoints.py` — `POST /custom_component`: `CurrentActiveUser`,
+  the `Component(_code=...)` build, and the `400` detail shape (`detail.error`, `detail.traceback`).
+- `src/lfx/src/lfx/components/prototypes/python_function.py` — the Python Function component and
+  its `function_code` `CodeInput`, the only UI caller of `validate/code`.
+- Upstream references: `langflow-ai/langflow#696` (2023), `#13336` + fix `#13696`
+  (GHSA-2wcq-pvw2-xh7v, 2026), `#7900` (GHSA-4xph-gxg8-rp48).

--- a/tests/tests-automations/regression/security/code-execution-endpoints.spec.ts
+++ b/tests/tests-automations/regression/security/code-execution-endpoints.spec.ts
@@ -1,0 +1,460 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { openFlowById } from "../../../helpers/flows/open-flow-by-id";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { addCustomComponent } from "../../../helpers/flows/add-custom-component";
+import { addLegacyComponents } from "../../../helpers/flows/add-legacy-components";
+
+// Code submitted to the paths that only claim to INSPECT it must never run
+// (langflow-ai/langflow#696 in 2023 and #13336 in 2026 — the same endpoint, three
+// years apart, fixed upstream in #13696 / GHSA-2wcq-pvw2-xh7v), and the path that
+// DOES execute posted code by design must stay behind authentication (#7900 /
+// GHSA-4xph-gxg8-rp48). See docs/security/code-execution-endpoints.md.
+//
+// "Rejects" here means "refuses to execute", NOT "answers 4xx": the crafted
+// payload is syntactically valid, so a healthy `validate/code` answers 200 with
+// empty error lists in milliseconds — #696's PoC is explicit that the exploit
+// comes back clean. A spec asserting 4xx on that endpoint would be red on a fixed
+// instance and green on a vulnerable one.
+//
+// So the payload is crafted to make execution observable in the response itself:
+// evaluating the default argument both sleeps and raises, which gives two
+// independent discriminators out of one request —
+//   pre-fix (exec):   function.errors == ["division by zero"], >= SLEEP_SECONDS
+//   fixed (compile):  function.errors == [],                   milliseconds
+// The error list is the primary signal; the timing still catches a regression
+// that re-introduces exec but swallows the exception. `1 / 0` is not
+// constant-folded (measured: compile() succeeds and the endpoint answers clean),
+// and it cannot be produced by the imports checker, so "division by zero" in the
+// response can only mean the expression ran.
+
+/**
+ * Seconds the crafted default argument sleeps before raising. Long enough that a
+ * loaded instance cannot be mistaken for an executing one (measured on nightly
+ * 1.12.0.dev30: a clean validate answers in ~50-230 ms, i.e. >15x under the
+ * no-exec ceiling below), and short enough that the control in Test 2 — which
+ * DOES execute it — costs one sleep, not several.
+ */
+const SLEEP_SECONDS = 8;
+
+/** A response this fast cannot have evaluated the sleeping default argument. */
+const MAX_NO_EXEC_MS = 4000;
+
+/**
+ * Floor for the build path, which is MEANT to execute the payload. Below the
+ * sleep budget on purpose: it proves the expression ran without pinning the test
+ * to the exact scheduling of a container under load (measured: 8.27 s in the UI,
+ * 8.0-8.3 s over the API).
+ */
+const MIN_EXEC_MS = SLEEP_SECONDS * 1000 * 0.75;
+
+/**
+ * The catalog's own Custom Component scaffold, used only as Test 3's benign
+ * control. Kept verbatim (imports included) so the build exercises the same code
+ * path the crafted payload takes, minus the default argument.
+ */
+const SCAFFOLD_COMPONENT_CODE = `from lfx.custom.custom_component.component import Component
+from lfx.io import MessageTextInput, Output
+from lfx.schema.data import Data
+
+
+class CustomComponent(Component):
+    display_name = "Custom Component"
+    description = "Use as a template to create your own component."
+    icon = "code"
+    name = "CustomComponent"
+
+    inputs = [
+        MessageTextInput(
+            name="input_value",
+            display_name="Input Value",
+            info="This is a custom component Input",
+            value="Hello, World!",
+            tool_mode=True,
+        ),
+    ]
+
+    outputs = [
+        Output(display_name="Output", name="output", method="build_output"),
+    ]
+
+    def build_output(self) -> Data:
+        data = Data(value=self.input_value)
+        self.status = data
+        return data
+`;
+
+/**
+ * The `#696` / `#13336` payload shape: a MODULE-LEVEL function whose default
+ * argument is an executable expression. `validate_code()` walks `tree.body` for
+ * `ast.FunctionDef` nodes, so only a module-level def reaches the line the fix
+ * changed — a method inside the class body would never be visited and the test
+ * would pass vacuously.
+ *
+ * `sleep()` returns `None`, so the `or` always evaluates `1 / 0`.
+ */
+function canaryFunction(name: string, sentinel: string): string {
+  return `def ${name}(_probe=__import__("time").sleep(${SLEEP_SECONDS}) or 1 / 0) -> str:
+    return "${sentinel}"
+`;
+}
+
+/** Unique per test so a match in a stored flow can never be coincidental. */
+function uniqueSentinel(): string {
+  return `E2E-CODEEXEC-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Read one template field of the flow's single node from the saved flow. */
+async function readNodeTemplateValue(
+  request: APIRequestContext,
+  bearer: string,
+  flowId: string,
+  field: string,
+): Promise<string | undefined> {
+  const res = await request.get(`/api/v1/flows/${flowId}`, {
+    headers: { Authorization: bearer },
+  });
+  expect(res.status()).toBe(200);
+  const body = (await res.json()) as {
+    data: {
+      nodes: Array<{
+        data: { node: { template: Record<string, { value?: unknown }> } };
+      }>;
+    };
+  };
+  const value = body.data.nodes[0]?.data?.node?.template?.[field]?.value;
+  return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Replace the open ACE editor's content. `fill()` does not reach ACE — the repo
+ * convention is to go through ACE's own API (#496).
+ */
+async function setAceValue(page: Page, value: string): Promise<void> {
+  await page.locator(".ace_editor").waitFor({ state: "visible", timeout: 10000 });
+  await page.evaluate((code) => {
+    const w = window as unknown as {
+      ace: {
+        edit: (el: Element | null) => {
+          setValue: (v: string, cursor: number) => void;
+          getValue: () => string;
+        };
+      };
+    };
+    w.ace.edit(document.querySelector(".ace_editor")).setValue(code, -1);
+  }, value);
+}
+
+/** The open ACE editor's current content. */
+async function getAceValue(page: Page): Promise<string> {
+  await page.locator(".ace_editor").waitFor({ state: "visible", timeout: 10000 });
+  return page.evaluate(() => {
+    const w = window as unknown as {
+      ace: { edit: (el: Element | null) => { getValue: () => string } };
+    };
+    return w.ace.edit(document.querySelector(".ace_editor")).getValue();
+  });
+}
+
+// Ids of flows created by each test — deleted id-scoped in afterEach (repo
+// convention #490/#681). Every flow here is created through the API by this
+// file, so nothing else can be caught by the sweep.
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(
+      () => {},
+    );
+  }
+});
+
+/** Create a blank flow via the API (parallel-safe unique name) and open it. */
+async function openBlankFlow(
+  page: Page,
+  request: APIRequestContext,
+  bearer: string,
+): Promise<string> {
+  const flowId = await createFlow(
+    request,
+    {
+      name: `Code Exec ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      description: "",
+      data: { nodes: [], edges: [] },
+      is_component: false,
+    },
+    { headers: { Authorization: bearer } },
+  );
+  createdFlowIds.push(flowId);
+  await openFlowById(page, flowId);
+  await page
+    .getByTestId("sidebar-search-input")
+    .waitFor({ state: "visible", timeout: 60000 });
+  return flowId;
+}
+
+test.describe("Code execution endpoints", () => {
+  test(
+    "validating a crafted default-argument payload does not execute it",
+    { tag: ["@api", "@regression", "@components"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const sentinel = uniqueSentinel();
+      // `python_function` is the name the component's scaffold already uses, so
+      // the crafted code differs from a legitimate edit ONLY in the default
+      // argument — the thing under test.
+      const craftedCode = canaryFunction("python_function", sentinel);
+
+      let flowId = "";
+
+      await test.step("open a flow holding a Python Function component", async () => {
+        flowId = await openBlankFlow(page, request, bearer);
+        // Python Function carries `function_code`, the only `CodeInput` field in
+        // the whole catalog and therefore the only UI surface that reaches
+        // POST /api/v1/validate/code (a node's own source editor posts to
+        // /custom_component instead — measured on 1.12.0.dev30). It is
+        // `legacy: true`, so the sidebar hides it until the Legacy toggle is on.
+        await addLegacyComponents(page);
+        await addComponentFromSidebar(
+          page,
+          "Python Function",
+          "add-component-button-python-function",
+        );
+        await expect(page.getByTestId("title-Python Function")).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      let validateStatus = 0;
+      let validateMs = 0;
+      let validateBody: {
+        imports?: { errors?: string[] };
+        function?: { errors?: string[] };
+      } = {};
+
+      await test.step("submit the crafted code through the field's code editor", async () => {
+        await page.getByTestId("codearea_code_function_code").click();
+        await expect(page.getByTestId("checkAndSaveBtn")).toBeVisible({
+          timeout: 15000,
+        });
+        await setAceValue(page, craftedCode);
+
+        const responsePromise = page.waitForResponse(
+          (response) =>
+            response.url().includes("/api/v1/validate/code") &&
+            response.request().method() === "POST",
+          { timeout: 60000 },
+        );
+        const startedAt = Date.now();
+        await page.getByTestId("checkAndSaveBtn").click();
+        const response = await responsePromise;
+        validateMs = Date.now() - startedAt;
+        validateStatus = response.status();
+        validateBody = await response.json();
+      });
+
+      await test.step("the endpoint validated statically instead of executing", async () => {
+        expect(validateStatus).toBe(200);
+        // The pre-fix implementation exec'd the function definition, caught the
+        // resulting exception and appended it here. An empty list is the fix.
+        expect(validateBody.function?.errors ?? []).toEqual([]);
+        expect(validateBody.imports?.errors ?? []).toEqual([]);
+        // Belt and braces: catches a regression that re-introduces exec but
+        // swallows the exception — the sleep would still be paid.
+        expect(
+          validateMs,
+          `validate/code answered in ${validateMs}ms; the payload sleeps ${SLEEP_SECONDS}s when executed`,
+        ).toBeLessThan(MAX_NO_EXEC_MS);
+      });
+
+      await test.step("the editor accepted the code and saved it", async () => {
+        // A vulnerable backend would have reported "division by zero", which the
+        // modal renders as an error while staying open. The modal closing is the
+        // user-visible half of the same verdict.
+        await expect(page.getByTestId("checkAndSaveBtn")).toBeHidden({
+          timeout: 15000,
+        });
+        // Control: the click actually did something. Without this, both
+        // assertions above would also hold for a click that never landed.
+        await expect
+          .poll(
+            () =>
+              readNodeTemplateValue(request, bearer, flowId, "function_code"),
+            { timeout: 20000 },
+          )
+          .toContain(sentinel);
+      });
+    },
+  );
+
+  test(
+    "the build endpoint refuses the same payload and leaves no partial component",
+    { tag: ["@api", "@regression", "@components"] },
+    async ({ page, request }) => {
+      // The build POST is driven into a 400 on purpose — declare it so the
+      // fixture's advisory HTTP log stays trustworthy for every other spec
+      // (#1084).
+      (page as unknown as { allowHttpErrors: () => void }).allowHttpErrors();
+
+      const bearer = await getAuthToken(request);
+      const sentinel = uniqueSentinel();
+
+      let flowId = "";
+      let scaffoldCode = "";
+
+      await test.step("open a flow holding a scaffold Custom Component", async () => {
+        flowId = await openBlankFlow(page, request, bearer);
+        await addCustomComponent(page);
+        await expect(page.getByTestId("title-Custom Component")).toBeVisible({
+          timeout: 15000,
+        });
+        // The scaffold as PERSISTED — the baseline the failed save must not move.
+        await expect
+          .poll(() => readNodeTemplateValue(request, bearer, flowId, "code"), {
+            timeout: 30000,
+          })
+          .toContain("class CustomComponent");
+        scaffoldCode =
+          (await readNodeTemplateValue(request, bearer, flowId, "code")) ?? "";
+      });
+
+      let buildStatus = 0;
+      let buildMs = 0;
+      let buildBody = "";
+
+      await test.step("submit the crafted code through the component's code editor", async () => {
+        await page.getByTestId("code-button-modal").last().click();
+        await expect(page.getByTestId("checkAndSaveBtn")).toBeVisible({
+          timeout: 15000,
+        });
+        // Prepend the canary to the editor's own scaffold: everything else about
+        // the component stays valid, so a failure can only come from the default
+        // argument.
+        const editorScaffold = await getAceValue(page);
+        await setAceValue(
+          page,
+          `${canaryFunction("_e2e_code_exec_canary", sentinel)}\n\n${editorScaffold}`,
+        );
+
+        const responsePromise = page.waitForResponse(
+          (response) =>
+            response.url().includes("/api/v1/custom_component") &&
+            response.request().method() === "POST",
+          { timeout: 90000 },
+        );
+        const startedAt = Date.now();
+        await page.getByTestId("checkAndSaveBtn").click();
+        const response = await responsePromise;
+        buildMs = Date.now() - startedAt;
+        buildStatus = response.status();
+        buildBody = await response.text();
+      });
+
+      await test.step("the payload IS live code, and the build refuses it", async () => {
+        // This is the control for the sibling test: the identical expression, on
+        // the endpoint that is meant to execute posted code, both sleeps its full
+        // budget and raises. A clean, instant `validate/code` therefore cannot be
+        // explained by an inert payload.
+        expect(buildStatus).toBe(400);
+        expect(buildBody).toMatch(/ZeroDivisionError|division by zero/i);
+        expect(
+          buildMs,
+          `the build answered in ${buildMs}ms; executing the payload costs ${SLEEP_SECONDS}s`,
+        ).toBeGreaterThanOrEqual(MIN_EXEC_MS);
+      });
+
+      await test.step("the failure is visible to the user, not silent", async () => {
+        await expect(page.getByTestId("title_error_code_modal")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByTestId("title_error_code_modal")).toContainText(
+          /division by zero/i,
+        );
+        // The modal stays open: the code was not accepted.
+        await expect(page.getByTestId("checkAndSaveBtn")).toBeVisible();
+      });
+
+      await test.step("no partial component was created", async () => {
+        await expect(page.locator('[data-testid^="rf__node-"]')).toHaveCount(1);
+        await expect(page.getByTestId("title-Custom Component")).toBeVisible();
+
+        const persisted = await readNodeTemplateValue(
+          request,
+          bearer,
+          flowId,
+          "code",
+        );
+        expect(persisted).not.toContain(sentinel);
+        expect(persisted).not.toContain("_e2e_code_exec_canary");
+        // Byte-identical to the baseline: the rejected payload left no trace at
+        // all, not merely "no sentinel".
+        expect(persisted).toBe(scaffoldCode);
+      });
+    },
+  );
+
+  test(
+    "both endpoints refuse an unauthenticated caller before executing anything",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // Pure API through the `request` fixture: these calls never go through the
+      // page, so they are outside the fixture's HTTP monitor and need no
+      // allowHttpErrors(). No Authorization header is sent.
+      const sentinel = uniqueSentinel();
+      const craftedCode = canaryFunction("python_function", sentinel);
+
+      await test.step("validate/code refuses an anonymous caller", async () => {
+        const startedAt = Date.now();
+        const response = await request.post("/api/v1/validate/code", {
+          data: { code: craftedCode },
+        });
+        const elapsed = Date.now() - startedAt;
+
+        expect([401, 403]).toContain(response.status());
+        expect(await response.text()).toMatch(/credential|authenticat/i);
+        expect(
+          elapsed,
+          `answered in ${elapsed}ms; executing the payload costs ${SLEEP_SECONDS}s`,
+        ).toBeLessThan(MAX_NO_EXEC_MS);
+      });
+
+      await test.step("the custom-component endpoint refuses an anonymous caller", async () => {
+        // #7900's boundary: this route DOES execute posted code, so the refusal
+        // has to land before the code is reached — which the timing is what
+        // proves.
+        const startedAt = Date.now();
+        const response = await request.post("/api/v1/custom_component", {
+          data: { code: craftedCode },
+        });
+        const elapsed = Date.now() - startedAt;
+
+        expect([401, 403]).toContain(response.status());
+        expect(await response.text()).toMatch(/credential|authenticat/i);
+        expect(
+          elapsed,
+          `answered in ${elapsed}ms; executing the payload costs ${SLEEP_SECONDS}s`,
+        ).toBeLessThan(MAX_NO_EXEC_MS);
+      });
+
+      await test.step("the same route answers an authenticated caller", async () => {
+        // Without this, the refusals above are ambiguous: an instance with
+        // LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false answers 403 to EVERY caller on
+        // this route. A benign build proves the refusals are about credentials.
+        const bearer = await getAuthToken(request);
+        const response = await request.post("/api/v1/custom_component", {
+          headers: { Authorization: bearer },
+          data: { code: SCAFFOLD_COMPONENT_CODE },
+        });
+        expect(
+          response.status(),
+          `authenticated scaffold build failed: ${(await response.text()).slice(0, 300)}`,
+        ).toBe(200);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1392.

Closes the three `[ ]` bullets in `QA-CHECKLIST.md` §17.2 — Code Execution Endpoints — with `security/code-execution-endpoints.spec.ts`. Distinct from `security/tweaks-injection.spec.ts`, which covers the *run* entry point (`POST /api/v1/run/{id}` refusing executable tweak fields): this one covers the two endpoints that take raw Python directly, `POST /api/v1/validate/code` (must never execute it) and `POST /api/v1/custom_component` (executes it by design, so it must stay behind authentication).

Two premises in the issue did not survive measurement on the nightly, and both changed the design. They are argued in the spec doc rather than left for the next reader to re-derive.

**"Rejects" means "refuses to execute", not "answers 4xx".** The crafted payload is syntactically valid, so a fixed instance answers `200` with empty error lists in milliseconds — `#696`'s PoC is explicit that the exploit comes back clean. A spec asserting `4xx` on `validate/code` would be red on a healthy instance and green on a vulnerable one.

**The custom-component code editor is not the UI caller of `validate/code`.** Measured on `1.12.0.dev30` (frontend bundle plus a live scout): the code modal posts to `/custom_component` when editing a node's own source — on the Custom Component *and* on a built-in such as Chat Input — and to `/validate/code` only from a `CodeInput` field's editor. The whole catalog has exactly one such field: Python Function's `function_code` (`prototypes`, `legacy: true`). Anchoring the first bullet on the custom-component editor would have shipped a spec that never touches the endpoint the bullet names.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `validating a crafted default-argument payload does not execute it` | Through Python Function's `function_code` editor — the only UI caller of `POST /api/v1/validate/code` — the endpoint answers `200` with `imports.errors == []` and `function.errors == []`, in under 4 s; the modal closes and the code persists. Catches `#696`/`#13336`: `validate_code()` compiled **and `exec`'d** every module-level `FunctionDef`, and Python evaluates default arguments at definition time, so `def f(x=…)` was arbitrary code execution during "validation". |
| 2 | `the build endpoint refuses the same payload and leaves no partial component` | The identical string, submitted through the Custom Component code editor, makes `POST /api/v1/custom_component` answer `400` naming `ZeroDivisionError` after paying the full 8 s sleep; the error renders in the modal (`title_error_code_modal`), the canvas still holds exactly one `Custom Component` node, and the flow's stored `template.code.value` is byte-identical to the scaffold recorded before the attempt. This is both the *no partial component* bullet and the **control** for test 1 — a clean, instant validation cannot be explained by an inert payload. |
| 3 | `both endpoints refuse an unauthenticated caller before executing anything` | Anonymous `POST /api/v1/validate/code` and `POST /api/v1/custom_component` answer `401`/`403` with a credentials-naming detail, each in under 4 s — refused *before* the code is reached, which the timing is what proves. `#7900`'s boundary. An authenticated scaffold build answering `200` separates "refused for lacking credentials" from "refused for everyone" (an instance with `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false` answers `403` to every caller on that route). |

## 2. How the test was built

- **Setup:** each test creates its own flow through `POST /api/v1/flows/` (`createFlow`, parallel-safe unique name), opens it with `openFlowById`, and deletes that id in `afterEach`. No pre-test wipe, no `.first()` on the home grid.
- **The payload carries its own evidence.** `def f(_probe=__import__("time").sleep(8) or 1 / 0)`: `sleep()` returns `None`, so the `or` always evaluates `1 / 0`. Executing it therefore costs 8 s **and** raises, giving two independent discriminators from one response — pre-fix `function.errors == ["division by zero"]` and ≥ 8 s; fixed, an empty list in milliseconds. The error list is the primary signal; the timing still catches a regression that re-introduces `exec` but swallows the exception. `1 / 0` is not constant-folded (measured: `compile()` succeeds and the endpoint answers clean) and cannot be produced by the imports checker.
- **Module-level on purpose.** `validate_code()` walks `tree.body` for `ast.FunctionDef`, so a method inside a class body would never be visited and the test would pass vacuously.
- **Live-confirmed selectors** (nightly `1.12.0.dev30`, `playwright-cli`, none invented): `codearea_code_function_code`, `checkAndSaveBtn`, `.ace_editor`, `code-button-modal`, `title_error_code_modal`, `title-Python Function`, `title-Custom Component`, `sidebar-search-input`, `rf__node-*`. The error text is asserted through `title_error_code_modal` rather than by text — `getByText(/division by zero/)` resolves to two elements.
- **Interaction mechanism:** ACE ignores `fill()`, so the editor is driven through `window.ace.edit(...).setValue(code, -1)` (repo convention, #496). Both sidebar adds go through the shared primitives that repair Langflow's swallowed add click (`addComponentFromSidebar`, `addCustomComponent` — #1301/#1304).
- **Assertion rationale:** every refusal is paired with the control that makes it evidence. Test 1's clean validation is meaningful only because test 2 shows the same string executing; test 3's `403` is meaningful only because the authenticated build answers `200`; test 1's "the sentinel persisted" is what rules out a click that never landed.
- `page.allowHttpErrors()` is declared in test 2 only — the deliberate `400`. Test 3's calls go through the `request` fixture, outside the page's monitor.

## 3. Dependencies

- **None** — no LLM, no provider key, no model resolution. Nothing here runs a flow.
- Requires `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` (every CI lane and both start scripts set it, #668/#746) and the `legacy` Python Function component in the catalog; the spec fails naming it rather than skipping silently.
- Parallel-safe: API-created flows with unique names, id-scoped cleanup, no shared state.

## 4. Tags

`@api @regression @components`. No functional tag applies — the tag table has no security area, and all three sibling specs under `regression/security/` carry cross-cutting tags only (the reason is recorded in `docs/security/tweaks-injection.md`).

**`@stable` is deliberately absent on this first delivery** (maintainer decision at spec time). The sibling security specs shipped `@stable` on day one, but they are pure API (~3 s); this one is UI-driven, adds two sidebar components, and spends ~16 s of deliberate sleep budget proving the payload is live. It takes a validation cycle in the normal lane first, so the checklist bullets ship as `[-]` and the promotion is a follow-up.

## Validation (nightly `1.12.0.dev30`, `--workers=1 --retries=0`)

- typecheck ✅ (`tsc --noEmit`, 0 errors) · eslint ✅ (0 errors, 0 warnings on the new file)
- 3 clean runs in the deterministic burst — `expected=3 unexpected=0 flaky=0` each, no flake ✅
- zero `🚨 Backend Error` ✅ (`backendErrors=false` on every run)
- force-fail ✅ — one behavioural mutation per test, each verified red, each reverted:
  - test 1 — submit syntactically invalid code so `validate/code` reports a non-empty `function.errors` (the pre-fix signature) → failed as expected
  - test 2 — submit the plain scaffold without the canary so the build succeeds → failed as expected
  - test 3 — send a valid Bearer on the "anonymous" call so it answers `200` → failed as expected
- final green run after all reverts ✅
- zero orphan flows before and after (`GET /api/v1/flows/?remove_example_flows=true&header_flows=true` → 0)

Measured while designing the spec (same string, three destinations — the table the assertions are built on):

| request | credentials | status | time |
|---|---|---|---|
| `POST /api/v1/validate/code` — crafted | Bearer | `200`, both error lists empty | 0.05 s |
| `POST /api/v1/validate/code` — `def broken(:` | Bearer | `200`, `["invalid syntax (<unknown>, line 1)"]` | 0.01 s |
| `POST /api/v1/custom_component` — crafted | Bearer | `400` `ZeroDivisionError(division by zero)` | 8.27 s |
| `POST /api/v1/custom_component` — crafted | *none* | `403` `No authentication credentials provided` | 0.01 s |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
