### PR TITLE
test(enterprise): cover the credential lifecycle of a bootstrapped superuser

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -1051,7 +1051,7 @@
 - [-] An accepted rollback **appends** rather than rewinds — new higher revision, `source: "rollback"`, `rollback_of_revision` pointing at the target, `reason` echoed — and the restored content is enforced, not just recorded → `governance/model-provider-policy/provider-allowlist-and-bundle-revisioning.spec.ts`
 - [ ] `GET /api/v1/catalog-policy/usage` and `usage/flows` report the blast radius of a block (which flows use the component) before an operator applies it
 
-## enterprise/ — Environment-Declared Policy (EE)
+## enterprise/ — Enterprise-only Surfaces (EE)
 
 > **New area (2026-08-19).** The remainder § 21 names as Enterprise-owned: a
 > policy the **operator** declares in the deployment, which EE reads at boot
@@ -1074,6 +1074,14 @@
 - [ ] The same authority question for the other three knobs: template blocklist, provider allowlist, model blocklist
 - [ ] `enterprise-admin/catalog/components` reflects the operator-declared policy
 - [ ] Readiness stays unhealthy rather than serving permissively when the declared policy cannot be loaded (fail-closed)
+
+#### 22.2 Credential Lifecycle
+
+- [-] The forced-rotation gate is an **allowlist**: identity and discovery stay reachable (`users/whoami`, `account/password-status`, `auth/methods`, `config`) while product and admin surfaces are refused `403 must_change_password` — **`api_key/` among them**, so an account under a pending rotation cannot mint a key and walk around the gate → `enterprise/auth/credential-lifecycle.spec.ts`
+- [-] Rotating refuses a wrong current password and a new password below the minimum, and accepts the correct pair → `enterprise/auth/credential-lifecycle.spec.ts`
+- [-] After rotating, `account/password-status` stops reporting a pending rotation, a refused surface answers, and the token that performed the rotation is rejected (`401`) → `enterprise/auth/credential-lifecycle.spec.ts`
+- [ ] Whether a **self-service** password reset should also invalidate previously minted tokens — measured today that it does not, unlike the forced path; asserted in neither direction until the product answers
+- [ ] `auth/methods`, break-glass defaults and the CLI login approval flow (issue #1501)
 
 ---
 

--- a/docs/enterprise/auth/credential-lifecycle.md
+++ b/docs/enterprise/auth/credential-lifecycle.md
@@ -1,0 +1,101 @@
+# Enterprise — Credential Lifecycle (forced rotation, status, token invalidation)
+
+**Last validated:** Langflow Enterprise 1.12.0 (image built from `IBM-Langflow@release-1.12.0`)
+
+---
+
+## What this test validates *(required)*
+
+What Enterprise does to a credential that OSS does not do at all. The superuser
+bootstrapped from the environment is created **already required to rotate**, and
+until it does, the product is closed to it.
+
+Three properties, measured on the running image and asserted here:
+
+1. **The gate is an allowlist, and its shape is the point.** Identity and
+   discovery stay reachable — `users/whoami`, `account/password-status`,
+   `auth/methods`, `config`, `version` — because a client that cannot discover
+   the requirement cannot satisfy it. Everything else is refused `403` with
+   `must_change_password`: flows, projects, variables, the component catalog, all
+   three policy surfaces, `sso/settings`, `authz`, and **`api_key/`**. That last
+   one is the security property: an account under a forced rotation cannot mint
+   an API key and walk around the gate.
+2. **`account/password-status` agrees with enforcement**, before and after. It is
+   what a client reads to decide whether to show the change-password screen at
+   all, so a status that disagrees with the gate is worse than either alone.
+3. **The rotation invalidates tokens minted before it.** The token that performed
+   the rotation is rejected (`401`) immediately afterwards, and a token obtained
+   with the new password works.
+
+## Relationship to the OSS auth specs
+
+`core-functionality/auth/` covers the OSS login surface: an admin changing
+another user's password (`admin-password-change`), missing or invalid tokens
+(`session-expired`), password-first mode existing (`auto-login-off`). **None of
+them covers a forced rotation**, which does not exist in OSS — there is no
+`/api/v1/account/*` there at all.
+
+## Tags *(required)*
+
+`@enterprise` `@api` `@auth`
+
+No `@stable`: there is no scheduled Enterprise lane, and `@stable` without one is
+a test that silently never runs (#1010).
+
+## Step by step *(required)*
+
+`mode: "serial"` — the three tests are one story told in order, and the state is
+consumed as it is told.
+
+**Test 1 — the gate, before rotating**
+1. Log in with the bootstrap password; require `password-status` to report the
+   rotation is pending, and skip naming the start command otherwise.
+2. Assert the allowlisted endpoints answer `200`.
+3. Assert the product and admin endpoints answer `403` carrying
+   `must_change_password`, `api_key/` among them.
+
+**Test 2 — rotating**
+1. A wrong current password is refused.
+2. A new password below the minimum length is refused.
+3. The correct rotation answers `200`.
+4. `password-status` now reports no pending rotation, and an endpoint that was
+   refused in test 1 answers `200`.
+
+**Test 3 — the old token**
+1. The token minted before the rotation is rejected (`401`).
+2. A token obtained with the new password is accepted.
+
+## Validation criterion *(required)*
+
+Fails if the gate lets a blocked surface through (especially `api_key/`), if it
+blocks the discovery endpoints a client needs to satisfy it, if the status
+disagrees with enforcement in either direction, if a wrong or too-short password
+is accepted, or if a token minted before the rotation still works after it.
+
+## External dependencies *(required)*
+
+- A Langflow **Enterprise** instance whose superuser has **not yet rotated**:
+  `LANGFLOW_EE_PASSWORD=langflow123 ./scripts/start-langflow-enterprise.sh`
+  (matching the bootstrap password makes the script's own rotation a no-op).
+- **One-shot per container.** This spec consumes the state it observes: after it
+  runs, the rotation is done and it will skip until a fresh container exists.
+  That is deliberate — the state is only reachable once, and a spec that
+  pretended otherwise would be asserting on a rotated instance.
+  The condition is detected **before** the login is spent, from the login's own
+  status: on an already-rotated instance the bootstrap password answers `401`,
+  and that IS the one-shot signal. Reading it afterwards made the second run
+  report "login failed", a red about the environment rather than the product —
+  which is the failure mode this gate exists to prevent.
+- **Login budget.** Langflow rate-limits `/api/v1/login` per IP, so the spec
+  spends exactly two logins (one before the rotation, one after) and reuses the
+  tokens for everything else.
+- No LLM provider, no network egress.
+
+## Open question, deliberately not asserted
+
+The **self-service** reset (`PATCH /api/v1/users/{id}/reset-password` on one's
+own id) does **not** invalidate previously minted tokens — measured: the old
+token still answered `200`. Whether that asymmetry with the forced path is
+intended is a product question, and it is not asserted here in either direction
+until it is answered. Pinning today's behaviour would freeze a possible defect;
+asserting the opposite would invent a requirement.

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -49,7 +49,7 @@ const MODULES: ModuleConfig[] = [
   { label: "`i18n/` — Language and Localization",            sectionStart: "## i18n/" },
   { label: "`memory/` — Memory Base Registration",           sectionStart: "## memory/" },
   { label: "`governance/` — Catalog and Provider Policy",    sectionStart: "## governance/" },
-  { label: "`enterprise/` — Environment-Declared Policy",    sectionStart: "## enterprise/" },
+  { label: "`enterprise/` — Enterprise-only Surfaces",       sectionStart: "## enterprise/" },
 ];
 
 const PART_II_HEADER = "# PART II — TEST AUTOMATION COVERAGE";

--- a/tests/helpers/enterprise/enterprise-auth.ts
+++ b/tests/helpers/enterprise/enterprise-auth.ts
@@ -120,6 +120,39 @@ async function tokenStillValid(request: APIRequestContext, token: string): Promi
   }
 }
 
+/**
+ * A single, UNCACHED password login.
+ *
+ * Exported because the credential-lifecycle spec has to authenticate as a
+ * password the cache knows nothing about — the bootstrap one, before the forced
+ * rotation — and has to observe what happens to that exact token afterwards.
+ * Caching it would defeat both halves.
+ *
+ * Every caller spends one unit of the per-IP login budget, so callers state how
+ * many they spend in their spec doc rather than discovering it as a 429.
+ */
+export async function loginWithPassword(
+  request: APIRequestContext,
+  password: string,
+): Promise<string> {
+  const response = await request.post("/api/v1/login", {
+    form: { username: EE_USERNAME, password },
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(
+      `Enterprise login failed for '${EE_USERNAME}' (${response.status()}): ${body.slice(0, 200)}`,
+    );
+  }
+
+  const body = (await response.json()) as { access_token?: string };
+  if (!body.access_token) {
+    throw new Error("Enterprise login returned no access_token");
+  }
+  return `Bearer ${body.access_token}`;
+}
+
 async function loginOnce(request: APIRequestContext): Promise<string> {
   const cached = readCachedToken();
   if (cached && (await tokenStillValid(request, cached))) {

--- a/tests/tests-automations/regression/enterprise/auth/credential-lifecycle.spec.ts
+++ b/tests/tests-automations/regression/enterprise/auth/credential-lifecycle.spec.ts
@@ -1,0 +1,194 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  EE_PASSWORD,
+  EE_USERNAME,
+  loginWithPassword,
+} from "../../../../helpers/enterprise/enterprise-auth";
+
+/**
+ * What Enterprise does to a credential that OSS does not do at all (see
+ * docs/enterprise/auth/credential-lifecycle.md).
+ *
+ * ONE-SHOT PER CONTAINER. The state under test — a superuser that has not yet
+ * rotated — exists exactly once per instance, and this spec consumes it. An
+ * admin cannot recreate it for a throwaway user either: resetting someone
+ * else's password is refused. So the spec asserts what is reachable once,
+ * honestly, and skips afterwards rather than pretending to be repeatable.
+ *
+ * It also leaves the instance on the lane's password, which is the state every
+ * other `@enterprise` spec expects — running this one first sets the lane up.
+ */
+const BOOTSTRAP_PASSWORD = process.env.LANGFLOW_SUPERUSER_PASSWORD || "langflow123";
+
+/**
+ * Reachable while the rotation is pending: identity plus what a login screen
+ * reads. A client that cannot discover the requirement cannot satisfy it, so
+ * these staying open is a property, not a leak.
+ */
+const ALLOWED_WHILE_PENDING = [
+  "/api/v1/users/whoami",
+  "/api/v1/account/password-status",
+  "/api/v1/auth/methods",
+  "/api/v1/config",
+];
+
+/**
+ * Refused while the rotation is pending. `api_key/` is the one that matters:
+ * an account under a forced rotation must not be able to mint an API key and
+ * walk around the gate.
+ */
+const BLOCKED_WHILE_PENDING = [
+  "/api/v1/flows/",
+  "/api/v1/projects/",
+  "/api/v1/variables/",
+  "/api/v1/all",
+  "/api/v1/catalog-policy/components",
+  "/api/v1/policy-bundle",
+  "/api/v1/sso/settings",
+  "/api/v1/api_key/",
+];
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Enterprise — credential lifecycle", () => {
+  let bootstrapToken: string;
+
+  test(
+    "the forced-rotation gate is an allowlist, not a blanket refusal",
+    { tag: ["@enterprise", "@api", "@auth"] },
+    async ({ request }) => {
+      test.skip(
+        BOOTSTRAP_PASSWORD === EE_PASSWORD,
+        `The bootstrap and rotated passwords are identical ('${BOOTSTRAP_PASSWORD}'), so there is nothing to rotate to. ` +
+          "Start the instance with LANGFLOW_EE_PASSWORD=langflow123 ./scripts/start-langflow-enterprise.sh and leave LANGFLOW_EE_PASSWORD unset here.",
+      );
+
+      // One of the two logins this spec is allowed to spend — and the first
+      // signal of whether the state still exists. It is attempted directly
+      // rather than through the throwing helper because a refused bootstrap
+      // login IS the one-shot condition: on a container that already rotated,
+      // that password is gone. Letting the helper throw here produced a red
+      // reading "login failed", which is a statement about the environment and
+      // not about the product.
+      const login = await request.post("/api/v1/login", {
+        form: { username: EE_USERNAME, password: BOOTSTRAP_PASSWORD },
+      });
+
+      test.skip(
+        login.status() === 401,
+        `The bootstrap password is no longer accepted, so ${EE_USERNAME} has already rotated on this instance. ` +
+          "The state is reachable once per container — start a fresh one with: " +
+          "LANGFLOW_EE_PASSWORD=langflow123 ./scripts/start-langflow-enterprise.sh",
+      );
+
+      // Not a skip: a 429 means the lane spent its per-IP login budget, which
+      // hides the product behind an environment condition the run can fix by
+      // waiting. Failing names it instead of reporting a green all-skip.
+      expect(
+        login.status(),
+        "login was rate-limited (429) — this lane's budget is per IP; re-run after the window",
+      ).not.toBe(429);
+      expect(login.status()).toBe(200);
+      bootstrapToken = `Bearer ${(await login.json()).access_token}`;
+
+      const status = await request.get("/api/v1/account/password-status", {
+        headers: { Authorization: bootstrapToken },
+      });
+      expect(status.status()).toBe(200);
+      const pending = (await status.json()).must_change_password;
+
+      test.skip(
+        pending !== true,
+        `${EE_USERNAME} has already rotated on this instance, and the state is reachable once per container. ` +
+          "Start a fresh one with: LANGFLOW_EE_PASSWORD=langflow123 ./scripts/start-langflow-enterprise.sh",
+      );
+
+      await test.step("identity and discovery stay reachable", async () => {
+        for (const path of ALLOWED_WHILE_PENDING) {
+          const response = await request.get(path, {
+            headers: { Authorization: bootstrapToken },
+          });
+          expect(response.status(), `${path} must stay reachable`).toBe(200);
+        }
+      });
+
+      await test.step("product and admin surfaces are refused, api_key included", async () => {
+        for (const path of BLOCKED_WHILE_PENDING) {
+          const response = await request.get(path, {
+            headers: { Authorization: bootstrapToken },
+          });
+          expect(response.status(), `${path} must be refused`).toBe(403);
+          // The reason, not just the status: a 403 for any other cause would
+          // satisfy the assertion above while meaning something else entirely.
+          expect(await response.text()).toContain("must_change_password");
+        }
+      });
+    },
+  );
+
+  test(
+    "rotating requires the current password and a long enough new one",
+    { tag: ["@enterprise", "@api", "@auth"] },
+    async ({ request }) => {
+      test.skip(!bootstrapToken, "the gate test did not run");
+      const headers = { Authorization: bootstrapToken };
+
+      await test.step("a wrong current password is refused", async () => {
+        const response = await request.post("/api/v1/account/force-password-change", {
+          headers,
+          data: { current_password: `not-${BOOTSTRAP_PASSWORD}`, new_password: EE_PASSWORD },
+        });
+        expect(response.ok()).toBe(false);
+      });
+
+      await test.step("a new password below the minimum is refused", async () => {
+        const response = await request.post("/api/v1/account/force-password-change", {
+          headers,
+          data: { current_password: BOOTSTRAP_PASSWORD, new_password: "short" },
+        });
+        expect(response.ok()).toBe(false);
+      });
+
+      await test.step("the correct rotation is accepted", async () => {
+        const response = await request.post("/api/v1/account/force-password-change", {
+          headers,
+          data: { current_password: BOOTSTRAP_PASSWORD, new_password: EE_PASSWORD },
+        });
+        expect(response.status()).toBe(200);
+      });
+    },
+  );
+
+  test(
+    "after rotating, the status agrees and the old token is dead",
+    { tag: ["@enterprise", "@api", "@auth"] },
+    async ({ request }) => {
+      test.skip(!bootstrapToken, "the gate test did not run");
+
+      await test.step("the token that performed the rotation is rejected", async () => {
+        const response = await request.get("/api/v1/users/whoami", {
+          headers: { Authorization: bootstrapToken },
+        });
+        expect(response.status()).toBe(401);
+      });
+
+      // The second and last login this spec spends.
+      const rotatedToken = await loginWithPassword(request, EE_PASSWORD);
+
+      await test.step("the status no longer reports a pending rotation", async () => {
+        const status = await request.get("/api/v1/account/password-status", {
+          headers: { Authorization: rotatedToken },
+        });
+        expect(status.status()).toBe(200);
+        expect((await status.json()).must_change_password).toBe(false);
+      });
+
+      await test.step("a surface the gate refused now answers", async () => {
+        const response = await request.get("/api/v1/api_key/", {
+          headers: { Authorization: rotatedToken },
+        });
+        expect(response.status()).toBe(200);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1500

## What this adds

One spec (3 tests, serial) under `regression/enterprise/auth/`, covering what Enterprise does to a credential that OSS does not do at all: the env-bootstrapped superuser is created **already required to rotate**, and the product is closed to it until that happens.

**The gate is an allowlist, and that shape is the assertion.** Identity and discovery stay reachable — `users/whoami`, `account/password-status`, `auth/methods`, `config` — because a client that cannot discover the requirement cannot satisfy it. Product and admin surfaces are refused `403 must_change_password`, **`api_key/` among them**: an account under a pending rotation must not be able to mint an API key and walk around the gate. Refusals are asserted on the *reason*, not only the status, since a 403 from any other cause would pass a status-only check while meaning something else.

**The status agrees with enforcement on both sides**, and **the rotation kills what came before it** — the token that performed it is rejected `401`, a token from the new password works.

## One-shot per container, stated rather than worked around

The state exists once per instance and this spec consumes it. An admin cannot recreate it for a throwaway user either: resetting another user's password is refused (`404 "You can't change another user's password"`). So the spec asserts what is reachable once and skips afterwards.

The condition is detected **before** the login is spent, from the login's own status: on an already-rotated instance the bootstrap password answers `401`, and that *is* the one-shot signal. An earlier revision read it afterwards, and the second run reported "login failed" — a red about the environment rather than the product, which is exactly what the gate exists to prevent. A `429` fails loudly instead of skipping, because a spent login budget must never read as a green all-skip.

Two logins per run, declared in the spec doc: Langflow rate-limits `/api/v1/login` per IP, so everything else reuses the tokens.

## Deliberately not asserted

Whether a **self-service** password reset should also invalidate previously minted tokens. Measured: it does not, unlike the forced path. Pinning today's behaviour would freeze a possible defect; asserting the opposite would invent a requirement. The checklist carries it as an open question until the product answers.

## Validation

- Fresh container: **3 passed**.
- Already-rotated container: **3 skipped, 0 failed** — the one-shot path, verified in both directions.
- Force-fail: moving `api_key/` into the allowlist reproduces a red naming the route, so the central assertion is not vacuous.
- `npm run typecheck`, `npm run lint` (0 errors), `npm run check:checklist-coverage`: clean.
- `npm run test:units` → 712 tests, 1 fail: `playwright.config.test.ts` → "the daily's prep command produces parseable JSON", which fails on this machine only and passes in CI.

Run it with:

    LANGFLOW_EE_PASSWORD=langflow123 ./scripts/start-langflow-enterprise.sh
    PW_ENTERPRISE=1 PLAYWRIGHT_BASE_URL=http://localhost:7890 npx playwright test tests/tests-automations/regression/enterprise/auth

(matching the bootstrap password makes the start script's own rotation a no-op, which is what leaves the state observable)

CI will report that this PR's spec was **not executed** — there is no Enterprise instance on the runner. That warning is the mechanism added in #1499 working as intended, not a gap being hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)