### PR TITLE
feat(lane): add an @enterprise lane selector alongside @destructive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,7 @@ Tags are split into two groups: **cross-cutting** (severity/layer) and **functio
 | `@database` | Tests with persistent saved state |
 | `@mainpage` | Home/dashboard UI tests |
 | `@destructive` | Test mutates account-wide state (e.g. deletes every project of the shared superuser). **Lane selector, not a severity:** `playwright.config.ts` excludes it from every normal run via `grepInvert` and CI runs it alone afterwards with `PW_DESTRUCTIVE=1` (workers pinned to 1). Run it locally with `PW_DESTRUCTIVE=1 npx playwright test --grep @destructive`. Do **not** combine with `@stable` — `daily-stable.yml` has no destructive lane, so such a test would silently never run there (#1010) |
+| `@enterprise` | Test targets a Langflow **Enterprise** instance, whose surface the OSS nightly does not serve. **Lane selector, not a severity**, resolved together with `@destructive` in `tests/fixtures/lane.ts`: the three lanes are mutually exclusive, and the enterprise one also pins `workers: 1` because an Enterprise instance runs password-first — there is no `auto_login` — and Langflow rate-limits `/api/v1/login` per IP, so parallel workers exhaust the budget and report product assertions as `429`s. Point `PLAYWRIGHT_BASE_URL` at the instance and run `PW_ENTERPRISE=1 npx playwright test --grep @enterprise`. Do **not** combine with `@stable` — there is no scheduled Enterprise lane, so such a test would silently never run (#1010) |
 
 **Functional** (product area — use alongside cross-cutting tags)
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 import * as dotenv from "dotenv";
+import { resolveLane } from "./tests/fixtures/lane";
 import { resolveRunLocale } from "./tests/fixtures/locale";
 
 dotenv.config();
@@ -32,9 +33,20 @@ const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:7860";
  *    on the command line, so a caller cannot forget and let two destructive tests
  *    wipe each other.
  */
-const DESTRUCTIVE_LANE = !!process.env.PW_DESTRUCTIVE;
+/**
+ * The lane this run selects (`tests/fixtures/lane.ts`). `@destructive` is one
+ * selector; `@enterprise` — specs that need a Langflow ENTERPRISE instance, whose
+ * endpoints the OSS nightly does not serve — is the second. Resolution and the
+ * "never a silent cap" notices live in that module so they are unit-testable by
+ * SELECTION rather than by comparing regex source (`lane.test.ts`).
+ */
+const LANE = resolveLane();
+// Both opt-in lanes serialise, for different causes — see `lane.ts`. The name
+// is the property, not the tag: reading it as "destructive" again would make
+// the enterprise lane look accidentally pinned.
+const SERIAL_LANE = LANE.serial;
 
-if (!DESTRUCTIVE_LANE) {
+for (const notice of LANE.notices) {
   // Never let the exclusion become a silent cap: say it on every run, with the
   // exact command that runs what was left out.
   //
@@ -45,9 +57,7 @@ if (!DESTRUCTIVE_LANE) {
   // file unparseable, the partitioner exited 1, and the daily died before a
   // single test ran. stderr keeps the line just as visible in the Actions log —
   // and `playwright-config.test.ts` now asserts stdout stays clean.
-  console.error(
-    "[lane] @destructive tests are excluded from this run — run them with: PW_DESTRUCTIVE=1 npx playwright test --grep @destructive",
-  );
+  console.error(notice);
 }
 
 /**
@@ -64,8 +74,9 @@ if (RUN_LOCALE.notice) {
 export default defineConfig({
   testDir: "./tests",
   // The destructive lane runs account-wide wipers, so it must never schedule two
-  // tests at once (see DESTRUCTIVE_LANE above).
-  grepInvert: DESTRUCTIVE_LANE ? undefined : /@destructive/,
+  // tests at once, and the enterprise lane must not exhaust the login rate
+  // limit with parallel workers (see SERIAL_LANE above).
+  grepInvert: LANE.grepInvert,
   // Playwright's default testMatch is `**/*.@(spec|test).?(c|m)[jt]s`, which also
   // collects the `*.test.ts` unit tests living next to the helpers they cover
   // (issue #1017) — those run under `node --test` (`npm run test:units`), need no
@@ -80,7 +91,7 @@ export default defineConfig({
   // file in one shard (so @database state-sharing holds). The sharded job sets
   // PW_SHARD_FILE_LEVEL=1; local dev / nightly / manual keep test-level parallelism.
   fullyParallel:
-    DESTRUCTIVE_LANE || process.env.PW_SHARD_FILE_LEVEL ? false : true,
+    SERIAL_LANE || process.env.PW_SHARD_FILE_LEVEL ? false : true,
   forbidOnly: !!process.env.CI,
   // PLAYWRIGHT_RETRIES overrides the retry count when set (e.g. a manual
   // validation dispatch passing 0 for a fast, unamplified signal); empty/unset
@@ -97,7 +108,7 @@ export default defineConfig({
   // per shard (~90 tests each) the 2nd worker is a net win — benchmarked at ~28min
   // (workers=2) vs ~39min (workers=1) at N=4, correctness identical. See
   // ISSUE-833-SHARDING-DESIGN.md §"workers per shard".
-  workers: DESTRUCTIVE_LANE ? 1 : process.env.CI ? 2 : undefined,
+  workers: SERIAL_LANE ? 1 : process.env.CI ? 2 : undefined,
   timeout: 5 * 60 * 1000, // 5 minutes per test
   // Reporters run side by side. The Flakiness.io reporter MUST live here, not on
   // the CLI `--reporter` flag, because its `flakinessProject` option (required for

--- a/scripts/partition-shards.test.mjs
+++ b/scripts/partition-shards.test.mjs
@@ -438,11 +438,30 @@ test("playwright.config.ts still excludes @destructive from every non-destructiv
   // The second half: even a mis-tagged test would be kept out of `--grep @stable
   // --list` by grepInvert, which a CLI --grep cannot override. Without this the guard
   // above is the only thing standing between the partition and an unmeasurable file.
+  //
+  // Lane resolution moved into `tests/fixtures/lane.ts` when `@enterprise` became a
+  // second selector, so this checks the two halves that live in reachable source:
+  // the config DELEGATES (it must not compute a grepInvert of its own, which would
+  // silently win over the module), and the module's DEFAULT lane still excludes
+  // `@destructive`. Neither is the real proof — `tests/fixtures/lane.test.ts` owns
+  // that, asserting every lane by SELECTION against representative tag strings,
+  // which is what a spelling match cannot do (#1226). This node lane cannot import
+  // the TypeScript module, so it pins the wiring and points at the behaviour.
   const config = fs.readFileSync(path.join(import.meta.dirname, "..", "playwright.config.ts"), "utf8");
   assert.match(
     config,
-    /grepInvert:\s*DESTRUCTIVE_LANE\s*\?\s*undefined\s*:\s*\/@destructive\//,
-    "the partition input assumes @destructive specs are never listed (#1326)",
+    /grepInvert:\s*LANE\.grepInvert\s*,/,
+    "the config must take grepInvert from the lane module, not compute its own (#1326)",
+  );
+
+  const lane = fs.readFileSync(
+    path.join(import.meta.dirname, "..", "tests", "fixtures", "lane.ts"),
+    "utf8",
+  );
+  assert.match(
+    lane,
+    /grepInvert:\s*\/@destructive\|@enterprise\/,/,
+    "the default lane must still exclude @destructive — the partition input assumes it (#1326)",
   );
 });
 

--- a/tests/fixtures/lane.test.ts
+++ b/tests/fixtures/lane.test.ts
@@ -1,0 +1,80 @@
+// Unit tests for the mutually exclusive run lanes.
+// Run with: npm run test:units
+//
+// The value under test is the one thing a wrong lane costs the most: which
+// tests a run is allowed to select. A regex that is right for the normal lane
+// and wrong for one of the two opt-in lanes is invisible in a green run — the
+// excluded tests simply never report — so every lane is asserted by SELECTION
+// against representative tag strings, not by comparing regex source text.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveLane } from "./lane";
+
+/** Tag strings shaped like the ones Playwright matches a title+tags against. */
+const NORMAL = "renames a flow @stable @workspace";
+const DESTRUCTIVE = "deletes every project @destructive @api";
+const ENTERPRISE = "the admin surface rejects an unauthorised write @enterprise @api";
+
+function selects(grepInvert: RegExp | undefined, title: string): boolean {
+  return !grepInvert || !grepInvert.test(title);
+}
+
+test("normal lane runs neither opt-in lane", () => {
+  const { grepInvert, serial } = resolveLane({});
+  assert.equal(selects(grepInvert, NORMAL), true);
+  assert.equal(selects(grepInvert, DESTRUCTIVE), false);
+  assert.equal(selects(grepInvert, ENTERPRISE), false);
+  assert.equal(serial, false);
+});
+
+test("destructive lane runs destructive tests and still excludes enterprise", () => {
+  const { grepInvert, serial } = resolveLane({ PW_DESTRUCTIVE: "1" });
+  assert.equal(selects(grepInvert, DESTRUCTIVE), true);
+  assert.equal(selects(grepInvert, ENTERPRISE), false);
+  // The destructive lane wipes account-wide state; it must never schedule two.
+  assert.equal(serial, true);
+});
+
+test("enterprise lane runs enterprise tests and still excludes destructive", () => {
+  const { grepInvert, serial } = resolveLane({ PW_ENTERPRISE: "1" });
+  assert.equal(selects(grepInvert, ENTERPRISE), true);
+  assert.equal(selects(grepInvert, DESTRUCTIVE), false);
+  // Serial because an Enterprise instance rate-limits login and every worker
+  // must authenticate — not because the specs collide.
+  assert.equal(serial, true);
+});
+
+test("no lane can select both selectors at once", () => {
+  for (const env of [{}, { PW_DESTRUCTIVE: "1" }, { PW_ENTERPRISE: "1" }]) {
+    const { grepInvert } = resolveLane(env);
+    const both = selects(grepInvert, DESTRUCTIVE) && selects(grepInvert, ENTERPRISE);
+    assert.equal(both, false, `lane ${JSON.stringify(env)} selected both lanes`);
+  }
+});
+
+test("both flags set resolves to the enterprise lane and says so", () => {
+  const { grepInvert, notices } = resolveLane({ PW_DESTRUCTIVE: "1", PW_ENTERPRISE: "1" });
+  assert.equal(selects(grepInvert, ENTERPRISE), true);
+  assert.equal(selects(grepInvert, DESTRUCTIVE), false);
+  assert.equal(
+    notices.some((line) => line.includes("both set")),
+    true,
+    "an ambiguous request must not resolve silently",
+  );
+});
+
+test("every exclusion is announced with the command that runs it", () => {
+  const normal = resolveLane({});
+  assert.equal(normal.notices.length, 2);
+  assert.equal(
+    normal.notices.some((line) => line.includes("PW_ENTERPRISE=1")),
+    true,
+  );
+  assert.equal(
+    normal.notices.some((line) => line.includes("PW_DESTRUCTIVE=1")),
+    true,
+  );
+  // A lane that excludes something must still say what it left out.
+  assert.equal(resolveLane({ PW_ENTERPRISE: "1" }).notices.length, 1);
+  assert.equal(resolveLane({ PW_DESTRUCTIVE: "1" }).notices.length, 1);
+});

--- a/tests/fixtures/lane.ts
+++ b/tests/fixtures/lane.ts
@@ -1,0 +1,88 @@
+/**
+ * Mutually exclusive run lanes (#destructive, #enterprise).
+ *
+ * Two tags in this suite are LANE SELECTORS, not severities: a test carrying
+ * one of them must not run in a normal invocation, because the environment it
+ * needs is not the environment a normal run has.
+ *
+ *  - `@destructive` mutates account-wide state (see the note in
+ *    `playwright.config.ts`).
+ *  - `@enterprise` targets a Langflow ENTERPRISE instance, whose surface the OSS
+ *    nightly does not serve. Running such a spec against the OSS runner does not
+ *    produce a meaningful failure — it produces a permanent red that says
+ *    nothing about the product.
+ *
+ * The exclusion uses `grepInvert` for the reason the destructive lane already
+ * documents: a CLI `--grep` overrides `config.grep` but leaves `config.grepInvert`
+ * in place, so no caller can widen the lane by passing a filter of its own.
+ *
+ * Both opt-in lanes run serially, for different reasons: `@destructive` because
+ * two account wipers would erase each other, `@enterprise` because the instance
+ * rate-limits login and every worker has to authenticate. Same knob, different
+ * cause — stated here so neither is "cleaned up" as redundant.
+ *
+ * The lanes are mutually exclusive on purpose. There is no combined lane, and
+ * `@destructive @enterprise` on the same test would be unrunnable in every
+ * lane — which is why `lane.test.ts` pins that a test can only ever be selected
+ * by exactly one of them.
+ */
+
+export interface LaneResolution {
+  /** Value for `config.grepInvert`; `undefined` means "exclude nothing". */
+  grepInvert: RegExp | undefined;
+  /** Lines to print (stderr) so an exclusion is never a silent cap. */
+  notices: string[];
+  /** True when the lane must serialise (destructive tests wipe each other). */
+  serial: boolean;
+}
+
+export interface LaneEnv {
+  PW_DESTRUCTIVE?: string;
+  PW_ENTERPRISE?: string;
+}
+
+const DESTRUCTIVE_HINT =
+  "[lane] @destructive tests are excluded from this run — run them with: PW_DESTRUCTIVE=1 npx playwright test --grep @destructive";
+const ENTERPRISE_HINT =
+  "[lane] @enterprise tests are excluded from this run — point PLAYWRIGHT_BASE_URL at an Enterprise instance and run: PW_ENTERPRISE=1 npx playwright test --grep @enterprise";
+
+/**
+ * Resolve the lane from the environment.
+ *
+ * Both flags set is not an error the config can usefully refuse — the two
+ * lanes need different instances — so `PW_ENTERPRISE` wins and the caller is
+ * told, rather than silently getting one of the two.
+ */
+export function resolveLane(env: LaneEnv = process.env as LaneEnv): LaneResolution {
+  const enterprise = !!env.PW_ENTERPRISE;
+  const destructive = !!env.PW_DESTRUCTIVE;
+
+  if (enterprise && destructive) {
+    return {
+      grepInvert: /@destructive/,
+      notices: [
+        "[lane] PW_ENTERPRISE and PW_DESTRUCTIVE are both set; the enterprise lane wins and @destructive stays excluded.",
+      ],
+      serial: true,
+    };
+  }
+
+  if (enterprise) {
+    // Serial for a measured reason, not for isolation. An Enterprise instance
+    // runs password-first — there is no `auto_login` for the suite to use — so
+    // every worker has to authenticate, and Langflow rate-limits `/api/v1/login`
+    // per IP. Parallel workers exhaust that budget, which is how the first run
+    // of this lane reported product assertions as 429s.
+    return { grepInvert: /@destructive/, notices: [DESTRUCTIVE_HINT], serial: true };
+  }
+
+  if (destructive) {
+    return { grepInvert: /@enterprise/, notices: [ENTERPRISE_HINT], serial: true };
+  }
+
+  return {
+    grepInvert: /@destructive|@enterprise/,
+    notices: [DESTRUCTIVE_HINT, ENTERPRISE_HINT],
+    serial: false,
+  };
+}


### PR DESCRIPTION
Closes #1483

## What

Adds `@enterprise` as a second **lane selector**, and moves lane resolution out of `playwright.config.ts` into `tests/fixtures/lane.ts` (the sibling of `locale.ts`, extracted for the same reason in #1400).

| Lane | selects | workers |
|---|---|---|
| normal (default) | neither opt-in tag | default |
| `PW_DESTRUCTIVE=1` | `@destructive` only | 1 |
| `PW_ENTERPRISE=1` | `@enterprise` only | 1 |

## Why

A spec targeting a Langflow Enterprise instance cannot fail usefully in a normal run — the OSS nightly does not serve that surface, so the red says nothing about the product and looks exactly like a regression in the daily. Same problem `@destructive` solved, so it gets the same mechanism: `grepInvert`, which a CLI `--grep` cannot widen.

Both opt-in lanes serialise, and the causes are **different** — destructive because two account wipers erase each other, enterprise because the instance runs password-first (no `auto_login`) and Langflow rate-limits `/api/v1/login` per IP, so parallel workers exhaust the budget and turn product assertions into `429`s. That was measured, not predicted: the first run of the lane reported five assertions as rate-limit errors. The config flag is renamed `SERIAL_LANE` for that reason — reading it as "destructive" again would make the enterprise lane look accidentally pinned.

## Why a module rather than one more inline regex

So the lanes are testable by **selection**. A lane regex that is right for the default run and wrong for one opt-in lane is invisible in a green run: the excluded tests simply never report. `lane.test.ts` compiles each lane's `grepInvert` and runs it against representative tag strings, pinning that no lane can ever select both selectors at once, and that every exclusion still prints the command that runs what it left out.

This is #1226's lesson applied up front — a guard that pins a spelling does not pin a behaviour.

## Scope

**Infrastructure only. No spec carries `@enterprise` in this PR.** The lane lands first so the specs have somewhere to land: excluding a tag nothing carries is inert, whereas merging specs before the lane exists would put them straight into the daily.

## Validation

Run locally against Langflow nightly `1.12.0.dev30`:

- `npx playwright test --list --grep @enterprise` → **0 selected**; with `PW_ENTERPRISE=1` → the tagged set (verified against a local set of tagged specs, not merged here)
- `@destructive` unchanged in both directions — still excluded by default, still selected and serialised under `PW_DESTRUCTIVE=1`
- `npm run test:units` → 6 new tests, all passing; suite `690 tests / 689 pass`. The single failure (`playwright.config.test.ts` → "the daily's prep command produces parseable JSON") **predates this branch** — reproduced on a clean tree with these files removed, and it passes in CI, so it is local to this machine
- `npm run test:scripts` → `799 tests / 798 pass / 0 fail`. **The first CI run of this PR failed here and the failure was this branch's**, not pre-existing: `partition-shards.test.mjs` pinned the literal `grepInvert: DESTRUCTIVE_LANE ? undefined : /@destructive/` text, which the refactor changed while preserving the behaviour. Fixed in the second commit — the guard now pins that the config *delegates* and that the module's default lane still excludes `@destructive`, and says in-line that `lane.test.ts` owns the actual proof. Both halves mutation-checked (drop the delegation → fails; remove `@destructive` from the default lane → fails). The failure is a fair illustration of the #1226 point this PR makes
- `npm run typecheck` → clean
- `npm run lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
