### PR TITLE
fix(ci): keep the PR lane green when every impacted spec is @destructive (#1495)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -227,6 +227,9 @@ jobs:
       # True when no spec imports the diff but this lane runs what changed, so the
       # lane runs a fixed canary set instead of skipping (#1159).
       canary: ${{ steps.diff.outputs.canary }}
+      # True when EVERY selected spec is `@destructive`, so the normal run below
+      # would match nothing and exit 1 while the destructive lane runs them fine.
+      destructive_only: ${{ steps.diff.outputs.destructive_only }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -427,11 +430,33 @@ jobs:
           # pass (#1012).
           HAS_SPECS=false
           if [ -n "$SPECS" ]; then HAS_SPECS=true; fi
+
+          # Would the NORMAL lane match anything? `playwright.config.ts` grep-inverts
+          # `@destructive` out of it (#1010), so a selection where every spec is
+          # destructive makes `npx playwright test` exit 1 with "No tests found" —
+          # a red job whose destructive step then reports those same specs passing
+          # (measured on PR #1494: `13 passed` under a `fail` verdict). Skipping the
+          # normal run in that one case is not `--pass-with-no-tests`: a selection of
+          # paths that no longer exist must keep failing here, which is why the
+          # verdict reads the specs' tags instead of tolerating an empty match.
+          # Logic and its conservative defaults live in the script, covered by
+          # `npm run test:scripts`; a verdict it cannot produce exits 2 and fails this
+          # step rather than guessing (#1216).
+          DESTRUCTIVE_ONLY=false
+          if [ "$HAS_SPECS" = "true" ]; then
+            DESTRUCTIVE_ONLY=$(node scripts/destructive-only-selection.mjs --specs "$SPECS") \
+              || { echo "::error::destructive-only classification failed — a spec in the selection could not be read"; exit 1; }
+          fi
+          if [ "$DESTRUCTIVE_ONLY" = "true" ]; then
+            echo "::warning::Every impacted spec is @destructive, so the normal lane is skipped for this PR — the destructive lane below is what runs them (workers=1). Read its result, not the normal run's absence (#1010)."
+          fi
+
           {
             echo "has_specs=$HAS_SPECS"
             echo "specs=$SPECS"
             echo "needs_models=$NEEDS_MODELS"
             echo "canary=$CANARY"
+            echo "destructive_only=$DESTRUCTIVE_ONLY"
           } >> "$GITHUB_OUTPUT"
 
   e2e:
@@ -865,6 +890,12 @@ jobs:
           TOKENS_MAX_SECONDS: "3300"
 
       - name: Run impacted specs
+        # Skipped only when the selection is 100% `@destructive`, in which case
+        # this run would match nothing and exit 1 while the destructive lane below
+        # runs those very specs. The verdict comes from `detect-specs` (tag-based,
+        # conservative: any ambiguity keeps this step), and the skip is announced
+        # there as a `::warning::` so it can never read as coverage (#1012).
+        if: needs.detect-specs.outputs.destructive_only != 'true'
         env:
           CI: "true"
           # When "Collect models" is skipped (needs_models == false) the provider

--- a/scripts/destructive-only-selection.mjs
+++ b/scripts/destructive-only-selection.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Decides whether an impacted-spec selection contains ANYTHING the normal PR
+ * lane can run — i.e. whether every selected spec is `@destructive`.
+ *
+ * Why this exists. `playwright.config.ts` `grepInvert`s `/@destructive/` out of
+ * every normal run (#1010), and `pr-validation.yml` runs the impacted set twice:
+ * once normally, then once more with `PW_DESTRUCTIVE=1 --grep @destructive
+ * --pass-with-no-tests`. When EVERY selected spec is destructive the first run
+ * matches nothing, and `npx playwright test` exits 1 with `Error: No tests
+ * found.` — so the job goes red on a lane detail while the destructive step that
+ * follows reports the specs passing. Measured on PR #1494: `13 passed (10.2s)`
+ * in the destructive step of a job whose verdict was `fail`.
+ *
+ * It had never fired because the suite's only `@destructive` spec until then
+ * (`core-functionality/project-management/folder-deletion-integrity.spec.ts`)
+ * carries non-destructive tests in the same file, so the selection always held
+ * something the normal lane could run.
+ *
+ * The fix is NOT a blanket `--pass-with-no-tests` on the normal run: that would
+ * also swallow a selection of paths that no longer exist, which is a real defect
+ * this lane should keep catching. Instead the workflow asks this script, up
+ * front, whether the normal lane is expected to match nothing, and skips that
+ * step — loudly — only in that case.
+ *
+ * Conservative by construction: every ambiguity resolves to "runnable", which
+ * preserves today's behaviour. The failure this must never produce is the
+ * opposite one — declaring a selection destructive-only when it holds runnable
+ * tests would skip the normal lane and lose their coverage silently.
+ *
+ * Usage:
+ *   node scripts/destructive-only-selection.mjs --specs "a.spec.ts b.spec.ts"
+ *   node scripts/destructive-only-selection.mjs --specs "…" --format=json
+ *
+ * Prints `true` / `false` (or the JSON verdict). Exits 2 when a listed spec
+ * cannot be read: an unreadable spec is UNDECIDABLE, and defaulting it either
+ * way is how #1216's silent-default class of bug reaches the lane again.
+ */
+
+import { readFileSync } from "node:fs";
+
+/**
+ * Every `tag: [ … ]` array in a spec's source.
+ *
+ * `[^\]]*` spans newlines, so a multi-line array matches — the same shape
+ * `provider-dependent-specs.mjs` relies on. Tags are read from a `tag:` array,
+ * never from anywhere in the file: the loose substring test counts a `@destructive`
+ * written in a comment, which is exactly how a runnable spec would get skipped.
+ */
+const TAG_ARRAY_RE = /tag:\s*\[[^\]]*\]/g;
+const DESTRUCTIVE = "@destructive";
+
+/**
+ * True when this source declares at least one tag array and EVERY one of them
+ * carries `@destructive`.
+ *
+ * A file with no tag array at all is reported runnable rather than undecidable.
+ * The repo requires every test to be tagged, so this should not happen — and if
+ * it does, running the normal lane is the outcome that cannot lose coverage.
+ *
+ * Known conservative gap: Playwright merges a `test.describe(…, { tag })` into
+ * the tags of the tests inside it, and this counts arrays independently. A file
+ * whose `@destructive` lives only on the describe (or only on the tests, with an
+ * untagged describe array present) reads as runnable, so the lane behaves as it
+ * does today. That direction is safe; the reverse would not be.
+ */
+export function isDestructiveOnlySource(source) {
+  const arrays = source.match(TAG_ARRAY_RE);
+  if (!arrays || arrays.length === 0) return false;
+  return arrays.every((array) => array.includes(DESTRUCTIVE));
+}
+
+/**
+ * Classify a selection.
+ *
+ * @param specs     spec paths, as the workflow's `$SPECS` splits them
+ * @param readSpec  reads a spec's source; throws when it cannot (injected so the
+ *                  unit tests never touch the filesystem)
+ * @returns `{ destructiveOnly, destructive, runnable }`
+ */
+export function classifySelection(specs, readSpec) {
+  const destructive = [];
+  const runnable = [];
+
+  for (const spec of specs) {
+    let source;
+    try {
+      source = readSpec(spec);
+    } catch (error) {
+      throw new Error(
+        `cannot read selected spec "${spec}" (${error.message}) — an unreadable spec is undecidable, not runnable`,
+      );
+    }
+    if (isDestructiveOnlySource(source)) destructive.push(spec);
+    else runnable.push(spec);
+  }
+
+  return {
+    // An EMPTY selection is not destructive-only. The job's own `has_specs`
+    // gate already skips the E2E job in that case, and answering `true` here
+    // would skip the normal lane for a reason that has nothing to do with tags.
+    destructiveOnly: specs.length > 0 && runnable.length === 0,
+    destructive,
+    runnable,
+  };
+}
+
+function parseArgs(argv) {
+  const args = { specs: "", format: "value" };
+  for (const arg of argv) {
+    if (arg.startsWith("--specs=")) args.specs = arg.slice("--specs=".length);
+    else if (arg === "--specs") args.specsNext = true;
+    else if (arg.startsWith("--format=")) args.format = arg.slice("--format=".length);
+    else if (args.specsNext) {
+      args.specs = arg;
+      args.specsNext = false;
+    }
+  }
+  return args;
+}
+
+function main() {
+  const { specs, format } = parseArgs(process.argv.slice(2));
+  const list = specs.split(/\s+/).filter(Boolean);
+
+  let verdict;
+  try {
+    verdict = classifySelection(list, (spec) => readFileSync(spec, "utf8"));
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exit(2);
+  }
+
+  if (format === "json") {
+    process.stdout.write(`${JSON.stringify(verdict)}\n`);
+  } else {
+    process.stdout.write(`${verdict.destructiveOnly}\n`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/destructive-only-selection.test.mjs
+++ b/scripts/destructive-only-selection.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import {
+  classifySelection,
+  isDestructiveOnlySource,
+} from "./destructive-only-selection.mjs";
+
+const DESTRUCTIVE_SPEC = `
+  test("blocks a component", { tag: ["@destructive", "@api", "@governance"] }, async () => {});
+  test("puts it back", { tag: ["@destructive", "@api", "@governance"] }, async () => {});
+`;
+
+const MIXED_SPEC = `
+  test("lists folders", { tag: ["@stable", "@api"] }, async () => {});
+  test("deletes every project", { tag: ["@destructive", "@release", "@api"] }, async () => {});
+`;
+
+const NORMAL_SPEC = `
+  test("searches the sidebar", { tag: ["@stable", "@workspace", "@ui-ux"] }, async () => {});
+`;
+
+function sources(map) {
+  return (spec) => {
+    if (!(spec in map)) throw new Error("ENOENT: no such file");
+    return map[spec];
+  };
+}
+
+describe("isDestructiveOnlySource", () => {
+  it("is true when every tag array carries @destructive", () => {
+    assert.equal(isDestructiveOnlySource(DESTRUCTIVE_SPEC), true);
+  });
+
+  it("is false when one test in the file is runnable in the normal lane", () => {
+    // The shape that kept this bug hidden: folder-deletion-integrity.spec.ts.
+    assert.equal(isDestructiveOnlySource(MIXED_SPEC), false);
+  });
+
+  it("is false for a spec with no destructive test at all", () => {
+    assert.equal(isDestructiveOnlySource(NORMAL_SPEC), false);
+  });
+
+  it("is false when the file declares no tag array", () => {
+    // Untagged is against the repo rule, but running the normal lane is the
+    // outcome that cannot lose coverage.
+    assert.equal(isDestructiveOnlySource("test('untagged', async () => {});"), false);
+  });
+
+  it("reads the tag from a tag array, never from a comment", () => {
+    const commented = `
+      // @destructive would be wrong here — this suite is safe to run in parallel.
+      test("safe", { tag: ["@stable", "@api"] }, async () => {});
+    `;
+    assert.equal(isDestructiveOnlySource(commented), false);
+  });
+
+  it("matches a multi-line tag array", () => {
+    const multiline = `
+      test(
+        "blocks a component",
+        {
+          tag: [
+            "@destructive",
+            "@api",
+          ],
+        },
+        async () => {},
+      );
+    `;
+    assert.equal(isDestructiveOnlySource(multiline), true);
+  });
+});
+
+describe("classifySelection", () => {
+  it("reports destructiveOnly when no selected spec can run in the normal lane", () => {
+    const verdict = classifySelection(
+      ["a.spec.ts", "b.spec.ts"],
+      sources({ "a.spec.ts": DESTRUCTIVE_SPEC, "b.spec.ts": DESTRUCTIVE_SPEC }),
+    );
+    assert.equal(verdict.destructiveOnly, true);
+    assert.deepEqual(verdict.runnable, []);
+    assert.equal(verdict.destructive.length, 2);
+  });
+
+  it("one runnable spec is enough to keep the normal lane", () => {
+    const verdict = classifySelection(
+      ["a.spec.ts", "b.spec.ts"],
+      sources({ "a.spec.ts": DESTRUCTIVE_SPEC, "b.spec.ts": MIXED_SPEC }),
+    );
+    assert.equal(verdict.destructiveOnly, false);
+    assert.deepEqual(verdict.runnable, ["b.spec.ts"]);
+  });
+
+  it("an empty selection is not destructive-only", () => {
+    // `has_specs` already skips the job there; answering true would skip the
+    // normal lane for a reason unrelated to tags.
+    const verdict = classifySelection([], sources({}));
+    assert.equal(verdict.destructiveOnly, false);
+  });
+
+  it("throws on an unreadable spec instead of guessing", () => {
+    assert.throws(
+      () => classifySelection(["gone.spec.ts"], sources({})),
+      /cannot read selected spec "gone.spec.ts".*undecidable/s,
+    );
+  });
+});
+
+describe("against the suite's real specs", () => {
+  it("the governance specs are destructive-only and folder-deletion-integrity is not", () => {
+    const governance =
+      "tests/tests-automations/regression/governance/catalog-policy/component-blocklist-enforcement.spec.ts";
+    const mixed =
+      "tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts";
+
+    // Both files are committed sources, so this pins the classifier against the
+    // two real shapes rather than against fixtures only. A spec that moves makes
+    // this fail loudly, which is the intent.
+    let governanceSource;
+    try {
+      governanceSource = readFileSync(governance, "utf8");
+    } catch {
+      // The governance specs land in a sibling PR (#1494); until it merges this
+      // half is skipped rather than red.
+      governanceSource = null;
+    }
+    if (governanceSource !== null) {
+      assert.equal(isDestructiveOnlySource(governanceSource), true);
+    }
+
+    assert.equal(
+      isDestructiveOnlySource(readFileSync(mixed, "utf8")),
+      false,
+      `${mixed} is expected to carry non-destructive tests — if that changed, the lane's assumptions changed with it`,
+    );
+  });
+});
+
+describe("pr-validation.yml wiring", () => {
+  // Presence checks only. #1226's lesson is that a regex over YAML pins a
+  // spelling, not a behaviour — the behaviour above is what the rest of this
+  // file asserts. These exist because the bug reached the lane by the step
+  // simply not knowing about the destructive lane at all, and a deleted gate
+  // would restore exactly that.
+  const workflow = readFileSync(".github/workflows/pr-validation.yml", "utf8");
+
+  it("detect-specs exports the verdict and the run step is gated on it", () => {
+    assert.match(workflow, /destructive_only: \$\{\{ steps\.diff\.outputs\.destructive_only \}\}/);
+    assert.match(
+      workflow,
+      /if: needs\.detect-specs\.outputs\.destructive_only != 'true'/,
+    );
+  });
+
+  it("the skip is announced, so it cannot read as coverage", () => {
+    assert.match(workflow, /::warning::Every impacted spec is @destructive/);
+  });
+
+  it("the normal run still fails on an empty match it did not predict", () => {
+    // i.e. the fix is the gate, NOT --pass-with-no-tests on the normal run.
+    const normalRun = workflow.slice(
+      workflow.indexOf("- name: Run impacted specs"),
+      workflow.indexOf("# Destructive lane (#1010)"),
+    );
+    assert.ok(normalRun.includes("npx playwright test $SPECS --reporter=github"));
+    assert.ok(!normalRun.includes("--pass-with-no-tests"));
+  });
+});


### PR DESCRIPTION
**Fixes #1495.**

## Problem

`pr-validation.yml` runs the impacted selection twice — normally, then as the
destructive lane. `playwright.config.ts` grep-inverts `@destructive` out of the
first run (#1010), so a selection where **every** spec is destructive makes it
match nothing and exit 1:

```
[lane] @destructive tests are excluded from this run — run them with: PW_DESTRUCTIVE=1 …
Error: No tests found.
##[error]Error: No tests found.
```

…while the destructive step immediately after runs those same specs and reports
`13 passed (10.2s)`. Job verdict `fail`, specs green. Measured on PR #1494, job
[96120118169](https://github.com/oriontech-me/langflow-e2e/actions/runs/32268855928/job/96120118169).

Never fired before because `folder-deletion-integrity.spec.ts` — the suite's only
`@destructive` spec until now — carries three `@stable` tests in the same file, so
any selection containing it always held something the normal lane could run. It is
not specific to #1494: any PR touching only destructive specs hits it.

## Fix

`detect-specs` classifies the run list from the specs' own `tag:` arrays and
exports `destructive_only`; `Run impacted specs` is gated on it and the skip is
announced as a `::warning::`, so a skipped normal lane can never read as coverage
(#1012).

**Rejected: `--pass-with-no-tests` on the normal run.** It fixes the symptom and
takes a real signal with it — a selection pointing at paths that no longer exist
would stop failing here. The whole point is to skip that step *only* in the one
case the workflow can predict.

The verdict lives in `scripts/destructive-only-selection.mjs` rather than inline
shell, for #1226's reason: three wrong figures shipped out of this same YAML while
their only guard was a regex over it. It is conservative in exactly one direction
— no tag array, a `@destructive` written in a comment, or a describe-level tag all
report **runnable**, because skipping the normal lane while it still holds
coverage is the failure that must not happen; the reverse merely reproduces
today's behaviour. An unreadable spec is undecidable and exits 2 (#1216).

## Scope note

Nothing about selection, capping, the provider verdict, the canary path or the
destructive lane itself changes. The normal run's command line is untouched — the
tests assert it still lacks `--pass-with-no-tests`.

## Validation

- `npm run test:scripts` ✅ — 810 → 824 tests, the 14 new ones covering: all-destructive ⇒
  skip, one mixed file ⇒ run, no destructive ⇒ run, untagged ⇒ run, comment-only
  `@destructive` ⇒ run, multi-line `tag:` array, empty selection ⇒ run, unreadable spec ⇒
  throw
- Real shapes pinned: `folder-deletion-integrity.spec.ts` ⇒ `false`; the governance specs
  from #1494 ⇒ `true` (that half self-skips until #1494 merges, so the two PRs can land in
  either order)
- CLI checked by hand: stale path exits **2** naming the file, real mixed spec prints
  `false`
- `pr-validation.yml` parses (`yaml.safe_load`, 7 jobs) ✅
- This PR's own lane is the interesting case: the diff is CI-only, so
  `ci-change-coverage.mjs` should return **canary** and run the 3-spec canary set —
  which exercises the changed step on its non-destructive path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
