### PR TITLE
fix(knowledge-ingestion): hydrate fixture component code from the running image (#1478)

### DIFF
--- a/docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
+++ b/docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts`
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.0.dev31
 
 ---
 
@@ -191,7 +191,10 @@ provider recorded `inactive` in `providers.json` (`providerSkipGate("google")`, 
   `temperature = 0`, `api_key` from the `GOOGLE_API_KEY` global variable) → Chat
   Output. Both Knowledge nodes' `knowledge_base` is a placeholder (`__KB_NAME__`)
   the spec replaces per run. Built + configured live on the canvas and validated
-  end-to-end on 1.11.0.dev38.
+  end-to-end on 1.11.0.dev38. Before the flow is created, `loadFixtureFlow`
+  rehydrates every node's component `code` field from the running image's
+  current catalog, since the stored source can drift from the image and a
+  stale copy can fail to build the graph at all (#1478).
 - `GOOGLE_API_KEY` — required (embeds each chunk with `models/gemini-embedding-001` and
   answers with `gemini-flash-latest`), **and** Google recorded `active` in
   `providers.json` by `collect-models` (#1029).

--- a/docs/core-functionality/knowledge-ingestion-management/vector-store-index-query.md
+++ b/docs/core-functionality/knowledge-ingestion-management/vector-store-index-query.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts`
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.0.dev31
 
 ---
 
@@ -168,7 +168,10 @@ local `providers.json`.
   Knowledge (`mode = Ingest`); plus a standalone Knowledge (`mode = Retrieve`,
   `top_k = 1`, `search_query` = the embedding-topic query). Both Knowledge nodes'
   `knowledge_base` is a placeholder (`__KB_NAME__`) the spec replaces per run.
-  Built live on the canvas and exported on 1.11.0.dev38.
+  Built live on the canvas and exported on 1.11.0.dev38. Before the flow is
+  created, `loadFixtureFlow` rehydrates every node's component `code` field from
+  the running image's current catalog, since the stored source can drift from
+  the image and a stale copy can fail to build the graph at all (#1478).
 - `GOOGLE_API_KEY` — required (the KB embeds each chunk with
   `models/gemini-embedding-001`), **and** Google recorded `active` in
   `providers.json` by `collect-models` (#1029).

--- a/tests/helpers/flows/component-code-index.test.ts
+++ b/tests/helpers/flows/component-code-index.test.ts
@@ -1,0 +1,51 @@
+// Unit tests for the component code index (#1478).
+// Run with: npm run test:units
+//
+// Fixtures are shaped after the real `GET /api/v1/all` measured on
+// 1.12.0.dev31: `{ category: { ComponentType: { template: { code: { value } } } } }`,
+// plus the `component_display_names` metadata map that is NOT a category.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildCodeIndex } from "./component-code-index";
+
+test("indexes component types by their stored code value", () => {
+  const index = buildCodeIndex({
+    files_and_knowledge: {
+      Knowledge: { template: { code: { value: "KNOWLEDGE SOURCE" } } },
+    },
+    inputs: { ChatInput: { template: { code: { value: "CHATINPUT SOURCE" } } } },
+  });
+
+  assert.deepEqual(index, {
+    Knowledge: "KNOWLEDGE SOURCE",
+    ChatInput: "CHATINPUT SOURCE",
+  });
+});
+
+test("component_display_names is skipped — it is a metadata map, not a category", () => {
+  // 189 entries keyed by the lowercased type name; folding it in would add
+  // phantom types with no code at all.
+  const index = buildCodeIndex({
+    component_display_names: { knowledge: "Knowledge", chatinput: "Chat Input" },
+    inputs: { ChatInput: { template: { code: { value: "SRC" } } } },
+  });
+
+  assert.deepEqual(Object.keys(index), ["ChatInput"]);
+});
+
+test("a component with no code field is omitted rather than indexed as empty", () => {
+  const index = buildCodeIndex({
+    inputs: { NoCode: { template: {} }, WithCode: { template: { code: { value: "SRC" } } } },
+  });
+
+  assert.deepEqual(Object.keys(index), ["WithCode"]);
+});
+
+test("a catalog that yields zero types is refused, not returned empty", () => {
+  // A 200 with an empty body (registry still starting, a disguised 401) would
+  // otherwise mark every fixture node `missing` and blame the fixture for an
+  // instance problem — the 200-with-no-categories floor (#1012).
+  assert.throws(() => buildCodeIndex({}), /no component types/);
+  assert.throws(() => buildCodeIndex({ detail: "Not authenticated" }), /no component types/);
+  assert.throws(() => buildCodeIndex(null), /no component types/);
+});

--- a/tests/helpers/flows/component-code-index.ts
+++ b/tests/helpers/flows/component-code-index.ts
@@ -1,0 +1,88 @@
+import type { APIRequestContext } from "@playwright/test";
+import { getAuthToken } from "../auth/get-auth-token";
+import type { CodeIndex } from "./hydrate-fixture-code";
+
+// `type -> installed component source`, read from the running image (#1478).
+//
+// `GET /api/v1/all` is the component registry:
+//   { category: { ComponentType: { template: { code: { value: "<python>" } } } } }
+// A fixture node's `data.type` matches those second-level keys (measured on
+// 1.12.0.dev31), which is what lets a fixture's frozen source be replaced by the
+// image's.
+//
+// One request per PROCESS: globalSetup already fetches this same endpoint for
+// catalog drift (70-85ms / 524KB), and a second fetch per spec would be waste.
+
+/** Not a category: 189 entries keyed by the lowercased type name. */
+const NON_CATEGORY_KEYS = new Set(["component_display_names"]);
+
+const ALL_COMPONENTS_PATH = "/api/v1/all";
+
+let cached: CodeIndex | undefined;
+
+/**
+ * Builds the index from a raw `GET /api/v1/all` body.
+ *
+ * Throws when the body yields ZERO component types. `snapshotCatalog` learned
+ * this the hard way: a tolerant reader turns `{}`, `null` and
+ * `{"detail": "Not authenticated"}` into "no components exist", which downstream
+ * reads as "every fixture node is missing from the image" — blaming the fixture
+ * for an instance that is still starting.
+ */
+export function buildCodeIndex(catalog: unknown): CodeIndex {
+  const index: CodeIndex = {};
+  if (catalog && typeof catalog === "object") {
+    for (const [category, components] of Object.entries(
+      catalog as Record<string, unknown>,
+    )) {
+      if (NON_CATEGORY_KEYS.has(category)) continue;
+      if (!components || typeof components !== "object") continue;
+      for (const [type, entry] of Object.entries(
+        components as Record<string, unknown>,
+      )) {
+        const value = (
+          entry as { template?: { code?: { value?: unknown } } } | undefined
+        )?.template?.code?.value;
+        if (typeof value === "string" && value.length > 0) index[type] = value;
+      }
+    }
+  }
+  if (Object.keys(index).length === 0) {
+    throw new Error(
+      `GET ${ALL_COMPONENTS_PATH} yielded no component types with source code — ` +
+        `the catalog is unreadable (backend still starting, or an auth failure ` +
+        `answered as 200). Refusing to treat an empty catalog as "no drift".`,
+    );
+  }
+  return index;
+}
+
+/** Fetches and caches the index for this process. */
+export async function getComponentCodeIndex(
+  request: APIRequestContext,
+  options?: { headers?: Record<string, string> },
+): Promise<CodeIndex> {
+  if (cached) return cached;
+
+  const headers = { ...(options?.headers ?? {}) };
+  if (!headers.Authorization) {
+    const authHeader = await getAuthToken(request);
+    if (authHeader) headers.Authorization = authHeader;
+  }
+
+  const res = await request.get(ALL_COMPONENTS_PATH, { headers });
+  if (res.status() !== 200) {
+    const body = (await res.text()).slice(0, 200);
+    throw new Error(
+      `GET ${ALL_COMPONENTS_PATH} answered ${res.status()} — cannot hydrate ` +
+        `fixture component code. Body: ${body}`,
+    );
+  }
+  cached = buildCodeIndex(await res.json());
+  return cached;
+}
+
+/** Test-only: clears the per-process cache. */
+export function resetComponentCodeIndexCache(): void {
+  cached = undefined;
+}

--- a/tests/helpers/flows/hydrate-fixture-code.test.ts
+++ b/tests/helpers/flows/hydrate-fixture-code.test.ts
@@ -1,0 +1,149 @@
+// Unit tests for fixture component-code hydration (#1478).
+// Run with: npm run test:units
+//
+// Context: fixture flows under tests/assets/flows/ store a FROZEN copy of each
+// component's Python source in `node.data.node.template.code.value`, and Langflow
+// execs that copy instead of the installed component. On 2026-08-18 upstream
+// commit 99ea9044f (PR #14413, release-1.12.0) deleted `load_kb_metadata` from
+// `_kb_paths`, so the frozen copy raised ImportError at graph build and two
+// @stable specs waited 90s for a duration badge that could never render.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatHydrationReport,
+  hydrateFixtureCode,
+  type CodeIndex,
+} from "./hydrate-fixture-code";
+
+const node = (id: string, type: string, code?: string) => ({
+  id,
+  data: {
+    type,
+    node: {
+      template: code === undefined ? {} : { code: { value: code } },
+    },
+  },
+});
+
+const flow = (nodes: unknown[]) => ({ nodes, edges: [] });
+
+test("a node whose frozen code differs from the catalog is hydrated", () => {
+  const data = flow([node("Knowledge-ingest", "Knowledge", "OLD SOURCE")]);
+  const index: CodeIndex = { Knowledge: "NEW SOURCE" };
+
+  const r = hydrateFixtureCode(data, index);
+
+  assert.deepEqual(r.hydrated, ["Knowledge-ingest"]);
+  assert.deepEqual(r.unchanged, []);
+  assert.equal(
+    (r.data.nodes[0]! as ReturnType<typeof node>).data.node.template.code!.value,
+    "NEW SOURCE",
+  );
+});
+
+test("a node already identical to the catalog is NOT counted as hydrated", () => {
+  // Otherwise every run reports drift for every node and the report is noise —
+  // the mode=count lesson: a line nobody can act on is a line nobody reads.
+  const data = flow([node("SplitText-doc01", "SplitText", "SAME")]);
+
+  const r = hydrateFixtureCode(data, { SplitText: "SAME" });
+
+  assert.deepEqual(r.hydrated, []);
+  assert.deepEqual(r.unchanged, ["SplitText-doc01"]);
+});
+
+test("a component type absent from the index is reported, and no node is rewritten", () => {
+  // A partially rewritten payload is worse than an untouched one: it would be
+  // created, then fail at graph build with a cause the report already knew.
+  const data = flow([
+    node("Knowledge-ingest", "Knowledge", "OLD"),
+    node("Gone-1", "VanishedComponent", "OLD"),
+  ]);
+
+  const r = hydrateFixtureCode(data, { Knowledge: "NEW" });
+
+  assert.deepEqual(r.missing, ["VanishedComponent"]);
+  assert.equal(
+    (r.data.nodes[0]! as ReturnType<typeof node>).data.node.template.code!.value,
+    "OLD",
+  );
+  assert.deepEqual(r.hydrated, []);
+});
+
+test("a duplicated missing type is reported once, sorted", () => {
+  const data = flow([
+    node("b", "Zeta", "OLD"),
+    node("a", "Alpha", "OLD"),
+    node("c", "Zeta", "OLD"),
+  ]);
+
+  const r = hydrateFixtureCode(data, {});
+
+  assert.deepEqual(r.missing, ["Alpha", "Zeta"]);
+});
+
+test("a node without template.code is skipped, never reported as missing", () => {
+  // Not every node is a coded component; counting those as drift would make the
+  // report unreadable, and counting them as missing would blame the image.
+  const data = flow([node("Note-1", "NoteNode")]);
+
+  const r = hydrateFixtureCode(data, {});
+
+  assert.deepEqual(r.skipped, ["Note-1"]);
+  assert.deepEqual(r.missing, []);
+});
+
+test("the caller's payload is never mutated", () => {
+  // A spec hydrates once per test in a serial file; a mutated input would leak
+  // the previous test's state into the next one.
+  const data = flow([node("Knowledge-ingest", "Knowledge", "OLD")]);
+
+  hydrateFixtureCode(data, { Knowledge: "NEW" });
+
+  assert.equal(
+    (data.nodes[0] as ReturnType<typeof node>).data.node.template.code!.value!,
+    "OLD",
+  );
+});
+
+test("regression #1478: hydration removes the frozen load_kb_metadata import", () => {
+  // The exact failure: the frozen copy imports a symbol deleted upstream in
+  // 99ea9044f, so `Graph.from_payload` raises
+  // ImportError(Cannot import name 'load_kb_metadata' ...) and the graph is
+  // never built. Fails if hydration is ever reverted.
+  const frozen =
+    "from lfx.components.files_and_knowledge._kb_paths import (\n    load_kb_metadata,\n)\n";
+  const current =
+    "from lfx.components.files_and_knowledge._kb_paths import (\n    get_knowledge_bases_root_path,\n)\n";
+  const data = flow([node("Knowledge-ingest", "Knowledge", frozen)]);
+
+  const r = hydrateFixtureCode(data, { Knowledge: current });
+
+  assert.equal(
+    (r.data.nodes[0]! as ReturnType<typeof node>).data.node.template.code!.value!.includes(
+      "load_kb_metadata",
+    ),
+    false,
+  );
+});
+
+test("the report names what happened, and says so even when nothing changed", () => {
+  // Never silent: "no line" must be readable as "the mechanism did not run".
+  const allCurrent = hydrateFixtureCode(
+    flow([node("a", "ChatInput", "SAME")]),
+    { ChatInput: "SAME" },
+  );
+  assert.match(
+    formatHydrationReport("x-fixture.json", allCurrent),
+    /all 1 node[s]? already current/,
+  );
+
+  const changed = hydrateFixtureCode(flow([node("a", "ChatInput", "OLD")]), {
+    ChatInput: "NEW",
+  });
+  assert.match(formatHydrationReport("x-fixture.json", changed), /hydrated: a/);
+});
+
+test("a payload with no nodes array is refused as malformed", () => {
+  assert.throws(() => hydrateFixtureCode({}, {}), /nodes/);
+});

--- a/tests/helpers/flows/hydrate-fixture-code.test.ts
+++ b/tests/helpers/flows/hydrate-fixture-code.test.ts
@@ -10,6 +10,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  AUTHORED_CODE_TYPES,
   formatHydrationReport,
   hydrateFixtureCode,
   type CodeIndex,
@@ -146,4 +147,31 @@ test("the report names what happened, and says so even when nothing changed", ()
 
 test("a payload with no nodes array is refused as malformed", () => {
   assert.throws(() => hydrateFixtureCode({}, {}), /nodes/);
+});
+
+test("a component type inherited from Object.prototype is never treated as present", () => {
+  // `type in index` reads true for "toString"/"constructor" on a plain object
+  // even when the index never declared them, and would assign a function to
+  // code.value. Object.hasOwn must be used instead.
+  const data = flow([node("Weird-1", "toString", "OLD")]);
+
+  const r = hydrateFixtureCode(data, {});
+
+  assert.deepEqual(r.missing, ["toString"]);
+  assert.deepEqual(r.hydrated, []);
+});
+
+test("a CustomComponent node's authored code is refused, not hydrated", () => {
+  // Its stored code is the spec's subject; silently replacing it with the
+  // catalog's empty template would make the spec pass having verified
+  // nothing.
+  assert.ok(AUTHORED_CODE_TYPES.has("CustomComponent"));
+  const data = flow([
+    node("Custom-1", "CustomComponent", "def build(self): ..."),
+  ]);
+
+  assert.throws(
+    () => hydrateFixtureCode(data, { CustomComponent: "OTHER" }),
+    /authored/,
+  );
 });

--- a/tests/helpers/flows/hydrate-fixture-code.ts
+++ b/tests/helpers/flows/hydrate-fixture-code.ts
@@ -26,11 +26,17 @@
 
 export type CodeIndex = Record<string, string>;
 
+export interface TemplateField {
+  value?: string;
+  options?: string[];
+  [key: string]: unknown;
+}
+
 interface FixtureNode {
   id: string;
   data?: {
     type?: string;
-    node?: { template?: Record<string, { value?: string } | undefined> };
+    node?: { template?: Record<string, TemplateField | undefined> };
   };
 }
 

--- a/tests/helpers/flows/hydrate-fixture-code.ts
+++ b/tests/helpers/flows/hydrate-fixture-code.ts
@@ -23,12 +23,31 @@
 // replaced plus a report of what it did. It performs no I/O and never decides
 // policy — an absent component type is REPORTED, and the caller
 // (`load-fixture-flow.ts`) is what turns that into a thrown error.
+//
+// It replaces the stored source of EVERY node in the fixture, not just the
+// one the spec exercises. That is safe for a stock catalog component: its
+// code is an installed artifact identical across every flow using that type,
+// so hydrating it only re-syncs a frozen copy with the image it will actually
+// run on. It is NOT safe for a component whose stored code is the thing under
+// test — a `CustomComponent` node's `code` IS the spec's subject, and
+// hydrating it would silently replace that authored behaviour with the empty
+// template, making the spec pass having verified nothing. `AUTHORED_CODE_TYPES`
+// below is the refusal for that case.
 
 export type CodeIndex = Record<string, string>;
 
+/** Component types whose stored code is authored by the test, not installed
+ * by the image. Hydrating one of these would replace the behaviour under
+ * test — this module refuses instead. Extending this set (e.g. to cover a
+ * fixture with a `CustomComponent` node) is the migration follow-up's
+ * decision, not something this helper works around on its own. */
+export const AUTHORED_CODE_TYPES: ReadonlySet<string> = new Set([
+  "CustomComponent",
+]);
+
 export interface TemplateField {
-  value?: string;
-  options?: string[];
+  value?: unknown;
+  options?: unknown[];
   [key: string]: unknown;
 }
 
@@ -90,7 +109,15 @@ export function hydrateFixtureCode(
       continue;
     }
     const type = node.data?.type;
-    if (!type || !(type in index)) {
+    if (type && AUTHORED_CODE_TYPES.has(type)) {
+      throw new Error(
+        `hydrateFixtureCode: node ${node.id} is a ${type} — its stored code is ` +
+          `authored by the test, not installed by the image, and hydrating it ` +
+          `would silently replace the behaviour under test. This helper cannot ` +
+          `hydrate authored code; the migration must decide how to handle it.`,
+      );
+    }
+    if (!type || !Object.hasOwn(index, type)) {
       missing.add(type ?? `<node ${node.id} has no data.type>`);
       continue;
     }

--- a/tests/helpers/flows/hydrate-fixture-code.ts
+++ b/tests/helpers/flows/hydrate-fixture-code.ts
@@ -1,0 +1,143 @@
+// Fixture component-code hydration (#1478).
+//
+// A fixture flow under tests/assets/flows/ stores a FROZEN copy of each
+// component's Python source in `node.data.node.template.code.value`, captured
+// on whatever image the fixture was recorded against. Langflow EXECS that copy
+// (lfx/custom/validate.py: prepare_global_scope -> create_class), not the
+// installed component — so a fixture is a dependency on one specific build.
+//
+// On 2026-08-18 upstream commit 99ea9044f (PR #14413, release-1.12.0 — the line
+// the nightly is cut from) deleted `load_kb_metadata` from `_kb_paths`. The
+// frozen copy still imported it, `Graph.from_payload` raised ImportError, the
+// graph was never built, and two @stable specs waited the full 90s for a
+// duration badge that could not exist.
+//
+// Dropping the field is NOT an option and the measurement is recorded so nobody
+// re-derives it: `POST /api/v1/flows/` accepts a payload with no `code` and does
+// not repopulate it, and the graph build then fails with
+// `Error while creating graph from payload: 'code'` — a message that names
+// nothing. `code` is required; what has to change is WHERE its value comes from.
+//
+// This module is the pure half: given the flow data and a `type -> code` index
+// built from the running image, it returns a cloned payload with the code
+// replaced plus a report of what it did. It performs no I/O and never decides
+// policy — an absent component type is REPORTED, and the caller
+// (`load-fixture-flow.ts`) is what turns that into a thrown error.
+
+export type CodeIndex = Record<string, string>;
+
+interface FixtureNode {
+  id: string;
+  data?: {
+    type?: string;
+    node?: { template?: Record<string, { value?: string } | undefined> };
+  };
+}
+
+export interface FlowData {
+  nodes: FixtureNode[];
+  [key: string]: unknown;
+}
+
+export interface HydrationReport {
+  data: FlowData;
+  /** Node ids whose stored code differed from the image's and was replaced. */
+  hydrated: string[];
+  /** Node ids whose stored code already matched the image's. */
+  unchanged: string[];
+  /** Node ids carrying no `template.code` — not a drift signal, but counted. */
+  skipped: string[];
+  /** Component types absent from the index, deduped and sorted. */
+  missing: string[];
+}
+
+/**
+ * Replaces every node's stored component source with the image's, returning a
+ * NEW payload plus the report.
+ *
+ * When any component type is absent from the index, NOTHING is rewritten: a
+ * half-hydrated payload would be created successfully and then fail at graph
+ * build, with a cause this function already knew. The caller inspects
+ * `missing` and refuses before creating the flow.
+ */
+export function hydrateFixtureCode(
+  data: unknown,
+  index: CodeIndex,
+): HydrationReport {
+  const source = data as FlowData | undefined;
+  if (!source || !Array.isArray(source.nodes)) {
+    throw new Error(
+      "hydrateFixtureCode: flow data has no `nodes` array — not a fixture payload",
+    );
+  }
+
+  const clone = structuredClone(source) as FlowData;
+  const hydrated: string[] = [];
+  const unchanged: string[] = [];
+  const skipped: string[] = [];
+  const missing = new Set<string>();
+
+  for (const node of clone.nodes) {
+    const code = node.data?.node?.template?.code;
+    if (!code || typeof code.value !== "string") {
+      skipped.push(node.id);
+      continue;
+    }
+    const type = node.data?.type;
+    if (!type || !(type in index)) {
+      missing.add(type ?? `<node ${node.id} has no data.type>`);
+      continue;
+    }
+    if (code.value === index[type]) {
+      unchanged.push(node.id);
+      continue;
+    }
+    hydrated.push(node.id);
+  }
+
+  // Any missing type poisons the whole payload — return the ORIGINAL values.
+  if (missing.size > 0) {
+    return {
+      data: structuredClone(source) as FlowData,
+      hydrated: [],
+      unchanged: [],
+      skipped,
+      missing: [...missing].sort(),
+    };
+  }
+
+  for (const node of clone.nodes) {
+    const code = node.data?.node?.template?.code;
+    const type = node.data?.type;
+    if (code && typeof code.value === "string" && type) {
+      code.value = index[type];
+    }
+  }
+
+  return { data: clone, hydrated, unchanged, skipped, missing: [] };
+}
+
+/** One always-emitted line per fixture, in the shape of the catalog-drift report. */
+export function formatHydrationReport(
+  fixtureName: string,
+  report: HydrationReport,
+): string {
+  const total =
+    report.hydrated.length + report.unchanged.length + report.skipped.length;
+  if (report.hydrated.length === 0) {
+    const noun = total === 1 ? "node" : "nodes";
+    let msg = `all ${total} ${noun} already current`;
+    if (report.skipped.length > 0) {
+      msg += ` (${report.skipped.length} without code field)`;
+    }
+    return `[fixture] ${fixtureName} — ${msg}`;
+  }
+  const parts = [`hydrated: ${report.hydrated.join(", ")}`];
+  if (report.unchanged.length > 0) {
+    parts.push(`unchanged: ${report.unchanged.join(", ")}`);
+  }
+  if (report.skipped.length > 0) {
+    parts.push(`no code field: ${report.skipped.join(", ")}`);
+  }
+  return `[fixture] ${fixtureName} — ${parts.join(" · ")}`;
+}

--- a/tests/helpers/flows/load-fixture-flow.ts
+++ b/tests/helpers/flows/load-fixture-flow.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "fs";
+import path from "path";
+import type { APIRequestContext } from "@playwright/test";
+import { getComponentCodeIndex } from "./component-code-index";
+import {
+  formatHydrationReport,
+  hydrateFixtureCode,
+  type FlowData,
+} from "./hydrate-fixture-code";
+
+// Reads a fixture flow and hydrates its component source from the running image
+// before any flow is created (#1478).
+//
+// Callers used to do `JSON.parse(readFileSync(FIXTURE_PATH))` and hand the
+// payload straight to `createFlow`, which shipped a frozen copy of every
+// component's Python source into the run. `createFlow` is deliberately NOT
+// changed: most of its callers build payloads that are not fixtures at all.
+
+export interface FixtureFlow {
+  data: FlowData;
+  description?: string;
+  name?: string;
+}
+
+/**
+ * A fixture whose component source is the IMAGE's, not the recording's.
+ *
+ * Throws — before creating anything — when a component type in the fixture is
+ * absent from the image's catalog. That state has no honest outcome: the spec
+ * cannot exercise a component this build does not ship, and letting it through
+ * reproduces the #1478 failure (a 90s wait for a duration badge that cannot
+ * render, because the graph was never built).
+ */
+export async function loadFixtureFlow(
+  request: APIRequestContext,
+  fixturePath: string,
+  options?: { headers?: Record<string, string> },
+): Promise<FixtureFlow> {
+  let parsed: FixtureFlow;
+  try {
+    parsed = JSON.parse(readFileSync(fixturePath, "utf-8")) as FixtureFlow;
+  } catch (e) {
+    throw new Error(`Cannot read fixture flow ${fixturePath}: ${String(e)}`);
+  }
+
+  const index = await getComponentCodeIndex(request, options);
+  const report = hydrateFixtureCode(parsed.data, index);
+
+  if (report.missing.length > 0) {
+    throw new Error(
+      `Fixture ${path.basename(fixturePath)} uses component type(s) absent ` +
+        `from this image's catalog: ${report.missing.join(", ")}. ` +
+        `The catalog exposes ${Object.keys(index).length} types. This is a ` +
+        `packaging/renaming change in the image, not a fixture value problem — ` +
+        `refusing to create a flow that cannot build.`,
+    );
+  }
+
+  // Always emitted: a run where nothing changed says so, so the ABSENCE of this
+  // line can only mean the hydration did not run (#1012).
+  console.log(formatHydrationReport(path.basename(fixturePath), report));
+
+  return { ...parsed, data: report.data };
+}

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
@@ -121,10 +121,16 @@ async function openRagFlow(page: Page): Promise<void> {
   for (const node of fixture.data.nodes) {
     if (node.data?.type === "Knowledge") {
       const kb = node.data.node?.template?.knowledge_base;
-      if (kb) {
-        kb.value = kbName;
-        kb.options = [kbName];
+      if (!kb) {
+        throw new Error(
+          `${FIXTURE_PATH}: node ${node.id} (type Knowledge) has no ` +
+            `template.knowledge_base field — cannot pin it to the freshly-created ` +
+            `KB. If upstream renamed/removed this field, the pin must target the ` +
+            `new field instead of silently leaving the node unset.`,
+        );
       }
+      kb.value = kbName;
+      kb.options = [kbName];
     }
     // Point the answer Language Model at ANSWER_MODEL (an alias). The fixture was
     // captured pinned to a dated model that Google is retiring — pinned ids 404
@@ -134,27 +140,41 @@ async function openRagFlow(page: Page): Promise<void> {
     // (from the node's own options) AND the `model_name` string override.
     if (node.data?.type === "LanguageModelComponent") {
       const tmpl = node.data.node?.template;
-      // `model`'s `value`/`options` hold structured model-selection objects, not
-      // the string shape `TemplateField` declares for the generic `code`/`kb`
-      // fields — reached through the index signature via a computed key so no
-      // cast is needed to read or write the actual runtime shape.
-      const optionsKey: string = "options";
-      const valueKey: string = "value";
-      const modelOptions = tmpl?.model?.[optionsKey];
+      // `model`'s `value`/`options` hold structured model-selection objects —
+      // `TemplateField.options`/`value` are `unknown[]`/`unknown` precisely to
+      // accommodate this, so no computed-key index-signature workaround is
+      // needed. Cast each entry once, at the point it is actually shaped.
+      if (!tmpl?.model) {
+        throw new Error(
+          `${FIXTURE_PATH}: node ${node.id} (type LanguageModelComponent) has ` +
+            `no template.model field — cannot pin the answer model.`,
+        );
+      }
+      const modelOptions = tmpl.model.options;
       const modelOption = Array.isArray(modelOptions)
-        ? modelOptions.find(
+        ? (modelOptions as Array<Record<string, unknown>>).find(
             (o) =>
-              typeof o === "object" &&
-              o !== null &&
-              "name" in o &&
-              o.name === ANSWER_MODEL,
+              typeof o === "object" && o !== null && o.name === ANSWER_MODEL,
           )
         : undefined;
-      if (tmpl?.model && modelOption) tmpl.model[valueKey] = [modelOption];
-      if (tmpl?.model_name) {
-        tmpl.model_name[valueKey] = ANSWER_MODEL;
-        tmpl.model_name[optionsKey] = [ANSWER_MODEL];
+      if (!modelOption) {
+        throw new Error(
+          `${FIXTURE_PATH}: node ${node.id}'s template.model.options has no ` +
+            `entry named "${ANSWER_MODEL}" — cannot pin the answer model. If ` +
+            `Google's catalog dropped this alias, the pin target must be ` +
+            `updated instead of silently falling back to the fixture's dated ` +
+            `model id.`,
+        );
       }
+      tmpl.model.value = [modelOption];
+      if (!tmpl.model_name) {
+        throw new Error(
+          `${FIXTURE_PATH}: node ${node.id} (type LanguageModelComponent) has ` +
+            `no template.model_name field — cannot set the string override.`,
+        );
+      }
+      tmpl.model_name.value = ANSWER_MODEL;
+      tmpl.model_name.options = [ANSWER_MODEL];
     }
   }
 

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
@@ -1,9 +1,9 @@
-import { readFileSync } from "fs";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { loadFixtureFlow } from "../../../../helpers/flows/load-fixture-flow";
 import {
   assertEmbeddingCredentialConfigured,
   createKnowledgeBase,
@@ -110,16 +110,21 @@ async function openRagFlow(page: Page): Promise<void> {
   );
   createdKbNames.push(kbName);
 
-  const fixture = JSON.parse(readFileSync(FIXTURE_PATH, "utf-8"));
+  // The fixture stores a frozen copy of each component's source; hydrate it from
+  // the running image before creating the flow, or an upstream refactor of a
+  // module that copy imports breaks the run at graph build (#1478).
+  const fixture = await loadFixtureFlow(page.request, FIXTURE_PATH, { headers });
   // Point both Knowledge nodes at the freshly-created KB. The DropdownInput only
   // treats a value as a valid selection when it is also present in `options`, so
   // set both — value alone leaves the node showing "Select an option" and it
   // will not run.
   for (const node of fixture.data.nodes) {
     if (node.data?.type === "Knowledge") {
-      const kb = node.data.node.template.knowledge_base;
-      kb.value = kbName;
-      kb.options = [kbName];
+      const kb = node.data.node?.template?.knowledge_base;
+      if (kb) {
+        kb.value = kbName;
+        kb.options = [kbName];
+      }
     }
     // Point the answer Language Model at ANSWER_MODEL (an alias). The fixture was
     // captured pinned to a dated model that Google is retiring — pinned ids 404
@@ -128,14 +133,27 @@ async function openRagFlow(page: Page): Promise<void> {
     // of false-failing on a retirement. Set the structured `model` selection
     // (from the node's own options) AND the `model_name` string override.
     if (node.data?.type === "LanguageModelComponent") {
-      const tmpl = node.data.node.template;
-      const modelOption = (tmpl.model?.options ?? []).find(
-        (o: { name?: string }) => o?.name === ANSWER_MODEL,
-      );
-      if (modelOption) tmpl.model.value = [modelOption];
-      if (tmpl.model_name) {
-        tmpl.model_name.value = ANSWER_MODEL;
-        tmpl.model_name.options = [ANSWER_MODEL];
+      const tmpl = node.data.node?.template;
+      // `model`'s `value`/`options` hold structured model-selection objects, not
+      // the string shape `TemplateField` declares for the generic `code`/`kb`
+      // fields — reached through the index signature via a computed key so no
+      // cast is needed to read or write the actual runtime shape.
+      const optionsKey: string = "options";
+      const valueKey: string = "value";
+      const modelOptions = tmpl?.model?.[optionsKey];
+      const modelOption = Array.isArray(modelOptions)
+        ? modelOptions.find(
+            (o) =>
+              typeof o === "object" &&
+              o !== null &&
+              "name" in o &&
+              o.name === ANSWER_MODEL,
+          )
+        : undefined;
+      if (tmpl?.model && modelOption) tmpl.model[valueKey] = [modelOption];
+      if (tmpl?.model_name) {
+        tmpl.model_name[valueKey] = ANSWER_MODEL;
+        tmpl.model_name[optionsKey] = [ANSWER_MODEL];
       }
     }
   }
@@ -240,7 +258,7 @@ test.afterEach(async ({ page }) => {
 
 test(
   "Full RAG pipeline grounds the model answer on the retrieved chunk",
-  { tag: ["@release", "@components", "@files"] },
+  { tag: ["@stable", "@release", "@components", "@files"] },
   async ({ page }) => {
     await test.step("open the pre-wired RAG pipeline fixture flow", async () => {
       await openRagFlow(page);

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
@@ -1,9 +1,9 @@
-import { readFileSync } from "fs";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { loadFixtureFlow } from "../../../../helpers/flows/load-fixture-flow";
 import {
   assertEmbeddingCredentialConfigured,
   createKnowledgeBase,
@@ -101,16 +101,23 @@ async function openVectorStoreFlow(page: Page): Promise<void> {
   );
   createdKbNames.push(kbName);
 
-  const fixture = JSON.parse(readFileSync(FIXTURE_PATH, "utf-8"));
+  // The fixture stores a frozen copy of each component's source; hydrate it from
+  // the running image before creating the flow, or an upstream refactor of a
+  // module that copy imports breaks the run at graph build (#1478).
+  const fixture = await loadFixtureFlow(page.request, FIXTURE_PATH, { headers });
   // Point both Knowledge nodes at the freshly-created KB. The DropdownInput only
   // treats a value as a valid selection when it is also present in `options`, so
   // set both — value alone leaves the node showing "Select an option" and it
   // will not run.
   for (const node of fixture.data.nodes) {
     if (node.data?.type === "Knowledge") {
-      const kb = node.data.node.template.knowledge_base;
-      kb.value = kbName;
-      kb.options = [kbName];
+      const kb = node.data.node?.template?.knowledge_base as
+        | { value?: string; options?: string[] }
+        | undefined;
+      if (kb) {
+        kb.value = kbName;
+        kb.options = [kbName];
+      }
     }
   }
 
@@ -205,7 +212,7 @@ test.afterEach(async ({ page }) => {
 
 test(
   "Knowledge Base indexes the ingested document chunks (available for query)",
-  { tag: ["@release", "@components", "@files"] },
+  { tag: ["@stable", "@release", "@components", "@files"] },
   async ({ page }) => {
     await test.step("open the pre-wired vector-store fixture flow", async () => {
       await openVectorStoreFlow(page);

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
@@ -112,10 +112,16 @@ async function openVectorStoreFlow(page: Page): Promise<void> {
   for (const node of fixture.data.nodes) {
     if (node.data?.type === "Knowledge") {
       const kb = node.data.node?.template?.knowledge_base;
-      if (kb) {
-        kb.value = kbName;
-        kb.options = [kbName];
+      if (!kb) {
+        throw new Error(
+          `${FIXTURE_PATH}: node ${node.id} (type Knowledge) has no ` +
+            `template.knowledge_base field — cannot pin it to the freshly-created ` +
+            `KB. If upstream renamed/removed this field, the pin must target the ` +
+            `new field instead of silently leaving the node unset.`,
+        );
       }
+      kb.value = kbName;
+      kb.options = [kbName];
     }
   }
 

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
@@ -111,9 +111,7 @@ async function openVectorStoreFlow(page: Page): Promise<void> {
   // will not run.
   for (const node of fixture.data.nodes) {
     if (node.data?.type === "Knowledge") {
-      const kb = node.data.node?.template?.knowledge_base as
-        | { value?: string; options?: string[] }
-        | undefined;
+      const kb = node.data.node?.template?.knowledge_base;
       if (kb) {
         kb.value = kbName;
         kb.options = [kbName];


### PR DESCRIPTION
## Summary

Fixes #1478.

Adds `loadFixtureFlow`, which hydrates a fixture flow's component `code` from the
running image's live catalog before the flow is created, and hard-refuses when a
fixture references a component type absent from that catalog. Adopted by the two
specs in this issue; the other 13 fixtures are a follow-up. Root cause: our
fixture JSONs embed a frozen copy of component source captured on
`1.11.0.dev38`; upstream commit `99ea9044f` (release-1.12.0, PR
langflow-ai/langflow#14413) removed `load_kb_metadata` from
`_kb_paths.py`, so the frozen Knowledge component's `import` failed and
`Graph.from_payload` never built the graph — `POST /api/v2/workflows` still
returned 200 with `event_type: "error"` in the stream, and
`vector-store-index-query.spec.ts` / `rag-pipeline.spec.ts` then waited the
full 90s for a duration badge that could never appear.

## How this was validated

- **Before:** 6/6 failed in CI run `32116967595`, plus 1/1 failed locally on
  `1.12.0.dev31`.
- **After:** 5 consecutive clean runs of both specs at `--retries=0` (15/15
  tests), following one unrelated infra abort (the known post-`collect-models`
  backend wedge, #922/#927 — reported separately, not counted in the tally).
- Forced-failure paths confirmed directly: a fixture referencing an absent
  component type fails before any flow is created (`uses component type(s)
  absent from this image's catalog: VanishedComponent. The catalog exposes 177
  types.`, flow count unchanged at 27); a dead backend fails at the bootstrap
  health gate naming `ECONNREFUSED`.
- Followed the full validation pipeline (typecheck, lint, playwright-test-linter
  checklist, clean run at `--retries=0`, forced failure, `--trace=on`, backend
  error audit).

## Failing loudly, deliberately

Three guards exist because the review found that convenience had reintroduced
this issue's own failure mode:

- A fixture field the spec pins (`template.knowledge_base`, the answer model's
  `model` / `model_name`) that is absent now **throws**, naming the fixture, the
  node and the field. The earlier `if (field) { … }` form would have left the KB
  pointer unset — the node renders "Select an option", never runs, and the spec
  dies on the same 90s badge wait with a new cause.
- `hydrateFixtureCode` **refuses** to hydrate a component type whose stored code
  is authored rather than installed (`CustomComponent`, in an exported constant).
  Five other fixtures contain such nodes, where the stored code *is* the test's
  subject — hydrating them would replace the behaviour under test and the spec
  would pass having verified nothing.
- A catalog that yields zero component types is an error, not "no drift": it
  would otherwise report every fixture node as absent from the image and blame
  the fixture for a backend that is merely still starting.

## Roadmap linkage

Fixes #1478 (`daily-failure` triage issue).

## What this restores

`@stable` on both tests of `vector-store-index-query.spec.ts`, including its
second test — which had never itself failed, but was skipping with an empty
reason on every run as a serial consequence of the first test's failure, so no
run had actually established the query path as green.

## What this does not cover (follow-ups)

- The remaining 13 fixtures under `tests/assets/flows/` still carry frozen
  component source and have not been re-measured for staleness.
- Hydration only refreshes `code`; field-schema drift is not covered — a
  renamed template field would still fail, just more quietly than an import
  error.
- A related suite gap: the backend named this failure's cause in the v2 run
  stream, but the suite currently logs a v2 verdict as `ADVISORY` only, so the
  test died on a downstream `element(s) not found` instead of the real cause.
  Tracked as a separate follow-up issue rather than fixed here.

## Dependencies

- No LLM provider required for the hydration mechanism itself; the two
  restored specs still require `GOOGLE_API_KEY` as documented in their spec
  docs.
- No other PR needs to merge first.
