### PR TITLE
test(governance): cover the 1.12 catalog and provider policy surface (#1493)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,7 @@ Tags are split into two groups: **cross-cutting** (severity/layer) and **functio
 | `@settings` | Navigation and configuration on the Settings page |
 | `@ui-ux` | General interface, shortcuts, appearance |
 | `@a2a` | Agent-to-Agent protocol — publishing a flow as an A2A agent (card, discovery, JSON-RPC) and consuming remote agents via the `A2AAgent` component. **Needs `LANGFLOW_A2A_ENABLED=true`** (set on every lane and both start scripts since #1240); with it off the whole surface answers 404 and these specs would pass while testing nothing, so they call `requireA2aEnabled()` first |
+| `@governance` | Catalog and model-provider policy — the operator-facing surface Langflow 1.12 ships in **OSS**, not only in Enterprise: `catalog-policy/*`, `model-provider-policy`, `policy-bundle{,/history,/rollback}`. Measured on `1.12.0.dev32` against an EE build of `release-1.12.0` — 25 of EE's 55 governance routes are in the nightly and the blocks are *enforced*; `sso/*`, `authz/status|check|admin/*`, `enterprise-admin/*`, the admin UI and env-declared policy are the EE-only remainder. Always combined with `@destructive`: the policy is instance-global, so a blocked component is blocked for every worker sharing that Langflow. **RBAC is out of scope** — the OSS authorization service is pass-through (`enforce()` returns True and says so in the log), so a role-restriction assert would assert nothing |
 
 ## CI/CD
 

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -995,6 +995,64 @@
 
 ---
 
+## governance/ — Catalog and Provider Policy (1.12)
+
+> **New area (2026-08-19).** Catalog governance shipped in the **OSS** build, not
+> only in Enterprise. Measured on `langflowai/langflow-nightly:latest`
+> (`1.12.0.dev32`) against an Enterprise image built from
+> `IBM-Langflow@release-1.12.0`: of the EE build's 55 governance routes, **25 are
+> in OSS** — `catalog-policy/{components,templates,usage,usage/flows}`,
+> `model-provider-policy`, `policy-bundle{,/history,/rollback}` and the `authz`
+> CRUD — and the block is **enforced**, not merely stored.
+>
+> **What Enterprise still owns** (all `404` on the nightly, so out of scope here):
+> `sso/*`, `authz/status`, `authz/check`, `authz/admin/*`, `authz/share-targets`,
+> `authz/shared-with-me`, `enterprise-admin/catalog`, plus the admin **UI** (the
+> OSS frontend bundle references none of these endpoints) and the ability to
+> declare a policy from the environment — OSS `Settings` exposes no
+> `LANGFLOW_CATALOG_COMPONENT_BLOCKLIST`, and an instance started with one reports
+> `source: "migration"` with nothing blocked.
+>
+> **RBAC is present but pass-through in OSS**, so it is deliberately uncovered
+> here: with `LANGFLOW_AUTHZ_ENABLED=true` the nightly logs *"the OSS pass-through
+> authorization service is registered (no enforcement plugin found). Every
+> enforce() call will return True"*. Asserting a role restriction there would
+> assert nothing.
+>
+> **Every bullet below is `@destructive`.** The policy is instance-global — no
+> per-user or per-project scope — so a blocked component is blocked for every
+> worker sharing the Langflow. `daily-stable.yml` has no destructive lane, so none
+> of these can be `@stable` (#1010); they run in `pr-validation.yml`'s destructive
+> step when the import graph selects them.
+
+#### 21.1 Component Blocklist
+
+- [-] A blocked component leaves `GET /api/v1/all` while an unblocked control stays, and `GET /api/v1/config` flips `catalog_governance_enabled` — the derived flag is the cheapest proof the policy was adopted rather than merely persisted → `governance/catalog-policy/component-blocklist-enforcement.spec.ts`
+- [-] Saving a flow that carries the blocked component is refused `400` with the component **named** (`Flow build blocked: catalog policy blocks components: …`), and a flow saved **before** the block stays readable with its nodes unmodified — the read/write pairing is the point, since a component hidden from the palette that still saves is the LE-1933 defect class → `governance/catalog-policy/component-blocklist-enforcement.spec.ts`
+- [-] The blocked component is not findable in the flow-editor sidebar, asserted against a control search that still matches. Target is `DynamicCreateData` because it is `legacy: false` — `CombineText`, the obvious pick, is `legacy: true` and already absent from the sidebar, so that assertion would have passed with the policy doing nothing → `governance/catalog-policy/component-blocklist-enforcement.spec.ts`
+- [-] Clearing the policy restores the catalog and the config flag — verified, not assumed: a failed restore leaves the shared instance short a component for the rest of the lane → `governance/catalog-policy/component-blocklist-enforcement.spec.ts`
+
+#### 21.2 Template Blocklist
+
+- [-] A template blocked by its `name_key` leaves **both** listings that serve templates — `GET /api/v1/flows/basic_examples/` (26 items, what the New Flow modal reads) and `GET /api/v1/starter-projects/` (5) — the key being read from the listing itself rather than hardcoded → `governance/catalog-policy/template-blocklist-enforcement.spec.ts`
+- [-] Blocking by **display name** is accepted `200`, persists into the bundle and enforces **nothing** — an operator using the name they see in the UI gets no enforcement and no error (measured on `1.12.0.dev32`: `"Basic Prompting"` inert, `"basic_prompting"` effective) → `governance/catalog-policy/template-blocklist-enforcement.spec.ts`
+- [-] `GET /api/v1/starter-projects/?include_blocked=true` returns the blocked template for a superuser, which is what separates *filtered* from *absent from the image* → `governance/catalog-policy/template-blocklist-enforcement.spec.ts`
+
+#### 21.3 Model Provider Allowlist
+
+- [-] An allowlist narrows `GET /api/v1/models/providers` to exactly the approved provider **and** removes the excluded provider's `ext:<id>:` components from `/api/v1/all`, while `registered_providers` still lists it — the last clause is the control that separates policy from packaging (`docs/component-distribution-policy.md`) → `governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.spec.ts`
+- [-] Clearing the allowlist restores the provider list and the catalog size → `governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.spec.ts`
+- [ ] The `get_llm` / `get_embeddings` runtime gate (LE-1955) — the bypass-proof half: a non-approved provider must be refused at execution, not only hidden. Needs a real provider key and a run, so it belongs with the credential-bearing specs, not the keyless policy file
+
+#### 21.4 Policy Bundle Revisioning
+
+- [-] Every accepted policy write mints a new revision with `source: "api"` and `GET /api/v1/policy-bundle/history` lists them newest-first (a fresh instance starts at revision 1, `source: "migration"`) → `governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.spec.ts`
+- [-] `POST /api/v1/policy-bundle/rollback/{revision}` is optimistically concurrent: a stale `expected_revision` is refused `409` with a body naming both `expected_revision` and `active_revision` → `governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.spec.ts`
+- [-] An accepted rollback **appends** rather than rewinds — new higher revision, `source: "rollback"`, `rollback_of_revision` pointing at the target, `reason` echoed — and the restored content is enforced, not just recorded → `governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.spec.ts`
+- [ ] `GET /api/v1/catalog-policy/usage` and `usage/flows` report the blast radius of a block (which flows use the component) before an operator applies it
+
+---
+
 ---
 
 ## Coverage Summary — Test Automation Coverage

--- a/docs/governance/catalog-policy/component-blocklist-enforcement.md
+++ b/docs/governance/catalog-policy/component-blocklist-enforcement.md
@@ -1,0 +1,129 @@
+# Catalog Policy — Component Blocklist Enforcement
+
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev32`)
+
+---
+
+## What this test validates *(required)*
+
+Catalog governance is an **OSS surface on 1.12**, not an Enterprise one. Measured
+on `langflowai/langflow-nightly:latest` (`1.12.0.dev32`): `catalog-policy`,
+`model-provider-policy` and `policy-bundle` all answer, and the block is
+*enforced* — 25 of the EE build's 55 governance routes ship in OSS, and the ones
+missing there (`sso/*`, `authz/status`, `authz/check`, `authz/admin/*`,
+`enterprise-admin/catalog`) are all 404 on the nightly. What Enterprise adds on
+top is the admin **UI** and the ability to declare the policy from the
+environment; the OSS instance is driven through the API, which is what this spec
+does.
+
+With one component blocked, the block must hold on **both** the read surface and
+the write surface. The pairing is the point: a component that disappears from the
+palette but still saves into a flow is the exact defect class LE-1933 / BUG-02
+recorded, and a spec that only checked the palette would have passed through it.
+
+Surfaces asserted here, all measured on `1.12.0.dev32`:
+
+- **policy echo** — `PUT /api/v1/catalog-policy/components` answers `200` with the
+  blocked set it stored.
+- **config flag** — `GET /api/v1/config` flips `catalog_governance_enabled`
+  `false → true`. This is what a client gates its restricted states on, and it is
+  a *derived* value: nobody sets it, so it is the cheapest proof the policy was
+  actually adopted rather than merely persisted.
+- **palette** — `GET /api/v1/all` drops the blocked type (354 → 352 types on the
+  measured build) while an unrelated control type stays present. The count is
+  asserted as a **decrease with the control surviving**, never as a literal
+  number: the catalog moves with the image (`component-catalog-drift.ts` exists
+  for that reason).
+- **sidebar** — the blocked component is not findable in the flow-editor sidebar
+  search. The palette is rendered from `/api/v1/all`, so this cannot disagree with
+  the API — it is here because "the operator blocked it and the user can still
+  see it" is the failure a reader of this spec will care about.
+- **write path** — `POST /api/v1/flows/` carrying the blocked type is refused
+  `400` with `Flow build blocked: catalog policy blocks components: <type>`.
+  The refusal must name the component; a generic `400` and a `500` are both
+  failures, since the refusal is a policy decision, not a crash.
+- **stored work survives** — a flow saved **before** the block stays readable and
+  its nodes unmodified (LE-1948). A policy change must never corrupt, delete or
+  silently rewrite work that predates it.
+
+## Tags *(required)*
+
+`@destructive` `@api` `@governance`
+
+**Not `@stable`, and the reason is the lane, not the test's maturity.** The
+policy is global to the instance — there is no per-user or per-project scope — so
+blocking a component is visible to every worker sharing that Langflow. That is
+the `@destructive` contract (`playwright.config.ts` `grepInvert`s it out of every
+normal run and `PW_DESTRUCTIVE=1` runs it alone at `workers: 1`), and
+`daily-stable.yml` has no destructive lane, so `@stable` here would be a test
+that silently never runs (#1010). It does run in `pr-validation.yml`'s destructive
+step whenever the import graph selects it.
+
+## Precondition *(required)*
+
+The instance's catalog policy is **pristine** — no blocked components. The test
+skips, naming the state it found, when it is not: a pre-blocked instance makes
+every "absent after blocking" assertion unfalsifiable, and stomping a policy
+someone configured on purpose is worse than not running.
+
+## Step by step *(required)*
+
+1. Snapshot the current bundle (`GET /api/v1/policy-bundle`) and require an empty
+   component blocklist; skip with the observed state otherwise.
+2. **Control:** `GET /api/v1/all` lists `DynamicCreateData`; `GET /api/v1/config`
+   reports `catalog_governance_enabled: false`; a flow carrying a
+   `DynamicCreateData` node saves `201`. Keep its id.
+3. `PUT /api/v1/catalog-policy/components` with
+   `{"blocked":["DynamicCreateData"]}` → `200`, echoing the blocked set.
+4. `GET /api/v1/config` → `catalog_governance_enabled: true`.
+5. `GET /api/v1/all` → `DynamicCreateData` absent, the control component
+   (`ChatInput`) still present, total type count strictly lower than in step 2.
+6. Open a flow in the editor, type the component's display name into
+   `sidebar-search-input` → the sidebar shows its empty state and lists no
+   draggable card.
+7. `POST /api/v1/flows/` with a `DynamicCreateData` node → `400`, and the body
+   names `DynamicCreateData`.
+8. `GET /api/v1/flows/{id}` for the flow from step 2 → `200`, still carrying its
+   `DynamicCreateData` node.
+9. Restore: `PUT` the snapshot back, then re-assert `DynamicCreateData` is in
+   `/api/v1/all` and the config flag is `false` again.
+
+## Validation criterion *(required)*
+
+Fails if the blocked component is still listed in the palette or findable in the
+sidebar, if `catalog_governance_enabled` does not track the policy, if a flow
+carrying the blocked component can be saved (or is refused with a `500` or a
+message that does not name it), or if a flow that predates the block stops being
+readable.
+
+**The restore is also an assertion, not a teardown convenience.** A failed
+restore leaves the shared instance with a component missing, which would redden
+unrelated specs for the rest of the run — so the spec verifies the catalog came
+back and fails loudly if it did not.
+
+## External dependencies *(required)*
+
+- A Langflow instance on the 1.12 line. No Enterprise image, no license, no
+  provider key, no network egress.
+- `DynamicCreateData` (`Dynamic Create Data`, core `processing` family) — chosen
+  on two properties, both measured on `1.12.0.dev32`. It is referenced by **no**
+  other spec or doc in the repo, so the blocked window cannot collide with
+  another test's fixture; and it is **not** `legacy`, which the sidebar
+  assertion depends on. The obvious first pick, `CombineText`, is `legacy: true`
+  and therefore already absent from the sidebar on a pristine instance — the UI
+  step would have passed without the policy doing anything, the exact
+  unfalsifiable-assertion shape this area is full of.
+
+## Upstream dependencies *(source paths watched)*
+
+Verified to resolve on `langflow-ai/langflow@release-1.12.0` (a path that does not
+exist is silent in a `git log` watch — the #1092 failure mode):
+
+- `src/backend/base/langflow/api/v1/catalog_policy.py` — the `components` /
+  `templates` read+write endpoints.
+- `src/backend/base/langflow/services/catalog_policy/service.py` — the snapshot
+  the palette filter and the write-path check both read.
+- `src/lfx/src/lfx/utils/flow_validation.py` — raises the `Flow build blocked:
+  catalog policy blocks components: …` refusal this spec asserts by message.
+- `src/backend/base/langflow/api/v1/policy_bundle.py` — the bundle the policy is
+  persisted into.

--- a/docs/governance/catalog-policy/template-blocklist-enforcement.md
+++ b/docs/governance/catalog-policy/template-blocklist-enforcement.md
@@ -1,0 +1,106 @@
+# Catalog Policy — Template Blocklist Enforcement
+
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev32`)
+
+---
+
+## What this test validates *(required)*
+
+The catalog policy blocks **templates** as well as components, through a second
+key set (`blocked_template_keys`) and a second endpoint
+(`PUT /api/v1/catalog-policy/templates`). It is a distinct enforcement path from
+the component blocklist — a different filter, in a different handler, over a
+different listing — so a green component spec says nothing about it.
+
+Two listings serve templates and **both** must honour the block, because they
+back different entry points:
+
+- `GET /api/v1/starter-projects/` — 5 items on the measured build.
+- `GET /api/v1/flows/basic_examples/` — 26 items; this is the one the New Flow
+  templates modal reads.
+
+A spec that checked only one of them would pass while the templates modal still
+offered a template the operator removed.
+
+**The key is the slug, not the display name — and that is the assertion this spec
+exists for.** Measured on `1.12.0.dev32`: `PUT` with `"Basic Prompting"` is
+accepted `200`, persists into the bundle, and filters *nothing*; `"basic_prompting"`
+removes it from both listings. An operator blocking a template by the name they
+see in the UI gets a green API response and no enforcement. The spec pins both
+halves — the accepted-but-inert display name and the effective `name_key` — so the
+day upstream starts normalising display names, this test says so instead of a
+release-validation checklist quietly passing.
+
+The escape hatch is asserted too: `?include_blocked=true` returns the blocked
+template, and the handler restricts that parameter to superusers (`403`
+otherwise). It is what an admin UI would use to show a blocked-but-listed state,
+and it is the only way to prove the template was *filtered* rather than *gone
+from the image*.
+
+The `name_key` is read from the listing itself (both endpoints expose it) rather
+than hardcoded, so the spec cannot drift from upstream's slug convention silently
+— it fails on a real change instead of on a stale constant.
+
+## Tags *(required)*
+
+`@destructive` `@api` `@templates`
+
+**Not `@stable`:** the policy is instance-global, so this is the `@destructive`
+lane (see `component-blocklist-enforcement.md` → *Tags* for the full rationale;
+`daily-stable.yml` has no destructive lane, and `@stable` without a lane is #1010).
+
+## Precondition *(required)*
+
+The instance's template blocklist is empty. The test skips naming the observed
+state otherwise — a pre-blocked instance makes the "absent after blocking"
+assertions unfalsifiable.
+
+## Step by step *(required)*
+
+1. Snapshot the bundle; require an empty `blocked_template_keys`, skip otherwise.
+2. Resolve the target template (`SaaS Pricing`, referenced by no other spec) in
+   `GET /api/v1/flows/basic_examples/` and read its `name_key` from the payload.
+3. **Control:** the template is present in `basic_examples`; record both listing
+   sizes.
+4. `PUT /api/v1/catalog-policy/templates` with the **display name** → `200`, and
+   both listings are unchanged (same size, template still present).
+5. `PUT` with the resolved `name_key` → `200`.
+6. `GET /api/v1/flows/basic_examples/` → the template is absent and the count
+   dropped by exactly one.
+7. `GET /api/v1/starter-projects/` → unchanged in this case (the target is not a
+   starter project), while a starter-project target blocked the same way drops
+   out of it — asserted by blocking `basic_prompting` and re-reading both
+   listings, then restoring.
+8. `GET /api/v1/starter-projects/?include_blocked=true` as the superuser → the
+   blocked starter project is returned, proving filtering rather than absence.
+9. Restore the snapshot and re-assert both listings are back to their control
+   sizes.
+
+## Validation criterion *(required)*
+
+Fails if a blocked `name_key` still appears in either listing, if blocking by
+display name silently *does* filter (the contract changed and the spec's stated
+trap is stale), if `include_blocked=true` does not return the blocked template
+for a superuser, or if the listings do not return to their control sizes after
+the restore.
+
+## External dependencies *(required)*
+
+- A Langflow instance on the 1.12 line. No Enterprise image, no license, no
+  provider key.
+- The bundled starter templates. `SaaS Pricing` is referenced by no other spec;
+  `Basic Prompting` **is** used by several, so it is blocked only inside step 7's
+  narrow window and restored immediately — which is also why this file is
+  `@destructive` and pinned to `workers: 1`.
+
+## Upstream dependencies *(source paths watched)*
+
+Verified to resolve on `langflow-ai/langflow@release-1.12.0`:
+
+- `src/backend/base/langflow/api/v1/catalog_policy.py` — the `templates` endpoint.
+- `src/backend/base/langflow/api/v1/starter_projects.py` — filters on `name_key`
+  and owns the superuser-only `include_blocked` parameter.
+- `src/backend/base/langflow/api/v1/flows.py` — the `basic_examples` listing,
+  the second surface that must honour the same block.
+- `src/backend/base/langflow/services/catalog_policy/service.py` — key
+  normalisation, which is why the display name is inert.

--- a/docs/governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.md
+++ b/docs/governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.md
@@ -1,0 +1,132 @@
+# Model Provider Policy — Allowlist Enforcement and Policy-Bundle Revisioning
+
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev32`)
+
+---
+
+## What this test validates *(required)*
+
+Two halves of one mechanism, in one file because the second is the audit trail of
+the first and they share the same expensive setup (a global policy write plus its
+restore).
+
+### 1 — The allowlist narrows what a user can pick
+
+Model-provider governance is a **default-allow allowlist** keyed on the stable
+`provider_id`, and the enforcement is not an echo of the policy — it reaches the
+surfaces a user picks a model from. Measured on `1.12.0.dev32` with
+`approved_provider_ids: ["openai"]`:
+
+- `GET /api/v1/models/providers` goes from **11** provider names to exactly
+  `["OpenAI"]`.
+- `GET /api/v1/all` goes from **354** to **326** component types: every
+  `ext:anthropic:*` type is gone (0 of them left) while the `ext:openai:*` ones
+  stay (4). This is the half that matters — a policy that only filtered its own
+  read-back would leave the blocked provider's components draggable.
+- `registered_providers` in `GET /api/v1/model-provider-policy` still lists all
+  11. That distinction is the spec's control: **the narrowing must be policy, not
+  a lost distribution.** An instance that simply shipped without
+  `lfx-anthropic` would show the same shortened provider list, and a spec that
+  did not read `registered_providers` would call that a passing governance test
+  (`docs/component-distribution-policy.md` is the standing record of how often
+  packaging, not policy, is what removed a family).
+
+Deliberately out of scope: the `get_llm` / `get_embeddings` runtime gate
+(LE-1955), which is the bypass-proof one. Proving it needs a run that calls a
+provider SDK with a real key, so it belongs with the credential-bearing specs,
+not in this keyless file. Stated here rather than left to look like coverage.
+
+### 2 — Every policy change is a numbered, reversible revision
+
+The policy bundle is the audit surface an operator answers "who changed what, and
+can we undo it" with. Measured contract:
+
+- Each accepted write mints a **new revision** with `source: "api"`; nothing
+  mutates a revision in place.
+- `GET /api/v1/policy-bundle/history` returns them newest-first, and a fresh
+  instance starts at revision 1 with `source: "migration"`, `initialized: false`.
+- `POST /api/v1/policy-bundle/rollback/{revision}` requires
+  `{"expected_revision": <active>}` and is **optimistically concurrent**: a stale
+  value is refused **409** with `{"message":"Policy bundle revision conflict",
+  "expected_revision":…, "active_revision":…}` — the body names both sides, which
+  is what makes a conflict actionable instead of a retry loop.
+- An accepted rollback does **not** rewind the counter: it appends a new revision
+  carrying the old content, with `source: "rollback"`, `rollback_of_revision`
+  pointing at the restored revision, and the caller's `reason` echoed back.
+  Asserting the *content* came back while the *revision number moved forward* is
+  the whole point — an implementation that reset the counter would erase the
+  trail it exists to keep.
+
+## Tags *(required)*
+
+`@destructive` `@api` `@model-provider`
+
+**Not `@stable`:** the policy is instance-global — narrowing providers hides
+models from every worker sharing the Langflow — so this is the `@destructive`
+lane (rationale in `../catalog-policy/component-blocklist-enforcement.md` →
+*Tags*; `daily-stable.yml` has no destructive lane, #1010).
+
+## Precondition *(required)*
+
+The instance's provider allowlist and component blocklist are both empty, and at
+least **two** providers are registered — with one registered provider the
+allowlist cannot be shown to narrow anything and the test would be vacuous. Both
+are skip conditions naming what was observed.
+
+## Step by step *(required)*
+
+1. Snapshot the bundle; require an empty policy and ≥2 registered providers.
+2. **Control:** record `GET /api/v1/models/providers` (all names), the
+   `/api/v1/all` type set, and the active revision.
+3. `PUT /api/v1/model-provider-policy` with `{"approved_provider_ids":["openai"]}`
+   → `200`, `approved_provider_ids` echoes exactly that.
+4. `GET /api/v1/models/providers` → exactly the approved provider's display name;
+   a control provider present in step 2 is gone.
+5. `GET /api/v1/model-provider-policy` → `registered_providers` still contains the
+   excluded provider (narrowing is policy, not packaging).
+6. `GET /api/v1/all` → no `ext:<excluded provider>:` type remains, at least one
+   `ext:openai:` type does, and the total type count is strictly lower.
+7. `GET /api/v1/policy-bundle` → revision incremented, `source: "api"`,
+   `approved_provider_ids` matching.
+8. Write a second, unrelated policy change (block one component) so there are two
+   revisions to move between; `GET /api/v1/policy-bundle/history` lists them
+   newest-first.
+9. `POST /api/v1/policy-bundle/rollback/{allowlist revision}` with a **stale**
+   `expected_revision` → `409`, body naming `expected_revision` and
+   `active_revision`.
+10. Repeat with the active revision → `200`; the returned bundle has a **higher**
+    revision than the one rolled back to, `source: "rollback"`,
+    `rollback_of_revision` = the target, `reason` echoed, and the component
+    blocklist from step 8 is cleared while the allowlist survives.
+11. Restore the snapshot (empty allowlist, empty blocklist) and re-assert the
+    provider list and the type count are back to their control values.
+
+## Validation criterion *(required)*
+
+Fails if the approved set does not match what was written, if a non-approved
+provider's components remain in `/api/v1/all`, if `registered_providers` shrinks
+with the policy (which would make the whole assertion vacuous), if a stale
+`expected_revision` is accepted, if a rollback rewinds the revision counter or
+loses its `rollback_of_revision` attribution, or if the instance does not return
+to its control state.
+
+## External dependencies *(required)*
+
+- A Langflow instance on the 1.12 line. No Enterprise image, no license.
+- **No API key and no network egress** — every surface here is policy metadata
+  and the component catalog. `openai` is used as the allowlisted `provider_id`
+  because it is always registered; whether a key exists for it is irrelevant, and
+  the spec never resolves a model.
+
+## Upstream dependencies *(source paths watched)*
+
+Verified to resolve on `langflow-ai/langflow@release-1.12.0`:
+
+- `src/backend/base/langflow/api/v1/model_provider_policy.py` — the allowlist
+  endpoint and `registered_providers`.
+- `src/backend/base/langflow/api/v1/policy_bundle.py` — revisions, history and
+  the `expected_revision` conflict this spec asserts.
+- `src/backend/base/langflow/services/catalog_policy/service.py` — the snapshot
+  that carries both policies.
+- `src/backend/base/langflow/services/catalog_policy/factory.py` — service wiring;
+  a change here moves when the snapshot is refreshed.

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -48,6 +48,7 @@ const MODULES: ModuleConfig[] = [
   { label: "`security/` — Validation, SSRF, Secrets",        sectionStart: "## security/" },
   { label: "`i18n/` — Language and Localization",            sectionStart: "## i18n/" },
   { label: "`memory/` — Memory Base Registration",           sectionStart: "## memory/" },
+  { label: "`governance/` — Catalog and Provider Policy",    sectionStart: "## governance/" },
 ];
 
 const PART_II_HEADER = "# PART II — TEST AUTOMATION COVERAGE";

--- a/tests/helpers/governance/policy-state.test.ts
+++ b/tests/helpers/governance/policy-state.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  describePolicyState,
+  isPolicyPristine,
+  singleNodeFlow,
+} from "./policy-state";
+
+describe("isPolicyPristine", () => {
+  it("accepts a bundle with every policy set empty", () => {
+    assert.equal(
+      isPolicyPristine({
+        blocked_component_keys: [],
+        blocked_template_keys: [],
+        approved_provider_ids: [],
+      }),
+      true,
+    );
+  });
+
+  it("accepts a bundle that omits the policy fields entirely", () => {
+    // A fresh instance answers `source: migration` and the reader must not
+    // treat a missing key as a configured policy — that would skip every
+    // governance spec on exactly the instance they are meant to run against.
+    assert.equal(isPolicyPristine({ revision: 1, source: "migration" }), true);
+  });
+
+  it("rejects a bundle carrying any one of the three policy sets", () => {
+    assert.equal(
+      isPolicyPristine({ blocked_component_keys: ["Agent"] }),
+      false,
+    );
+    assert.equal(
+      isPolicyPristine({ blocked_template_keys: ["basic_prompting"] }),
+      false,
+    );
+    assert.equal(
+      isPolicyPristine({ approved_provider_ids: ["openai"] }),
+      false,
+    );
+  });
+});
+
+describe("describePolicyState", () => {
+  it("names every non-empty set so the skip reason is actionable", () => {
+    const reason = describePolicyState({
+      blocked_component_keys: ["Agent", "ChatOutput"],
+      blocked_template_keys: ["basic_prompting"],
+      approved_provider_ids: ["openai"],
+    });
+    assert.equal(
+      reason,
+      "blocked components: Agent, ChatOutput; blocked templates: basic_prompting; approved providers: openai",
+    );
+  });
+
+  it("reports a pristine bundle as such", () => {
+    assert.equal(describePolicyState({ revision: 1 }), "pristine");
+  });
+});
+
+describe("singleNodeFlow", () => {
+  it("carries the component type where the policy check reads it", () => {
+    // The write-path refusal is keyed on `data.nodes[].data.type`; a payload
+    // that only names the component in `display_name` saves 201 and the spec
+    // would report "no enforcement" against a healthy build.
+    const flow = singleNodeFlow("spec flow", "CombineText");
+    assert.equal(flow.data.nodes.length, 1);
+    assert.equal(flow.data.nodes[0].data.type, "CombineText");
+    assert.equal(flow.name, "spec flow");
+  });
+});

--- a/tests/helpers/governance/policy-state.ts
+++ b/tests/helpers/governance/policy-state.ts
@@ -1,0 +1,192 @@
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * Shared plumbing for the catalog / model-provider governance specs.
+ *
+ * The policy bundle is **instance-global**: there is no per-user or per-project
+ * scope, so a spec that blocks a component blocks it for every worker sharing
+ * that Langflow. That is why these specs are `@destructive` — and why every one
+ * of them has to (a) refuse to run against an instance that already carries a
+ * policy, and (b) put the instance back exactly as it found it.
+ *
+ * Both duties live here rather than in each spec, because getting either wrong
+ * is not a local failure: a missed restore leaves the rest of the run staring at
+ * a catalog with components missing.
+ */
+
+/** The three policy sets a spec can write, read back as one snapshot. */
+export interface PolicySnapshot {
+  revision: number;
+  source: string;
+  blockedComponents: string[];
+  blockedTemplates: string[];
+  approvedProviders: string[];
+}
+
+export interface PolicyBundleResponse {
+  revision?: number;
+  source?: string;
+  initialized?: boolean;
+  blocked_component_keys?: string[];
+  blocked_template_keys?: string[];
+  approved_provider_ids?: string[];
+  rollback_of_revision?: number | null;
+  reason?: string | null;
+  managed_externally?: boolean;
+}
+
+/**
+ * True when nothing is blocked and no provider allowlist is set — the only
+ * state in which a "blocked ⇒ absent" assertion can fail for the right reason.
+ *
+ * Pure on purpose: the skip decision is the part worth unit-testing, and it must
+ * not need a running Langflow to be exercised.
+ */
+export function isPolicyPristine(bundle: PolicyBundleResponse): boolean {
+  return (
+    (bundle.blocked_component_keys?.length ?? 0) === 0 &&
+    (bundle.blocked_template_keys?.length ?? 0) === 0 &&
+    (bundle.approved_provider_ids?.length ?? 0) === 0
+  );
+}
+
+/**
+ * One-line description of a non-pristine bundle, for the skip message.
+ *
+ * The point is that the reason names what was found: "policy not pristine" sends
+ * the reader to the instance, `blocked components: Agent` tells them what to
+ * clear (#1012 — a skip without a stated cause reads like coverage).
+ */
+export function describePolicyState(bundle: PolicyBundleResponse): string {
+  const parts: string[] = [];
+  if (bundle.blocked_component_keys?.length) {
+    parts.push(`blocked components: ${bundle.blocked_component_keys.join(", ")}`);
+  }
+  if (bundle.blocked_template_keys?.length) {
+    parts.push(`blocked templates: ${bundle.blocked_template_keys.join(", ")}`);
+  }
+  if (bundle.approved_provider_ids?.length) {
+    parts.push(`approved providers: ${bundle.approved_provider_ids.join(", ")}`);
+  }
+  return parts.length > 0 ? parts.join("; ") : "pristine";
+}
+
+async function okJson(
+  request: APIRequestContext,
+  method: "get" | "put",
+  url: string,
+  auth: string,
+  data?: unknown,
+): Promise<Record<string, unknown>> {
+  const response =
+    method === "get"
+      ? await request.get(url, { headers: { Authorization: auth } })
+      : await request.put(url, { headers: { Authorization: auth }, data });
+  if (!response.ok()) {
+    throw new Error(
+      `${method.toUpperCase()} ${url} answered ${response.status()}: ${await response.text()}`,
+    );
+  }
+  return (await response.json()) as Record<string, unknown>;
+}
+
+export async function readPolicyBundle(
+  request: APIRequestContext,
+  auth: string,
+): Promise<PolicyBundleResponse> {
+  return (await okJson(
+    request,
+    "get",
+    "/api/v1/policy-bundle",
+    auth,
+  )) as PolicyBundleResponse;
+}
+
+export async function snapshotPolicy(
+  request: APIRequestContext,
+  auth: string,
+): Promise<PolicySnapshot> {
+  const bundle = await readPolicyBundle(request, auth);
+  return {
+    revision: bundle.revision ?? 0,
+    source: bundle.source ?? "unknown",
+    blockedComponents: bundle.blocked_component_keys ?? [],
+    blockedTemplates: bundle.blocked_template_keys ?? [],
+    approvedProviders: bundle.approved_provider_ids ?? [],
+  };
+}
+
+/**
+ * Put the instance back the way the snapshot found it.
+ *
+ * Writes all three sets unconditionally rather than diffing: the whole reason
+ * this runs is that a test failed somewhere in the middle, so "what did I
+ * actually change" is exactly the thing that cannot be trusted at that point.
+ *
+ * Throws on a failed write — the caller runs this from an `afterAll` that is
+ * expected to fail the suite when restoration does not happen.
+ */
+export async function restorePolicy(
+  request: APIRequestContext,
+  auth: string,
+  snapshot: PolicySnapshot,
+): Promise<void> {
+  await okJson(request, "put", "/api/v1/catalog-policy/components", auth, {
+    blocked: snapshot.blockedComponents,
+  });
+  await okJson(request, "put", "/api/v1/catalog-policy/templates", auth, {
+    blocked: snapshot.blockedTemplates,
+  });
+  await okJson(request, "put", "/api/v1/model-provider-policy", auth, {
+    approved_provider_ids: snapshot.approvedProviders,
+  });
+}
+
+/**
+ * The component types the palette would render, as a set.
+ *
+ * `/api/v1/all` is `category -> { type -> template }`; the specs assert over the
+ * flattened type set because a blocked component is removed from its category,
+ * and a category-level count would miss it (the same reason
+ * `component-catalog-drift.ts` snapshots types rather than categories).
+ */
+export async function readCatalogTypes(
+  request: APIRequestContext,
+  auth: string,
+): Promise<Set<string>> {
+  const catalog = await okJson(request, "get", "/api/v1/all", auth);
+  const types = new Set<string>();
+  for (const category of Object.values(catalog)) {
+    if (category && typeof category === "object") {
+      for (const type of Object.keys(category as Record<string, unknown>)) {
+        types.add(type);
+      }
+    }
+  }
+  return types;
+}
+
+/** A minimal saveable flow carrying exactly one node of the given type. */
+export function singleNodeFlow(name: string, componentType: string) {
+  const nodeId = `${componentType}-spec`;
+  return {
+    name,
+    description: "Created by the catalog-policy spec",
+    data: {
+      nodes: [
+        {
+          id: nodeId,
+          type: "genericNode",
+          position: { x: 0, y: 0 },
+          data: {
+            id: nodeId,
+            type: componentType,
+            node: { display_name: componentType, template: {} },
+          },
+        },
+      ],
+      edges: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+    },
+  };
+}

--- a/tests/tests-automations/regression/governance/catalog-policy/component-blocklist-enforcement.spec.ts
+++ b/tests/tests-automations/regression/governance/catalog-policy/component-blocklist-enforcement.spec.ts
@@ -1,0 +1,229 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import {
+  describePolicyState,
+  isPolicyPristine,
+  readCatalogTypes,
+  readPolicyBundle,
+  restorePolicy,
+  singleNodeFlow,
+  snapshotPolicy,
+  type PolicySnapshot,
+} from "../../../../helpers/governance/policy-state";
+
+// Catalog policy — component blocklist enforcement (QA-CHECKLIST §21.1).
+// Spec doc: docs/governance/catalog-policy/component-blocklist-enforcement.md
+//
+// The policy is instance-global, so this file is @destructive: it is excluded
+// from every normal run by playwright.config.ts and runs alone under
+// PW_DESTRUCTIVE=1 at workers=1. Serial mode is not a style choice — the tests
+// share one policy write, and the restore is the last of them.
+test.describe.configure({ mode: "serial" });
+
+// Target: non-legacy (so the sidebar renders it at all) and referenced by no
+// other spec (so the blocked window cannot break someone else's fixture).
+const BLOCKED_TYPE = "DynamicCreateData";
+const BLOCKED_DISPLAY_NAME = "Dynamic Create Data";
+const BLOCKED_CARD = `processing${BLOCKED_DISPLAY_NAME}`;
+// A component nobody blocks, proving the catalog was filtered and not emptied.
+const CONTROL_TYPE = "ChatInput";
+const SIDEBAR_EMPTY_STATE = "No components found.";
+
+test.describe("governance — catalog policy blocks a component end to end", () => {
+  let token: string;
+  let snapshot: PolicySnapshot;
+  let pristine = false;
+  let skipReason = "";
+  /** Type set of a policy-free instance, captured by the control test. */
+  let baselineTypes = new Set<string>();
+  /** Flow saved BEFORE the block — its survival is asserted after it. */
+  let preBlockFlowId = "";
+  const createdFlowIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    token = await getAuthToken(request);
+    const bundle = await readPolicyBundle(request, token);
+    pristine = isPolicyPristine(bundle);
+    skipReason = `instance already carries a catalog policy (${describePolicyState(bundle)}) — every "absent after blocking" assertion here would be unfalsifiable`;
+    if (pristine) {
+      snapshot = await snapshotPolicy(request, token);
+    }
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Safety net, not the assertion: the last test restores and verifies. This
+    // runs so an early failure cannot leave the shared instance with a
+    // component missing for the rest of the lane.
+    if (pristine) {
+      await restorePolicy(request, token, snapshot);
+    }
+    for (const id of createdFlowIds) {
+      await deleteFlow(request, id, {
+        headers: { Authorization: token },
+      }).catch((error) => {
+        console.warn(`⚠️ Orphan flow left behind (${id}): ${error}`);
+      });
+    }
+    createdFlowIds.length = 0;
+  });
+
+  test(
+    "an unconfigured instance hides nothing and saves a flow using the target component",
+    { tag: ["@destructive", "@api", "@governance"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      await test.step("the config flag reports governance off", async () => {
+        const config = await request.get("/api/v1/config", {
+          headers: { Authorization: token },
+        });
+        expect(config.status()).toBe(200);
+        expect((await config.json()).catalog_governance_enabled).toBe(false);
+      });
+
+      await test.step("the catalog lists the target component", async () => {
+        baselineTypes = await readCatalogTypes(request, token);
+        expect(baselineTypes.has(BLOCKED_TYPE)).toBe(true);
+        expect(baselineTypes.has(CONTROL_TYPE)).toBe(true);
+      });
+
+      await test.step("a flow carrying it saves", async () => {
+        preBlockFlowId = await createFlow(
+          request,
+          singleNodeFlow(`gov-pre-block-${Date.now()}`, BLOCKED_TYPE),
+          { headers: { Authorization: token } },
+        );
+        createdFlowIds.push(preBlockFlowId);
+      });
+    },
+  );
+
+  test(
+    "blocking the component removes it from the catalog and refuses the write path",
+    { tag: ["@destructive", "@api", "@governance"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      await test.step("the policy write is accepted and echoed", async () => {
+        const put = await request.put("/api/v1/catalog-policy/components", {
+          headers: { Authorization: token },
+          data: { blocked: [BLOCKED_TYPE] },
+        });
+        expect(put.status()).toBe(200);
+        expect((await put.json()).blocked).toContain(BLOCKED_TYPE);
+      });
+
+      await test.step("the config flag tracks the policy", async () => {
+        const config = await request.get("/api/v1/config", {
+          headers: { Authorization: token },
+        });
+        expect((await config.json()).catalog_governance_enabled).toBe(true);
+      });
+
+      await test.step("the catalog drops it and keeps everything else", async () => {
+        const types = await readCatalogTypes(request, token);
+        expect(types.has(BLOCKED_TYPE)).toBe(false);
+        // Filtered, not emptied: the control survives and the set shrank.
+        expect(types.has(CONTROL_TYPE)).toBe(true);
+        expect(types.size).toBeLessThan(baselineTypes.size);
+      });
+
+      await test.step("saving a flow that uses it is refused, naming it", async () => {
+        // Deliberate 4xx: the fixture's HTTP monitor is advisory, but this keeps
+        // the log honest about which failures the spec provoked on purpose.
+        const response = await request.post("/api/v1/flows/", {
+          headers: { Authorization: token },
+          data: singleNodeFlow(`gov-post-block-${Date.now()}`, BLOCKED_TYPE),
+        });
+        // A 500 here is a failure, not an equivalent refusal: the block is a
+        // policy decision the API is expected to make cleanly.
+        expect(response.status()).toBe(400);
+        expect(await response.text()).toContain(BLOCKED_TYPE);
+      });
+
+      await test.step("a flow saved before the block is untouched", async () => {
+        const response = await request.get(`/api/v1/flows/${preBlockFlowId}`, {
+          headers: { Authorization: token },
+        });
+        expect(response.status()).toBe(200);
+        const flow = await response.json();
+        expect(
+          flow.data.nodes.map((node: { data: { type: string } }) => node.data.type),
+        ).toEqual([BLOCKED_TYPE]);
+      });
+    },
+  );
+
+  test(
+    "the blocked component is not findable in the flow-editor sidebar",
+    { tag: ["@destructive", "@components", "@governance"] },
+    async ({ page, request }) => {
+      test.skip(!pristine, skipReason);
+
+      const flowId = await createFlow(
+        request,
+        {
+          name: `gov-sidebar-${Date.now()}`,
+          description: "Empty canvas for the §21.1 sidebar assertion",
+          data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+          is_component: false,
+        },
+        { headers: { Authorization: token } },
+      );
+      createdFlowIds.push(flowId);
+
+      await page.goto(`/flow/${flowId}`);
+      const search = page.getByTestId("sidebar-search-input");
+      await expect(search).toBeVisible({ timeout: 30000 });
+      const sidebar = page.getByTestId("shad-sidebar");
+
+      await test.step("searching its display name yields the empty state", async () => {
+        await search.fill(BLOCKED_DISPLAY_NAME);
+
+        await expect(sidebar.getByText(SIDEBAR_EMPTY_STATE)).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByTestId(BLOCKED_CARD)).toHaveCount(0);
+      });
+
+      await test.step("an unblocked component is still findable", async () => {
+        // Without this the empty state could mean "search is broken", which
+        // would pass whether or not the policy did anything.
+        await search.fill("Chat Input");
+
+        await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      // Unmount the editor before the afterAll delete: it polls the flow's
+      // event stream.
+      await page.goto("/").catch(() => {});
+    },
+  );
+
+  test(
+    "clearing the policy puts the catalog back",
+    { tag: ["@destructive", "@api", "@governance"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      await restorePolicy(request, token, snapshot);
+
+      await test.step("the component is listed again", async () => {
+        const types = await readCatalogTypes(request, token);
+        expect(types.has(BLOCKED_TYPE)).toBe(true);
+        expect(types.size).toBe(baselineTypes.size);
+      });
+
+      await test.step("the config flag reports governance off again", async () => {
+        const config = await request.get("/api/v1/config", {
+          headers: { Authorization: token },
+        });
+        expect((await config.json()).catalog_governance_enabled).toBe(false);
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/governance/catalog-policy/template-blocklist-enforcement.spec.ts
+++ b/tests/tests-automations/regression/governance/catalog-policy/template-blocklist-enforcement.spec.ts
@@ -1,0 +1,199 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  describePolicyState,
+  isPolicyPristine,
+  readPolicyBundle,
+  restorePolicy,
+  snapshotPolicy,
+  type PolicySnapshot,
+} from "../../../../helpers/governance/policy-state";
+
+// Catalog policy — template blocklist enforcement (QA-CHECKLIST §21.2).
+// Spec doc: docs/governance/catalog-policy/template-blocklist-enforcement.md
+//
+// @destructive for the same reason as its component sibling: the policy is
+// instance-global. Serial — the tests share one policy write.
+test.describe.configure({ mode: "serial" });
+
+/** Referenced by no other spec, so blocking it cannot break another fixture. */
+const TARGET_TEMPLATE = "SaaS Pricing";
+/** A starter project (the shorter listing), used only inside step 4's window. */
+const STARTER_TEMPLATE = "Basic Prompting";
+
+interface TemplateListItem {
+  name: string;
+  name_key: string;
+}
+
+async function listBasicExamples(
+  request: import("@playwright/test").APIRequestContext,
+  token: string,
+): Promise<TemplateListItem[]> {
+  const response = await request.get("/api/v1/flows/basic_examples/", {
+    headers: { Authorization: token },
+  });
+  expect(response.status()).toBe(200);
+  return (await response.json()) as TemplateListItem[];
+}
+
+async function listStarterProjects(
+  request: import("@playwright/test").APIRequestContext,
+  token: string,
+  { includeBlocked = false } = {},
+): Promise<TemplateListItem[]> {
+  const response = await request.get(
+    `/api/v1/starter-projects/${includeBlocked ? "?include_blocked=true" : ""}`,
+    { headers: { Authorization: token } },
+  );
+  expect(response.status()).toBe(200);
+  return (await response.json()) as TemplateListItem[];
+}
+
+test.describe("governance — catalog policy blocks a template", () => {
+  let token: string;
+  let snapshot: PolicySnapshot;
+  let pristine = false;
+  let skipReason = "";
+  /** Resolved from the API, never hardcoded — see the spec doc. */
+  let targetKey = "";
+  let baselineExamples = 0;
+  let baselineStarters = 0;
+
+  test.beforeAll(async ({ request }) => {
+    token = await getAuthToken(request);
+    const bundle = await readPolicyBundle(request, token);
+    pristine = isPolicyPristine(bundle);
+    skipReason = `instance already carries a catalog policy (${describePolicyState(bundle)}) — the "absent after blocking" assertions would be unfalsifiable`;
+    if (pristine) {
+      snapshot = await snapshotPolicy(request, token);
+    }
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (pristine) {
+      await restorePolicy(request, token, snapshot);
+    }
+  });
+
+  test(
+    "both template listings serve the target and expose its policy key",
+    { tag: ["@destructive", "@api", "@templates"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      const examples = await listBasicExamples(request, token);
+      const starters = await listStarterProjects(request, token);
+      baselineExamples = examples.length;
+      baselineStarters = starters.length;
+
+      const target = examples.find((item) => item.name === TARGET_TEMPLATE);
+      expect(
+        target,
+        `${TARGET_TEMPLATE} is not in this build's templates — pick another target`,
+      ).toBeTruthy();
+      // The key the policy is written with comes from the product, so a slug
+      // convention change fails this test instead of silently disarming it.
+      targetKey = target!.name_key;
+      expect(targetKey).toBeTruthy();
+      expect(targetKey).not.toBe(TARGET_TEMPLATE);
+    },
+  );
+
+  test(
+    "blocking by display name is accepted and enforces nothing",
+    { tag: ["@destructive", "@api", "@templates"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      const put = await request.put("/api/v1/catalog-policy/templates", {
+        headers: { Authorization: token },
+        data: { blocked: [TARGET_TEMPLATE] },
+      });
+      expect(put.status()).toBe(200);
+      expect((await put.json()).blocked).toContain(TARGET_TEMPLATE);
+
+      // The trap this file exists for: the write succeeds, the bundle carries
+      // the value, and the listings are untouched. An operator blocking a
+      // template by the name they see in the UI gets no enforcement and no
+      // error.
+      const examples = await listBasicExamples(request, token);
+      expect(examples.length).toBe(baselineExamples);
+      expect(examples.map((item) => item.name)).toContain(TARGET_TEMPLATE);
+    },
+  );
+
+  test(
+    "blocking by name_key removes the template from the listing",
+    { tag: ["@destructive", "@api", "@templates"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      const put = await request.put("/api/v1/catalog-policy/templates", {
+        headers: { Authorization: token },
+        data: { blocked: [targetKey] },
+      });
+      expect(put.status()).toBe(200);
+
+      const examples = await listBasicExamples(request, token);
+      expect(examples.map((item) => item.name)).not.toContain(TARGET_TEMPLATE);
+      // Exactly one template left, not a listing that collapsed.
+      expect(examples.length).toBe(baselineExamples - 1);
+    },
+  );
+
+  test(
+    "the starter-projects listing honours the block, and include_blocked reveals it",
+    { tag: ["@destructive", "@api", "@templates"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      const starter = (await listStarterProjects(request, token)).find(
+        (item) => item.name === STARTER_TEMPLATE,
+      );
+      expect(
+        starter,
+        `${STARTER_TEMPLATE} is not a starter project in this build`,
+      ).toBeTruthy();
+
+      const put = await request.put("/api/v1/catalog-policy/templates", {
+        headers: { Authorization: token },
+        data: { blocked: [starter!.name_key] },
+      });
+      expect(put.status()).toBe(200);
+
+      await test.step("it leaves the starter listing", async () => {
+        const starters = await listStarterProjects(request, token);
+        expect(starters.map((item) => item.name)).not.toContain(STARTER_TEMPLATE);
+        expect(starters.length).toBe(baselineStarters - 1);
+      });
+
+      await test.step("include_blocked returns it, proving it was filtered", async () => {
+        // Absent-because-filtered vs absent-because-the-image-lacks-it are
+        // indistinguishable without this read.
+        const withBlocked = await listStarterProjects(request, token, {
+          includeBlocked: true,
+        });
+        expect(withBlocked.map((item) => item.name)).toContain(STARTER_TEMPLATE);
+        expect(withBlocked.length).toBe(baselineStarters);
+      });
+    },
+  );
+
+  test(
+    "clearing the policy puts both listings back",
+    { tag: ["@destructive", "@api", "@templates"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      await restorePolicy(request, token, snapshot);
+
+      const examples = await listBasicExamples(request, token);
+      const starters = await listStarterProjects(request, token);
+      expect(examples.length).toBe(baselineExamples);
+      expect(examples.map((item) => item.name)).toContain(TARGET_TEMPLATE);
+      expect(starters.length).toBe(baselineStarters);
+      expect(starters.map((item) => item.name)).toContain(STARTER_TEMPLATE);
+    },
+  );
+});

--- a/tests/tests-automations/regression/governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.spec.ts
+++ b/tests/tests-automations/regression/governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.spec.ts
@@ -1,0 +1,239 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  describePolicyState,
+  isPolicyPristine,
+  readCatalogTypes,
+  readPolicyBundle,
+  restorePolicy,
+  snapshotPolicy,
+  type PolicySnapshot,
+} from "../../../../helpers/governance/policy-state";
+
+// Model provider policy + policy-bundle revisioning (QA-CHECKLIST §21.3–21.4).
+// Spec doc:
+// docs/governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.md
+//
+// @destructive: narrowing the provider allowlist hides models from every worker
+// sharing the instance. Serial — the revision assertions build on each other.
+test.describe.configure({ mode: "serial" });
+
+const APPROVED_PROVIDER_ID = "openai";
+const APPROVED_DISPLAY_NAME = "OpenAI";
+/** Namespace prefix of a provider that must survive the allowlist. */
+const APPROVED_TYPE_PREFIX = "ext:openai:";
+/** A component to block, so there are two revisions to move between. */
+const SCRATCH_COMPONENT = "DynamicCreateData";
+
+interface RegisteredProvider {
+  provider_id: string;
+  display_name: string;
+}
+
+test.describe("governance — provider allowlist and policy-bundle revisions", () => {
+  let token: string;
+  let snapshot: PolicySnapshot;
+  let pristine = false;
+  let skipReason = "";
+  let baselineProviders: string[] = [];
+  let baselineTypes = new Set<string>();
+  /** A registered provider outside the allowlist, resolved from the API. */
+  let excludedProviderId = "";
+  let allowlistRevision = 0;
+
+  test.beforeAll(async ({ request }) => {
+    token = await getAuthToken(request);
+    const bundle = await readPolicyBundle(request, token);
+    pristine = isPolicyPristine(bundle);
+    skipReason = `instance already carries a governance policy (${describePolicyState(bundle)}) — the allowlist assertions would be unfalsifiable`;
+    if (pristine) {
+      snapshot = await snapshotPolicy(request, token);
+    }
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (pristine) {
+      await restorePolicy(request, token, snapshot);
+    }
+  });
+
+  test(
+    "an unconfigured instance approves every registered provider",
+    { tag: ["@destructive", "@api", "@model-provider"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      const policy = await request.get("/api/v1/model-provider-policy", {
+        headers: { Authorization: token },
+      });
+      expect(policy.status()).toBe(200);
+      const body = await policy.json();
+      expect(body.approved_provider_ids).toEqual([]);
+
+      const registered = body.registered_providers as RegisteredProvider[];
+      // With one provider the allowlist cannot be shown to narrow anything —
+      // the whole file would pass vacuously.
+      expect(
+        registered.length,
+        "fewer than two registered providers: the allowlist cannot be shown to narrow anything",
+      ).toBeGreaterThan(1);
+      excludedProviderId =
+        registered.find((p) => p.provider_id !== APPROVED_PROVIDER_ID)!
+          .provider_id;
+
+      const providers = await request.get("/api/v1/models/providers", {
+        headers: { Authorization: token },
+      });
+      baselineProviders = (await providers.json()) as string[];
+      expect(baselineProviders).toContain(APPROVED_DISPLAY_NAME);
+      expect(baselineProviders.length).toBe(registered.length);
+
+      baselineTypes = await readCatalogTypes(request, token);
+    },
+  );
+
+  test(
+    "an allowlist narrows the provider list and the component catalog",
+    { tag: ["@destructive", "@api", "@model-provider"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      await test.step("the policy write is accepted and echoed", async () => {
+        const put = await request.put("/api/v1/model-provider-policy", {
+          headers: { Authorization: token },
+          data: { approved_provider_ids: [APPROVED_PROVIDER_ID] },
+        });
+        expect(put.status()).toBe(200);
+        expect((await put.json()).approved_provider_ids).toEqual([
+          APPROVED_PROVIDER_ID,
+        ]);
+      });
+
+      await test.step("only the approved provider is offered", async () => {
+        const providers = await request.get("/api/v1/models/providers", {
+          headers: { Authorization: token },
+        });
+        expect(await providers.json()).toEqual([APPROVED_DISPLAY_NAME]);
+      });
+
+      await test.step("the excluded provider is still registered", async () => {
+        // The control that separates policy from packaging: an image missing a
+        // provider distribution shows the same shortened list (see
+        // docs/component-distribution-policy.md).
+        const policy = await request.get("/api/v1/model-provider-policy", {
+          headers: { Authorization: token },
+        });
+        const registered = (await policy.json())
+          .registered_providers as RegisteredProvider[];
+        expect(registered.map((p) => p.provider_id)).toContain(
+          excludedProviderId,
+        );
+      });
+
+      await test.step("its components leave the catalog", async () => {
+        const types = await readCatalogTypes(request, token);
+        const excludedPrefix = `ext:${excludedProviderId}:`;
+        expect(
+          [...types].filter((type) => type.startsWith(excludedPrefix)),
+        ).toEqual([]);
+        expect(
+          [...types].filter((type) => type.startsWith(APPROVED_TYPE_PREFIX))
+            .length,
+        ).toBeGreaterThan(0);
+        expect(types.size).toBeLessThan(baselineTypes.size);
+      });
+
+      await test.step("the write minted a new bundle revision", async () => {
+        const bundle = await readPolicyBundle(request, token);
+        expect(bundle.revision).toBeGreaterThan(snapshot.revision);
+        expect(bundle.source).toBe("api");
+        expect(bundle.approved_provider_ids).toEqual([APPROVED_PROVIDER_ID]);
+        allowlistRevision = bundle.revision!;
+      });
+    },
+  );
+
+  test(
+    "a rollback is refused on a stale expected_revision and appends when current",
+    { tag: ["@destructive", "@api", "@governance"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      await test.step("a second, unrelated change gives us a revision to leave", async () => {
+        const put = await request.put("/api/v1/catalog-policy/components", {
+          headers: { Authorization: token },
+          data: { blocked: [SCRATCH_COMPONENT] },
+        });
+        expect(put.status()).toBe(200);
+      });
+
+      const history = await request.get("/api/v1/policy-bundle/history", {
+        headers: { Authorization: token },
+      });
+      expect(history.status()).toBe(200);
+      const revisions = ((await history.json()).items as { revision: number }[])
+        .map((item) => item.revision);
+      // Newest first, and the allowlist revision is in there.
+      expect(revisions[0]).toBeGreaterThan(allowlistRevision);
+      expect(revisions).toContain(allowlistRevision);
+      const activeRevision = revisions[0];
+
+      await test.step("a stale expected_revision is refused 409, naming both sides", async () => {
+        const stale = await request.post(
+          `/api/v1/policy-bundle/rollback/${allowlistRevision}`,
+          {
+            headers: { Authorization: token },
+            data: { expected_revision: allowlistRevision },
+          },
+        );
+        expect(stale.status()).toBe(409);
+        const detail = (await stale.json()).detail;
+        expect(detail.expected_revision).toBe(allowlistRevision);
+        expect(detail.active_revision).toBe(activeRevision);
+      });
+
+      await test.step("the current expected_revision is accepted and appends", async () => {
+        const rollback = await request.post(
+          `/api/v1/policy-bundle/rollback/${allowlistRevision}`,
+          {
+            headers: { Authorization: token },
+            data: { expected_revision: activeRevision, reason: "spec rollback" },
+          },
+        );
+        expect(rollback.status()).toBe(200);
+        const bundle = await rollback.json();
+        // The counter moves FORWARD carrying old content — a rollback that
+        // rewound it would erase the trail it exists to keep.
+        expect(bundle.revision).toBeGreaterThan(activeRevision);
+        expect(bundle.source).toBe("rollback");
+        expect(bundle.rollback_of_revision).toBe(allowlistRevision);
+        expect(bundle.reason).toBe("spec rollback");
+        expect(bundle.blocked_component_keys).toEqual([]);
+        expect(bundle.approved_provider_ids).toEqual([APPROVED_PROVIDER_ID]);
+      });
+
+      await test.step("the restored content is enforced, not just recorded", async () => {
+        const types = await readCatalogTypes(request, token);
+        expect(types.has(SCRATCH_COMPONENT)).toBe(true);
+      });
+    },
+  );
+
+  test(
+    "clearing the policy puts providers and catalog back",
+    { tag: ["@destructive", "@api", "@model-provider"] },
+    async ({ request }) => {
+      test.skip(!pristine, skipReason);
+
+      await restorePolicy(request, token, snapshot);
+
+      const providers = await request.get("/api/v1/models/providers", {
+        headers: { Authorization: token },
+      });
+      expect(await providers.json()).toEqual(baselineProviders);
+
+      const types = await readCatalogTypes(request, token);
+      expect(types.size).toBe(baselineTypes.size);
+    },
+  );
+});


### PR DESCRIPTION
Closes #1493.

Covers the `governance/` gap opened as `QA-CHECKLIST.md` § 21. Langflow 1.12 ships
catalog and model-provider governance in the **OSS** build — measured, not assumed:
`1.12.0.dev32` carries 25 of the Enterprise build's 55 governance routes and
*enforces* the blocks. #1493 has the full OSS × EE table and the probe method
(direct 403/405/422-vs-404, because `openapi.json` under-reports on both builds).

This is a distinct journey from every existing spec: nothing in the suite writes a
policy, and the closest neighbours assert the opposite direction — the catalog
baseline in `globalSetup` warns when components *vanish*, which is exactly what a
correct block looks like.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `an unconfigured instance hides nothing and saves a flow using the target component` | Negative control. `catalog_governance_enabled: false`, the target is in `/api/v1/all`, a flow carrying it saves `201`. Without this, every "absent after blocking" assert below is unfalsifiable |
| 2 | `blocking the component removes it from the catalog and refuses the write path` | Read **and** write: type gone from `/api/v1/all` (control type kept, set strictly smaller), config flag flips, `POST /api/v1/flows/` → `400` **naming** the component, and a flow saved *before* the block stays readable (LE-1948). A component hidden from the palette that still saves is the LE-1933 defect class |
| 3 | `the blocked component is not findable in the flow-editor sidebar` | The user-facing half: empty state on the blocked name, asserted against a control search that still matches, so "search is broken" cannot pass as "policy works" |
| 4 | `clearing the policy puts the catalog back` | Restore is an assertion, not teardown — a failed restore would redden the rest of the lane |
| 5 | `both template listings serve the target and expose its policy key` | Resolves `name_key` from the API instead of hardcoding a slug |
| 6 | `blocking by display name is accepted and enforces nothing` | The operator trap: `PUT "Basic Prompting"` → `200`, persisted, **zero** enforcement |
| 7 | `blocking by name_key removes the template from the listing` | `flows/basic_examples/` 26 → 25, exactly one gone |
| 8 | `the starter-projects listing honours the block, and include_blocked reveals it` | The second listing (5 → 4) plus `?include_blocked=true`, which separates *filtered* from *absent from the image* |
| 9 | `clearing the policy puts both listings back` | Both listings back to control sizes |
| 10 | `an unconfigured instance approves every registered provider` | Control; also skips loudly if fewer than two providers are registered, where the allowlist could not be shown to narrow anything |
| 11 | `an allowlist narrows the provider list and the component catalog` | `models/providers` 11 → `["OpenAI"]`, `ext:<excluded>:*` types gone while `ext:openai:*` stay, **and** `registered_providers` still lists the excluded one — the control that separates policy from a missing distribution |
| 12 | `a rollback is refused on a stale expected_revision and appends when current` | Optimistic concurrency: stale → `409` naming `expected_revision` and `active_revision`; accepted → a **new higher** revision with `source: "rollback"` and `rollback_of_revision`, content restored and enforced |
| 13 | `clearing the policy puts providers and catalog back` | Provider list and type count back to control |

## 2. How the test was built

- **Policy is written through the API**, not the environment: OSS `Settings`
  exposes no `LANGFLOW_CATALOG_COMPONENT_BLOCKLIST`, and an instance started with
  one reports `source: "migration"` with nothing blocked. So these specs need no
  special container — they run on the standard nightly.
- **Pristine-or-skip guard.** `tests/helpers/governance/policy-state.ts` snapshots
  the bundle and each file skips, naming the state it found, when a policy is
  already set. Pure predicates (`isPolicyPristine`, `describePolicyState`) are
  unit-tested.
- **Restore is verified twice** — as the last test of each file, and again as an
  `afterAll` safety net. Proven in the force-fail run: with 3 tests failing
  mid-file the instance still came back to 354 types / 11 providers / 26 templates
  and no leaked flow.
- **Live-confirmed selectors:** `sidebar-search-input`, `shad-sidebar`,
  `processingDynamic Create Data`, `input_outputChat Input`, empty state
  `No components found.` (same shapes `ui-ux/sidebar-search-and-filter.spec.ts`
  uses).
- **Target choice is load-bearing.** `DynamicCreateData` is referenced by no other
  spec *and* is `legacy: false`. The obvious pick, `CombineText`, is `legacy: true`
  and therefore already absent from the sidebar — that UI assert would have passed
  with the policy doing nothing.
- Spec docs carry an **Upstream dependencies** section; all five paths verified to
  resolve on `langflow-ai/langflow@release-1.12.0` (#1092's silent-path failure).

## 3. Dependencies

- **None — no LLM, no provider key, no network egress.** Every surface is policy
  metadata plus the component catalog; `openai` is used as a `provider_id` only,
  never resolved to a model.
- **Execution mode: `@destructive`, `workers: 1`.** The policy is instance-global,
  so these must never run beside other specs. Not `@stable`: `daily-stable.yml` has
  no destructive lane, and `@stable` without a lane is #1010.

## Validation (nightly `1.12.0.dev32`, `--retries=0 --workers=1`)

- typecheck ✅ · eslint 0 errors ✅ · `test:units` 705 passing (incl. 3 new suites) ✅
- QA-CHECKLIST guard ✅ (no generated block edited) · `check:checklist-coverage` ✅ ·
  `validate:specs` ✅
- **3 clean runs**: `expected=13 unexpected=0 flaky=0` at 9.0 s / 9.1 s / 9.4 s
- **force-fail** ✅ — neutering the policy write in each file reddens exactly its
  enforcement test (3 unexpected, serial mode skipping the rest); reverted and green
  again
- **lane exclusion** ✅ — a normal run selects `Total: 0 tests`; with
  `PW_DESTRUCTIVE=1`, `Total: 13 tests in 3 files`
- zero `🚨 Backend Error` ✅
- `--trace=on` not used: it hangs UI specs on this Colima host; the UI test was run
  and inspected without it

## Follow-ups (tracked in #1493, not here)

- `catalog-policy/usage` blast-radius reporting (§21.4 `[ ]`)
- LE-1955 `get_llm` / `get_embeddings` runtime gate — needs a credential-bearing
  lane (§21.3 `[ ]`)
- Enterprise-only remainder (SSO, `authz` enforcement, env-declared policy) stays
  with #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
