### PR TITLE
fix(helpers): assert the auth retry backoff without a clock (#1454)

### DIFF
--- a/tests/helpers/auth/get-auth-token.test.ts
+++ b/tests/helpers/auth/get-auth-token.test.ts
@@ -98,10 +98,42 @@ test("the budget is bounded — it gives up instead of looping forever", async (
 });
 
 test("waits between attempts so a booting worker is not hammered", async () => {
+  // Asserted on what the helper ASKS FOR, not on the clock. The previous shape
+  // slept 50 ms and compared `Date.now()`, which sits exactly on a timer
+  // boundary: Node may fire a `setTimeout(50)` a fraction of a millisecond
+  // before `Date.now()` reports 50 elapsed, so the `>=` failed on a runner whose
+  // granularity landed the wrong way — twice in a row on PR #1496 while green
+  // locally (#1454). Widening the margin would only move the boundary; removing
+  // the clock removes the class.
+  const { request, calls } = fakeRequest([timeout(), timeout(), okResponse("slow")]);
+  const slept: number[] = [];
+  const token = await getAuthToken(request, {
+    retryDelaysMs: [50, 250],
+    sleep: async (ms) => {
+      slept.push(ms);
+    },
+  });
+
+  assert.equal(token, "Bearer slow");
+  assert.equal(calls(), 3);
+  // One wait per retry, in order, with the configured backoff — the property
+  // that keeps a wedged backend from being hammered.
+  assert.deepEqual(slept, [50, 250]);
+});
+
+test("the wait is a real one — the default sleep is awaited, not skipped", async () => {
+  // Guards the injection itself: with `sleep` defaulted away or the `await`
+  // dropped, the test above would still pass while the helper spun. Tolerant by
+  // a wide margin (20 ms asked, 10 ms asserted) because this one does touch the
+  // clock, and its job is to separate "waited" from "did not wait at all" —
+  // never to measure the delay.
   const { request } = fakeRequest([timeout(), okResponse("slow")]);
   const started = Date.now();
-  assert.equal(await getAuthToken(request, { retryDelaysMs: [50] }), "Bearer slow");
-  assert.ok(Date.now() - started >= 50, "expected the helper to wait before retrying");
+  assert.equal(await getAuthToken(request, { retryDelaysMs: [20] }), "Bearer slow");
+  assert.ok(
+    Date.now() - started >= 10,
+    "expected the default backoff to actually suspend the retry loop",
+  );
 });
 
 test("the default budget spans the observed ~1-minute outage", async () => {

--- a/tests/helpers/auth/get-auth-token.ts
+++ b/tests/helpers/auth/get-auth-token.ts
@@ -23,7 +23,24 @@ export const DEFAULT_RETRY_DELAYS_MS = [2000, 8000, 20000];
 export interface GetAuthTokenOptions {
   /** Override the backoff. Tests pass `[]` or short delays; callers should not set it. */
   retryDelaysMs?: number[];
+  /**
+   * Override how the backoff waits. **Unit tests only** — a spec must not pass it.
+   *
+   * The wait is a real `setTimeout`, and the only way to assert it *happened*
+   * from the outside was to sleep and compare `Date.now()` against the delay.
+   * Node may fire a timer a fraction of a millisecond before `Date.now()` shows
+   * the full interval elapsed, so that assertion sat exactly on the boundary and
+   * failed on a runner whose clock granularity landed the wrong way (#1454 —
+   * twice in a row on PR #1496, green locally). Injecting the sleep lets the test
+   * assert what the helper *asked for*, which is the actual contract, with no
+   * clock in the loop.
+   */
+  sleep?: (ms: number) => Promise<void>;
 }
+
+/** The real backoff wait, kept out of the loop so tests can replace it. */
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Retrieves a Langflow authentication token.
@@ -45,7 +62,10 @@ export interface GetAuthTokenOptions {
  */
 export async function getAuthToken(
   request: APIRequestContext,
-  { retryDelaysMs = DEFAULT_RETRY_DELAYS_MS }: GetAuthTokenOptions = {},
+  {
+    retryDelaysMs = DEFAULT_RETRY_DELAYS_MS,
+    sleep = realSleep,
+  }: GetAuthTokenOptions = {},
 ): Promise<string> {
   for (let attempt = 0; ; attempt++) {
     try {
@@ -66,7 +86,7 @@ export async function getAuthToken(
       console.warn(
         `⚠️  auth: /api/v1/auto_login did not answer (${(error as Error)?.message?.split("\n")[0] ?? error}) — retry ${attempt + 1}/${retryDelaysMs.length} in ${delay}ms. The backend is wedged or recycling (see #1077).`,
       );
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await sleep(delay);
     }
   }
 }


### PR DESCRIPTION
**Fixes #1454.**

## Problem

```ts
const started = Date.now();
await getAuthToken(request, { retryDelaysMs: [50] });
assert.ok(Date.now() - started >= 50, "expected the helper to wait before retrying");
```

Node can fire a `setTimeout(50)` a fraction of a millisecond before `Date.now()`
reports 50 elapsed, so this assertion sits exactly on a timer boundary. It is
green locally (20/20 here) and went red **twice in a row** on PR
[#1496](https://github.com/oriontech-me/langflow-e2e/pull/1496)'s runner —
698 of 699 tests passing around it, in a job that gates every PR:

```
not ok 126 - waits between attempts so a booting worker is not hammered
  location: 'tests/helpers/auth/get-auth-token.test.ts:71:22'
  error: 'expected the helper to wait before retrying'
```

It has reddened unrelated branches too (`chore/quarantine-1488`,
`feat/issue-1483` earlier the same day), which is the real cost: a boundary
assertion in the shared unit lane spends other people's re-runs.

## Fix

The backoff wait is now injectable (`sleep`, a unit-test-only option documented
beside `retryDelaysMs`, which already carries the same warning), so the test
asserts **what the helper asks for** — one wait per retry, in order, with the
configured delays — and no clock takes part.

**Rejected: widening the margin** (`>= 45`). It only moves the boundary; the
class of failure survives.

A second test keeps the property the injection could otherwise hide — with the
default sleep, the retry loop really does suspend. It is deliberately tolerant
(20 ms configured, 10 ms asserted): its job is to separate "waited" from "did not
wait at all", never to measure the delay.

## Scope note

The retry budget, the rethrow-the-original-error contract, the non-ok
no-retry rule and `DEFAULT_RETRY_DELAYS_MS` are all unchanged. Production callers
pass no `sleep` and take the same `setTimeout` path as before.

## Validation

- **Force-fail** ✅ — dropping the `await` on the backoff reddens the end-to-end
  test (`fail 1`); replacing the configured delay with `0` reddens both (`fail 2`);
  reverted ⇒ `pass 10 / fail 0`
- **20 consecutive runs** of the file, zero failures ✅
- `npm run test:units` 700 passing ✅ · `npm run typecheck` ✅ · `npm run lint`
  0 errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
