### PR TITLE
fix(auto-save-off): await the manual save before leaving the editor (#1489)

### DIFF
--- a/docs/flow-functionality/auto-save-off.md
+++ b/docs/flow-functionality/auto-save-off.md
@@ -69,10 +69,11 @@ before anything else runs.
 7. Re-open the flow; assert **`title-Chat Input`** is visible — the edit persisted
 8. Add a **Chat Output** component (hover the sidebar entry →
    `add-component-button-chat-output`), click **`save-flow-button`** (the
-   on-canvas manual save), leave via the back button. The exit-guard dialog is
-   timing-dependent here — if the manual save settled, the exit is clean;
-   otherwise **Save And Exit** appears and is clicked. Either path persists, and
-   either way the editor must be left
+   on-canvas manual save) and **wait for that save to complete** — its
+   `PATCH /api/v1/flows/<id>` must answer **200**. Only then leave via the back
+   button. With the save confirmed the flow is no longer dirty, so the exit is
+   clean: the unsaved-changes dialog must **not** appear, and the editor must be
+   left. Nothing here is conditional (see the #1489 note)
 9. Re-open the flow; assert both `title-Chat Input` and `title-Chat Output` are
    visible and `div-generic-node` count = **2**
 
@@ -83,15 +84,21 @@ before anything else runs.
 - After **Exit Anyway** on an unsaved change: the re-opened flow's
   `div-generic-node` count is **0** (discard worked).
 - After a **save**: the re-opened flow shows `title-Chat Input`.
+- The **on-canvas manual save** answers for itself: the `save-flow-button` click
+  produces a `PATCH /api/v1/flows/<id>` → **200**, and the exit that follows it
+  raises **no** unsaved-changes dialog.
 - After the second save: both `title-Chat Input` and `title-Chat Output` are
   visible and `div-generic-node` count is exactly **2** (both edits persisted
   server-side).
 
 Each observable is a hard count/visibility on the re-opened flow — a mutated
-assertion (wrong count, wrong discard) fails deterministically. The only
-conditional (the third exit's dialog) handles a genuinely timing-optional
-confirmation and is gated by the `div-generic-node` count === 2 assert, which
-fails if either save did not persist (see Notes on the hardening).
+assertion (wrong count, wrong discard) fails deterministically. No step is
+conditional: the third exit waits on the manual save's own response before
+leaving, so the dialog either does not appear or the test fails (#1489). That
+also makes the manual save falsifiable on its own — under the previous design a
+broken `save-flow-button` still passed, because the optional **Save And Exit**
+fallback persisted the same graph and the final `div-generic-node` count === 2
+could not tell the two paths apart.
 
 ---
 
@@ -102,7 +109,10 @@ fails if either save did not persist (see Notes on the hardening).
   auto-save is off).
 - `data-testid="icon-ChevronLeft"` — back-to-list navigation.
 - Exit dialog: **"Exit Anyway"** (discard) / **"Save And Exit"** (persist; its
-  primary button carries `data-testid="replace-button"`).
+  primary button carries `data-testid="replace-button"`). Only the first two
+  exits reach it — the third confirms its save first and must exit without it.
+- `PATCH /api/v1/flows/{id}` — the save request behind both the on-canvas
+  **Save** button and the dialog's **Save And Exit**.
 - `data-testid="input_outputChat Input"` / `add-component-button-chat-input` /
   `input_outputChat Output` / `add-component-button-chat-output` /
   `sidebar-search-input` — Chat Input / Chat Output sidebar entries, add buttons,
@@ -157,6 +167,32 @@ fails if either save did not persist (see Notes on the hardening).
   again, from the other side). The re-open is therefore by URL, and each exit now
   asserts the editor was left — verified by forcing the save PATCH to 500, which
   now fails at the exit step instead of 45 s later on an unrelated locator.
+- **#1489 (the third exit hung on a dialog the spec never waited for).**
+  Recurrent on the 2026-08-18 and 2026-08-19 dailies:
+  `page.waitForURL: Timeout 30000ms exceeded` inside `expectLeftEditor`, reached
+  from the **third** exit — not from the initial navigation the issue title
+  describes. Not a product regression, and not the mid-run backend wedge the
+  triage recorded either: the 2026-08-19 occurrence ran on shard 4, measured at
+  0 outages, and the 2026-08-18 one comes from a daily the mass-failure guard
+  never tripped. The daily's own `error-context` names the cause — at the moment
+  of the timeout the unsaved-changes dialog was **open and untouched**, so the
+  editor could not leave `/flow/…` because a modal was blocking it. The guard
+  meant to dismiss it read
+  `if (await saveAndExit.isVisible({ timeout: 5000 }))`, and Playwright
+  **ignores that timeout**: `locator.isVisible()` "does not wait for the element
+  to become visible and returns immediately" (`types.d.ts`, 1.58.2). The probe
+  therefore fired ~1 ms after the back-click and committed to the "no dialog"
+  branch before the modal had painted — the same class already recorded in
+  `mcp/server/mcp-server.spec.ts` (#1422). The fix removes the conditional
+  rather than widening it: the spec now waits for the manual save's own
+  `PATCH /api/v1/flows/{id}` → 200 before leaving, which makes the exit
+  deterministic **and** closes the coverage hole described under Validation
+  criterion.
+  One further observation from the same artifact is a **product** finding and is
+  filed separately as **LE-2255**: the dialog reported "Last saved: **Never**"
+  for a flow whose graph was already persisted — the same attempt had just
+  asserted `title-Chat Input` after a full reload. It is not what this spec
+  asserts and does not block it.
 - **#1342 (the re-open uses the repo's by-id entry, not a local `goto`).** #1336's
   fix hand-rolled `page.goto('/flow/{id}')` + a canvas wait, which was the fourth
   copy of the block `helpers/flows/open-flow-by-id.ts` (#1214) was extracted to

--- a/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
@@ -75,6 +75,46 @@ async function expectLeftEditor(page: Page): Promise<void> {
 }
 
 /**
+ * The third exit's assertion: the editor must leave WITHOUT raising the
+ * unsaved-changes dialog, because the manual save that precedes it is awaited to
+ * completion.
+ *
+ * Polling both outcomes is what buys the attribution, and that is the whole
+ * lesson of #1489: a bare `waitForURL` reports 30 s of nothing while the cause —
+ * a modal nobody dismissed — sits on screen the entire time. Naming it in the
+ * failure is the difference between "the save never navigated" (the triage's
+ * reading, and wrong) and "the flow was still dirty when we left".
+ */
+async function expectCleanExit(page: Page): Promise<void> {
+  const dialog = page
+    .locator('[role="dialog"]')
+    .getByText("Unsaved changes will be permanently lost.");
+  const deadline = Date.now() + 30000;
+
+  for (;;) {
+    if (!new URL(page.url()).pathname.startsWith("/flow/")) return;
+    // A no-argument `isVisible()` is exactly right INSIDE a poll — the immediate
+    // check is what the loop wants. Handing it a timeout is what broke the guard
+    // this replaced: Playwright ignores that option and answers in ~2 ms.
+    if (await dialog.isVisible().catch(() => false)) {
+      throw new Error(
+        `[auto-save-off] the unsaved-changes dialog appeared after a manual ` +
+          `save that had already answered PATCH /api/v1/flows/{id} 200 — the ` +
+          `editor still considers the flow dirty (#1489).`,
+      );
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `[auto-save-off] the editor did not leave /flow/ within 30000ms and no ` +
+          `unsaved-changes dialog is on screen — the back-click did not ` +
+          `navigate (the swallowed-click class, #420 / LE-2019).`,
+      );
+    }
+    await page.waitForTimeout(200);
+  }
+}
+
+/**
  * Re-open THIS test's flow by id and wait until its graph has been applied to
  * the canvas.
  *
@@ -131,11 +171,9 @@ async function reopenFlow(page: Page, flowId: string): Promise<void> {
   await flowLoaded;
 }
 
-// Quarantined for #1489 — manual save never navigates to the new flow URL
-// (recurrent 2×: dailies 2026-08-18 and 2026-08-19).
-test.fixme(
+test(
   "user should be able to manually save a flow when the auto_save is off",
-  { tag: ["@release", "@api", "@database", "@components"] },
+  { tag: ["@stable", "@release", "@api", "@database", "@components"] },
   async ({ page }) => {
     trackCreatedFlows(page);
 
@@ -306,22 +344,50 @@ test.fixme(
 
     await adjustScreenView(page);
 
-    // Exercise the on-canvas manual save button, then exit. The exit guard is
-    // timing-dependent here: if the manual save settled, the exit is clean;
-    // otherwise the unsaved-changes dialog appears and "Save And Exit" persists.
-    // Either path is fine — the node count === 2 below is the gate that proves
-    // both nodes persisted server-side, regardless of which path ran.
+    // Exercise the on-canvas manual save — and prove it landed BEFORE leaving.
+    //
+    // What this replaced was
+    // `if (await saveAndExit.isVisible({ timeout: 5000 })) { … }`, and the
+    // timeout in it never existed: Playwright ignores that option, because
+    // `locator.isVisible()` "does not wait for the element to become visible and
+    // returns immediately" (`types.d.ts`, 1.58.2). Measured on 1.12.0.dev30 with
+    // the save held in flight, the probe answered `false` in **2–5 ms** while
+    // the dialog painted at **35–37 ms** — so whenever the save had not settled
+    // by the back-click, nothing dismissed the modal, the route change was
+    // blocked, and the exit burned its 30 s. That is #1489, recurrent on the
+    // 2026-08-18 and 2026-08-19 dailies and reproduced here 7/10 at
+    // `--retries=0 --workers=1`.
+    //
+    // Awaiting the save's own response removes the branch instead of widening
+    // it, and makes the manual save falsifiable: under the old design a broken
+    // `save-flow-button` still passed, because the optional "Save And Exit"
+    // persisted the same graph and the final count === 2 could not tell the two
+    // paths apart.
+    const manualSave = page.waitForResponse(
+      (resp) =>
+        new URL(resp.url()).pathname === `/api/v1/flows/${flowUnderTest}` &&
+        resp.request().method() === "PATCH",
+      { timeout: 60000 },
+    );
     // Explicit timeout above the 20s default: the manual-save click was the
     // signature that blew the default action timeout under CI saturation (#790).
     await page.getByTestId("save-flow-button").click({ timeout: 45000 });
+    // Asserted rather than filtered into the predicate: a save that answers 500
+    // fails here naming the status, instead of waiting out 60 s for a 200 that
+    // is never coming. The fixture would not catch it either — an `http_error`
+    // is advisory and never fails a test.
+    expect((await manualSave).status()).toBe(200);
+
+    // The 200 is the server's word. What upstream's exit blocker reads is the
+    // store's `changesNotSaved`, and this button's disabled state is that same
+    // flag — so this is the store-side half of the fact, and a positive signal
+    // rather than a silence probe. Measured true once the save settles.
+    await expect(page.getByTestId("save-flow-button")).toBeDisabled({
+      timeout: 10000,
+    });
+
     await page.getByTestId("icon-ChevronLeft").last().click();
-    const saveAndExit2 = page.getByText("Save And Exit", { exact: true }).last();
-    if (
-      await saveAndExit2.isVisible({ timeout: 5000 }).catch(() => false)
-    ) {
-      await saveAndExit2.click();
-    }
-    await expectLeftEditor(page);
+    await expectCleanExit(page);
 
     await reopenFlow(page, flowUnderTest);
 


### PR DESCRIPTION
**Closes #1489.** Fixes #1489.

## Problem

`auto-save-off.spec.ts` failed on two consecutive dailies (2026-08-18 run `32116967595`, 2026-08-19 run `32233221457`) with `TimeoutError: page.waitForURL: Timeout 30000ms exceeded`, and was quarantined in #1490.

The issue title ("manual save never navigates to the new flow URL") points at the wrong call. The stack in the daily's own artifact is `expectLeftEditor` (line 72) reached from **line 322** — the **third** exit, after the on-canvas `save-flow-button` click — not the initial navigation. The CI `error-context` shows why: at the moment of the timeout the unsaved-changes dialog was **open and untouched**. The editor could not leave `/flow/…` because a modal was blocking it.

Root cause is the guard meant to dismiss that modal:

```ts
if (await saveAndExit2.isVisible({ timeout: 5000 }).catch(() => false)) { … }
```

Playwright **ignores** that timeout — `locator.isVisible()` "does not wait for the element to become visible and returns immediately" (`types.d.ts`, 1.58.2). Instrumented on nightly `1.12.0.dev30` with the save held in flight, two independent runs:

```
[scout] chevron clicked
[scout] isVisible({timeout:5000}) -> false after 2ms      (run 2: 5ms)
[scout] dialog visible after 35ms                          (run 2: 37ms)
```

So whenever the manual save had not settled by the back-click, the probe committed to the "no dialog" branch ~2 ms in, the dialog painted ~33 ms later, nothing dismissed it, and the exit burned its 30 s. Pre-fix baseline on the unmodified spec: **7/10 failures** at `--retries=0 --workers=1`, plus 3/3 in a JSON-reported follow-up (10/13 overall), every one with the daily's exact signature and stack.

The local rate is far above CI's two hits in 30 days because the containerised backend answers the save `PATCH` more slowly here; in CI it usually lands during Playwright's actionability work on the chevron, which is what kept the defect latent.

Same class as the guard already documented at `mcp/server/mcp-server.spec.ts:1221` (#1422).

## Fix

The conditional is **removed**, not widened. The third exit now:

1. arms `page.waitForResponse` on `PATCH /api/v1/flows/{id}` before clicking `save-flow-button`;
2. asserts that response answered **200** — the save is now falsifiable on its own;
3. asserts `save-flow-button` went **disabled** — the store's `changesNotSaved`, which is what upstream's exit blocker actually reads, so this is the client-side half of the same fact;
4. clicks the chevron and asserts a **clean** exit, failing with the cause named if the dialog appears anyway.

Validated under a 3 s injected `PATCH` delay — the worst case for the race: `save-flow-button disabled=true`, dialog `-1` (never appears), spec green.

This also closes a coverage hole. Under the old design a broken `save-flow-button` still passed, because the optional **Save And Exit** fallback persisted the same graph and the final `div-generic-node` count === 2 could not tell the two paths apart.

**Rejected alternatives.** (a) Keeping the dialog optional but awaiting it properly — fixes the flake, keeps the fallback that can mask a broken Save button. (b) Reusing `leaveFlowEditor` — its `BLOCKER_TITLE` is the autosave-mode `"Flow has unsaved changes"`, which does not substring-match this build's auto-save-off title `"<flow name> has unsaved changes"`, so a real dialog would be reported as the swallowed-click class (#420 / LE-2019) — wrong attribution.

## Scope note

The first two exits are unchanged: they click **Exit Anyway** / **Save And Exit** explicitly and were already deterministic. The discard assertion, both persistence assertions and the final `div-generic-node` count === 2 are unchanged. Tags unchanged apart from the quarantine lift. Flow cleanup (`afterEach`, id-scoped) unchanged — audited via `GET /api/v1/flows/`, 0 flows leaked across 20+ runs.

**Quarantine lifted** as the issue requires: `test.fixme` removed and `@stable` restored on top of #1490.

## Related, not fixed here

- **LE-2255** (filed): with the dialog up, it reads `Last saved: Never` while `GET /api/v1/flows/{id}` answers `updated_at=2026-08-19T14:23:05+00:00`. Measured to be independent of any reload — it shows `Never` in the same page session seconds after a manual save that answered 200. Not what this spec asserts and it does not block it.
- The arm64 build of `langflowai/langflow-nightly:latest` at `1.12.0.dev32` serves **no** frontend (`/`, `/index.html`, `/favicon.ico` → 404 while the API is healthy), which is why validation below is on `dev30`. amd64 is unaffected — dev32 was published 03:38Z and the 08:48Z daily ran it with 484 UI specs passing. Tracked separately.

## Validation (nightly `1.12.0.dev30`, `--retries=0 --workers=1`)

- `tsc --noEmit` ✅ 0 errors · `eslint tests/` ✅ 0 errors
- **8 clean runs, no flake** — 3 on the spec path, 3 on the `--grep` target, 1 final green after the force-fail revert, 1 after the rebase. `expected=1` on every one (no zero-test run), `backendErrors=false` on every one:

```
run 1/3 …auto-save-off.spec.ts: clean expected=1 unexpected=0 flaky=0 backendErrors=false
run 2/3 …auto-save-off.spec.ts: clean expected=1 unexpected=0 flaky=0 backendErrors=false
run 3/3 …auto-save-off.spec.ts: clean expected=1 unexpected=0 flaky=0 backendErrors=false
run 1/3 --grep:manually save a flow…: clean expected=1 unexpected=0 flaky=0 backendErrors=false
run 2/3 --grep:manually save a flow…: clean expected=1 unexpected=0 flaky=0 backendErrors=false
run 3/3 --grep:manually save a flow…: clean expected=1 unexpected=0 flaky=0 backendErrors=false
run 1/1 …auto-save-off.spec.ts: clean expected=1 unexpected=0 flaky=0 backendErrors=false
```

- **Force-fail** ✅ — `expect((await manualSave).status()).toBe(200)` → `toBe(201)` produced `unexpected=1`; mutation reverted and the final green run re-confirmed.
- Zero `🚨 Backend Error` ✅ (the runner's backend-error scan reported `backendErrors=false` on every run).
- `--trace=on` was **not** run: it hangs UI specs on this local Docker setup with no error and no artifact. Failure evidence came from the CI blob instead (screenshot + `error-context` page snapshot) plus the instrumented scouts quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
