### PR TITLE
test(enterprise): cover CLI sign-in, the login surface and break-glass defaults

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -1082,7 +1082,21 @@
 - [-] Rotating refuses a wrong current password and a new password below the minimum, and accepts the correct pair → `enterprise/auth/credential-lifecycle.spec.ts`
 - [-] After rotating, `account/password-status` stops reporting a pending rotation, a refused surface answers, and the token that performed the rotation is rejected (`401`) → `enterprise/auth/credential-lifecycle.spec.ts`
 - [ ] Whether a **self-service** password reset should also invalidate previously minted tokens — measured today that it does not, unlike the forced path; asserted in neither direction until the product answers
-- [ ] `auth/methods`, break-glass defaults and the CLI login approval flow (issue #1501)
+#### 22.3 CLI Sign-in (authorization code + PKCE)
+
+- [-] A correct exchange issues a token that **authenticates** a subsequent call — not merely a token-shaped payload → `enterprise/auth/cli-login-pkce.spec.ts`
+- [-] The code is bound to its `code_verifier`, its `state` and its `redirect_uri`; each is refused on its **own** authorization, because a failed exchange consumes the code and reusing one would make later assertions pass for the wrong reason → `enterprise/auth/cli-login-pkce.spec.ts`
+- [-] An authorization code cannot be spent twice → `enterprise/auth/cli-login-pkce.spec.ts`
+- [-] The consent step confines its form (`form-action` restricted to the requested redirect, `frame-ancestors 'none'`, `no-store`) and refuses a bad CSRF token or a foreign origin → `enterprise/auth/cli-login-pkce.spec.ts`
+- [ ] Authorization code expiry — the refusal message names expiry, but no spec advances a clock past it
+
+#### 22.4 Login Surface and Break-glass
+
+- [-] Password login survives SSO being switched on but unusable: `auth/methods` still offers the local form, and the advertised form actually works — the invariant that an SSO mistake must never lock an organisation out → `enterprise/auth/login-surface.spec.ts`
+- [-] Break-glass ships disabled and unused, while still naming its account → `enterprise/auth/login-surface.spec.ts`
+- [-] Enabling break-glass is explicit and reflected, and arming it does **not** stamp `break_glass_last_used_at` → `enterprise/auth/login-surface.spec.ts`
+- [ ] Actually using break-glass records the use — needs an SSO-only state, which needs a connection, which is entitlement-gated
+- [ ] A created SSO connection is disabled by default, plan limits are enforced server-side, and the client secret is masked on read — all blocked without a licence (issue #1501)
 
 ---
 

--- a/docs/enterprise/auth/cli-login-pkce.md
+++ b/docs/enterprise/auth/cli-login-pkce.md
@@ -1,0 +1,85 @@
+# Enterprise — CLI Sign-in (authorization code + PKCE)
+
+**Last validated:** Langflow Enterprise 1.12.0 (image built from `IBM-Langflow@release-1.12.0`)
+
+---
+
+## What this test validates *(required)*
+
+`auth/cli-login` is a **credential-issuance** endpoint: it mints a full access
+token for a client that never sees the user's password. It is an authorization
+code flow with PKCE, and every one of its refusals is what keeps a stolen or
+guessed code from becoming a session.
+
+Measured on the running image, one **fresh authorization per case**:
+
+| Case | Outcome |
+|---|---|
+| Wrong `code_verifier` (valid length) | refused `400` |
+| `state` different from the one authorized | refused `400` |
+| `redirect_uri` different from the one authorized | refused `400` |
+| All four correct | `200` with an access token |
+| The same code exchanged twice | refused `400` |
+
+The consent step is hardened too, and the spec pins it: the page is served
+`no-store` with `default-src 'none'`, `frame-ancestors 'none'` and a
+**`form-action` restricted to the requested `redirect_uri`**, and the approval
+POST carries a `csrf_token` and is rejected outright when the request's origin
+does not match (`403 CLI login confirmation origin is invalid`).
+
+## Tags *(required)*
+
+`@enterprise` `@api` `@auth`
+
+No `@stable`: no scheduled Enterprise lane (#1010).
+
+## Step by step *(required)*
+
+A helper performs one authorization per case: `GET /api/v1/auth/cli-login` with
+a fresh `state` and the challenge, scrape `request_id` + `csrf_token`, POST them
+to `/approve` with a matching `Origin`, and read the `code` from the `302`
+`Location`.
+
+**Test 1 — the happy path issues a real token**
+Exchange with the correct code, state, redirect and verifier; assert `200` and an
+`access_token` that authenticates a subsequent call.
+
+**Test 2 — each binding is enforced, each on its own code**
+Wrong verifier, wrong state, wrong redirect: each refused. One fresh
+authorization per case, for the reason in the trap below.
+
+**Test 3 — a code is single-use**
+Exchange successfully, then exchange the same code again: refused.
+
+**Test 4 — the consent step resists CSRF and framing**
+The page carries the restrictive CSP above; `/approve` with a bad `csrf_token`
+is refused, and with a foreign `Origin` is refused.
+
+## Validation criterion *(required)*
+
+Fails if any binding stops being enforced (a code usable with the wrong verifier,
+state or redirect), if a code can be spent twice, if the approval accepts a
+foreign origin or a bad CSRF token, or if the consent page loses its
+`form-action` restriction.
+
+## The trap this spec is built around
+
+**A failed exchange consumes the code.** Measured: after a refused attempt, the
+*correct* exchange of the same code is also refused. Good behaviour — it stops a
+verifier from being brute-forced against a live code — but it means a spec that
+reuses one authorization across cases measures nothing after the first: every
+later assertion passes for the wrong reason. Each negative case therefore starts
+from its own authorization, and the helper exists to make that the easy path.
+
+**All refusals share one opaque message.** `Invalid, expired, or already used CLI
+authorization code` is returned for a wrong verifier, a wrong state, a wrong
+redirect and a spent code alike. That is deliberate non-disclosure, so the spec
+asserts the refusal and never the reason — asserting distinct messages would pin
+an information leak the product avoids on purpose.
+
+## External dependencies *(required)*
+
+- A Langflow **Enterprise** instance: `./scripts/start-langflow-enterprise.sh`.
+- One login per run (the lane's cached token), then everything else is bearer-authenticated.
+- No LLM provider, no network egress: the `redirect_uri` is never actually
+  fetched, only echoed and compared.

--- a/docs/enterprise/auth/login-surface.md
+++ b/docs/enterprise/auth/login-surface.md
@@ -1,0 +1,68 @@
+# Enterprise — Login Surface and Break-glass Defaults
+
+**Last validated:** Langflow Enterprise 1.12.0 (image built from `IBM-Langflow@release-1.12.0`)
+
+---
+
+## What this test validates *(required)*
+
+What the login screen is allowed to offer, and the emergency account behind it.
+
+**Password login must survive a non-working SSO.** This is the golden invariant
+of the area: an SSO mistake must never lock an organisation out of its own
+instance. It is assertable today without a licence, because an instance with
+`LANGFLOW_SSO_ENABLED=true` and no usable connection is exactly the misconfigured
+state — measured: `GET /api/v1/auth/methods` answers
+`{"show_local_form": true, "sso": {"enabled": false, "providers": []}}`, and the
+password login still works. SSO *switched on* is not SSO *available*, and the
+login screen must reflect the second, not the first.
+
+**Break-glass is off by default and its use is recorded.** `GET /api/v1/sso/settings`
+reports `break_glass_enabled: false` with `break_glass_last_used_at: null` on a
+fresh instance. An emergency account that ships enabled, or whose use leaves no
+trace, is the kind of default nobody notices until it matters.
+
+## Tags *(required)*
+
+`@enterprise` `@api` `@auth` `@sso`
+
+`@sso` because the surface is the SSO admin's, even though no SSO connection
+exists here. No `@stable`: no scheduled Enterprise lane (#1010).
+
+## Step by step *(required)*
+
+**Test 1 — the login screen still offers the local form**
+`auth/methods` reports `show_local_form: true`, and `sso.enabled` is false while
+no connection is usable. Then authenticate with the password and assert the token
+works — the assertion that makes the first half mean something.
+
+**Test 2 — break-glass defaults**
+`sso/settings` reports `break_glass_enabled: false` and
+`break_glass_last_used_at: null`, and names a `break_glass_user_id`.
+
+**Test 3 — enabling it is an explicit, reversible admin act**
+`PATCH sso/settings {break_glass_enabled: true}` answers `200` and the read
+reflects it; enabling alone does **not** stamp `break_glass_last_used_at`, which
+must only record actual use. Restore to `false` afterwards.
+
+## Validation criterion *(required)*
+
+Fails if the local form disappears while SSO is merely switched on (the lock-out
+scenario), if password login stops working in that state, if break-glass ships
+enabled, if enabling it silently marks it as used, or if the settings read does
+not reflect a write.
+
+## External dependencies *(required)*
+
+- A Langflow **Enterprise** instance: `./scripts/start-langflow-enterprise.sh`
+  (the script already sets `LANGFLOW_SSO_ENABLED=true`, which is the state under
+  test).
+- **Test 3 mutates instance settings** and restores them. It is the only write
+  here; a failure between write and restore leaves break-glass enabled, which the
+  spec reports rather than hides.
+
+## Out of scope, and why
+
+Creating an SSO **connection** is entitlement-gated and answers `503` without a
+licence, so "a connection is disabled by default", plan limits and secret masking
+cannot be asserted here. They are tracked in the issue, not silently dropped.

--- a/tests/helpers/enterprise/cli-login.ts
+++ b/tests/helpers/enterprise/cli-login.ts
@@ -1,0 +1,141 @@
+import { createHash, randomBytes } from "node:crypto";
+import type { APIRequestContext, APIResponse } from "@playwright/test";
+
+/**
+ * The Enterprise CLI sign-in flow: authorization code + PKCE.
+ *
+ * Lives in a helper because every negative case needs its OWN authorization.
+ * A failed exchange CONSUMES the code — measured: after a refused attempt, the
+ * correct exchange of the same code is refused too. Reusing one authorization
+ * across cases would make every assertion after the first pass for the wrong
+ * reason, so "one fresh authorization per case" has to be the easy path.
+ */
+export interface CliAuthorization {
+  code: string;
+  state: string;
+  redirectUri: string;
+  codeVerifier: string;
+}
+
+/** RFC 7636 requires 43..128 characters; below that the API rejects on length. */
+export function createVerifier(): string {
+  return randomBytes(48).toString("base64url");
+}
+
+function challengeFor(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+function scrape(html: string, field: string): string {
+  const match = html.match(new RegExp(`name="${field}" value="([^"]+)"`));
+  if (!match) {
+    throw new Error(`the consent page carries no ${field} — the flow changed shape`);
+  }
+  return match[1];
+}
+
+/**
+ * Drive consent + approval and return an unspent authorization code.
+ *
+ * `redirectUri` is never fetched: it is echoed into the `302` and compared at
+ * exchange time, which is what makes this reachable with no listener.
+ */
+export async function authorizeCliLogin(
+  request: APIRequestContext,
+  auth: string,
+  { state, redirectUri = "http://127.0.0.1:9999/callback" }: { state: string; redirectUri?: string },
+): Promise<CliAuthorization> {
+  const codeVerifier = createVerifier();
+
+  const consent = await request.get("/api/v1/auth/cli-login", {
+    headers: { Authorization: auth },
+    params: {
+      redirect_uri: redirectUri,
+      state,
+      code_challenge: challengeFor(codeVerifier),
+      code_challenge_method: "S256",
+    },
+  });
+  if (!consent.ok()) {
+    throw new Error(`the consent page answered ${consent.status()}`);
+  }
+  const html = await consent.text();
+
+  const approval = await approveCliLogin(request, auth, {
+    requestId: scrape(html, "request_id"),
+    csrfToken: scrape(html, "csrf_token"),
+  });
+  if (approval.status() !== 302) {
+    throw new Error(`approval answered ${approval.status()} instead of redirecting`);
+  }
+
+  const location = approval.headers()["location"];
+  const code = new URL(location).searchParams.get("code");
+  if (!code) {
+    throw new Error(`the approval redirect carried no code: ${location}`);
+  }
+
+  return { code, state, redirectUri, codeVerifier };
+}
+
+/**
+ * POST the approval form. Exposed on its own so the CSRF and origin cases can
+ * drive it with deliberately wrong values.
+ *
+ * `maxRedirects: 0` is load-bearing: following the redirect would hand the code
+ * to a listener that does not exist and lose it from the response.
+ */
+export function approveCliLogin(
+  request: APIRequestContext,
+  auth: string,
+  {
+    requestId,
+    csrfToken,
+    origin = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:7890",
+  }: { requestId: string; csrfToken: string; origin?: string },
+): Promise<APIResponse> {
+  return request.post("/api/v1/auth/cli-login/approve", {
+    headers: { Authorization: auth, Origin: origin },
+    form: { request_id: requestId, csrf_token: csrfToken },
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  });
+}
+
+/** Exchange an authorization for tokens. Overrides drive the negative cases. */
+export function exchangeCliCode(
+  request: APIRequestContext,
+  auth: string,
+  authorization: CliAuthorization,
+  overrides: Partial<Pick<CliAuthorization, "state" | "redirectUri" | "codeVerifier">> = {},
+): Promise<APIResponse> {
+  return request.post("/api/v1/auth/cli-login/token", {
+    headers: { Authorization: auth },
+    data: {
+      code: authorization.code,
+      state: overrides.state ?? authorization.state,
+      redirect_uri: overrides.redirectUri ?? authorization.redirectUri,
+      code_verifier: overrides.codeVerifier ?? authorization.codeVerifier,
+    },
+    failOnStatusCode: false,
+  });
+}
+
+/** Read the consent page's raw response, for the header assertions. */
+export function fetchConsentPage(
+  request: APIRequestContext,
+  auth: string,
+  { state, redirectUri = "http://127.0.0.1:9999/callback" }: { state: string; redirectUri?: string },
+): Promise<APIResponse> {
+  const verifier = createVerifier();
+  return request.get("/api/v1/auth/cli-login", {
+    headers: { Authorization: auth },
+    params: {
+      redirect_uri: redirectUri,
+      state,
+      code_challenge: challengeFor(verifier),
+      code_challenge_method: "S256",
+    },
+    failOnStatusCode: false,
+  });
+}

--- a/tests/tests-automations/regression/enterprise/auth/cli-login-pkce.spec.ts
+++ b/tests/tests-automations/regression/enterprise/auth/cli-login-pkce.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  approveCliLogin,
+  authorizeCliLogin,
+  createVerifier,
+  exchangeCliCode,
+  fetchConsentPage,
+} from "../../../../helpers/enterprise/cli-login";
+import { getEnterpriseAuthToken } from "../../../../helpers/enterprise/enterprise-auth";
+
+/**
+ * CLI sign-in is credential ISSUANCE (see docs/enterprise/auth/cli-login-pkce.md):
+ * it mints a full access token for a client that never sees the password. Every
+ * refusal below is what stops a stolen or guessed code from becoming a session.
+ *
+ * Each negative case takes its OWN authorization, because a failed exchange
+ * consumes the code — reusing one would make every later assertion pass for the
+ * wrong reason.
+ *
+ * The refusals all share one opaque message on purpose, so these assert the
+ * REFUSAL and never the reason: pinning distinct messages would pin an
+ * information leak the product deliberately avoids.
+ */
+test.describe("Enterprise — CLI sign-in (authorization code + PKCE)", () => {
+  test(
+    "a correct exchange issues a token that actually authenticates",
+    { tag: ["@enterprise", "@api", "@auth"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const authorization = await authorizeCliLogin(request, auth, { state: "happy-path" });
+
+      const response = await exchangeCliCode(request, auth, authorization);
+      expect(response.status()).toBe(200);
+      const issued = (await response.json()).access_token;
+      expect(issued).toBeTruthy();
+
+      // "Issued" must mean usable, not merely present in a payload.
+      const whoami = await request.get("/api/v1/users/whoami", {
+        headers: { Authorization: `Bearer ${issued}` },
+      });
+      expect(whoami.status()).toBe(200);
+    },
+  );
+
+  test(
+    "the code is bound to its verifier, its state and its redirect",
+    { tag: ["@enterprise", "@api", "@auth"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+
+      await test.step("a wrong code_verifier is refused", async () => {
+        const authorization = await authorizeCliLogin(request, auth, { state: "wrong-verifier" });
+        const response = await exchangeCliCode(request, auth, authorization, {
+          // Valid length, wrong value: below 43 characters the API refuses on
+          // length alone, which would assert validation instead of PKCE.
+          codeVerifier: createVerifier(),
+        });
+        expect(response.ok()).toBe(false);
+      });
+
+      await test.step("a state other than the authorized one is refused", async () => {
+        const authorization = await authorizeCliLogin(request, auth, { state: "bound-state" });
+        const response = await exchangeCliCode(request, auth, authorization, {
+          state: "some-other-state",
+        });
+        expect(response.ok()).toBe(false);
+      });
+
+      await test.step("a redirect other than the authorized one is refused", async () => {
+        const authorization = await authorizeCliLogin(request, auth, { state: "bound-redirect" });
+        const response = await exchangeCliCode(request, auth, authorization, {
+          redirectUri: "http://127.0.0.1:8888/elsewhere",
+        });
+        expect(response.ok()).toBe(false);
+      });
+    },
+  );
+
+  test(
+    "an authorization code cannot be spent twice",
+    { tag: ["@enterprise", "@api", "@auth"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const authorization = await authorizeCliLogin(request, auth, { state: "single-use" });
+
+      expect((await exchangeCliCode(request, auth, authorization)).status()).toBe(200);
+      expect((await exchangeCliCode(request, auth, authorization)).ok()).toBe(false);
+    },
+  );
+
+  test(
+    "the consent step resists CSRF, foreign origins and framing",
+    { tag: ["@enterprise", "@api", "@auth"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+
+      const consent = await fetchConsentPage(request, auth, { state: "consent-headers" });
+      expect(consent.status()).toBe(200);
+
+      await test.step("the page confines where its form may post", async () => {
+        const csp = consent.headers()["content-security-policy"];
+        expect(csp).toBeTruthy();
+        // The form may only post back to this instance and to the redirect the
+        // caller asked for — the restriction that keeps an approval from being
+        // driven into someone else's endpoint.
+        expect(csp).toContain("form-action 'self' http://127.0.0.1:9999");
+        expect(csp).toContain("frame-ancestors 'none'");
+        expect(consent.headers()["cache-control"]).toContain("no-store");
+      });
+
+      const html = await consent.text();
+      const requestId = html.match(/name="request_id" value="([^"]+)"/)?.[1] as string;
+      const csrfToken = html.match(/name="csrf_token" value="([^"]+)"/)?.[1] as string;
+
+      await test.step("a bad CSRF token is refused", async () => {
+        const response = await approveCliLogin(request, auth, {
+          requestId,
+          csrfToken: "not-the-issued-token",
+        });
+        expect(response.ok()).toBe(false);
+      });
+
+      await test.step("a foreign origin is refused", async () => {
+        const response = await approveCliLogin(request, auth, {
+          requestId,
+          csrfToken,
+          origin: "http://attacker.example",
+        });
+        expect(response.ok()).toBe(false);
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/enterprise/auth/login-surface.spec.ts
+++ b/tests/tests-automations/regression/enterprise/auth/login-surface.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  EE_PASSWORD,
+  getEnterpriseAuthToken,
+  loginWithPassword,
+} from "../../../../helpers/enterprise/enterprise-auth";
+
+/**
+ * What the login screen may offer, and the emergency account behind it (see
+ * docs/enterprise/auth/login-surface.md).
+ *
+ * The golden invariant here is that an SSO mistake must never lock an
+ * organisation out of its own instance. It is reachable without a licence
+ * because an instance with SSO switched on and no usable connection IS the
+ * misconfigured state.
+ */
+test.describe("Enterprise — login surface and break-glass defaults", () => {
+  test(
+    "password login survives SSO being switched on but unusable",
+    { tag: ["@enterprise", "@api", "@auth", "@sso"] },
+    async ({ request }) => {
+      const methods = await request.get("/api/v1/auth/methods");
+      expect(methods.status()).toBe(200);
+      const body = await methods.json();
+
+      // SSO *switched on* is not SSO *available*: with no usable connection the
+      // login screen must still offer the local form, or the instance is shut.
+      expect(body.show_local_form).toBe(true);
+      expect(body.sso.enabled).toBe(false);
+      expect(body.sso.providers).toEqual([]);
+
+      // The half that makes the first half mean something: the advertised form
+      // has to actually work.
+      const token = await loginWithPassword(request, EE_PASSWORD);
+      const whoami = await request.get("/api/v1/users/whoami", {
+        headers: { Authorization: token },
+      });
+      expect(whoami.status()).toBe(200);
+    },
+  );
+
+  test(
+    "break-glass ships disabled and unused",
+    { tag: ["@enterprise", "@api", "@auth", "@sso"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const settings = await request.get("/api/v1/sso/settings", {
+        headers: { Authorization: auth },
+      });
+      expect(settings.status()).toBe(200);
+      const body = await settings.json();
+
+      expect(body.break_glass_enabled).toBe(false);
+      expect(body.break_glass_last_used_at).toBeNull();
+      // The account exists even while disabled — that is what makes "disabled by
+      // default" a decision rather than an absence.
+      expect(body.break_glass_user_id).toBeTruthy();
+    },
+  );
+
+  test(
+    "enabling break-glass is explicit, reflected, and does not count as using it",
+    { tag: ["@enterprise", "@api", "@auth", "@sso"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const headers = { Authorization: auth };
+
+      try {
+        const enabled = await request.patch("/api/v1/sso/settings", {
+          headers,
+          data: { break_glass_enabled: true },
+        });
+        expect(enabled.status()).toBe(200);
+        const body = await enabled.json();
+        expect(body.break_glass_enabled).toBe(true);
+
+        // Arming it is not using it. A timestamp here would make the audit trail
+        // useless for the only question it answers.
+        expect(body.break_glass_last_used_at).toBeNull();
+
+        const readBack = await request.get("/api/v1/sso/settings", { headers });
+        expect((await readBack.json()).break_glass_enabled).toBe(true);
+      } finally {
+        // The only write in this area. Leaving break-glass armed would be a
+        // worse outcome than the test failing.
+        await request.patch("/api/v1/sso/settings", {
+          headers,
+          data: { break_glass_enabled: false },
+        });
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #1501

## What this adds

Two specs (7 tests) over what Enterprise offers at the door. Neither is reachable from the OSS lane — those endpoints do not exist there.

### `cli-login-pkce.spec.ts` — credential issuance

`auth/cli-login` mints a full access token for a client that never sees the password. It is an authorization code flow with **PKCE**, so the spec asserts the bindings that stop a stolen or guessed code from becoming a session:

- the code is bound to its `code_verifier`, its `state` and its `redirect_uri`;
- a code cannot be spent twice;
- the happy path issues a token that **actually authenticates** a later call, not merely a token-shaped payload;
- the consent step confines its own form (`form-action` restricted to the requested redirect, `frame-ancestors 'none'`, `no-store`) and refuses a bad CSRF token or a foreign origin.

### `login-surface.spec.ts` — the golden invariant, plus break-glass

**An SSO mistake must never lock an organisation out of its own instance.** Assertable without a licence, because an instance with SSO switched on and no usable connection *is* the misconfigured state: `auth/methods` answers `show_local_form: true` with `sso.enabled: false`. The spec then logs in with the password — an advertised form that does not work is the same lock-out by another route.

Break-glass ships **disabled and unused** while still naming its account, and arming it must not stamp `break_glass_last_used_at`: a timestamp there would make the audit trail useless for the only question it answers. That test is the only write in the area, and it restores the setting.

## Two properties that shaped the design

Both were found by getting them wrong first, and both are recorded in the spec docs.

**A failed exchange consumes the code.** After a refused attempt, the *correct* exchange of the same code is refused too. Good behaviour — a verifier cannot be brute-forced against a live code — but it means a spec reusing one authorization across cases measures nothing after the first: every later assertion passes for the wrong reason. Each negative case therefore starts from its own authorization, which is what the helper exists to make easy.

**Every refusal shares one opaque message**, whatever failed. Deliberate non-disclosure, so these assert the refusal and never the reason. Pinning distinct messages would pin an information leak the product avoids on purpose.

## Out of scope, recorded rather than dropped

Authorization code expiry (needs a clock to advance), and everything requiring an SSO **connection** to exist — disabled-by-default, plan limits, secret masking — which is entitlement-gated and answers `503` without a licence. Both are `[ ]` checklist items with the reason attached.

## Validation

- **7 passed** against a local Enterprise build of `release-1.12.0`.
- Force-fail in both specs: exchanging with the **correct** verifier while still expecting a refusal, and requiring break-glass to ship **enabled** — each reproduces a red, so neither central assertion is vacuous.
- `npm run typecheck`, `npm run lint` (0 errors), `npm run check:checklist-coverage`: clean.

CI will report that these specs were **not executed** — there is no Enterprise instance on the runner. That is the mechanism from #1499 working, not a gap being hidden.

Run them with:

    ./scripts/start-langflow-enterprise.sh
    PW_ENTERPRISE=1 PLAYWRIGHT_BASE_URL=http://localhost:7890 npx playwright test tests/tests-automations/regression/enterprise/auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)