### PR TITLE
fix(playground): create the test flow under a unique name, not "New Flow" (#1479)

### DIFF
--- a/docs/core-functionality/playground/playground-output-data.md
+++ b/docs/core-functionality/playground/playground-output-data.md
@@ -82,44 +82,87 @@ each and differs only in which Mock Data output is selected.
 - Re-validated after PR #120: `runNoInputFlow` now waits for the first message instead of an exact count of 2; `cleanAllFlows` was replaced with REST API-based flow deletion.
 - Re-validated after #279: `runNoInputFlow` no longer asserts `button-stop` becomes visible — on instant Mock Data flows the Send→Stop→Hidden transition completed in <100 ms, faster than Playwright's auto-wait could observe. At that point `toBeHidden` alone was used as the build-finished signal (later superseded by #465 below, which waits on the rendered output content instead); `setupMockDataFlow` also gained an explicit `toBeVisible` wait on `sidebar-search-input` (same race pattern as #278).
 - Fixed after #465: the recurring flake (4×+ across weekly + daily) was a **concurrent flow-deletion race**, not the run-completion wait. The `afterEach` called the global `cleanAllFlows(page)`, which deletes *every* flow of the single shared `auto_login` user. Under `fullyParallel`, the JSON and DataFrame tests run in separate workers; whichever finished first deleted the sibling's flow **mid-build**, so the output never rendered ("run does not settle"), then passed on retry. Confirmed empirically: serial (`--workers=1`) passed 3/3, parallel failed with the bare home empty-state snapshot, and the failing run logged `Flow not found` 404s on `/api/v1/flows/<id>` (a page loading a flow a sibling had just deleted). The `afterEach` now deletes **only the flow the test created** (its id captured from the `/flow/<id>` URL in `setupMockDataFlow`) — collision-free, and it also stops this spec from deleting other specs' flows. `@stable` restored on the DataFrame test. The broader suite-wide hazard (other validated specs still calling the global `cleanAllFlows`) is tracked in #515.
-- **Fixed after #1479 — the setup no longer competes for the flow name `New Flow`.**
+- **Fixed after #1479 — the setup no longer competes for the flow name `New Flow`,
+  and the sidebar fills now go through #1468's barrier.**
   The DataFrame test flaked on the 2026-08-17 and 2026-08-18 dailies with the same
-  signature, and was quarantined at triage (`test.fixme` + `@stable` removed, PR #1481).
-  The failure was recorded as "the Chat Output sidebar row never enters the DOM", but
-  the `error-context` of both dailies is **byte-identical** and shows something else:
-  banner + `main` holding `Loading...`, which is the **home** (`MainPage/pages/main-page.tsx`,
-  the branch taken while `flows && examples && folders` are still pending), not the flow
-  editor. The browser was never in the editor, so the row it waited for could not exist.
+  signature and was quarantined at triage (`test.fixme` + `@stable` removed, PR #1481).
 
-  **Mechanism, measured on nightly `1.12.0.dev30`.** `POST /api/v1/flows/` deduplicates
-  the requested name (`_deduplicate_flow_name` in `api/v1/flows_helpers.py`: `SELECT`,
-  then append `(N)`) and only afterwards inserts, with no transaction covering the two
-  steps, against `UniqueConstraint("user_id", "name")`. Two creations that arrive
-  together therefore both read the same name as free and the second violates the
-  constraint; `_handle_unique_constraint_error` (`api/v1/flows.py`) turns that into
-  **400 `{"detail":"Name must be unique"}`**. Measured directly against the API:
-  **10 of 20 requests fail at 2 concurrent creations of the same name (one per round,
-  10/10 rounds) and 30 of 40 at 4** — the dedup does not survive any concurrency at all.
-  On the client, `hooks/flows/use-add-flow.ts` handles that 400 with a toast and a
-  `reject`, with no retry under another name, so the app never navigates and stays on
-  the home screen. Reproduced end-to-end at **6 %** (6 of 100 adds) under four parallel
-  harnesses, and once in 32 runs of this very file — in the **JSON** test, which was the
-  one still running, which is why quarantining only the DataFrame test removed coverage
-  without removing exposure.
+  **What the two dailies actually show.** The failure is at the Chat Output **row**
+  wait inside `setupMockDataFlow`, which the triage recorded correctly. Reaching that
+  line requires `sidebar-search-input` to have been visible **and** filled inside the
+  20 s `actionTimeout`, and that testid exists upstream in exactly one place —
+  `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/searchInput.tsx`
+  — so the browser was in the flow editor when it failed. The `error-context` snapshot
+  of both attempts (the home screen with `Loading...`, byte-identical across the two
+  days) does **not** contradict that, and reading it as "the editor never opened" is a
+  mistake this note records rather than repeats: Playwright writes that snapshot from
+  `didFinishTest`, i.e. **after** `afterEach`, and this spec's `afterEach` calls
+  `page.goto("/")`. The home screen is therefore what teardown produces for *any*
+  failure of this file, and byte-identical is what a deterministic teardown navigation
+  looks like, not corroboration. Measured twice on the repo's own Playwright 1.58.2,
+  the second time on this spec: a test failing on `data:text/html,<h1>DURING</h1>` with
+  an `afterEach` that navigates to `<h1>TEARDOWN</h1>` writes TEARDOWN into
+  `error-context.md`; and a throw injected into `setupMockDataFlow` between the create
+  and `openFlowById` — browser still on `about:blank`, no Langflow page ever loaded —
+  produced an `error-context` showing the home screen with `Loading...`, i.e. the
+  dailies' snapshot, from a failure that provably never reached any screen. The
+  failure-time artefacts are `test-failed-1.png` (captured from
+  `didFinishTestFunction`, before the hooks) and the first-retry trace. So the remaining explanation for those two days is
+  #1468's sidebar remount on a call site its barriers did not cover, which is what the
+  issue suspected, and `fillSidebarSearch` — adopted here on **both** fills — is its
+  measured barrier (23 failures in 220 adds before, 0 in 200 after, on the call site
+  #1468 measured).
 
-  **Why the fix is a unique name and not a repair.** This is the same upstream race
-  #588 filed and closed in July ("the unique-name suffixing is not transaction-safe
-  upstream […] we cannot fix the backend here"), whose answer was `helpers/flows/create-flow.ts`
-  — explicit unique names plus a retry for the transient 5xx — adopted by 22 files.
-  This spec had simply never been migrated: it still created its flow through
-  `New Flow → Blank Flow`, i.e. it asked for the name `New Flow` that every other
-  worker asks for at the same moment. Creating through `createFlow` under a per-run
-  unique name removes the collision at its source, so there is nothing to repair and
-  nothing to mask — preferred over a repair barrier for exactly that reason. The
-  product defect is real but is **not** a regression and has no single-user path
-  (batch import in `use-upload-flow.ts` is sequential, so the backend dedups it
-  normally); it is reported upstream separately and deliberately does not gate this
-  spec's coverage.
+  **Second change, with its own justification: the flow is created through the REST
+  API under a per-run unique name.** `POST /api/v1/flows/` deduplicates the requested
+  name (`_deduplicate_flow_name` in `api/v1/flows_helpers.py`: `SELECT`, then append
+  `(N)`) and only afterwards inserts, with no transaction covering the two steps,
+  against `UniqueConstraint("user_id", "name")`. Two creations that arrive together
+  both read the name as free and the second violates the constraint;
+  `_handle_unique_constraint_error` (`api/v1/flows.py`) turns that into
+  **400 `{"detail":"Name must be unique"}`**. Measured on nightly `1.12.0.dev30`
+  directly against the API: **10 of 20 requests fail at 2 concurrent creations of one
+  name and 30 of 40 at 4** — the dedup survives no concurrency at all. On the client,
+  `hooks/flows/use-add-flow.ts` answers that 400 with a toast and a `reject` and never
+  retries under another name, so the app stays on the home screen. This spec created
+  its flow through `New Flow → Blank Flow`, i.e. it asked for the name `New Flow` that
+  every other parallel worker asks for at the same moment. Measured on this file, 4
+  lanes × 4 repeats: **7 `Name must be unique` backend errors and 1 failed test**
+  before, **0 of each** after — the failed one being the **JSON** sibling that was
+  never quarantined, which is why quarantining only the DataFrame test removed
+  coverage without removing exposure. Creating under a unique name removes the
+  collision at its source, so — unlike a repair barrier — there is nothing here that
+  can mask a real create failure. It is the answer #588 already reached for this same
+  upstream race ("the unique-name suffixing is not transaction-safe upstream […] we
+  cannot fix the backend here"), shipped as `helpers/flows/create-flow.ts` and
+  imported by **27** other files; this spec had simply never been migrated to it.
+  The editor is then entered by id (`openFlowById`, #1214) rather than by clicking the
+  flow's card on the home grid, which is where other workers' residual cards intercept
+  the open button (#580/#588).
+
+  **Upstream defect: deliberately not filed.** The race is real, but it is not a
+  regression and has no single-user path — batch import (`use-upload-flow.ts`) is
+  sequential, so the backend dedups it normally; it needs two simultaneous creations
+  on one account, which is what parallel test workers produce and a user practically
+  does not. Recorded here and on #1479 rather than reported, and it is not a
+  `REGRESSIONS.md` row for the same reason.
+
+  **Not extended to the shared sidebar helper.** `helpers/flows/add-component-from-sidebar.ts`
+  fills `sidebar-search-input` raw and is reached by dozens of specs, so it carries the
+  same #1468 exposure. It is left alone here on purpose: `fillSidebarSearch`'s only
+  measured repair is a `page.reload()` (4 of 4, against 0 of 4 for re-typing), and that
+  helper is called *after* nodes are placed, where a reload would discard the canvas
+  the caller has already built. Adopting it there is a separate change with its own
+  blast radius, not a quiet widening of this one.
+
+  **Teardown hardened alongside it.** The flow id is recorded the moment
+  `POST /api/v1/flows/` returns rather than handed back at the end of
+  `setupMockDataFlow`, so a setup that fails at any of the canvas steps still leaves
+  the `afterEach` a flow to delete. Measured on `1.12.0.dev30` with a throw injected
+  between the create and `openFlowById`: the account goes **27 → 28** flows with the id
+  recorded on return, **27 → 27** with it recorded at create time. The `afterEach`'s
+  URL fallback could not cover that case — the failure it was written against leaves no
+  `/flow/<id>` in the URL either — and is kept only as belt-and-braces.
 
   Quarantine lifted in the same change: `test.fixme` removed and `@stable` restored on
   the DataFrame test.

--- a/docs/core-functionality/playground/playground-output-data.md
+++ b/docs/core-functionality/playground/playground-output-data.md
@@ -1,6 +1,6 @@
 # Playground Output — Structured Data
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -23,16 +23,32 @@ Both tests run without user input and without an API key or LLM — the Mock Dat
 
 ## Step by step *(required)*
 
+Both tests share `setupMockDataFlow()`, which builds the canvas the same way for
+each and differs only in which Mock Data output is selected.
+
+**Shared setup — `setupMockDataFlow()`**
+
+1. Create an **empty flow through the REST API under a per-run unique name**
+   (`createFlow`), then enter the editor by id (`openFlowById`). The flow is
+   never created through `New Flow → Blank Flow`, and that is load-bearing —
+   see the #1479 note below
+2. Add Chat Output from the component sidebar (`fillSidebarSearch`, which
+   confirms the sidebar kept the typed term before waiting for its row — #1468)
+3. Add Mock Data by dragging its sidebar row onto the canvas, and — for the JSON
+   test only — switch the node's output from Table (DataFrame) to JSON
+4. Connect Mock Data's selected output to Chat Output's input, and assert the
+   canvas holds 2 nodes and 1 edge before the run
+
 **Test 1 — JSON Data output as code block**
 
-1. Create a flow with the Mock Data component connected to ChatOutput (its flow id is captured for scoped teardown)
+1. Set up the flow with `selectDataOutput: true` and open the Playground
 2. Run the flow without user input via `runNoInputFlow`, which waits directly on the rendered output content
 3. Assert the chat message contains a `<code>` element with text including `"records"` (root key of the serialized JSON)
 4. In `afterEach`, delete only this test's flow by id (never a global `cleanAllFlows`)
 
 **Test 2 — DataFrame output as Markdown table**
 
-1. Create a flow with the Mock Data component (dataframe output) connected to ChatOutput (its flow id is captured for scoped teardown)
+1. Set up the flow with the default (dataframe) output and open the Playground
 2. Run the flow without user input via `runNoInputFlow`, which waits directly on the rendered output content
 3. Assert the chat message contains a `<table>` element rendered by react-markdown with remarkGfm
 4. In `afterEach`, delete only this test's flow by id (never a global `cleanAllFlows`)
@@ -50,6 +66,7 @@ Both tests run without user input and without an API key or LLM — the Mock Dat
 
 - `src/lfx/src/lfx/components/data_source/` — Mock Data component; changes to serialization logic (`_serialize_data` or `df.to_markdown`) would alter the rendered output format
 - `src/frontend/src/components/core/chatComponents/` — Markdown and code block rendering in the Playground chat; changes to react-markdown plugins or code block CSS classes would break the assertions
+- `src/backend/base/langflow/api/v1/flows.py` and `api/v1/flows_helpers.py` — flow creation and its name deduplication; the setup enters the editor by id after creating through this endpoint, so a change to the create contract (status codes, name handling) changes how the setup fails
 
 ---
 
@@ -65,4 +82,45 @@ Both tests run without user input and without an API key or LLM — the Mock Dat
 - Re-validated after PR #120: `runNoInputFlow` now waits for the first message instead of an exact count of 2; `cleanAllFlows` was replaced with REST API-based flow deletion.
 - Re-validated after #279: `runNoInputFlow` no longer asserts `button-stop` becomes visible — on instant Mock Data flows the Send→Stop→Hidden transition completed in <100 ms, faster than Playwright's auto-wait could observe. At that point `toBeHidden` alone was used as the build-finished signal (later superseded by #465 below, which waits on the rendered output content instead); `setupMockDataFlow` also gained an explicit `toBeVisible` wait on `sidebar-search-input` (same race pattern as #278).
 - Fixed after #465: the recurring flake (4×+ across weekly + daily) was a **concurrent flow-deletion race**, not the run-completion wait. The `afterEach` called the global `cleanAllFlows(page)`, which deletes *every* flow of the single shared `auto_login` user. Under `fullyParallel`, the JSON and DataFrame tests run in separate workers; whichever finished first deleted the sibling's flow **mid-build**, so the output never rendered ("run does not settle"), then passed on retry. Confirmed empirically: serial (`--workers=1`) passed 3/3, parallel failed with the bare home empty-state snapshot, and the failing run logged `Flow not found` 404s on `/api/v1/flows/<id>` (a page loading a flow a sibling had just deleted). The `afterEach` now deletes **only the flow the test created** (its id captured from the `/flow/<id>` URL in `setupMockDataFlow`) — collision-free, and it also stops this spec from deleting other specs' flows. `@stable` restored on the DataFrame test. The broader suite-wide hazard (other validated specs still calling the global `cleanAllFlows`) is tracked in #515.
+- **Fixed after #1479 — the setup no longer competes for the flow name `New Flow`.**
+  The DataFrame test flaked on the 2026-08-17 and 2026-08-18 dailies with the same
+  signature, and was quarantined at triage (`test.fixme` + `@stable` removed, PR #1481).
+  The failure was recorded as "the Chat Output sidebar row never enters the DOM", but
+  the `error-context` of both dailies is **byte-identical** and shows something else:
+  banner + `main` holding `Loading...`, which is the **home** (`MainPage/pages/main-page.tsx`,
+  the branch taken while `flows && examples && folders` are still pending), not the flow
+  editor. The browser was never in the editor, so the row it waited for could not exist.
+
+  **Mechanism, measured on nightly `1.12.0.dev30`.** `POST /api/v1/flows/` deduplicates
+  the requested name (`_deduplicate_flow_name` in `api/v1/flows_helpers.py`: `SELECT`,
+  then append `(N)`) and only afterwards inserts, with no transaction covering the two
+  steps, against `UniqueConstraint("user_id", "name")`. Two creations that arrive
+  together therefore both read the same name as free and the second violates the
+  constraint; `_handle_unique_constraint_error` (`api/v1/flows.py`) turns that into
+  **400 `{"detail":"Name must be unique"}`**. Measured directly against the API:
+  **10 of 20 requests fail at 2 concurrent creations of the same name (one per round,
+  10/10 rounds) and 30 of 40 at 4** — the dedup does not survive any concurrency at all.
+  On the client, `hooks/flows/use-add-flow.ts` handles that 400 with a toast and a
+  `reject`, with no retry under another name, so the app never navigates and stays on
+  the home screen. Reproduced end-to-end at **6 %** (6 of 100 adds) under four parallel
+  harnesses, and once in 32 runs of this very file — in the **JSON** test, which was the
+  one still running, which is why quarantining only the DataFrame test removed coverage
+  without removing exposure.
+
+  **Why the fix is a unique name and not a repair.** This is the same upstream race
+  #588 filed and closed in July ("the unique-name suffixing is not transaction-safe
+  upstream […] we cannot fix the backend here"), whose answer was `helpers/flows/create-flow.ts`
+  — explicit unique names plus a retry for the transient 5xx — adopted by 22 files.
+  This spec had simply never been migrated: it still created its flow through
+  `New Flow → Blank Flow`, i.e. it asked for the name `New Flow` that every other
+  worker asks for at the same moment. Creating through `createFlow` under a per-run
+  unique name removes the collision at its source, so there is nothing to repair and
+  nothing to mask — preferred over a repair barrier for exactly that reason. The
+  product defect is real but is **not** a regression and has no single-user path
+  (batch import in `use-upload-flow.ts` is sequential, so the backend dedups it
+  normally); it is reported upstream separately and deliberately does not gate this
+  spec's coverage.
+
+  Quarantine lifted in the same change: `test.fixme` removed and `@stable` restored on
+  the DataFrame test.
 - Also hardened in the same change: `runNoInputFlow` no longer gates completion on the `button-stop` → hidden transition. It takes the expected output locator (the chat message that actually contains the `<table>` / `<code>`) and waits directly on that (90 s timeout) — the rendered content only appears once the build has produced its result, whereas the bare `div-chat-message` mounts early as a loading placeholder (`bot-message.tsx`) and is not a build-complete signal. `button-stop` → hidden is demoted to a best-effort idle wait that never fails the run.

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -11,26 +11,74 @@ import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 type SetupOptions = { selectDataOutput?: boolean };
 
 /**
+ * Id of the flow the current test created, recorded by `setupMockDataFlow` the
+ * moment `POST /api/v1/flows/` returns — BEFORE the editor is opened and before
+ * any of the canvas steps that can throw. That ordering is the whole point: while
+ * this lived in the `describe` and was assigned from the helper's return value, a
+ * setup that failed anywhere after the create left it unset and the teardown had
+ * nothing to delete but whatever the URL happened to hold — which on the very
+ * redirect-to-the-list this file's `createEmptyFlow` note describes is not the
+ * flow at all, so the run orphaned it. Measured on 1.12.0.dev30 with a throw
+ * injected between the create and `openFlowById`: the account goes 27 -> 28 flows
+ * with the id recorded on return, and 27 -> 27 with it recorded here.
+ *
+ * Module scope rather than `describe` scope only because the helper lives here.
+ * Each Playwright worker is its own process, so this is per-worker state — the two
+ * tests below never share it even when they run in parallel.
+ */
+let createdFlowId: string | undefined;
+
+/**
  * Creates the empty canvas this spec builds on, through the REST API and under a
  * per-run unique name (#1479).
  *
- * NOT `New Flow -> Blank Flow`, which is how this spec used to start and is what
- * made it flake: that path asks the backend for the name `New Flow`, the same one
- * every other parallel worker asks for at the same moment.
- * `POST /api/v1/flows/` deduplicates a taken name with a `SELECT` and only then
- * inserts, with no transaction across the two, so two simultaneous creations both
- * read the name as free and the loser violates `UNIQUE(user_id, name)` and comes
- * back `400 {"detail":"Name must be unique"}`. Measured on 1.12.0.dev30 straight
- * against the API: 10 of 20 requests fail at 2 concurrent creations of one name,
- * 30 of 40 at 4 — the dedup survives no concurrency at all. `use-add-flow.ts` then
- * shows a toast and never retries under another name, so the app stays on the home
- * screen; the spec waited 30 s for an editor that was never opened, which is the
- * `Loading...` home both failing dailies captured.
+ * NOT `New Flow -> Blank Flow`, which is how this spec used to start: that path
+ * asks the backend for the name `New Flow`, the same one every other parallel
+ * worker asks for at the same moment. `POST /api/v1/flows/` deduplicates a taken
+ * name with a `SELECT` and only then inserts, with no transaction across the two,
+ * so two simultaneous creations both read the name as free and the loser violates
+ * `UNIQUE(user_id, name)` and comes back `400 {"detail":"Name must be unique"}`.
+ * Measured on 1.12.0.dev30 straight against the API: 10 of 20 requests fail at 2
+ * concurrent creations of one name, 30 of 40 at 4 — the dedup survives no
+ * concurrency at all. `use-add-flow.ts` then shows a toast and never retries under
+ * another name, so the app never leaves the home screen. On this file, 4 lanes x 4
+ * repeats produced 7 `Name must be unique` backend errors and 1 failed test on the
+ * old path, and 0 of each on this one.
  *
- * A unique name removes the collision at its source, so there is nothing to repair
- * here and nothing that could mask a real create failure. This is the answer #588
- * already reached for the same upstream race ("we cannot fix the backend here") and
- * shipped as `createFlow`; this spec had simply never been migrated to it.
+ * **That is exposure removed, NOT the diagnosis of the two dailies #1479 was filed
+ * for.** The first version of this change claimed the name race was what those
+ * dailies hit; the claim is withdrawn, and the reasoning behind it is recorded here
+ * because it is the kind that gets reused. It rested on the failing attempts'
+ * `error-context` — the home screen with `Loading...`, byte-identical on both days
+ * — read as "the editor never opened". Playwright writes that snapshot from
+ * `didFinishTest`, i.e. AFTER the `afterEach`, and this spec's `afterEach` calls
+ * `page.goto("/")`: the home snapshot is therefore what teardown produces for ANY
+ * failure of this file, and byte-identical is what a deterministic teardown
+ * navigation looks like, not corroboration. Measured twice on the repo's own
+ * Playwright 1.58.2, the second time on THIS spec: a test failing on
+ * `data:text/html,<h1>DURING</h1>` with an `afterEach` that navigates to
+ * `<h1>TEARDOWN</h1>` writes TEARDOWN into `error-context.md`; and a throw injected
+ * here between the create and `openFlowById` — with the browser still on
+ * `about:blank`, having never loaded a Langflow page at all — produced an
+ * `error-context` showing the home screen with `Loading...`, i.e. the dailies'
+ * snapshot, from a failure that provably never reached any screen. The
+ * failure-time artefacts are `test-failed-1.png` (taken from
+ * `didFinishTestFunction`, before the hooks) and the first-retry trace.
+ *
+ * The stack says the opposite of that snapshot: both dailies failed at the Chat
+ * Output ROW wait, which is only reachable after `sidebar-search-input` was visible
+ * AND filled inside the 20 s `actionTimeout` — and that testid exists upstream in
+ * exactly one place: `pages/FlowPage/components/flowSidebarComponent/components/searchInput.tsx`,
+ * i.e. the editor. The browser WAS in the editor, so #1468's
+ * sidebar remount remains the open explanation for those two days; that is what
+ * `fillSidebarSearch` below is the measured barrier for, and why it is adopted here
+ * rather than incidentally.
+ *
+ * A unique name is still how this flow should be created: it removes the collision
+ * at its source, so there is nothing to repair and nothing that could mask a real
+ * create failure. It is the answer #588 already reached for the same upstream race
+ * ("we cannot fix the backend here"), shipped as `createFlow` and imported by 27
+ * other files; this spec had simply never been migrated to it.
  *
  * Not `setupBlankFlow`, which wraps the same create: that helper enters the editor
  * by clicking the flow's card on the home grid, a step it took because
@@ -63,9 +111,12 @@ async function setupMockDataFlow(
   page: Page,
   request: APIRequestContext,
   { selectDataOutput = false }: SetupOptions = {},
-): Promise<string> {
+): Promise<void> {
   const token = await getAuthToken(request);
+  // Record the id on the line that produces it — see `createdFlowId` above for why
+  // handing it back at the end of this function was not good enough.
   const flowId = await createEmptyFlow(request, token);
+  createdFlowId = flowId;
   await openFlowById(page, flowId);
 
   // Add Chat Output. `fillSidebarSearch` confirms the sidebar actually kept the
@@ -129,12 +180,9 @@ async function setupMockDataFlow(
     timeout: 8000,
   });
 
-  // Return this flow's id so the test can delete ONLY its own flow on teardown
-  // (see the afterEach note on why a global cleanAllFlows races sibling tests).
-  // The id comes from the create call, not from the URL: it is known before the
-  // editor is ever opened, so a setup that fails midway still has an id to clean
-  // up (the afterEach keeps its URL fallback for the same reason).
-  return flowId;
+  // Nothing is returned: the id the teardown needs was recorded at create time
+  // (`createdFlowId`), not here, so that a setup failing at any of the steps above
+  // still leaves the `afterEach` a flow to delete.
 }
 
 async function runNoInputFlow(
@@ -168,11 +216,6 @@ async function runNoInputFlow(
 }
 
 test.describe("Playground Output – Structured Data", () => {
-  // Id of the flow the current test created, set by setupMockDataFlow. Each
-  // Playwright worker is its own process, so this is per-worker state — the two
-  // tests below never share it even when they run in parallel.
-  let createdFlowId: string | undefined;
-
   test.afterEach(async ({ page }) => {
     // Delete ONLY the flow this test created — never a global cleanAllFlows().
     // The suite runs fullyParallel against a single shared auto_login user, so a
@@ -181,10 +224,14 @@ test.describe("Playground Output – Structured Data", () => {
     // Scoped deletion by id is collision-free. (The broader suite-wide hazard —
     // other specs still calling the global cleanAllFlows — is tracked in #515.)
     //
-    // Fall back to the id in the current URL when setup threw before returning
-    // it: the flow was already created (we navigated to /flow/<id>) but the
-    // fragile drag/connect steps failed, so createdFlowId is still unset. Without
-    // this, a partial setup failure would orphan the flow it created.
+    // The URL fallback is belt-and-braces, and it is worth saying which: since the
+    // id is recorded the moment the create returns (`createdFlowId` above), a
+    // partial setup failure no longer depends on it — that is what the fallback
+    // used to be for, and it could not do the job, because the one failure mode it
+    // was written against (a create that succeeded, then a redirect back to the
+    // list) leaves no `/flow/<id>` in the URL either. It is kept because it costs a
+    // regex and it can only ever name a flow this worker itself opened, so a future
+    // edit that reintroduces a UI-side create still cleans up after itself.
     const flowId =
       createdFlowId ?? page.url().match(/\/flow\/([0-9a-f-]+)/i)?.[1];
     createdFlowId = undefined;
@@ -214,9 +261,7 @@ test.describe("Playground Output – Structured Data", () => {
       await test.step(
         "Set up Mock Data (data_output) → Chat Output flow and open playground",
         async () => {
-          createdFlowId = await setupMockDataFlow(page, request, {
-            selectDataOutput: true,
-          });
+          await setupMockDataFlow(page, request, { selectDataOutput: true });
           await page.getByTestId("playground-btn-flow-io").click();
           await expect(page.getByTestId("button-send")).toBeVisible({
             timeout: 15000,
@@ -244,13 +289,16 @@ test.describe("Playground Output – Structured Data", () => {
   );
 
   // Quarantined at triage on the 2026-08-17/18 dailies (PR #1481) and restored
-  // here (#1479). The triage read the failure as "the Chat Output sidebar row
-  // never enters the DOM"; both dailies' `error-context` are byte-identical and
-  // show the HOME screen with `Loading...`, so the browser was never in the
-  // editor and no row could exist. The cause is the flow-create name race
-  // documented on `createEmptyFlow` above, and it hit whichever test ran — it was
-  // the JSON one in 1 of 32 measured runs of this file, so quarantining only this
-  // test never removed the exposure.
+  // here (#1479). The triage's reading — "the Chat Output sidebar row never enters
+  // the DOM" — stands: the failure is at the row wait, which is reachable only from
+  // inside the editor, and the home screen in the `error-context` does not say
+  // otherwise (that snapshot is taken after this file's `afterEach` navigates; see
+  // `createEmptyFlow` above). What the quarantine did not do is remove the
+  // exposure: both tests share `setupMockDataFlow`, and the sibling JSON test —
+  // never quarantined — failed once in 32 runs of this file measured on the old
+  // setup. Restored because that setup now goes through `fillSidebarSearch`,
+  // #1468's measured barrier for the sidebar remount, and creates the flow under a
+  // unique name; re-validated per CONTRIBUTING.md.
   test(
     "playground must render DataFrame output as a markdown table",
     { tag: ["@stable", "@release", "@regression", "@playground"] },
@@ -258,7 +306,7 @@ test.describe("Playground Output – Structured Data", () => {
       await test.step(
         "Set up Mock Data (dataframe_output) → Chat Output flow and open playground",
         async () => {
-          createdFlowId = await setupMockDataFlow(page, request);
+          await setupMockDataFlow(page, request);
           await page.getByTestId("playground-btn-flow-io").click();
           await expect(page.getByTestId("button-send")).toBeVisible({
             timeout: 15000,

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -1,30 +1,79 @@
-import type { Locator, Page } from "@playwright/test";
+import type { APIRequestContext, Locator, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { createFlow } from "../../../../helpers/flows/create-flow";
+import { fillSidebarSearch } from "../../../../helpers/flows/fill-sidebar-search";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { openFlowById } from "../../../../helpers/flows/open-flow-by-id";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 type SetupOptions = { selectDataOutput?: boolean };
 
+/**
+ * Creates the empty canvas this spec builds on, through the REST API and under a
+ * per-run unique name (#1479).
+ *
+ * NOT `New Flow -> Blank Flow`, which is how this spec used to start and is what
+ * made it flake: that path asks the backend for the name `New Flow`, the same one
+ * every other parallel worker asks for at the same moment.
+ * `POST /api/v1/flows/` deduplicates a taken name with a `SELECT` and only then
+ * inserts, with no transaction across the two, so two simultaneous creations both
+ * read the name as free and the loser violates `UNIQUE(user_id, name)` and comes
+ * back `400 {"detail":"Name must be unique"}`. Measured on 1.12.0.dev30 straight
+ * against the API: 10 of 20 requests fail at 2 concurrent creations of one name,
+ * 30 of 40 at 4 — the dedup survives no concurrency at all. `use-add-flow.ts` then
+ * shows a toast and never retries under another name, so the app stays on the home
+ * screen; the spec waited 30 s for an editor that was never opened, which is the
+ * `Loading...` home both failing dailies captured.
+ *
+ * A unique name removes the collision at its source, so there is nothing to repair
+ * here and nothing that could mask a real create failure. This is the answer #588
+ * already reached for the same upstream race ("we cannot fix the backend here") and
+ * shipped as `createFlow`; this spec had simply never been migrated to it.
+ *
+ * Not `setupBlankFlow`, which wraps the same create: that helper enters the editor
+ * by clicking the flow's card on the home grid, a step it took because
+ * `page.goto('/flow/{id}')` right after an API create was observed redirecting back
+ * to the list on `release-1.10.0`. `openFlowById` (#1214) goes by URL — a full
+ * document load, so there is no SPA hop for a stale router cache to lose (#1005) —
+ * and it also waits for the canvas AND for the header to report writable, which the
+ * card click does not. The home grid is the more exposed of the two under parallel
+ * workers: it is where other workers' residual cards intercept the open button
+ * (#580/#588). Same create, fewer shared surfaces, and it matches what the two most
+ * recent specs of this shape do (`ui-ux/sidebar-add-component`, `sidebar-search-and-filter`).
+ */
+async function createEmptyFlow(
+  request: APIRequestContext,
+  token: string,
+): Promise<string> {
+  return createFlow(
+    request,
+    {
+      name: `playground-output-data-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      description: "Empty canvas for the Playground structured-output tests",
+      data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+      is_component: false,
+    },
+    { headers: { Authorization: token } },
+  );
+}
+
 async function setupMockDataFlow(
   page: Page,
+  request: APIRequestContext,
   { selectDataOutput = false }: SetupOptions = {},
 ): Promise<string> {
-  await awaitBootstrapTest(page);
-  await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-  await page.getByTestId("blank-flow").click();
+  const token = await getAuthToken(request);
+  const flowId = await createEmptyFlow(request, token);
+  await openFlowById(page, flowId);
 
-  // Add Chat Output
-  // Sidebar mounts after blank-flow.click() navigates — wait before filling
-  // to avoid the same race as #278 (in setup-playground.ts).
-  await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
-    timeout: 30000,
-  });
-  await page.getByTestId("sidebar-search-input").fill("chat output");
-  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
-    timeout: 30000,
-  });
+  // Add Chat Output. `fillSidebarSearch` confirms the sidebar actually kept the
+  // typed term before waiting for its row: the sidebar can remount ~100-215 ms
+  // after the fill and take the term with it, and since 1.12 a row only exists in
+  // the DOM under a filter, so the row wait would die as `element(s) not found`
+  // with nothing in flight to wait for (#1468).
+  await fillSidebarSearch(page, "chat output", "input_outputChat Output");
   await page
     .getByTestId("input_outputChat Output")
     .hover()
@@ -36,10 +85,7 @@ async function setupMockDataFlow(
   await zoomOut(page, 2);
 
   // Add Mock Data (section: data_source → testid prefix "data_source")
-  await page.getByTestId("sidebar-search-input").fill("mock data");
-  await expect(page.getByTestId("data_sourceMock Data")).toBeVisible({
-    timeout: 30000,
-  });
+  await fillSidebarSearch(page, "mock data", "data_sourceMock Data");
   await page
     .getByTestId("data_sourceMock Data")
     .dragTo(page.locator('//*[@id="react-flow-id"]'), {
@@ -85,11 +131,9 @@ async function setupMockDataFlow(
 
   // Return this flow's id so the test can delete ONLY its own flow on teardown
   // (see the afterEach note on why a global cleanAllFlows races sibling tests).
-  // Creating the blank flow navigates to /flow/<id>; the id is stable by now.
-  const flowId = page.url().match(/\/flow\/([0-9a-f-]+)/i)?.[1];
-  if (!flowId) {
-    throw new Error(`Could not extract flow id from URL: ${page.url()}`);
-  }
+  // The id comes from the create call, not from the URL: it is known before the
+  // editor is ever opened, so a setup that fails midway still has an id to clean
+  // up (the afterEach keeps its URL fallback for the same reason).
   return flowId;
 }
 
@@ -166,11 +210,11 @@ test.describe("Playground Output – Structured Data", () => {
   test(
     "playground must render JSON Data output as a code block",
     { tag: ["@stable", "@release", "@regression", "@playground"] },
-    async ({ page }) => {
+    async ({ page, request }) => {
       await test.step(
         "Set up Mock Data (data_output) → Chat Output flow and open playground",
         async () => {
-          createdFlowId = await setupMockDataFlow(page, {
+          createdFlowId = await setupMockDataFlow(page, request, {
             selectDataOutput: true,
           });
           await page.getByTestId("playground-btn-flow-io").click();
@@ -199,22 +243,22 @@ test.describe("Playground Output – Structured Data", () => {
     },
   );
 
-  // Quarantined at triage (daily #1477): recurrent flake — the Chat Output
-  // sidebar row (`input_outputChat Output`) never enters the DOM after the
-  // search box is filled, inside setupMockDataFlow(), so the DataFrame
-  // assertion this test exists for is never reached. Same signature on the
-  // 2026-08-17 and 2026-08-18 dailies. Same observable as #1468, on a call
-  // site its barrier helpers do not cover.
-  // Lifting the quarantine (remove test.fixme + restore @stable) is a
-  // deliverable of #1479.
-  test.fixme(
+  // Quarantined at triage on the 2026-08-17/18 dailies (PR #1481) and restored
+  // here (#1479). The triage read the failure as "the Chat Output sidebar row
+  // never enters the DOM"; both dailies' `error-context` are byte-identical and
+  // show the HOME screen with `Loading...`, so the browser was never in the
+  // editor and no row could exist. The cause is the flow-create name race
+  // documented on `createEmptyFlow` above, and it hit whichever test ran — it was
+  // the JSON one in 1 of 32 measured runs of this file, so quarantining only this
+  // test never removed the exposure.
+  test(
     "playground must render DataFrame output as a markdown table",
-    { tag: ["@release", "@regression", "@playground"] },
-    async ({ page }) => {
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
+    async ({ page, request }) => {
       await test.step(
         "Set up Mock Data (dataframe_output) → Chat Output flow and open playground",
         async () => {
-          createdFlowId = await setupMockDataFlow(page);
+          createdFlowId = await setupMockDataFlow(page, request);
           await page.getByTestId("playground-btn-flow-io").click();
           await expect(page.getByTestId("button-send")).toBeVisible({
             timeout: 15000,


### PR DESCRIPTION
**Closes #1479.**

## Problem

The DataFrame test of `playground-output-data.spec.ts` flaked on the 2026-08-17 and
2026-08-18 dailies with the same signature and was quarantined at triage (#1481 —
`test.fixme` plus `@stable` removed). Both failures land at the **Chat Output row
wait** inside `setupMockDataFlow`, which is what the triage recorded.

### What the failing attempts do and do not prove

An earlier revision of this PR claimed the cause was the flow-create name race,
reading the attempts' `error-context` (the home screen with `Loading...`,
byte-identical on both days) as *"the browser was never in the flow editor"*.
**That claim is withdrawn**, and the reasoning is recorded in the spec and the spec
doc because it is the kind that gets reused in triage:

- Playwright writes `error-context.md` from `didFinishTest` — **after** `afterEach`
  — and this spec's `afterEach` calls `page.goto("/")`. The home screen is therefore
  what teardown produces for *any* failure of this file, and byte-identical is what a
  deterministic teardown navigation looks like, not corroboration.
- Measured twice on the repo's own Playwright 1.58.2, the second time in situ: a test
  failing on `data:text/html,<h1>DURING</h1>` with an `afterEach` that navigates to
  `<h1>TEARDOWN</h1>` writes TEARDOWN into `error-context.md`; and a throw injected
  into `setupMockDataFlow` between the create and `openFlowById` — browser still on
  `about:blank`, no Langflow page ever loaded — produced an `error-context` showing
  the home with `Loading...`, i.e. the dailies' snapshot, from a failure that provably
  never reached any screen.
- The stack says the opposite of the snapshot: the row wait is reachable only after
  `sidebar-search-input` was visible **and** filled inside the 20 s `actionTimeout`,
  and that testid exists upstream in exactly one place —
  `pages/FlowPage/components/flowSidebarComponent/components/searchInput.tsx`, i.e.
  the editor.
- Failure-time evidence is `test-failed-1.png` (captured from
  `didFinishTestFunction`, before the hooks) and the first-retry trace.

So **#1468's sidebar remount remains the open explanation for those two days**, on a
call site its barriers did not cover — which is what the issue suspected.

## Fix

**1. Both sidebar fills go through `fillSidebarSearch` (#1468)** — the measured
barrier for the remount (23 failures in 220 adds before, 0 in 200 after, on the call
site #1468 measured). This is the part aimed at the two dailies.

**2. The flow is created through `createFlow` under a per-run unique name** and the
editor entered by id with `openFlowById`. Its own justification, independent of the
dailies: `POST /api/v1/flows/` deduplicates a taken name (`_deduplicate_flow_name`:
`SELECT`, then append `(N)`) and only afterwards inserts, with no transaction across
the two steps, against `UniqueConstraint("user_id", "name")`; the loser violates the
constraint and `_handle_unique_constraint_error` turns that into
`400 {"detail":"Name must be unique"}`. Measured straight against the API on nightly
`1.12.0.dev30`:

| Concurrent creations of one name | Requests | `400` |
|---|---|---|
| 2 (10 rounds) | 20 | **10** — exactly one per round |
| 4 (10 rounds) | 40 | **30** |

This spec asked for the name `New Flow`, the same one every other parallel worker
asks for at the same moment. `hooks/flows/use-add-flow.ts` answers the 400 with a
toast and a `reject`, with no retry under another name. A unique name removes the
collision at its source, so — unlike a repair barrier — there is nothing here that
can mask a real create failure. This is the answer #588 already reached for this same
race, shipped as `createFlow` and imported by **27** other files; this spec had never
been migrated to it.

**3. The flow id is recorded when the create returns**, not handed back at the end of
`setupMockDataFlow`, so a setup that fails at any canvas step still leaves the
`afterEach` a flow to delete. Measured on `1.12.0.dev30` with a throw injected between
the create and `openFlowById`: the account goes **27 → 28** flows with the id recorded
on return, **27 → 27** with it recorded at create time. The `afterEach`'s URL fallback
could not cover that case — the failure it was written against leaves no `/flow/<id>`
in the URL either — and is kept only as belt-and-braces, now described as such.

Not `setupBlankFlow`, which wraps the same create: that helper enters the editor by
clicking the flow's card on the home grid, which is where other workers' residual
cards intercept the open button (#580/#588). `openFlowById` goes by URL — a full
document load, so no SPA hop for a stale router cache to lose — and additionally waits
for the canvas and for the header to report writable (#1005).

**No assertion changed.** Both tests prove exactly what they proved before.

## Scope, stated explicitly

- **The shared helper is not touched** (deliverable of #1479).
  `helpers/flows/add-component-from-sidebar.ts` fills `sidebar-search-input` raw and
  carries the same #1468 exposure, but `fillSidebarSearch`'s only measured repair is a
  `page.reload()` (4 of 4, against 0 of 4 for re-typing) and that helper is called
  *after* nodes are placed, where a reload discards the canvas the caller has built.
  Adopting it there is a separate change with its own blast radius.
- `ui-ux/langflowShortcuts.spec.ts` creates its flow through `New Flow → Blank Flow`
  and has the same exposure. **Left running unchanged**: its assertions are its own
  and would need their own validation and force-fail, and **62 specs** still take the
  `blank-flow` path (34 of them `@stable`).
- **Upstream defect: deliberately not filed.** The race is real but is not a
  regression and has no single-user path — batch import (`use-upload-flow.ts`) is
  sequential, so the backend dedups it normally. It needs two simultaneous creations
  on one account, which is what the suite's parallel workers produce and a user
  practically does not. Not a `REGRESSIONS.md` row for the same reason.

## Validation (nightly `1.12.0.dev30`, `--retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ 0 errors · `npm run test:units` ✅ 699 pass
  / 0 fail · `npm run check:checklist-coverage` ✅
- Clean serial runs of the file: `2 passed` at 11.8 s / 12.3 s / 13.5 s before the
  review follow-up, and `2 passed` at 8.5 s / 10.8 s after it
- Under load, 4 lanes x 4 repeats of the file (same protocol before and after):

  | | before | after |
  |---|---|---|
  | Result | 31 passed, **1 failed** (2.3 min) | **32 passed** (1.2 min) |
  | `🚨 Backend Error` | **7**, all `Name must be unique` | **0** |

  The one failure in the baseline was the **JSON** test — the `@stable` sibling that
  was never quarantined — which is why quarantining only the DataFrame test removed
  coverage without removing exposure.
- Force-fail ✅ all executed, isolated with `--grep`, diff verified free of markers:
  - `FF:` test 1 — `toContain('"records"')` -> `'"recordsFFMUT"'` => 1 failed
  - `FF:` test 2 — filter `page.locator("table")` -> `"tableFFMUT"` => 1 failed
  - `FF:` mechanism — unique name -> fixed `"New Flow FFMUT"`, 4 lanes x 2 repeats =>
    **1 failed in 16** and `Name must be unique` returns
  - `FF:` teardown — throw between the create and `openFlowById`, with and without the
    early id record => **27 → 27** vs **27 → 28** flows (the leak the record closes)
- `--trace=on` ✅ ran clean on both tests, and the trace shows the new path: straight
  to `/flow/<id>`, no home and no templates modal
- Zero leaked flows: `GET /api/v1/flows/` back to 27 (starters only) after every run

## Quarantine

Lifted: `test.fixme` removed and `@stable` restored on the DataFrame test.
`QA-CHECKLIST.md` needs no edit — the manual Part II bullets already reference the
spec as `[x]`, and the generated `Phase 0` block regenerates on merge.
