### PR TITLE
ci: stop every PR paying a cold Playwright download, and bound the unguarded step

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -31,13 +31,37 @@ runs:
         key: ${{ runner.os }}-playwright-${{ steps.pw.outputs.version }}
 
     # System (apt) dependencies are never part of the cached browser directory,
-    # so install them on every run. Run WITHOUT a timeout on purpose: apt is
-    # local and interrupting it mid-transaction can leave dpkg half-configured,
-    # which would break every subsequent attempt. The observed stall is the
-    # browser download (below), not apt.
+    # so install them on every run.
+    #
+    # This step used to run WITHOUT any timeout, on the reasoning that apt is
+    # local and that interrupting it mid-transaction can leave dpkg
+    # half-configured. The first half of that stopped being true: on #1506 this
+    # action hung for 25 and 26 minutes across two runs, well past the ~15 min
+    # the download guard below can account for, so the time was being spent here
+    # or in the cache restore — not in the download the guard was written for.
+    #
+    # The second half still holds, which is why the bound does NOT abort the job.
+    # A ceiling generous enough that only a genuine stall reaches it, and a
+    # warning instead of a failure: a system dependency that really is missing
+    # surfaces a few steps later as a browser-launch error, which is loud and
+    # attributable. An unbounded hang surfaces as a job burning its entire
+    # budget, which is neither (#1507).
     - name: Install Playwright system dependencies
       shell: bash
-      run: npx playwright install-deps chromium
+      run: |
+        # Status captured from `timeout` itself: after `if cmd; then …; fi` with
+        # no else branch, `$?` is the status of the IF statement (0), not of the
+        # command — so reading it there would report "exit 0" on every stall and
+        # throw away the one diagnostic this warning carries. 124 means the
+        # ceiling was hit; anything else is apt's own failure.
+        set +e
+        timeout --kill-after=30s 8m npx playwright install-deps chromium
+        status=$?
+        set -e
+        if [ "$status" -eq 0 ]; then
+          exit 0
+        fi
+        echo "::warning::playwright install-deps exited ${status} (124 = hit the 8m ceiling). Continuing: a genuinely missing dependency surfaces as a browser launch failure, which is attributable, while hanging here is not (#1507)."
 
     # Download the browser binary with a per-attempt timeout + retries so a
     # stalled download is killed and retried instead of hanging. Run on BOTH

--- a/.github/workflows/cache-playwright.yml
+++ b/.github/workflows/cache-playwright.yml
@@ -1,0 +1,52 @@
+# Seed the Playwright browser cache on the DEFAULT BRANCH (#1507).
+#
+# Actions caches are scoped per ref: a pull request can read its own caches and
+# the default branch's, never another pull request's. `pr-validation.yml` runs
+# only on `pull_request`, so before this workflow existed the browser cache was
+# only ever written under `refs/pull/N/merge` — five such entries were created in
+# a single day, 249 MiB each, and not one of them was readable by the next PR.
+# Every pull request therefore paid a cold download, and one of those downloads
+# stalling is what hung #1506 twice.
+#
+# This job exists to write that cache once per relevant change on `main`, so PR
+# branches inherit it. It runs no tests and gates nothing.
+name: Cache Playwright browsers
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "package-lock.json"
+      - "package.json"
+      - ".github/actions/setup-playwright/action.yml"
+      - ".github/workflows/cache-playwright.yml"
+  # Manual runs matter after a cache eviction: GitHub evicts by LRU once the
+  # repository passes its size limit, and the browser entry is the largest one
+  # here, so it is the first to go on a quiet week.
+  workflow_dispatch:
+
+concurrency:
+  group: cache-playwright
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  warm:
+    name: Warm the browser cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          # Pinned to match every job in pr-validation.yml: the cache this warms
+          # is only useful if it was built by the same toolchain that will read it.
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      # The same composite action the PR lane uses, so what lands in the cache is
+      # exactly what that lane will look for — a second implementation here would
+      # be free to drift into caching the wrong path under the right key.
+      - uses: ./.github/actions/setup-playwright

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -231,6 +231,7 @@ jobs:
       # would match nothing and exit 1 while the destructive lane runs them fine.
       destructive_only: ${{ steps.diff.outputs.destructive_only }}
       excluded_only: ${{ steps.diff.outputs.excluded_only }}
+      browser_required: ${{ steps.diff.outputs.browser_required }}
       enterprise_specs: ${{ steps.diff.outputs.enterprise_specs }}
     steps:
       - uses: actions/checkout@v7
@@ -461,6 +462,22 @@ jobs:
           # Langflow Enterprise instance this runner does not have, so no step here
           # runs them. Saying so is the whole point — a skipped normal lane plus
           # silence reads as coverage (#1012).
+          # Whether anything selected actually opens a browser (#1507). Installing
+          # Chromium is the slowest step in this lane and it is unconditional, so a
+          # selection of request-only specs pays ~250 MiB and several minutes for a
+          # binary it never launches. Forced ON whenever `Collect models` runs (that
+          # spec drives a browser) or on a canary run, whose specs come from the CI
+          # classifier rather than from $SPECS. Every ambiguity inside the script
+          # resolves to "install": a wrong skip fails the run with a launch error
+          # that names nothing.
+          BROWSER_REQUIRED=true
+          if [ "$HAS_SPECS" = "true" ] && [ "$CANARY" != "true" ] && [ "$NEEDS_MODELS" != "true" ]; then
+            BROWSER_REQUIRED=$(node scripts/browser-required-selection.mjs --specs "$SPECS")
+          fi
+          if [ "$BROWSER_REQUIRED" = "false" ]; then
+            echo "::notice::No selected spec uses the page/context/browser fixtures, so the browser install is skipped for this PR (#1507)."
+          fi
+
           if [ -n "$ENTERPRISE_SPECS" ]; then
             echo "::warning::@enterprise specs in this PR are NOT executed by CI (no Enterprise instance on the runner): $ENTERPRISE_SPECS — run them locally with PW_ENTERPRISE=1 against one, and record the result in the PR."
           fi
@@ -473,6 +490,7 @@ jobs:
             echo "destructive_only=$DESTRUCTIVE_ONLY"
             echo "excluded_only=$EXCLUDED_ONLY"
             echo "enterprise_specs=$ENTERPRISE_SPECS"
+            echo "browser_required=$BROWSER_REQUIRED"
           } >> "$GITHUB_OUTPUT"
 
   e2e:
@@ -683,6 +701,9 @@ jobs:
       - run: npm ci
 
       - name: Install Playwright browsers
+        # Skipped when nothing selected opens a browser (#1507). The verdict is
+        # conservative by construction — see scripts/browser-required-selection.mjs.
+        if: needs.detect-specs.outputs.browser_required != 'false'
         uses: ./.github/actions/setup-playwright
 
       # Before ANY spec runs, including collect-models: point the echo-dependent

--- a/scripts/browser-required-selection.mjs
+++ b/scripts/browser-required-selection.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * Decides whether a spec selection needs a browser installed at all (#1507).
+ *
+ * Playwright launches a browser only for tests that use the `page`, `context`
+ * or `browser` fixtures. A spec that uses only `request` is an HTTP client:
+ * everything under `regression/enterprise/` today, plus several API specs.
+ * PR #1506 spent 26 minutes installing Chromium for seven such tests, twice,
+ * and both runs had to be cancelled — the install is the single slowest step in
+ * the lane and it is unconditional.
+ *
+ * The direction of caution is the opposite of `destructive-only-selection.mjs`.
+ * There, "runnable" was the safe default because skipping a lane loses coverage
+ * silently. Here the dangerous answer is a wrong SKIP: a browser-free verdict on
+ * a selection that actually opens a browser fails the run with a launch error
+ * that names nothing. So every ambiguity resolves to "install":
+ *
+ *   - a spec that cannot be read           => install
+ *   - a spec with no recognisable fixtures => install
+ *   - an empty selection                   => install
+ *
+ * Only a selection where EVERY spec is positively identified as browser-free
+ * skips the install, and the workflow additionally forces the install whenever
+ * `Collect models` runs (that spec drives a browser) or on a canary run.
+ *
+ * Usage:
+ *   node scripts/browser-required-selection.mjs --specs "a.spec.ts b.spec.ts"
+ *   node scripts/browser-required-selection.mjs --specs "…" --format=json
+ *
+ * Prints `true` / `false` (browser required), or the JSON verdict.
+ */
+
+import { readFileSync } from "node:fs";
+
+/**
+ * A destructured fixture list on an async callback: `async ({ page })`,
+ * `async ({ request, page })`, and the multi-line spellings prettier produces.
+ * Covers `test(...)`, `test.beforeEach(...)` and `test.step(...)` alike, because
+ * what matters is whether ANY callback in the file asks for a browser fixture.
+ */
+const FIXTURE_CALLBACK_RE = /async\s*\(\s*\{([^}]*)\}/g;
+const BROWSER_FIXTURES = ["page", "context", "browser"];
+
+/**
+ * `true` when the source positively asks for a browser fixture, `false` when it
+ * positively asks for none, and `null` when nothing recognisable was found —
+ * which the caller must treat as "install", never as "skip".
+ */
+export function usesBrowser(source) {
+  const lists = [...source.matchAll(FIXTURE_CALLBACK_RE)].map((match) => match[1]);
+  if (lists.length === 0) return null;
+
+  for (const list of lists) {
+    // Word boundaries: a fixture called `requestPage` or a property named
+    // `pageSize` must not read as the `page` fixture.
+    const names = list.split(",").map((entry) => entry.split(":")[0].trim());
+    if (names.some((name) => BROWSER_FIXTURES.includes(name))) return true;
+  }
+  return false;
+}
+
+/**
+ * @param specs     spec paths, as the workflow's `$SPECS` splits them
+ * @param readSpec  reads a spec's source; throws when it cannot
+ * @returns `{ browserRequired, browserFree, undecidable, browserUsing }`
+ */
+export function classifySelection(specs, readSpec) {
+  const browserFree = [];
+  const browserUsing = [];
+  const undecidable = [];
+
+  for (const spec of specs) {
+    let verdict;
+    try {
+      verdict = usesBrowser(readSpec(spec));
+    } catch {
+      // Unreadable is undecidable, and undecidable installs. This never fails
+      // the step: a selection this script cannot classify still runs, it just
+      // pays for the browser it might need.
+      undecidable.push(spec);
+      continue;
+    }
+    if (verdict === true) browserUsing.push(spec);
+    else if (verdict === false) browserFree.push(spec);
+    else undecidable.push(spec);
+  }
+
+  return {
+    browserRequired:
+      specs.length === 0 || browserUsing.length > 0 || undecidable.length > 0,
+    browserFree,
+    browserUsing,
+    undecidable,
+  };
+}
+
+function parseArgs(argv) {
+  const args = { specs: "", format: "value" };
+  for (const arg of argv) {
+    if (arg.startsWith("--specs=")) args.specs = arg.slice("--specs=".length);
+    else if (arg === "--specs") args.specsNext = true;
+    else if (arg.startsWith("--format=")) args.format = arg.slice("--format=".length);
+    else if (args.specsNext) {
+      args.specs = arg;
+      args.specsNext = false;
+    }
+  }
+  return args;
+}
+
+function main() {
+  const { specs, format } = parseArgs(process.argv.slice(2));
+  const list = specs.split(/\s+/).filter(Boolean);
+  const verdict = classifySelection(list, (spec) => readFileSync(spec, "utf8"));
+
+  if (format === "json") {
+    process.stdout.write(`${JSON.stringify(verdict)}\n`);
+  } else {
+    process.stdout.write(`${verdict.browserRequired}\n`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/browser-required-selection.test.mjs
+++ b/scripts/browser-required-selection.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import {
+  classifySelection,
+  usesBrowser,
+} from "./browser-required-selection.mjs";
+
+const API_SPEC = `
+  test("reads the policy", { tag: ["@api"] }, async ({ request }) => {});
+`;
+const UI_SPEC = `
+  test("opens the sidebar", { tag: ["@ui-ux"] }, async ({ page }) => {});
+`;
+const BEFORE_EACH_ONLY = `
+  test.beforeEach(async ({ page }) => { await page.goto("/"); });
+  test("does something", { tag: ["@ui-ux"] }, async ({ request }) => {});
+`;
+const MULTILINE = `
+  test("mixed", { tag: ["@api"] }, async ({
+    request,
+    page,
+  }) => {});
+`;
+const NOTHING_RECOGNISABLE = `
+  // a file with no fixture callbacks at all
+  export const helper = 1;
+`;
+
+function sources(map) {
+  return (spec) => {
+    if (!(spec in map)) throw new Error("ENOENT: no such file");
+    return map[spec];
+  };
+}
+
+describe("usesBrowser", () => {
+  it("sees a browser fixture, including one only a hook asks for", () => {
+    assert.equal(usesBrowser(UI_SPEC), true);
+    // The hook opens the browser for every test in the file, so the file needs
+    // one even though the test itself only takes `request`.
+    assert.equal(usesBrowser(BEFORE_EACH_ONLY), true);
+    assert.equal(usesBrowser(MULTILINE), true);
+  });
+
+  it("reports a request-only spec as browser-free", () => {
+    assert.equal(usesBrowser(API_SPEC), false);
+  });
+
+  it("reports UNDECIDABLE rather than browser-free when it recognises nothing", () => {
+    // The distinction that matters: `null` must not collapse into `false`, or an
+    // unparsed file would skip the install and fail at browser launch.
+    assert.equal(usesBrowser(NOTHING_RECOGNISABLE), null);
+  });
+
+  it("does not mistake a longer identifier for a browser fixture", () => {
+    assert.equal(usesBrowser(`async ({ requestPage }) => {}`), false);
+    assert.equal(usesBrowser(`async ({ pageSize }) => {}`), false);
+  });
+});
+
+describe("classifySelection", () => {
+  it("skips the install only when EVERY spec is positively browser-free", () => {
+    const verdict = classifySelection(
+      ["a.spec.ts", "b.spec.ts"],
+      sources({ "a.spec.ts": API_SPEC, "b.spec.ts": API_SPEC }),
+    );
+    assert.equal(verdict.browserRequired, false);
+    assert.equal(verdict.browserUsing.length, 0);
+  });
+
+  it("one browser spec makes the whole selection require it", () => {
+    const verdict = classifySelection(
+      ["a.spec.ts", "b.spec.ts"],
+      sources({ "a.spec.ts": API_SPEC, "b.spec.ts": UI_SPEC }),
+    );
+    assert.equal(verdict.browserRequired, true);
+    assert.deepEqual(verdict.browserUsing, ["b.spec.ts"]);
+  });
+
+  it("an unreadable spec installs, and does not throw", () => {
+    // The opposite default from destructive-only-selection.mjs, on purpose: a
+    // wrong skip here fails the run with a launch error that names nothing.
+    const verdict = classifySelection(
+      ["gone.spec.ts"],
+      sources({}),
+    );
+    assert.equal(verdict.browserRequired, true);
+    assert.deepEqual(verdict.undecidable, ["gone.spec.ts"]);
+  });
+
+  it("an unrecognisable spec installs", () => {
+    const verdict = classifySelection(
+      ["x.spec.ts"],
+      sources({ "x.spec.ts": NOTHING_RECOGNISABLE }),
+    );
+    assert.equal(verdict.browserRequired, true);
+  });
+
+  it("an EMPTY selection installs", () => {
+    // The job should not reach this with no specs, but answering `false` here
+    // would skip the install for a canary run, whose specs come from elsewhere.
+    assert.equal(classifySelection([], sources({})).browserRequired, true);
+  });
+});
+
+describe("the real suite", () => {
+  it("classifies a known API spec and a known UI spec correctly", () => {
+    const api = readFileSync(
+      "tests/tests-automations/regression/api/flows/api-health-check.spec.ts",
+      "utf8",
+    );
+    const ui = readFileSync(
+      "tests/tests-automations/regression/core-functionality/auth/logout-flow.spec.ts",
+      "utf8",
+    );
+    // Pinned against real files so a change in how specs are written — a new
+    // fixture style, say — shows up here instead of silently skipping installs.
+    assert.equal(usesBrowser(api), false);
+    assert.equal(usesBrowser(ui), true);
+  });
+});
+
+describe("pr-validation.yml wiring", () => {
+  const workflow = readFileSync(".github/workflows/pr-validation.yml", "utf8");
+
+  it("exports the verdict and gates the install step on it", () => {
+    assert.match(workflow, /browser_required: \$\{\{ steps\.diff\.outputs\.browser_required \}\}/);
+    assert.match(
+      workflow,
+      /if: needs\.detect-specs\.outputs\.browser_required != 'false'/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #1507

PR #1506 hung twice on `Install Playwright browsers` — 25 and 26 minutes — and both runs had to be cancelled while its other six checks were green in under two minutes. Three separate causes.

## The cache nothing could read

Actions caches are **scoped per ref**: a PR reads its own caches and the **default branch's**, never another PR's. `pr-validation.yml` runs only on `pull_request`, so the browser cache was only ever written under `refs/pull/N/merge`:

    refs/pull/1505/merge   refs/pull/1503/merge   refs/pull/1499/merge
    refs/pull/1494/merge   refs/pull/1496/merge

Five entries, 249 MiB each, one day, and not one readable by the next PR. Every PR paid a cold download.

`cache-playwright.yml` writes that cache on pushes to `main`, so PR branches inherit it. It runs no tests, gates nothing, and calls the **same composite action** the PR lane uses — a second implementation would be free to drift into caching the wrong path under the right key.

Worth stating because it was the first instinct: **clearing caches would not have helped.** There was no shared cache being reused to clear.

## The stall outside the guard

The action already bounds the browser **download**: three attempts, `timeout … 5m` each, from #344 — about 15 minutes, then a loud failure. Both hangs went **past** that, so the time was being spent where there was no bound: the cache restore, or `install-deps`, left unbounded on purpose with a comment stating *"the observed stall is the browser download, not apt"*. That stopped being true.

apt now has an 8m ceiling and, on hitting it, **warns and continues** instead of aborting. The original reasoning — interrupting apt mid-transaction can leave dpkg half-configured — still stands, so the fix is not to kill and fail. A dependency that really is missing surfaces a few steps later as a browser-launch error, which is attributable; an unbounded hang burns the whole job budget and is not.

One detail worth a look in review: the status for that warning is captured from `timeout` itself, **not** read after the `if`. With no `else` branch, `$?` there is the status of the IF statement — `0` — so the warning would have reported "exit 0" on every stall and thrown away its one diagnostic.

## The install nothing needed

Playwright launches a browser only for the `page`, `context` and `browser` fixtures. A spec using only `request` is an HTTP client — everything under `regression/enterprise/` is request-only today. #1506 spent 26 minutes installing Chromium, twice, for seven tests that never open one.

`browser-required-selection.mjs` decides this, and its caution runs **opposite** to `destructive-only-selection.mjs`. There, "runnable" was the safe default because skipping a lane loses coverage silently. Here the dangerous answer is a wrong **skip**: it fails the run with a launch error that names nothing. So an unreadable spec, an unrecognisable one, and an empty selection all resolve to *install*, and only a selection where **every** spec is positively browser-free skips it. The workflow forces the install anyway whenever `Collect models` runs (that spec drives a browser) or on a canary run, whose specs come from the CI classifier rather than from `$SPECS`.

## Validation

- `npm run test:scripts` → 828 tests, 0 fail (11 new).
- The new tests pin the traps: `null` (nothing recognisable) must not collapse into `false`; a `beforeEach`-only `page` still counts for the whole file; `requestPage` and `pageSize` are not mistaken for fixtures; and two **real** specs are classified, so a change in how specs are written surfaces here instead of silently skipping installs.
- Both workflows parse; the composite step's shell was checked with `bash -n` and exercised against a failing command to confirm the status is reported, not swallowed.

**This PR's own lane will install the browser**, because a CI-only change classifies as a canary run — the conservative path exercising itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)