### PR TITLE
test(enterprise): a deployment-declared catalog policy must be authoritative

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -230,6 +230,8 @@ jobs:
       # True when EVERY selected spec is `@destructive`, so the normal run below
       # would match nothing and exit 1 while the destructive lane runs them fine.
       destructive_only: ${{ steps.diff.outputs.destructive_only }}
+      excluded_only: ${{ steps.diff.outputs.excluded_only }}
+      enterprise_specs: ${{ steps.diff.outputs.enterprise_specs }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -442,13 +444,25 @@ jobs:
           # Logic and its conservative defaults live in the script, covered by
           # `npm run test:scripts`; a verdict it cannot produce exits 2 and fails this
           # step rather than guessing (#1216).
+          EXCLUDED_ONLY=false
           DESTRUCTIVE_ONLY=false
+          ENTERPRISE_SPECS=""
           if [ "$HAS_SPECS" = "true" ]; then
-            DESTRUCTIVE_ONLY=$(node scripts/destructive-only-selection.mjs --specs "$SPECS") \
-              || { echo "::error::destructive-only classification failed — a spec in the selection could not be read"; exit 1; }
+            VERDICT=$(node scripts/destructive-only-selection.mjs --specs "$SPECS" --format=json) \
+              || { echo "::error::lane classification failed — a spec in the selection could not be read"; exit 1; }
+            EXCLUDED_ONLY=$(printf '%s' "$VERDICT" | python3 -c 'import json,sys; print(str(json.load(sys.stdin)["excludedOnly"]).lower())')
+            DESTRUCTIVE_ONLY=$(printf '%s' "$VERDICT" | python3 -c 'import json,sys; print(str(json.load(sys.stdin)["destructiveOnly"]).lower())')
+            ENTERPRISE_SPECS=$(printf '%s' "$VERDICT" | python3 -c 'import json,sys; print(" ".join(json.load(sys.stdin)["enterprise"]))')
           fi
           if [ "$DESTRUCTIVE_ONLY" = "true" ]; then
             echo "::warning::Every impacted spec is @destructive, so the normal lane is skipped for this PR — the destructive lane below is what runs them (workers=1). Read its result, not the normal run's absence (#1010)."
+          fi
+          # `@enterprise` shares the symptom and not the remedy: those specs need a
+          # Langflow Enterprise instance this runner does not have, so no step here
+          # runs them. Saying so is the whole point — a skipped normal lane plus
+          # silence reads as coverage (#1012).
+          if [ -n "$ENTERPRISE_SPECS" ]; then
+            echo "::warning::@enterprise specs in this PR are NOT executed by CI (no Enterprise instance on the runner): $ENTERPRISE_SPECS — run them locally with PW_ENTERPRISE=1 against one, and record the result in the PR."
           fi
 
           {
@@ -457,6 +471,8 @@ jobs:
             echo "needs_models=$NEEDS_MODELS"
             echo "canary=$CANARY"
             echo "destructive_only=$DESTRUCTIVE_ONLY"
+            echo "excluded_only=$EXCLUDED_ONLY"
+            echo "enterprise_specs=$ENTERPRISE_SPECS"
           } >> "$GITHUB_OUTPUT"
 
   e2e:
@@ -895,7 +911,7 @@ jobs:
         # runs those very specs. The verdict comes from `detect-specs` (tag-based,
         # conservative: any ambiguity keeps this step), and the skip is announced
         # there as a `::warning::` so it can never read as coverage (#1012).
-        if: needs.detect-specs.outputs.destructive_only != 'true'
+        if: needs.detect-specs.outputs.excluded_only != 'true'
         env:
           CI: "true"
           # When "Collect models" is skipped (needs_models == false) the provider

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -1051,6 +1051,30 @@
 - [-] An accepted rollback **appends** rather than rewinds — new higher revision, `source: "rollback"`, `rollback_of_revision` pointing at the target, `reason` echoed — and the restored content is enforced, not just recorded → `governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.spec.ts`
 - [ ] `GET /api/v1/catalog-policy/usage` and `usage/flows` report the blast radius of a block (which flows use the component) before an operator applies it
 
+## enterprise/ — Environment-Declared Policy (EE)
+
+> **New area (2026-08-19).** The remainder § 21 names as Enterprise-owned: a
+> policy the **operator** declares in the deployment, which EE reads at boot
+> through `EnvironmentCatalogPolicyService`. OSS has no setting for it — an OSS
+> instance started with `LANGFLOW_CATALOG_COMPONENT_BLOCKLIST` reports
+> `source: "migration"` with nothing blocked — so this cannot live in § 21.
+>
+> Runs only in the `@enterprise` lane, against an instance started by
+> `scripts/start-langflow-enterprise.sh`. Enforcement itself is **not** re-tested
+> here; § 21 proves it. What is tested is **authority**: whether a runtime write
+> can undo what the deployment declared.
+>
+> **No `@stable`** while no scheduled Enterprise lane exists (#1010).
+>
+> Spec docs: `docs/enterprise/`.
+
+#### 22.1 Environment-Declared Policy
+
+- [!] A policy whose source is the deployment is reported as externally managed, and a runtime write can neither clear it nor survive into the palette — **expected red on current Enterprise builds**, tracked outside this repo; needs a fresh container per run → `enterprise/governance/environment-policy-authority.spec.ts`
+- [ ] The same authority question for the other three knobs: template blocklist, provider allowlist, model blocklist
+- [ ] `enterprise-admin/catalog/components` reflects the operator-declared policy
+- [ ] Readiness stays unhealthy rather than serving permissively when the declared policy cannot be loaded (fail-closed)
+
 ---
 
 ---

--- a/docs/enterprise/governance/environment-policy-authority.md
+++ b/docs/enterprise/governance/environment-policy-authority.md
@@ -1,0 +1,86 @@
+# Enterprise — Environment-Declared Policy Is Authoritative
+
+**Last validated:** Langflow Enterprise 1.12.0 (image built from `IBM-Langflow@release-1.12.0`)
+
+---
+
+## Relationship to `governance/catalog-policy/`
+
+`regression/governance/catalog-policy/` covers the surface Langflow 1.12 ships in
+**OSS**: write a blocklist through the admin API, and the component leaves the
+palette while the write path refuses it. That is enforcement, and it is proven
+there.
+
+This spec covers what that API cannot reach and OSS has no setting for — a policy
+the **operator** declared in the deployment, which EE reads at boot. The OSS
+checklist section names exactly this as the Enterprise remainder.
+
+## What this test validates *(required)*
+
+When policy comes from the **deployment** — the four governance knobs an operator
+sets in the Helm chart, the Operator CR or the container environment — a runtime
+admin API call must not be able to undo it.
+
+That is the whole premise of catalog governance in EE. The policy exists so that
+whoever runs the platform can constrain what its users may place and execute; a
+policy any authenticated administrator can clear at runtime constrains nobody,
+and it fails silently, because the container still advertises the blocklist in
+its environment while the running instance no longer enforces it.
+
+The spec asserts the invariant in three parts, which is what makes a failure
+diagnosable rather than merely red:
+
+1. **Provenance is reported.** `GET /api/v1/policy-bundle` says `source:
+   "environment"`, and the per-resource read (`GET /api/v1/catalog-policy/components`)
+   agrees by reporting `managed_externally: true`. Clients gate the "read-only,
+   managed by your operator" state on that field.
+2. **The write is refused.** `PUT /api/v1/catalog-policy/components` does not
+   succeed while the policy is externally owned.
+3. **Enforcement survives the attempt.** Whatever the API answered, the blocked
+   component is still absent from `GET /api/v1/all` afterwards. This is the
+   assertion that matters: a refusal that leaves the policy cleared anyway would
+   satisfy (2) and still be a governance escape.
+
+> **Known state.** This spec is **expected to fail** on current Enterprise
+> builds. The failure is a product finding, tracked outside this repository; it
+> is not a defect in the spec, and the assertions must not be relaxed to make the
+> lane green.
+>
+> It also needs a **fresh container** per run: the assertions read the policy's
+> declared source, and a previous run's write changes it — a stale instance fails
+> the spec for a different reason than the one it exists for.
+
+## Tags *(required)*
+
+`@enterprise` `@api` `@regression` `@governance`
+
+Reuses `@governance` rather than adding an Enterprise-only functional tag: it is
+the same product area as `governance/catalog-policy/`, and the `@enterprise`
+lane already separates the editions.
+
+## Step by step *(required)*
+
+1. Authenticate with password login.
+2. Require the instance to block `CombineText` — skip, naming the start command,
+   otherwise.
+3. `GET /api/v1/policy-bundle` → `source` is `environment` and
+   `blocked_component_keys` contains `CombineText`.
+4. `GET /api/v1/catalog-policy/components` → `managed_externally` is `true`.
+5. Attempt `PUT /api/v1/catalog-policy/components` with an empty blocked set →
+   the response is **not** a success status.
+6. `GET /api/v1/all` → `CombineText` is still absent.
+7. Restore: if step 5 did succeed, write the environment's blocked set back, so a
+   failing run does not leave the instance in a state that makes the sibling
+   specs report a second, derived failure.
+
+## Validation criterion *(required)*
+
+Fails when deployment-declared policy can be observed, overridden or defeated at
+runtime: a policy whose source is the environment reported as locally managed, an
+accepted write, or a component that reappears in the palette after the attempt.
+
+## External dependencies *(required)*
+
+- A Langflow **Enterprise** instance started with the component blocked:
+  `LANGFLOW_CATALOG_COMPONENT_BLOCKLIST=CombineText ./scripts/start-langflow-enterprise.sh`
+- No LLM provider and no network egress.

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -49,6 +49,7 @@ const MODULES: ModuleConfig[] = [
   { label: "`i18n/` — Language and Localization",            sectionStart: "## i18n/" },
   { label: "`memory/` — Memory Base Registration",           sectionStart: "## memory/" },
   { label: "`governance/` — Catalog and Provider Policy",    sectionStart: "## governance/" },
+  { label: "`enterprise/` — Environment-Declared Policy",    sectionStart: "## enterprise/" },
 ];
 
 const PART_II_HEADER = "# PART II — TEST AUTOMATION COVERAGE";

--- a/scripts/destructive-only-selection.mjs
+++ b/scripts/destructive-only-selection.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 /**
  * Decides whether an impacted-spec selection contains ANYTHING the normal PR
- * lane can run — i.e. whether every selected spec is `@destructive`.
+ * lane can run — i.e. whether every selected spec carries a LANE SELECTOR that
+ * `playwright.config.ts` grep-inverts out of a normal run: `@destructive`, or
+ * `@enterprise` since #1483.
  *
  * Why this exists. `playwright.config.ts` `grepInvert`s `/@destructive/` out of
  * every normal run (#1010), and `pr-validation.yml` runs the impacted set twice:
@@ -16,6 +18,12 @@
  * (`core-functionality/project-management/folder-deletion-integrity.spec.ts`)
  * carries non-destructive tests in the same file, so the selection always held
  * something the normal lane could run.
+ *
+ * The two selectors share the symptom and differ in the remedy, so the verdict
+ * reports them separately. A destructive-only selection IS executed — by the
+ * `PW_DESTRUCTIVE=1` step that follows. An enterprise-only selection is executed
+ * by nobody: those specs need a Langflow Enterprise instance the runner does not
+ * have, so skipping the normal lane is right and calling the PR covered is not.
  *
  * The fix is NOT a blanket `--pass-with-no-tests` on the normal run: that would
  * also swallow a selection of paths that no longer exist, which is a real defect
@@ -49,6 +57,16 @@ import { readFileSync } from "node:fs";
  */
 const TAG_ARRAY_RE = /tag:\s*\[[^\]]*\]/g;
 const DESTRUCTIVE = "@destructive";
+/**
+ * The second lane selector (#1483). `@enterprise` is grep-inverted out of the
+ * normal run for the same reason `@destructive` is, so it produces the same
+ * "No tests found" red — but the two are NOT interchangeable downstream: the
+ * workflow runs the destructive specs in a following step, while an Enterprise
+ * spec needs an instance this runner does not have and is therefore executed by
+ * NOBODY. Skipping the normal lane for it is still correct; reporting it as
+ * covered would not be, which is why the two lists stay separate.
+ */
+const ENTERPRISE = "@enterprise";
 
 /**
  * True when this source declares at least one tag array and EVERY one of them
@@ -65,9 +83,18 @@ const DESTRUCTIVE = "@destructive";
  * does today. That direction is safe; the reverse would not be.
  */
 export function isDestructiveOnlySource(source) {
+  return everyTagArrayCarries(source, DESTRUCTIVE);
+}
+
+/** The `@enterprise` counterpart — same rule, same conservative defaults. */
+export function isEnterpriseOnlySource(source) {
+  return everyTagArrayCarries(source, ENTERPRISE);
+}
+
+function everyTagArrayCarries(source, tag) {
   const arrays = source.match(TAG_ARRAY_RE);
   if (!arrays || arrays.length === 0) return false;
-  return arrays.every((array) => array.includes(DESTRUCTIVE));
+  return arrays.every((array) => array.includes(tag));
 }
 
 /**
@@ -76,10 +103,11 @@ export function isDestructiveOnlySource(source) {
  * @param specs     spec paths, as the workflow's `$SPECS` splits them
  * @param readSpec  reads a spec's source; throws when it cannot (injected so the
  *                  unit tests never touch the filesystem)
- * @returns `{ destructiveOnly, destructive, runnable }`
+ * @returns `{ destructiveOnly, excludedOnly, destructive, enterprise, runnable }`
  */
 export function classifySelection(specs, readSpec) {
   const destructive = [];
+  const enterprise = [];
   const runnable = [];
 
   for (const spec of specs) {
@@ -92,6 +120,7 @@ export function classifySelection(specs, readSpec) {
       );
     }
     if (isDestructiveOnlySource(source)) destructive.push(spec);
+    else if (isEnterpriseOnlySource(source)) enterprise.push(spec);
     else runnable.push(spec);
   }
 
@@ -99,8 +128,13 @@ export function classifySelection(specs, readSpec) {
     // An EMPTY selection is not destructive-only. The job's own `has_specs`
     // gate already skips the E2E job in that case, and answering `true` here
     // would skip the normal lane for a reason that has nothing to do with tags.
-    destructiveOnly: specs.length > 0 && runnable.length === 0,
+    // Kept as it was: "the destructive step covers everything selected".
+    destructiveOnly: specs.length > 0 && runnable.length === 0 && enterprise.length === 0,
+    // The gate the normal run gets skipped on — true whenever NOTHING selected
+    // can run there, whichever lane took it.
+    excludedOnly: specs.length > 0 && runnable.length === 0,
     destructive,
+    enterprise,
     runnable,
   };
 }
@@ -134,7 +168,7 @@ function main() {
   if (format === "json") {
     process.stdout.write(`${JSON.stringify(verdict)}\n`);
   } else {
-    process.stdout.write(`${verdict.destructiveOnly}\n`);
+    process.stdout.write(`${verdict.excludedOnly}\n`);
   }
 }
 

--- a/scripts/destructive-only-selection.test.mjs
+++ b/scripts/destructive-only-selection.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
   classifySelection,
   isDestructiveOnlySource,
+  isEnterpriseOnlySource,
 } from "./destructive-only-selection.mjs";
 
 const DESTRUCTIVE_SPEC = `
@@ -14,6 +15,10 @@ const DESTRUCTIVE_SPEC = `
 const MIXED_SPEC = `
   test("lists folders", { tag: ["@stable", "@api"] }, async () => {});
   test("deletes every project", { tag: ["@destructive", "@release", "@api"] }, async () => {});
+`;
+
+const ENTERPRISE_SPEC = `
+  test("the deployment's policy is authoritative", { tag: ["@enterprise", "@api", "@governance"] }, async () => {});
 `;
 
 const NORMAL_SPEC = `
@@ -147,14 +152,27 @@ describe("pr-validation.yml wiring", () => {
 
   it("detect-specs exports the verdict and the run step is gated on it", () => {
     assert.match(workflow, /destructive_only: \$\{\{ steps\.diff\.outputs\.destructive_only \}\}/);
+    assert.match(workflow, /excluded_only: \$\{\{ steps\.diff\.outputs\.excluded_only \}\}/);
+    // The gate is `excluded_only`, NOT `destructive_only` (#1483). Gating on the
+    // latter would leave the normal run selecting nothing whenever the selection
+    // is enterprise-only, which is the red this whole mechanism exists to avoid.
     assert.match(
       workflow,
+      /if: needs\.detect-specs\.outputs\.excluded_only != 'true'/,
+    );
+    assert.doesNotMatch(
+      workflow,
       /if: needs\.detect-specs\.outputs\.destructive_only != 'true'/,
+      "the run step must gate on excluded_only, which covers both lane selectors",
     );
   });
 
   it("the skip is announced, so it cannot read as coverage", () => {
     assert.match(workflow, /::warning::Every impacted spec is @destructive/);
+    // The enterprise case needs its OWN line: no step in this workflow runs
+    // those specs, so the destructive wording would claim a coverage that does
+    // not exist.
+    assert.match(workflow, /::warning::@enterprise specs in this PR are NOT executed by CI/);
   });
 
   it("the normal run still fails on an empty match it did not predict", () => {
@@ -165,5 +183,51 @@ describe("pr-validation.yml wiring", () => {
     );
     assert.ok(normalRun.includes("npx playwright test $SPECS --reporter=github"));
     assert.ok(!normalRun.includes("--pass-with-no-tests"));
+  });
+});
+
+describe("the @enterprise lane (#1483)", () => {
+  it("is excluded from the normal run, exactly like @destructive", () => {
+    assert.equal(isEnterpriseOnlySource(ENTERPRISE_SPEC), true);
+    assert.equal(isEnterpriseOnlySource(NORMAL_SPEC), false);
+    // The two selectors must not be conflated by the per-source predicates.
+    assert.equal(isDestructiveOnlySource(ENTERPRISE_SPEC), false);
+    assert.equal(isEnterpriseOnlySource(DESTRUCTIVE_SPEC), false);
+  });
+
+  it("skips the normal lane but is NOT reported as destructive-only", () => {
+    // The distinction that matters: a destructive-only selection is executed by
+    // the step that follows, an enterprise-only one is executed by nobody. A
+    // `destructive_only=true` here would announce coverage that never happened.
+    const verdict = classifySelection(
+      ["ee.spec.ts"],
+      sources({ "ee.spec.ts": ENTERPRISE_SPEC }),
+    );
+    assert.equal(verdict.excludedOnly, true, "the normal run would match nothing");
+    assert.equal(verdict.destructiveOnly, false, "nothing runs these — do not claim the destructive step does");
+    assert.deepEqual(verdict.enterprise, ["ee.spec.ts"]);
+    assert.deepEqual(verdict.runnable, []);
+  });
+
+  it("a mixed destructive + enterprise selection is not destructive-only either", () => {
+    const verdict = classifySelection(
+      ["d.spec.ts", "ee.spec.ts"],
+      sources({ "d.spec.ts": DESTRUCTIVE_SPEC, "ee.spec.ts": ENTERPRISE_SPEC }),
+    );
+    assert.equal(verdict.excludedOnly, true);
+    assert.equal(
+      verdict.destructiveOnly,
+      false,
+      "the destructive step covers d.spec.ts and not ee.spec.ts, so the pair is not covered",
+    );
+  });
+
+  it("one runnable spec keeps the normal lane running", () => {
+    const verdict = classifySelection(
+      ["ee.spec.ts", "n.spec.ts"],
+      sources({ "ee.spec.ts": ENTERPRISE_SPEC, "n.spec.ts": NORMAL_SPEC }),
+    );
+    assert.equal(verdict.excludedOnly, false);
+    assert.deepEqual(verdict.runnable, ["n.spec.ts"]);
   });
 });

--- a/scripts/start-langflow-enterprise.sh
+++ b/scripts/start-langflow-enterprise.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Start a local Langflow Enterprise (EE) instance for the @enterprise lane.
+#
+# Mirrors scripts/start-langflow-docker.sh, with three deliberate differences:
+#
+#   1. It BUILDS instead of pulling. The EE image lives in an IBM private
+#      registry we cannot pull from, so the only reachable image is one built
+#      from a local clone of the EE repository.
+#   2. It runs password-first (LANGFLOW_AUTO_LOGIN=false). That is the EE
+#      image default, baked into its Dockerfile — overriding it would test a
+#      configuration the product never ships.
+#   3. It parameterises the four governance knobs. EE owns catalog and model
+#      provider policy through the environment (EnvironmentCatalogPolicyService),
+#      so a policy state is a CONTAINER, not an API call: the admin write APIs
+#      answer "managed externally" here.
+#
+# Usage:
+#   ./scripts/start-langflow-enterprise.sh                    # build if needed, then run
+#   ./scripts/start-langflow-enterprise.sh --rebuild          # force a rebuild
+#   LANGFLOW_CATALOG_COMPONENT_BLOCKLIST=CombineText ./scripts/start-langflow-enterprise.sh
+set -euo pipefail
+
+EE_REPO="${LANGFLOW_EE_REPO:-$HOME/langflow-project/IBM-Langflow}"
+IMAGE="${LANGFLOW_EE_IMAGE:-langflow-enterprise:local}"
+CONTAINER_NAME="${LANGFLOW_EE_CONTAINER:-langflow-ee-runner}"
+# 7860/7861 belong to the OSS runner and 7870 is often taken by a parallel
+# session; the EE lane gets its own port so both can run side by side.
+PORT="${LANGFLOW_EE_PORT:-7890}"
+# Stable base64 key: a rotating one invalidates stored credentials between
+# restarts, which surfaces as a generic 400 on API key creation.
+SECRET_KEY="${LANGFLOW_SECRET_KEY:-ZTJlLWVudGVycHJpc2UtbG9jYWwtc2VjcmV0LWtleS0wMDE=}"
+# Two passwords, because EE uses two. BOOTSTRAP_PASSWORD is what the container
+# is seeded with; EE_PASSWORD is what the suite logs in with after the forced
+# rotation below. The EE minimum is 8 characters.
+BOOTSTRAP_PASSWORD="${LANGFLOW_SUPERUSER_PASSWORD:-langflow123}"
+EE_PASSWORD="${LANGFLOW_EE_PASSWORD:-Langflow123!}"
+
+if [ "${1:-}" = "--rebuild" ]; then
+  REBUILD=1
+else
+  REBUILD=0
+fi
+
+if [ ! -d "${EE_REPO}" ]; then
+  echo "ERROR: EE repo not found at ${EE_REPO}" >&2
+  echo "Clone the Langflow Enterprise repository there, or set LANGFLOW_EE_REPO." >&2
+  exit 2
+fi
+
+if [ "${REBUILD}" = "1" ] || ! docker image inspect "${IMAGE}" > /dev/null 2>&1; then
+  echo "Building ${IMAGE} from ${EE_REPO} (this takes ~20 min on a cold cache)..."
+  DOCKER_BUILDKIT=1 docker build -t "${IMAGE}" "${EE_REPO}"
+fi
+
+docker rm -f "${CONTAINER_NAME}" > /dev/null 2>&1 || true
+
+echo "Starting Langflow Enterprise: ${IMAGE} on port ${PORT}..."
+
+# LANGFLOW_ACCESS_SECURE / _REFRESH_SECURE default to true in the EE image. Over
+# plain HTTP on localhost a Secure cookie is never stored, so login succeeds and
+# every subsequent request is anonymous — the session dies silently.
+#
+# LANGFLOW_PUBLIC_URL is mandatory: the shipped Compose file declares it with
+# `:?`, and the backend uses it as the canonical browser-visible origin.
+docker run -d \
+  --name "${CONTAINER_NAME}" \
+  -p "${PORT}:7860" \
+  -e LANGFLOW_AUTO_LOGIN=false \
+  -e LANGFLOW_SSO_ENABLED=true \
+  -e LANGFLOW_NEW_USER_IS_ACTIVE=true \
+  -e LANGFLOW_SUPERUSER="${LANGFLOW_SUPERUSER:-langflow}" \
+  -e LANGFLOW_SUPERUSER_PASSWORD="${LANGFLOW_SUPERUSER_PASSWORD:-langflow123}" \
+  -e LANGFLOW_SECRET_KEY="${SECRET_KEY}" \
+  -e LANGFLOW_PUBLIC_URL="http://localhost:${PORT}" \
+  -e LANGFLOW_ACCESS_SECURE=false \
+  -e LANGFLOW_REFRESH_SECURE=false \
+  -e LANGFLOW_DEACTIVATE_TRACING=true \
+  -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS="${LANGFLOW_ALLOW_CUSTOM_COMPONENTS:-true}" \
+  -e LANGFLOW_WORKERS="${LANGFLOW_WORKERS:-1}" \
+  -e LANGFLOW_MODEL_PROVIDER_ALLOWLIST="${LANGFLOW_MODEL_PROVIDER_ALLOWLIST:-}" \
+  -e LANGFLOW_CATALOG_COMPONENT_BLOCKLIST="${LANGFLOW_CATALOG_COMPONENT_BLOCKLIST:-}" \
+  -e LANGFLOW_CATALOG_TEMPLATE_BLOCKLIST="${LANGFLOW_CATALOG_TEMPLATE_BLOCKLIST:-}" \
+  -e LANGFLOW_MODEL_BLOCKLIST="${LANGFLOW_MODEL_BLOCKLIST:-}" \
+  "${IMAGE}" > /dev/null
+
+echo "Waiting for Langflow Enterprise to become healthy..."
+for _ in $(seq 1 60); do
+  if curl -sf "http://localhost:${PORT}/health_check" > /dev/null 2>&1; then
+    echo "Langflow Enterprise is up at http://localhost:${PORT}"
+    curl -sf "http://localhost:${PORT}/api/v1/version" 2>/dev/null || true
+    echo
+    # EE forces a password change for the env-bootstrapped superuser
+    # (sso_auth_service.py, reason="bootstrap_superuser"): every authenticated
+    # endpoint answers 403 must_change_password until it is done. Doing it here
+    # keeps the instance usable by the suite the moment this script returns.
+    if ! curl -sf -X POST "http://localhost:${PORT}/api/v1/login" \
+         -H 'Content-Type: application/x-www-form-urlencoded' \
+         -d "username=${LANGFLOW_SUPERUSER:-langflow}&password=${EE_PASSWORD}" > /dev/null 2>&1; then
+      BOOTSTRAP_TOKEN="$(curl -sf -X POST "http://localhost:${PORT}/api/v1/login" \
+        -H 'Content-Type: application/x-www-form-urlencoded' \
+        -d "username=${LANGFLOW_SUPERUSER:-langflow}&password=${BOOTSTRAP_PASSWORD}" \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))')"
+      if [ -n "${BOOTSTRAP_TOKEN}" ]; then
+        curl -sf -X POST "http://localhost:${PORT}/api/v1/account/force-password-change" \
+          -H "Authorization: Bearer ${BOOTSTRAP_TOKEN}" \
+          -H 'Content-Type: application/json' \
+          -d "{\"current_password\":\"${BOOTSTRAP_PASSWORD}\",\"new_password\":\"${EE_PASSWORD}\"}" \
+          > /dev/null && echo "Superuser password rotated to the EE lane password."
+      fi
+    fi
+
+    echo "Sign in with ${LANGFLOW_SUPERUSER:-langflow} / ${EE_PASSWORD}"
+    echo "Policy in force:"
+    echo "  components blocked : ${LANGFLOW_CATALOG_COMPONENT_BLOCKLIST:-<none>}"
+    echo "  templates blocked  : ${LANGFLOW_CATALOG_TEMPLATE_BLOCKLIST:-<none>}"
+    echo "  providers approved : ${LANGFLOW_MODEL_PROVIDER_ALLOWLIST:-<all>}"
+    echo "  models blocked     : ${LANGFLOW_MODEL_BLOCKLIST:-<none>}"
+    exit 0
+  fi
+  sleep 5
+done
+
+echo "ERROR: Langflow Enterprise did not become healthy in 300s." >&2
+docker logs --tail 40 "${CONTAINER_NAME}" >&2 || true
+exit 1

--- a/tests/helpers/enterprise/enterprise-auth.ts
+++ b/tests/helpers/enterprise/enterprise-auth.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * Authentication for the `@enterprise` lane.
+ *
+ * The OSS runner boots with `LANGFLOW_AUTO_LOGIN=true`, so the rest of the suite
+ * gets a token from `/api/v1/auto_login` (`tests/helpers/auth/get-auth-token.ts`).
+ * The EE image cannot: `LANGFLOW_AUTO_LOGIN=false` is baked into its Dockerfile,
+ * and that endpoint answers 400 there. Password login is the only path.
+ *
+ * The second EE-only wrinkle is the forced rotation. EE marks the
+ * env-bootstrapped superuser `must_change_password` (`sso_auth_service.py`,
+ * reason `bootstrap_superuser`), and until it is done EVERY authenticated
+ * endpoint answers 403 `{"detail":"must_change_password"}` — including the ones
+ * these specs assert on. `scripts/start-langflow-enterprise.sh` performs the
+ * rotation right after the health check, so a lane started through the script is
+ * ready; a hand-started container is not, and that must read as a setup problem
+ * rather than as a policy failure, which is why this throws naming the fix.
+ */
+export const EE_USERNAME = process.env.LANGFLOW_SUPERUSER || "langflow";
+export const EE_PASSWORD = process.env.LANGFLOW_EE_PASSWORD || "Langflow123!";
+
+/**
+ * One login per worker process, cached.
+ *
+ * EE rate-limits `/api/v1/login` (429 with `retry_after: 60`). Measured on the
+ * first run of this lane: eight tests logging in independently across parallel
+ * workers exhausted the budget, five of them failed on 429, and the failures
+ * read as an authentication problem rather than as what they were — the suite
+ * hammering a limiter the OSS runner does not have, because `auto_login` needs
+ * no credentials at all.
+ *
+ * Caching the promise (not the token) means concurrent tests in one worker share
+ * a single in-flight request instead of racing to make several.
+ */
+let cachedToken: Promise<string> | undefined;
+
+/**
+ * Cross-PROCESS cache, on top of the per-worker one.
+ *
+ * The budget is 5 logins per minute for the whole machine, and a local session
+ * re-runs the lane far more often than once a minute — a failing spec, a fix, a
+ * re-run. Without this, the second run of the minute reports 429 instead of the
+ * assertion it was re-run to check, and the third reports it again. The file
+ * holds a token, not a credential, in the OS temp dir; it is keyed by base URL
+ * so two instances never share one, and it is only reused while the JWT's own
+ * `exp` still has a minute of life.
+ */
+const TOKEN_CACHE_DIR = join(tmpdir(), "langflow-e2e-enterprise");
+
+function tokenCachePath(): string {
+  const baseUrl = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:7890";
+  const key = createHash("sha256").update(`${baseUrl}|${EE_USERNAME}`).digest("hex").slice(0, 16);
+  return join(TOKEN_CACHE_DIR, `token-${key}.json`);
+}
+
+/** Seconds-since-epoch expiry of a JWT, or 0 when it cannot be read. */
+function tokenExpiry(token: string): number {
+  try {
+    const payload = token.split(".")[1];
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf-8"));
+    return typeof decoded.exp === "number" ? decoded.exp : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function readCachedToken(): string | undefined {
+  try {
+    const raw = readFileSync(tokenCachePath(), "utf-8");
+    const token = (JSON.parse(raw) as { token?: string }).token;
+    if (!token) return undefined;
+    return tokenExpiry(token) > Date.now() / 1000 + 60 ? token : undefined;
+  } catch {
+    // A missing or unreadable cache is a cold start, never a failure.
+    return undefined;
+  }
+}
+
+function writeCachedToken(token: string): void {
+  try {
+    if (!existsSync(TOKEN_CACHE_DIR)) mkdirSync(TOKEN_CACHE_DIR, { recursive: true });
+    writeFileSync(tokenCachePath(), JSON.stringify({ token }), { mode: 0o600 });
+  } catch {
+    // Best effort: failing to cache costs a login, not a run.
+  }
+}
+
+export async function getEnterpriseAuthToken(request: APIRequestContext): Promise<string> {
+  cachedToken ??= loginOnce(request);
+  try {
+    return await cachedToken;
+  } catch (error) {
+    // A failed login must not poison the worker for the rest of the run.
+    cachedToken = undefined;
+    throw error;
+  }
+}
+
+/**
+ * A cached token can be unexpired and still dead: the lane restarts the
+ * container between policy scenarios, and EE stamps the user's password version
+ * into the JWT (`lf_pwdv`), so a fresh database rejects yesterday's token.
+ * Reusing it blindly would turn every assertion into a 403 that looks like a
+ * permission finding. One cheap authenticated call settles it without spending
+ * any of the 5-per-minute login budget.
+ */
+async function tokenStillValid(request: APIRequestContext, token: string): Promise<boolean> {
+  try {
+    const response = await request.get("/api/v1/users/whoami", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.ok();
+  } catch {
+    return false;
+  }
+}
+
+async function loginOnce(request: APIRequestContext): Promise<string> {
+  const cached = readCachedToken();
+  if (cached && (await tokenStillValid(request, cached))) {
+    return `Bearer ${cached}`;
+  }
+
+  const response = await request.post("/api/v1/login", {
+    form: { username: EE_USERNAME, password: EE_PASSWORD },
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    const hint =
+      response.status() === 429
+        ? "EE rate-limits login; this lane logs in once per worker, so a 429 means another " +
+          "process is authenticating against the same instance. Re-run with --workers=1."
+        : "Start the instance with ./scripts/start-langflow-enterprise.sh — it performs the " +
+          "forced password rotation EE requires, and prints the credentials it leaves behind.";
+    throw new Error(
+      `Enterprise login failed for '${EE_USERNAME}' (${response.status()}): ${body.slice(0, 200)}\n${hint}`,
+    );
+  }
+
+  const body = (await response.json()) as { access_token?: string };
+  if (!body.access_token) {
+    throw new Error("Enterprise login returned no access_token");
+  }
+  writeCachedToken(body.access_token);
+  return `Bearer ${body.access_token}`;
+}

--- a/tests/helpers/enterprise/policy-gate.ts
+++ b/tests/helpers/enterprise/policy-gate.ts
@@ -1,0 +1,72 @@
+import { test, type APIRequestContext } from "@playwright/test";
+import {
+  readPolicyBundle,
+  type PolicyBundleResponse,
+} from "../governance/policy-state";
+
+/**
+ * Precondition for the Enterprise environment-policy spec.
+ *
+ * This is the mirror image of `isPolicyPristine()` in the governance helper, and
+ * the asymmetry is the point. An OSS governance spec WRITES the policy it needs,
+ * so it must refuse to run against an instance that already carries one. An
+ * Enterprise spec cannot write anything: `EnvironmentCatalogPolicyService` reads
+ * the governance knobs at boot, so the policy state IS the container, and the
+ * spec can only assert against the one it was started with.
+ *
+ * Hence a gate rather than a setup step — and one that skips naming the exact
+ * command that provides the missing state, because a red describing the
+ * environment instead of the product is the failure mode this lane is most
+ * exposed to.
+ */
+export interface RequiredEnvironmentPolicy {
+  /** Component keys the instance must have been started with. */
+  blockedComponents?: string[];
+  /** Provider ids the instance must approve. */
+  approvedProviders?: string[];
+}
+
+/** The `start-langflow-enterprise.sh` invocation that yields `required`. */
+function startCommandFor(required: RequiredEnvironmentPolicy): string {
+  const env: string[] = [];
+  if (required.blockedComponents?.length) {
+    env.push(`LANGFLOW_CATALOG_COMPONENT_BLOCKLIST=${required.blockedComponents.join(",")}`);
+  }
+  if (required.approvedProviders?.length) {
+    env.push(`LANGFLOW_MODEL_PROVIDER_ALLOWLIST=${required.approvedProviders.join(",")}`);
+  }
+  return `${env.join(" ")} ./scripts/start-langflow-enterprise.sh`.trim();
+}
+
+/**
+ * Skip unless the instance carries `required` **and declared it in the
+ * environment**. Returns the bundle so the caller need not read it twice.
+ *
+ * The source check is not a formality: the same blocked set written through the
+ * admin API would satisfy every other condition here while testing the OSS path
+ * the governance specs already cover.
+ */
+export async function requireEnvironmentPolicy(
+  request: APIRequestContext,
+  auth: string,
+  required: RequiredEnvironmentPolicy,
+): Promise<PolicyBundleResponse> {
+  const bundle = await readPolicyBundle(request, auth);
+
+  const missingComponents = (required.blockedComponents ?? []).filter(
+    (key) => !(bundle.blocked_component_keys ?? []).includes(key),
+  );
+  const missingProviders = (required.approvedProviders ?? []).filter(
+    (id) => !(bundle.approved_provider_ids ?? []).includes(id),
+  );
+
+  test.skip(
+    missingComponents.length > 0 || missingProviders.length > 0,
+    `Instance policy does not satisfy this spec (revision ${bundle.revision}, source '${bundle.source}'): ` +
+      `blocked components [${(bundle.blocked_component_keys ?? []).join(", ") || "none"}], ` +
+      `approved providers [${(bundle.approved_provider_ids ?? []).join(", ") || "all"}]. ` +
+      `Start the instance with: ${startCommandFor(required)}`,
+  );
+
+  return bundle;
+}

--- a/tests/tests-automations/regression/enterprise/governance/environment-policy-authority.spec.ts
+++ b/tests/tests-automations/regression/enterprise/governance/environment-policy-authority.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getEnterpriseAuthToken } from "../../../../helpers/enterprise/enterprise-auth";
+import { requireEnvironmentPolicy } from "../../../../helpers/enterprise/policy-gate";
+import { readCatalogTypes } from "../../../../helpers/governance/policy-state";
+
+/**
+ * The half of catalog governance that Enterprise still owns.
+ *
+ * `governance/catalog-policy/` covers the OSS surface — block a component, it
+ * leaves the palette and the write path refuses it — by writing the policy
+ * through the admin API. This spec covers the case that API cannot reach: a
+ * policy the OPERATOR declared in the deployment, which EE reads at boot and
+ * which OSS has no setting for at all.
+ *
+ * The invariant is authority, not enforcement. Enforcement is already proven by
+ * the OSS specs and holds here too; what must additionally be true is that a
+ * runtime write cannot undo what the deployment declared. A policy any
+ * authenticated administrator can clear constrains nobody, and it fails
+ * silently: the container goes on advertising the blocklist in its environment
+ * while the running instance no longer applies it.
+ *
+ * This spec is EXPECTED TO FAIL on current Enterprise builds. The failure is a
+ * product finding tracked outside this repository, not a defect in the spec —
+ * do not relax the assertions to make the lane green.
+ *
+ * It needs a FRESH container each run: the assertions read the policy's declared
+ * source, and a previous run's write changes it, which fails the spec for a
+ * different reason than the one it exists for.
+ */
+const BLOCKED_COMPONENT = "CombineText";
+
+test.describe("Enterprise — environment-declared policy is authoritative", () => {
+  test(
+    "policy declared by the deployment is reported as externally managed",
+    { tag: ["@enterprise", "@api", "@regression", "@governance"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const bundle = await requireEnvironmentPolicy(request, auth, {
+        blockedComponents: [BLOCKED_COMPONENT],
+      });
+
+      expect(bundle.source).toBe("environment");
+      expect(bundle.blocked_component_keys).toContain(BLOCKED_COMPONENT);
+
+      // The field a client gates the read-only admin state on, read from the
+      // per-resource endpoint an admin screen actually calls.
+      const response = await request.get("/api/v1/catalog-policy/components", {
+        headers: { Authorization: auth },
+      });
+      expect(response.status()).toBe(200);
+      expect((await response.json()).managed_externally).toBe(true);
+    },
+  );
+
+  test(
+    "a runtime write cannot clear a policy the deployment declared",
+    { tag: ["@enterprise", "@api", "@regression", "@governance"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const bundle = await requireEnvironmentPolicy(request, auth, {
+        blockedComponents: [BLOCKED_COMPONENT],
+      });
+
+      const attempt = await request.put("/api/v1/catalog-policy/components", {
+        headers: { Authorization: auth },
+        data: { blocked: [] },
+      });
+
+      try {
+        await test.step("the write is refused", async () => {
+          expect(attempt.ok()).toBe(false);
+        });
+
+        await test.step("enforcement survives the attempt", async () => {
+          // The assertion that matters. A refusal that left the policy cleared
+          // anyway would satisfy the step above and still be an escape.
+          expect(await readCatalogTypes(request, auth)).not.toContain(BLOCKED_COMPONENT);
+        });
+      } finally {
+        // Restore what the deployment declared. Without this a red run leaves
+        // the instance permissive, and anything reading the catalog afterwards
+        // reports a second, derived failure that hides this one.
+        if (attempt.ok()) {
+          await request.put("/api/v1/catalog-policy/components", {
+            headers: { Authorization: auth },
+            data: { blocked: bundle.blocked_component_keys ?? [] },
+          });
+        }
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #1498

## What this adds

One spec under `regression/enterprise/governance/`, covering the item § 21 names as the Enterprise remainder: a policy declared by the **deployment** rather than written through the admin API.

`regression/governance/` already proves *enforcement* — block a component, it leaves the palette and the write path refuses it — and that is edition-independent, so none of it is repeated here. What this asserts is **authority**: that a runtime admin write cannot undo what the operator declared. A policy any authenticated administrator can clear constrains nobody, and it fails quietly, because the container goes on advertising the blocklist in its environment while the running instance no longer applies it.

Three parts, so a failure says which half broke:

1. the bundle attributes the policy to the environment, and the per-resource read agrees by reporting it as externally managed;
2. the write is refused;
3. **enforcement survives the attempt** — a refusal that left the policy cleared anyway would satisfy (2) and still be an escape.

## Reuse, not a second copy

- `tests/helpers/governance/policy-state.ts` for reading the bundle and the catalog.
- `@governance` for the functional tag: same product area, and the `@enterprise` lane already separates the editions, so a per-edition tag would double the vocabulary without buying selection power.
- The gate is the mirror image of `isPolicyPristine()`. An OSS governance spec writes the policy it needs, so it must refuse an instance that already carries one; this spec cannot write anything — the knobs are read at boot — so it can only assert against the container it was given, and it **skips naming the exact start command** rather than failing about the environment.

`scripts/start-langflow-enterprise.sh` provides that container. The auth helper covers what Enterprise changes about getting in, all three measured while building this: it runs password-first (no `auto_login`), it forces a rotation on the env-bootstrapped superuser (every authenticated route answers 403 until that is done), and it rate-limits login — so the lane authenticates once and caches the token, per worker and across processes, validating a cached token before reuse because a container restart invalidates an unexpired one.

## Second commit: the PR lane

`@enterprise` is grep-inverted out of the normal run, so a selection made only of enterprise specs reproduces exactly the red #1496 fixed for `@destructive` — `No tests found`, exit 1. **This PR is the first selection that would hit it.**

The two selectors share the symptom and not the remedy, so widening `destructive_only` would have been the wrong one-character fix: it would announce, through the existing warning, that the destructive lane covers specs it never sees. Instead the gate becomes `excluded_only`, `destructive_only` keeps its exact meaning, and enterprise specs get their own warning naming them and stating they were **not executed** — a skipped lane plus silence reads as coverage (#1012).

## Validation

- **The spec is expected to FAIL on current Enterprise builds.** The failure is a product finding tracked outside this repository; it is not a defect in the spec, and the assertions must not be relaxed to make a lane green. Run locally against a local Enterprise container: 2 tests, both red on the intended assertions, with the run restoring the declared policy on the way out.
- It needs a **fresh container per run** — the assertions read the policy's declared source, and a previous run's write changes it, which fails the spec for a different reason than the one it exists for. Found the hard way: the first post-refactor run failed on `source` and read like a regression in the refactor.
- `npm run test:scripts` → 817 tests, 0 fail (4 new cases for the lane classification).
- `npm run test:units` → 712 tests, 1 fail: `playwright.config.test.ts` → "the daily's prep command produces parseable JSON", which fails on this machine only and passes in CI.
- `npm run typecheck`, `npm run lint` (0 errors), `npm run check:checklist-coverage` all clean.
- Lane selection: `@enterprise` selects 0 in a normal run and 2 under `PW_ENTERPRISE=1`; the three `regression/governance/` specs stay out of the Enterprise lane, since they are `@destructive`.

No `@stable`: there is no scheduled Enterprise lane, and `@stable` without one is a test that silently never runs (#1010).

🤖 Generated with [Claude Code](https://claude.com/claude-code)