### PR TITLE
test(auto-save-off): quarantine the manual-save test for #1489

### DIFF
--- a/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
@@ -131,9 +131,11 @@ async function reopenFlow(page: Page, flowId: string): Promise<void> {
   await flowLoaded;
 }
 
-test(
+// Quarantined for #1489 — manual save never navigates to the new flow URL
+// (recurrent 2×: dailies 2026-08-18 and 2026-08-19).
+test.fixme(
   "user should be able to manually save a flow when the auto_save is off",
-  { tag: ["@stable", "@release", "@api", "@database", "@components"] },
+  { tag: ["@release", "@api", "@database", "@components"] },
   async ({ page }) => {
     trackCreatedFlows(page);
 


### PR DESCRIPTION
Quarantines `auto-save-off.spec.ts:134` for #1489 (dispatched from daily-failure triage #1486).

### Why

`user should be able to manually save a flow when the auto_save is off` flaked with the **same signature on two dailies**:

| Daily | Run | Signature |
|---|---|---|
| 2026-08-18 | `32116967595` | `TimeoutError: page.waitForURL: Timeout 30000ms exceeded.` |
| 2026-08-19 | `32233221457` | `TimeoutError: page.waitForURL: Timeout 30000ms exceeded.` |

That meets the recurrent-flake criterion (`CONTRIBUTING.md` → *Triage protocol*), and the guard tripping on 2026-08-19 does not exempt it — the mass-failure guard governs hard failures only.

It is **not** wedge collateral: the 2026-08-19 occurrence ran on shard 4 (job `96007643278`), which the in-run liveness recorder measured at **0 outages / 0% backend down**, and the 2026-08-18 daily had 2 hard failures — the guard did not trip and no wedge was recorded, so the signature reproduces off a mass-failure day.

The file's other 30-day hits (2026-07-15/16 at line 55, 2026-07-22 and 2026-08-06 at line 59) carry a different signature and are context only.

### What changed

Both quarantine edits together, per `CONTRIBUTING.md`:

- `@stable` removed — `QA-CHECKLIST.md` Phase 0 is generated from `@stable` `test()` calls, so leaving it would keep counting a quarantined test as validated.
- `test.fixme` added — tag removal alone only stops the daily; the PR impacted-specs gate selects specs by **file diff**, not by tag (#871), so the test would keep going red there.

No test logic, spec doc or `QA-CHECKLIST.md` bullet touched. Lifting both edits is a deliverable of #1489, not of this PR — this PR deliberately carries no closing keyword.

### Checks

`npm run typecheck`, ESLint and `npm run check:checklist-coverage` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
