### PR TITLE
chore(playground): quarantine the DataFrame markdown-table test (#1479)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -199,9 +199,17 @@ test.describe("Playground Output – Structured Data", () => {
     },
   );
 
-  test(
+  // Quarantined at triage (daily #1477): recurrent flake — the Chat Output
+  // sidebar row (`input_outputChat Output`) never enters the DOM after the
+  // search box is filled, inside setupMockDataFlow(), so the DataFrame
+  // assertion this test exists for is never reached. Same signature on the
+  // 2026-08-17 and 2026-08-18 dailies. Same observable as #1468, on a call
+  // site its barrier helpers do not cover.
+  // Lifting the quarantine (remove test.fixme + restore @stable) is a
+  // deliverable of #1479.
+  test.fixme(
     "playground must render DataFrame output as a markdown table",
-    { tag: ["@stable", "@release", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up Mock Data (dataframe_output) → Chat Output flow and open playground",


### PR DESCRIPTION
Quarantine dispatched by the triage of daily umbrella #1477 (run [32116967595](https://github.com/oriontech-me/langflow-e2e/actions/runs/32116967595), 2026-08-18). Tracked by #1479 — this PR does **not** resolve it.

## What and why

`playground-output-data.spec.ts:202` met the recurrent-flake criterion: **2 hits, same `error_signature` both times** (2026-08-17 and 2026-08-18). The failure is not where the test title suggests — it is at `playground-output-data.spec.ts:25`, inside `setupMockDataFlow()`:

```
Locator: getByTestId('input_outputChat Output')
Expected: visible
Timeout: 30000ms
Error: element(s) not found
```

The Chat Output sidebar row never enters the DOM after the search box is filled, so no add-component click is attempted and the DataFrame assertion the test exists for is never reached.

## Both edits, deliberately

`@stable` removed **and** `test.fixme` added. Tag removal alone only stops the daily; the PR impacted-specs gate selects by **file diff, not by tag** (#871), so the test would keep going red there. Verified on this branch:

| Selection | Before | After |
|---|---|---|
| `--grep "@stable"` on this file | 2 tests | **1 test** (the line-166 sibling only) |
| Test body executes | yes | **no** — `test.fixme` |

The file has no `test.describe.configure({ mode: "serial" })`, so the sibling at line 166 is unaffected and keeps running.

## Context this inherits

Same observable as #1468, which closed on 2026-08-17 (merge `6935588`) after measuring the interaction at **8.9 %** failure under 4-process load and shipping two barrier helpers that took it to **0/200**. Those helpers — `fillSidebarSearch` and `openBlankFlowFromModal` — are imported by **exactly one spec** on `main`. This call site fills the search box raw, and so does the shared helper `tests/helpers/flows/add-component-from-sidebar.ts:214`, which many specs route through.

Whether the barrier belongs in that shared helper is a decision #1479 owes, with its own blast radius — deliberately not made here.

## Checks

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run check:checklist-coverage` — passes (the Part II bullet at `QA-CHECKLIST.md:545` already references this spec, and the spec doc is untouched: a temporary `@stable` removal is tracked by a GitHub issue, not by a doc change)
- `node scripts/check-checklist-guard.mjs` — no generated block edited

Refs #1479, #1477, #1468
