### PR TITLE
test(enterprise): assert policy authority on all four knobs, and pin the admin inventory

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -1072,8 +1072,11 @@
 #### 22.1 Environment-Declared Policy
 
 - [!] A policy whose source is the deployment is reported as externally managed, and a runtime write can neither clear it nor survive into the palette — **expected red on current Enterprise builds**, tracked outside this repo; needs a fresh container per run → `enterprise/governance/environment-policy-authority.spec.ts`
-- [ ] The same authority question for the other three knobs: template blocklist, provider allowlist, model blocklist
-- [ ] `enterprise-admin/catalog/components` reflects the operator-declared policy
+- [!] The same authority question for the other three knobs, each on the surface a user would notice — template blocklist on the template listing, provider allowlist on the provider listing, model blocklist on the bundle — **expected red on current Enterprise builds**, tracked outside this repo → `enterprise/governance/environment-policy-authority.spec.ts`
+- [-] The admin inventory is the palette **plus exactly** what policy blocks: a blocked component stays listed there (or it could not be unblocked from the screen that blocked it), every placeable component is governable, and nothing is hidden that the declared policy does not account for → `enterprise/governance/admin-catalog-inventory.spec.ts`
+- [-] Every declared blocklist key resolves through `policy_candidates` to a component the inventory lists — a key that resolves to nothing is accepted at boot, echoed by the bundle and enforces nothing → `enterprise/governance/admin-catalog-inventory.spec.ts`
+- [ ] Whether the model blocklist should also filter `GET /api/v1/models` — measured today that it does not, there or through a runtime write, because that listing filters by provider only; the per-model predicate is consumed solely by the component dropdown's option builder
+- [ ] Provenance survives a restart: environment and API policy cannot silently disagree (needs a second container or an orchestrated restart)
 - [ ] Readiness stays unhealthy rather than serving permissively when the declared policy cannot be loaded (fail-closed)
 
 #### 22.2 Credential Lifecycle

--- a/docs/enterprise/governance/admin-catalog-inventory.md
+++ b/docs/enterprise/governance/admin-catalog-inventory.md
@@ -1,0 +1,94 @@
+# Enterprise — The Admin Catalog Inventory Agrees With the Declared Policy
+
+**Last validated:** Langflow Enterprise 1.12.0 (image built from `IBM-Langflow@release-1.12.0`)
+
+---
+
+## What this test validates *(required)*
+
+`GET /api/v1/enterprise-admin/catalog/components` is the Enterprise-only endpoint
+an administrator's catalog screen reads. It answers one question — *what can I
+block, and what is blocked?* — and it is the only surface that answers it, so a
+wrong answer there is not cosmetic: it is the operator choosing policy from a
+list that does not describe the instance.
+
+It is deliberately **not** the palette. The palette is what policy already
+filtered; the inventory is what policy can be written *about*, so it must keep
+listing a component after that component has been blocked — otherwise blocking
+one would remove it from the screen used to unblock it.
+
+That gives an exact relationship rather than a vague one, and the spec asserts it
+in both directions:
+
+- **`inventory ⊇ palette`** — nothing a user can place is missing from the
+  administrator's list. A component absent here cannot be governed at all.
+- **`inventory − palette` = exactly the declared blocklist** — the difference is
+  the policy and nothing else. A component that is in the inventory, absent from
+  the palette and *not* in the policy is one being hidden by something the
+  operator never declared.
+
+Measured on the reference instance: 161 inventory types, 160 palette types, the
+difference being the single blocked component and the reverse difference empty.
+
+### `policy_candidates` — the answer to a trap this area already has
+
+Each entry carries `policy_keys`, and the payload carries a `policy_candidates`
+map resolving **every accepted spelling** to the canonical type — `Combine Text`,
+`CombineTextComponent` and `CombineText` all resolve to `CombineText`.
+
+That map is what makes a declared key verifiable instead of hopeful, and this
+product area needs it: `governance/catalog-policy/template-blocklist-enforcement`
+measures that blocking a *template* by its display name is accepted and enforces
+nothing. Components resolve aliases; templates do not. An operator has no way to
+know which behaviour they are getting except by reading this endpoint, so the
+spec asserts that the key the deployment declared resolves through it.
+
+A blocklist entry that resolves to nothing is the silent-no-op failure mode in its
+purest form: accepted at boot, echoed by the bundle, enforcing nothing, with no
+error anywhere.
+
+## Tags *(required)*
+
+`@enterprise` `@api` `@regression` `@governance`
+
+No `@stable`: there is no scheduled Enterprise lane, so a `@stable` test here
+would silently never run (#1010).
+
+## Step by step *(required)*
+
+1. Authenticate with password login.
+2. Require the instance to block the component in its environment — skip, naming
+   the start command, otherwise.
+3. `GET /api/v1/enterprise-admin/catalog/components` → `200`, with a non-empty
+   `components` map and a non-empty `policy_candidates` map. An empty payload
+   would satisfy every set relation below and prove nothing, so it is refused
+   first.
+4. The blocked component is **present** in the inventory, with the declared key
+   among its `policy_keys`.
+5. `GET /api/v1/all` → the same component is **absent** from the palette.
+6. Every palette type appears in the inventory (`palette − inventory` is empty).
+7. `inventory − palette` equals exactly the set of blocked component keys the
+   bundle reports.
+8. Every declared blocklist key resolves through `policy_candidates` to a type
+   the inventory lists.
+
+## Validation criterion *(required)*
+
+Fails when the administrator's inventory disagrees with the instance it
+describes: a blocked component missing from it (ungovernable), a palette type
+missing from it (invisible to policy), a component hidden from the palette that
+the declared policy does not account for, or a declared key that resolves to
+nothing.
+
+## External dependencies *(required)*
+
+- A Langflow **Enterprise** instance started with the component blocked:
+  `LANGFLOW_CATALOG_COMPONENT_BLOCKLIST=CombineText ./scripts/start-langflow-enterprise.sh`
+- No LLM provider and no network egress.
+
+## Notes
+
+Unlike its sibling `environment-policy-authority`, this spec is **expected to
+pass**. It asserts an agreement that holds today, and it exists so that a future
+change to either side of it — the inventory or the enforcement — cannot move one
+without the other silently.

--- a/docs/enterprise/governance/environment-policy-authority.md
+++ b/docs/enterprise/governance/environment-policy-authority.md
@@ -27,19 +27,52 @@ policy any authenticated administrator can clear at runtime constrains nobody,
 and it fails silently, because the container still advertises the blocklist in
 its environment while the running instance no longer enforces it.
 
-The spec asserts the invariant in three parts, which is what makes a failure
-diagnosable rather than merely red:
+### Why every knob is asserted, rather than one and an inference
+
+The invariant is a property of the **surface**, not of a key: whether a runtime
+write can undo what the operator declared. Proving it for the component blocklist
+and inferring the other three is exactly the inference this product area has
+already shown to be unsafe. `governance/catalog-policy/template-blocklist-enforcement`
+measures it directly: blocking a template by the display name an operator reads in
+the UI is accepted and enforces nothing, while blocking by the internal `name_key`
+works. Two inputs, one endpoint, opposite outcomes, and no error either way.
+
+So each knob is asserted on the surface a user would actually notice:
+
+| Knob | Declared as | Surface the assertion reads |
+|---|---|---|
+| Component blocklist | `LANGFLOW_CATALOG_COMPONENT_BLOCKLIST` | `GET /api/v1/all` — the palette |
+| Template blocklist | `LANGFLOW_CATALOG_TEMPLATE_BLOCKLIST` | `GET /api/v1/flows/basic_examples/` |
+| Provider allowlist | `LANGFLOW_MODEL_PROVIDER_ALLOWLIST` | `GET /api/v1/models/providers` |
+| Model blocklist | `LANGFLOW_MODEL_BLOCKLIST` | `GET /api/v1/policy-bundle` |
+
+The template key is the **internal** one (`saas_pricing`, not `SaaS Pricing`) for
+the reason above — a display name would leave the spec green while blocking
+nothing, which is the false negative it exists to prevent.
+
+The model blocklist reads the **bundle** and not a listing, and that asymmetry is
+deliberate rather than an omission. `GET /api/v1/models` filters by provider and
+never by model: its handler calls the policy's `allows`/`filter`, and the only
+consumer of the per-model predicate `allows_model` is the option builder behind a
+component's model dropdown. Asserting that a blocked model is absent from the REST
+listing would assert something the product never promised there, and would go red
+for a reason that has nothing to do with authority.
+
+### The shape of each assertion
+
+Each knob is asserted in three parts, which is what makes a failure diagnosable
+rather than merely red:
 
 1. **Provenance is reported.** `GET /api/v1/policy-bundle` says `source:
-   "environment"`, and the per-resource read (`GET /api/v1/catalog-policy/components`)
-   agrees by reporting `managed_externally: true`. Clients gate the "read-only,
-   managed by your operator" state on that field.
-2. **The write is refused.** `PUT /api/v1/catalog-policy/components` does not
-   succeed while the policy is externally owned.
-3. **Enforcement survives the attempt.** Whatever the API answered, the blocked
-   component is still absent from `GET /api/v1/all` afterwards. This is the
-   assertion that matters: a refusal that leaves the policy cleared anyway would
-   satisfy (2) and still be a governance escape.
+   "environment"`, and the per-resource read agrees by reporting
+   `managed_externally: true`. Clients gate the "read-only, managed by your
+   operator" state on that field.
+2. **The write is refused.** The runtime `PUT` does not succeed while the policy
+   is externally owned.
+3. **Enforcement survives the attempt.** Whatever the API answered, the surface
+   still reflects what the deployment declared. This is the assertion that
+   matters: a refusal that leaves the policy cleared anyway would satisfy (2) and
+   still be a governance escape.
 
 > **Known state.** This spec is **expected to fail** on current Enterprise
 > builds. The failure is a product finding, tracked outside this repository; it
@@ -48,7 +81,10 @@ diagnosable rather than merely red:
 >
 > It also needs a **fresh container** per run: the assertions read the policy's
 > declared source, and a previous run's write changes it — a stale instance fails
-> the spec for a different reason than the one it exists for.
+> the spec for a different reason than the one it exists for. The gate skips
+> rather than failing when it sees a policy whose source is no longer the
+> environment, so that stale state reads as "not the instance this spec needs"
+> instead of as a product defect.
 
 ## Tags *(required)*
 
@@ -58,29 +94,55 @@ Reuses `@governance` rather than adding an Enterprise-only functional tag: it is
 the same product area as `governance/catalog-policy/`, and the `@enterprise`
 lane already separates the editions.
 
+No `@stable`: there is no scheduled Enterprise lane, so a `@stable` test here
+would silently never run (#1010).
+
 ## Step by step *(required)*
 
-1. Authenticate with password login.
-2. Require the instance to block `CombineText` — skip, naming the start command,
-   otherwise.
-3. `GET /api/v1/policy-bundle` → `source` is `environment` and
-   `blocked_component_keys` contains `CombineText`.
-4. `GET /api/v1/catalog-policy/components` → `managed_externally` is `true`.
-5. Attempt `PUT /api/v1/catalog-policy/components` with an empty blocked set →
-   the response is **not** a success status.
-6. `GET /api/v1/all` → `CombineText` is still absent.
-7. Restore: if step 5 did succeed, write the environment's blocked set back, so a
-   failing run does not leave the instance in a state that makes the sibling
-   specs report a second, derived failure.
+Every test begins the same way — authenticate with password login, then require
+the instance to carry the declared policy, skipping and naming the start command
+otherwise.
+
+1. **Component blocklist is reported as externally managed.** `GET
+   /api/v1/policy-bundle` → `source` is `environment`;
+   `GET /api/v1/catalog-policy/components` → `managed_externally` is `true`.
+2. **A runtime write cannot clear the component blocklist.** `PUT
+   /api/v1/catalog-policy/components` with an empty set → not a success status;
+   `GET /api/v1/all` → the component is still absent. Restore on the way out.
+3. **A runtime write cannot clear the template blocklist.** Baseline: the
+   template is absent from `GET /api/v1/flows/basic_examples/`. `PUT
+   /api/v1/catalog-policy/templates` with an empty set → not a success status,
+   `managed_externally` is `true`, and the template is still absent afterwards.
+   Restore on the way out.
+4. **A runtime write cannot widen the provider allowlist.** Baseline: `GET
+   /api/v1/models/providers` lists only the approved provider. `PUT
+   /api/v1/model-provider-policy` adding a second provider → not a success
+   status, and the listing is unchanged afterwards. Restore on the way out.
+5. **A runtime write cannot clear the model blocklist.** `PUT
+   /api/v1/policy-bundle` with `blocked_model_keys: []` and the rest of the
+   bundle carried over → not a success status, and the bundle still carries the
+   declared key. Restore on the way out.
 
 ## Validation criterion *(required)*
 
 Fails when deployment-declared policy can be observed, overridden or defeated at
 runtime: a policy whose source is the environment reported as locally managed, an
-accepted write, or a component that reappears in the palette after the attempt.
+accepted write, or a surface that reverts to the unconstrained state after the
+attempt.
 
 ## External dependencies *(required)*
 
-- A Langflow **Enterprise** instance started with the component blocked:
-  `LANGFLOW_CATALOG_COMPONENT_BLOCKLIST=CombineText ./scripts/start-langflow-enterprise.sh`
-- No LLM provider and no network egress.
+- A Langflow **Enterprise** instance started with all four knobs declared:
+
+  ```
+  LANGFLOW_CATALOG_COMPONENT_BLOCKLIST=CombineText \
+  LANGFLOW_CATALOG_TEMPLATE_BLOCKLIST=saas_pricing \
+  LANGFLOW_MODEL_PROVIDER_ALLOWLIST=openai \
+  LANGFLOW_MODEL_BLOCKLIST=gpt-4o-mini \
+  ./scripts/start-langflow-enterprise.sh
+  ```
+
+  Each test skips independently when its own knob is missing, so a partial
+  declaration runs the part it can rather than failing.
+- No LLM provider and no network egress. The provider allowlist is asserted on
+  the catalog listing, which needs no credential.

--- a/scripts/start-langflow-enterprise.sh
+++ b/scripts/start-langflow-enterprise.sh
@@ -93,13 +93,39 @@ for _ in $(seq 1 60); do
     # (sso_auth_service.py, reason="bootstrap_superuser"): every authenticated
     # endpoint answers 403 must_change_password until it is done. Doing it here
     # keeps the instance usable by the suite the moment this script returns.
-    if ! curl -sf -X POST "http://localhost:${PORT}/api/v1/login" \
-         -H 'Content-Type: application/x-www-form-urlencoded' \
-         -d "username=${LANGFLOW_SUPERUSER:-langflow}&password=${EE_PASSWORD}" > /dev/null 2>&1; then
+    #
+    # The probe is an AUTHENTICATED route, never `login`. Login is not gated by
+    # must_change_password — it mints a token for a user who may not use it — so
+    # a login probe answers "the password works", which is a different question.
+    # With LANGFLOW_EE_PASSWORD set to the bootstrap password (the
+    # credential-lifecycle spec needs exactly that, so the rotation is still
+    # pending when it runs) the login succeeds, the script concludes the
+    # rotation already happened, and returns an instance answering 403 on every
+    # authenticated route.
+    ROTATION_TOKEN="$(curl -sf -X POST "http://localhost:${PORT}/api/v1/login" \
+      -H 'Content-Type: application/x-www-form-urlencoded' \
+      -d "username=${LANGFLOW_SUPERUSER:-langflow}&password=${EE_PASSWORD}" \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null || true)"
+    ROTATION_PENDING=1
+    if [ -n "${ROTATION_TOKEN}" ] && curl -sf \
+         -H "Authorization: Bearer ${ROTATION_TOKEN}" \
+         "http://localhost:${PORT}/api/v1/users/whoami" > /dev/null 2>&1; then
+      ROTATION_PENDING=0
+    fi
+    # Rotating to the password the container was seeded with is not a rotation,
+    # and asking for it is how the credential-lifecycle spec asks for an
+    # instance that has NOT rotated yet. Say so rather than attempting a change
+    # whose acceptance would silently consume the state that spec needs.
+    if [ "${EE_PASSWORD}" = "${BOOTSTRAP_PASSWORD}" ]; then
+      ROTATION_PENDING=0
+      echo "Forced rotation left PENDING: LANGFLOW_EE_PASSWORD equals the bootstrap password."
+      echo "Every authenticated route will answer 403 must_change_password until something rotates it."
+    fi
+    if [ "${ROTATION_PENDING}" -eq 1 ]; then
       BOOTSTRAP_TOKEN="$(curl -sf -X POST "http://localhost:${PORT}/api/v1/login" \
         -H 'Content-Type: application/x-www-form-urlencoded' \
         -d "username=${LANGFLOW_SUPERUSER:-langflow}&password=${BOOTSTRAP_PASSWORD}" \
-        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))')"
+        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("access_token",""))' || true)"
       if [ -n "${BOOTSTRAP_TOKEN}" ]; then
         curl -sf -X POST "http://localhost:${PORT}/api/v1/account/force-password-change" \
           -H "Authorization: Bearer ${BOOTSTRAP_TOKEN}" \

--- a/tests/helpers/enterprise/policy-gate.ts
+++ b/tests/helpers/enterprise/policy-gate.ts
@@ -5,7 +5,7 @@ import {
 } from "../governance/policy-state";
 
 /**
- * Precondition for the Enterprise environment-policy spec.
+ * Precondition for the Enterprise environment-policy specs.
  *
  * This is the mirror image of `isPolicyPristine()` in the governance helper, and
  * the asymmetry is the point. An OSS governance spec WRITES the policy it needs,
@@ -22,29 +22,104 @@ import {
 export interface RequiredEnvironmentPolicy {
   /** Component keys the instance must have been started with. */
   blockedComponents?: string[];
+  /** Template keys the instance must have been started with. */
+  blockedTemplates?: string[];
   /** Provider ids the instance must approve. */
   approvedProviders?: string[];
+  /** Model keys the instance must have been started with. */
+  blockedModels?: string[];
+}
+
+/** The environment variable that declares each part of the policy. */
+const KNOB: Record<keyof RequiredEnvironmentPolicy, string> = {
+  blockedComponents: "LANGFLOW_CATALOG_COMPONENT_BLOCKLIST",
+  blockedTemplates: "LANGFLOW_CATALOG_TEMPLATE_BLOCKLIST",
+  approvedProviders: "LANGFLOW_MODEL_PROVIDER_ALLOWLIST",
+  blockedModels: "LANGFLOW_MODEL_BLOCKLIST",
+};
+
+/** Where the bundle reports each part of the policy. */
+const BUNDLE_FIELD: Record<
+  keyof RequiredEnvironmentPolicy,
+  keyof PolicyBundleResponse
+> = {
+  blockedComponents: "blocked_component_keys",
+  blockedTemplates: "blocked_template_keys",
+  approvedProviders: "approved_provider_ids",
+  blockedModels: "blocked_model_keys",
+};
+
+const PARTS = Object.keys(KNOB) as (keyof RequiredEnvironmentPolicy)[];
+
+function declared(
+  bundle: PolicyBundleResponse,
+  part: keyof RequiredEnvironmentPolicy,
+): string[] {
+  return (bundle[BUNDLE_FIELD[part]] as string[] | undefined) ?? [];
 }
 
 /** The `start-langflow-enterprise.sh` invocation that yields `required`. */
 function startCommandFor(required: RequiredEnvironmentPolicy): string {
-  const env: string[] = [];
-  if (required.blockedComponents?.length) {
-    env.push(`LANGFLOW_CATALOG_COMPONENT_BLOCKLIST=${required.blockedComponents.join(",")}`);
-  }
-  if (required.approvedProviders?.length) {
-    env.push(`LANGFLOW_MODEL_PROVIDER_ALLOWLIST=${required.approvedProviders.join(",")}`);
-  }
+  const env = PARTS.filter((part) => required[part]?.length).map(
+    (part) => `${KNOB[part]}=${required[part]!.join(",")}`,
+  );
   return `${env.join(" ")} ./scripts/start-langflow-enterprise.sh`.trim();
 }
 
 /**
- * Skip unless the instance carries `required` **and declared it in the
- * environment**. Returns the bundle so the caller need not read it twice.
+ * The revision the deployment's own declaration created, or `undefined`.
  *
- * The source check is not a formality: the same blocked set written through the
- * admin API would satisfy every other condition here while testing the OSS path
- * the governance specs already cover.
+ * Read from `/api/v1/policy-bundle/history` rather than from the live bundle,
+ * and that is the whole design of this gate rather than an optimisation. The
+ * live `source` field answers "who wrote the policy that is in force NOW", which
+ * stops being the question the moment one of these specs makes its override
+ * attempt: on a build where the attempt succeeds the bundle flips to `api` and
+ * never reverts for the life of the container.
+ *
+ * Two earlier shapes of this check both failed on that. Reading the live source
+ * made the first failing test skip every test after it — the specs would have
+ * reported the defect on one surface and stayed silent about the other three,
+ * which is the opposite of why they exist. Memoising the first observation in a
+ * module variable did not survive either, because Playwright recycles the worker
+ * process after a failed test, so the memo was empty again for the next one.
+ *
+ * The history row is immune to both: it is durable, it carries the key lists the
+ * deployment declared, and a fresh container starts a fresh history. It also
+ * says something the live bundle cannot — what the operator declared, as opposed
+ * to what survived.
+ */
+async function readDeclaredRevision(
+  request: APIRequestContext,
+  auth: string,
+): Promise<PolicyBundleResponse | undefined> {
+  const response = await request.get("/api/v1/policy-bundle/history", {
+    headers: { Authorization: auth },
+  });
+  if (!response.ok()) return undefined;
+  const items = ((await response.json()) as { items?: PolicyBundleResponse[] })
+    .items;
+  if (!Array.isArray(items)) return undefined;
+  // Highest revision wins: a restart onto a persisted database appends a second
+  // bootstrap rather than replacing the first, and the newest is the one whose
+  // environment is running.
+  return items
+    .filter((item) => item.source === "environment")
+    .sort((a, b) => (b.revision ?? 0) - (a.revision ?? 0))[0];
+}
+
+/**
+ * Skip unless the **deployment** declared `required`. Returns the live bundle,
+ * which is what a caller needs for `expected_revision` and for restoring.
+ *
+ * The provenance half is not a formality, and it is what keeps this lane honest.
+ * The same blocked set written through the admin API satisfies every other
+ * condition here while exercising the OSS path `regression/governance/` already
+ * covers — and it is not a hypothetical state, since a previous run of these
+ * very specs leaves the container that way.
+ *
+ * Skipping is the right verdict rather than failing, for the same reason the
+ * rest of this gate skips: the instance is not the one the spec needs, which is
+ * a statement about the environment, not about Langflow.
  */
 export async function requireEnvironmentPolicy(
   request: APIRequestContext,
@@ -52,19 +127,30 @@ export async function requireEnvironmentPolicy(
   required: RequiredEnvironmentPolicy,
 ): Promise<PolicyBundleResponse> {
   const bundle = await readPolicyBundle(request, auth);
-
-  const missingComponents = (required.blockedComponents ?? []).filter(
-    (key) => !(bundle.blocked_component_keys ?? []).includes(key),
-  );
-  const missingProviders = (required.approvedProviders ?? []).filter(
-    (id) => !(bundle.approved_provider_ids ?? []).includes(id),
-  );
+  const declaration = await readDeclaredRevision(request, auth);
 
   test.skip(
-    missingComponents.length > 0 || missingProviders.length > 0,
-    `Instance policy does not satisfy this spec (revision ${bundle.revision}, source '${bundle.source}'): ` +
-      `blocked components [${(bundle.blocked_component_keys ?? []).join(", ") || "none"}], ` +
-      `approved providers [${(bundle.approved_provider_ids ?? []).join(", ") || "all"}]. ` +
+    declaration === undefined,
+    `This instance has no environment-declared policy revision (live bundle is ` +
+      `revision ${bundle.revision}, source '${bundle.source}'). These specs read ` +
+      `the policy the DEPLOYMENT declared, which the admin API cannot produce. ` +
+      `Start the instance with: ${startCommandFor(required)}`,
+  );
+
+  const missing = PARTS.flatMap((part) =>
+    (required[part] ?? [])
+      .filter((key) => !declared(declaration!, part).includes(key))
+      .map((key) => `${KNOB[part]} is missing '${key}'`),
+  );
+
+  const state = PARTS.map(
+    (part) => `${KNOB[part]}=[${declared(declaration!, part).join(", ") || "none"}]`,
+  ).join(", ");
+
+  test.skip(
+    missing.length > 0,
+    `The deployment's declared policy (revision ${declaration!.revision}) does ` +
+      `not satisfy this spec: ${missing.join("; ")}. It declared ${state}. ` +
       `Start the instance with: ${startCommandFor(required)}`,
   );
 

--- a/tests/helpers/governance/policy-state.ts
+++ b/tests/helpers/governance/policy-state.ts
@@ -30,6 +30,9 @@ export interface PolicyBundleResponse {
   blocked_component_keys?: string[];
   blocked_template_keys?: string[];
   approved_provider_ids?: string[];
+  // Carried by the bundle and writable through it, but with no dedicated
+  // per-resource endpoint of its own — unlike the three above.
+  blocked_model_keys?: string[];
   rollback_of_revision?: number | null;
   reason?: string | null;
   managed_externally?: boolean;
@@ -143,12 +146,19 @@ export async function restorePolicy(
 }
 
 /**
- * The component types the palette would render, as a set.
+ * The keys of every top-level map in `/api/v1/all`, as a set.
  *
  * `/api/v1/all` is `category -> { type -> template }`; the specs assert over the
  * flattened type set because a blocked component is removed from its category,
  * and a category-level count would miss it (the same reason
  * `component-catalog-drift.ts` snapshots types rather than categories).
+ *
+ * It folds in `component_display_names`, which is a **metadata map and not a
+ * category**, so the result is roughly twice the number of real types. That is
+ * harmless for the membership and relative-size assertions the governance specs
+ * make — its keys are lowercased display names, which collide with nothing —
+ * and wrong for anything that compares this set against another catalog. Use
+ * {@link readPaletteComponentTypes} for that.
  */
 export async function readCatalogTypes(
   request: APIRequestContext,
@@ -157,6 +167,41 @@ export async function readCatalogTypes(
   const catalog = await okJson(request, "get", "/api/v1/all", auth);
   const types = new Set<string>();
   for (const category of Object.values(catalog)) {
+    if (category && typeof category === "object") {
+      for (const type of Object.keys(category as Record<string, unknown>)) {
+        types.add(type);
+      }
+    }
+  }
+  return types;
+}
+
+/** The one top-level key of `/api/v1/all` that is not a component category. */
+const CATALOG_METADATA_KEY = "component_display_names";
+
+/**
+ * The component types the palette would render — and only those.
+ *
+ * The difference from {@link readCatalogTypes} is one excluded key and it
+ * decides whether set algebra over this catalog means anything: on the
+ * reference Enterprise instance the raw flatten yields 320 entries against 160
+ * real types, because `component_display_names` maps every type again by its
+ * lowercased display name. Comparing that against another catalog reports 160
+ * phantom absences.
+ *
+ * Kept as a second function rather than a flag on the first: the existing
+ * callers assert membership and relative size, where the metadata map costs
+ * nothing, and silently changing what their baseline counts would be a change
+ * to their meaning, not a fix to their helper.
+ */
+export async function readPaletteComponentTypes(
+  request: APIRequestContext,
+  auth: string,
+): Promise<Set<string>> {
+  const catalog = await okJson(request, "get", "/api/v1/all", auth);
+  const types = new Set<string>();
+  for (const [name, category] of Object.entries(catalog)) {
+    if (name === CATALOG_METADATA_KEY) continue;
     if (category && typeof category === "object") {
       for (const type of Object.keys(category as Record<string, unknown>)) {
         types.add(type);

--- a/tests/tests-automations/regression/enterprise/governance/admin-catalog-inventory.spec.ts
+++ b/tests/tests-automations/regression/enterprise/governance/admin-catalog-inventory.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getEnterpriseAuthToken } from "../../../../helpers/enterprise/enterprise-auth";
+import { requireEnvironmentPolicy } from "../../../../helpers/enterprise/policy-gate";
+import { readPaletteComponentTypes } from "../../../../helpers/governance/policy-state";
+
+/**
+ * `GET /api/v1/enterprise-admin/catalog/components` is the Enterprise-only
+ * endpoint an administrator's catalog screen reads. It answers one question —
+ * what can I block, and what is blocked — and it is the only surface that
+ * answers it, so a wrong answer there is not cosmetic: it is the operator
+ * choosing policy from a list that does not describe the instance.
+ *
+ * It is deliberately NOT the palette. The palette is what policy already
+ * filtered; the inventory is what policy can be written about, so it must keep
+ * listing a component after that component has been blocked — otherwise
+ * blocking one would remove it from the screen used to unblock it.
+ *
+ * That makes the relationship exact rather than vague, and both directions are
+ * asserted: the inventory is a superset of the palette (nothing a user can place
+ * is ungovernable), and the difference between them is the declared blocklist
+ * and nothing else (nothing is being hidden that the operator did not declare).
+ *
+ * Unlike its sibling `environment-policy-authority`, this spec is expected to
+ * PASS. It pins an agreement that holds today so a future change to either side
+ * of it cannot move one without the other.
+ */
+const BLOCKED_COMPONENT = "CombineText";
+
+
+interface CatalogInventory {
+  components: Record<string, Record<string, { policy_keys?: string[] }>>;
+  policy_candidates: Record<string, string[]>;
+}
+
+test.describe("Enterprise — the admin catalog inventory agrees with the policy", () => {
+  test(
+    "the inventory lists what policy can govern, including what it already blocks",
+    { tag: ["@enterprise", "@api", "@regression", "@governance"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      await requireEnvironmentPolicy(request, auth, {
+        blockedComponents: [BLOCKED_COMPONENT],
+      });
+
+      const response = await request.get(
+        "/api/v1/enterprise-admin/catalog/components",
+        { headers: { Authorization: auth } },
+      );
+      expect(response.status()).toBe(200);
+      const inventory = (await response.json()) as CatalogInventory;
+
+      await test.step("the payload is populated", async () => {
+        // Refused first: an empty inventory satisfies every set relation below
+        // while proving nothing, which is the shape of a false pass (#1012).
+        expect(Object.keys(inventory.components).length).toBeGreaterThan(0);
+        expect(Object.keys(inventory.policy_candidates).length).toBeGreaterThan(0);
+      });
+
+      await test.step("the blocked component is still offered to policy", async () => {
+        const entry = Object.values(inventory.components)
+          .map((category) => category[BLOCKED_COMPONENT])
+          .find(Boolean);
+        expect(
+          entry,
+          `${BLOCKED_COMPONENT} is blocked but absent from the admin inventory, ` +
+            `so it cannot be unblocked from the screen that blocked it`,
+        ).toBeTruthy();
+        expect(entry!.policy_keys).toContain(BLOCKED_COMPONENT);
+      });
+
+      await test.step("and it is absent from the palette", async () => {
+        expect(await readPaletteComponentTypes(request, auth)).not.toContain(
+          BLOCKED_COMPONENT,
+        );
+      });
+    },
+  );
+
+  test(
+    "the inventory is the palette plus exactly what policy blocks",
+    { tag: ["@enterprise", "@api", "@regression", "@governance"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const bundle = await requireEnvironmentPolicy(request, auth, {
+        blockedComponents: [BLOCKED_COMPONENT],
+      });
+
+      const response = await request.get(
+        "/api/v1/enterprise-admin/catalog/components",
+        { headers: { Authorization: auth } },
+      );
+      expect(response.status()).toBe(200);
+      const inventory = (await response.json()) as CatalogInventory;
+
+      const inventoryTypes = new Set(
+        Object.values(inventory.components).flatMap((category) =>
+          Object.keys(category),
+        ),
+      );
+      // Excludes `component_display_names`, which is a metadata map and not a
+      // category — folding it in doubles the set and reports every real type as
+      // a phantom absence here.
+      const paletteTypes = await readPaletteComponentTypes(request, auth);
+
+      await test.step("every placeable component is governable", async () => {
+        const ungovernable = [...paletteTypes].filter(
+          (type) => !inventoryTypes.has(type),
+        );
+        expect(
+          ungovernable,
+          "these types are in the palette but absent from the admin inventory, " +
+            "so no policy can be written about them",
+        ).toEqual([]);
+      });
+
+      await test.step("nothing is hidden that policy does not account for", async () => {
+        const hidden = [...inventoryTypes]
+          .filter((type) => !paletteTypes.has(type))
+          .sort();
+        expect(hidden).toEqual([...(bundle.blocked_component_keys ?? [])].sort());
+      });
+    },
+  );
+
+  test(
+    "every declared blocklist key resolves to a component the inventory lists",
+    { tag: ["@enterprise", "@api", "@regression", "@governance"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const bundle = await requireEnvironmentPolicy(request, auth, {
+        blockedComponents: [BLOCKED_COMPONENT],
+      });
+
+      const response = await request.get(
+        "/api/v1/enterprise-admin/catalog/components",
+        { headers: { Authorization: auth } },
+      );
+      expect(response.status()).toBe(200);
+      const inventory = (await response.json()) as CatalogInventory;
+
+      const inventoryTypes = new Set(
+        Object.values(inventory.components).flatMap((category) =>
+          Object.keys(category),
+        ),
+      );
+
+      // `policy_candidates` resolves every accepted spelling to the canonical
+      // type — display name, class name and type all map to the same entry.
+      // Templates have no such resolver, which is why blocking one by display
+      // name is accepted and enforces nothing
+      // (`governance/catalog-policy/template-blocklist-enforcement`). An
+      // operator cannot tell the two behaviours apart except by reading this,
+      // so a declared key that resolves to nothing is the silent no-op in its
+      // purest form: accepted at boot, echoed by the bundle, enforcing nothing.
+      for (const key of bundle.blocked_component_keys ?? []) {
+        const resolved = inventory.policy_candidates[key];
+        expect(
+          resolved,
+          `the deployment declared '${key}', which the admin inventory does not ` +
+            `offer as a policy key — it can never match a component`,
+        ).toBeTruthy();
+        expect(resolved!.length).toBeGreaterThan(0);
+        for (const type of resolved!) {
+          expect(inventoryTypes).toContain(type);
+        }
+      }
+    },
+  );
+});

--- a/tests/tests-automations/regression/enterprise/governance/environment-policy-authority.spec.ts
+++ b/tests/tests-automations/regression/enterprise/governance/environment-policy-authority.spec.ts
@@ -1,7 +1,11 @@
+import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getEnterpriseAuthToken } from "../../../../helpers/enterprise/enterprise-auth";
 import { requireEnvironmentPolicy } from "../../../../helpers/enterprise/policy-gate";
-import { readCatalogTypes } from "../../../../helpers/governance/policy-state";
+import {
+  readCatalogTypes,
+  readPolicyBundle,
+} from "../../../../helpers/governance/policy-state";
 
 /**
  * The half of catalog governance that Enterprise still owns.
@@ -19,17 +23,67 @@ import { readCatalogTypes } from "../../../../helpers/governance/policy-state";
  * silently: the container goes on advertising the blocklist in its environment
  * while the running instance no longer applies it.
  *
+ * All four governance knobs are asserted rather than one and an inference, and
+ * each on the surface a user would notice. The inference is unsafe in this exact
+ * area: `governance/catalog-policy/template-blocklist-enforcement` measures that
+ * blocking a template by its display name is accepted and enforces nothing,
+ * while the internal key works — two inputs to one endpoint, opposite outcomes,
+ * no error either way. Which is also why the template key here is the internal
+ * one.
+ *
  * This spec is EXPECTED TO FAIL on current Enterprise builds. The failure is a
  * product finding tracked outside this repository, not a defect in the spec —
  * do not relax the assertions to make the lane green.
  *
  * It needs a FRESH container each run: the assertions read the policy's declared
- * source, and a previous run's write changes it, which fails the spec for a
- * different reason than the one it exists for.
+ * source, and a previous run's write changes it. The gate skips on a written
+ * policy rather than failing, so that state reads as the wrong instance instead
+ * of a product defect.
  */
 const BLOCKED_COMPONENT = "CombineText";
+/** The internal key, never the display name — see the header. */
+const BLOCKED_TEMPLATE_KEY = "saas_pricing";
+const BLOCKED_TEMPLATE_NAME = "SaaS Pricing";
+const APPROVED_PROVIDER = "openai";
+/** A provider the deployment did NOT approve, used to attempt a widening. */
+const UNAPPROVED_PROVIDER = "anthropic";
+const BLOCKED_MODEL = "gpt-4o-mini";
+
+
+async function listedTemplates(
+  request: APIRequestContext,
+  auth: string,
+): Promise<string[]> {
+  const response = await request.get("/api/v1/flows/basic_examples/", {
+    headers: { Authorization: auth },
+  });
+  expect(response.status()).toBe(200);
+  return ((await response.json()) as { name: string }[]).map(
+    (item) => item.name,
+  );
+}
+
+async function listedProviders(
+  request: APIRequestContext,
+  auth: string,
+): Promise<string[]> {
+  const response = await request.get("/api/v1/models/providers", {
+    headers: { Authorization: auth },
+  });
+  expect(response.status()).toBe(200);
+  return (await response.json()) as string[];
+}
 
 test.describe("Enterprise — environment-declared policy is authoritative", () => {
+  // No retries, deliberately. Each test here attempts an override, and on a
+  // build where the attempt succeeds it consumes the very state the run needs:
+  // the live bundle's provenance flips to `api` and never reverts. A retry
+  // therefore re-runs against an instance the first attempt already changed, so
+  // it cannot confirm or refute anything — it only produces a second, differently
+  // worded failure. The gate reads the deployment's own history revision so the
+  // remaining tests still run; retrying is the one thing that cannot be salvaged.
+  test.describe.configure({ retries: 0 });
+
   test(
     "policy declared by the deployment is reported as externally managed",
     { tag: ["@enterprise", "@api", "@regression", "@governance"] },
@@ -53,7 +107,7 @@ test.describe("Enterprise — environment-declared policy is authoritative", () 
   );
 
   test(
-    "a runtime write cannot clear a policy the deployment declared",
+    "a runtime write cannot clear a component blocklist the deployment declared",
     { tag: ["@enterprise", "@api", "@regression", "@governance"] },
     async ({ request }) => {
       const auth = await getEnterpriseAuthToken(request);
@@ -84,6 +138,154 @@ test.describe("Enterprise — environment-declared policy is authoritative", () 
           await request.put("/api/v1/catalog-policy/components", {
             headers: { Authorization: auth },
             data: { blocked: bundle.blocked_component_keys ?? [] },
+          });
+        }
+      }
+    },
+  );
+
+  test(
+    "a runtime write cannot clear a template blocklist the deployment declared",
+    { tag: ["@enterprise", "@api", "@regression", "@governance"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const bundle = await requireEnvironmentPolicy(request, auth, {
+        blockedTemplates: [BLOCKED_TEMPLATE_KEY],
+      });
+
+      await test.step("the declared block is in force to begin with", async () => {
+        // Without this the test could pass against an instance where the key
+        // never enforced anything — the display-name no-op in miniature.
+        expect(await listedTemplates(request, auth)).not.toContain(
+          BLOCKED_TEMPLATE_NAME,
+        );
+      });
+
+      const attempt = await request.put("/api/v1/catalog-policy/templates", {
+        headers: { Authorization: auth },
+        data: { blocked: [] },
+      });
+
+      try {
+        await test.step("the write is refused", async () => {
+          expect(attempt.ok()).toBe(false);
+        });
+
+        await test.step("the template stays out of the listing", async () => {
+          expect(await listedTemplates(request, auth)).not.toContain(
+            BLOCKED_TEMPLATE_NAME,
+          );
+        });
+      } finally {
+        if (attempt.ok()) {
+          await request.put("/api/v1/catalog-policy/templates", {
+            headers: { Authorization: auth },
+            data: { blocked: bundle.blocked_template_keys ?? [] },
+          });
+        }
+      }
+    },
+  );
+
+  test(
+    "a runtime write cannot widen a provider allowlist the deployment declared",
+    { tag: ["@enterprise", "@api", "@regression", "@governance"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const bundle = await requireEnvironmentPolicy(request, auth, {
+        approvedProviders: [APPROVED_PROVIDER],
+      });
+
+      const baseline = await listedProviders(request, auth);
+      await test.step("the allowlist is in force to begin with", async () => {
+        // The unapproved provider must be absent for the widening attempt below
+        // to mean anything — otherwise it was never constrained.
+        expect(baseline.map((name) => name.toLowerCase())).not.toContain(
+          UNAPPROVED_PROVIDER,
+        );
+      });
+
+      const attempt = await request.put("/api/v1/model-provider-policy", {
+        headers: { Authorization: auth },
+        data: {
+          approved_provider_ids: [
+            ...(bundle.approved_provider_ids ?? []),
+            UNAPPROVED_PROVIDER,
+          ],
+        },
+      });
+
+      try {
+        await test.step("the write is refused", async () => {
+          expect(attempt.ok()).toBe(false);
+        });
+
+        await test.step("the provider listing is unchanged", async () => {
+          // Widening is the direction that matters: a runtime write that adds a
+          // provider the operator excluded defeats the allowlist just as
+          // completely as clearing it, and leaves the policy looking populated.
+          expect(await listedProviders(request, auth)).toEqual(baseline);
+        });
+      } finally {
+        if (attempt.ok()) {
+          await request.put("/api/v1/model-provider-policy", {
+            headers: { Authorization: auth },
+            data: { approved_provider_ids: bundle.approved_provider_ids ?? [] },
+          });
+        }
+      }
+    },
+  );
+
+  test(
+    "a runtime write cannot clear a model blocklist the deployment declared",
+    { tag: ["@enterprise", "@api", "@regression", "@governance"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      const bundle = await requireEnvironmentPolicy(request, auth, {
+        blockedModels: [BLOCKED_MODEL],
+      });
+
+      // Asserted on the bundle rather than on a listing, and deliberately so:
+      // `GET /api/v1/models` filters by provider and never by model — its
+      // handler calls the policy's `allows`/`filter`, while the only consumer
+      // of the per-model predicate is the option builder behind a component's
+      // model dropdown. Asserting absence from the REST listing would assert
+      // something the product never promised there.
+      const attempt = await request.put("/api/v1/policy-bundle", {
+        headers: { Authorization: auth },
+        data: {
+          expected_revision: bundle.revision,
+          approved_provider_ids: bundle.approved_provider_ids ?? [],
+          blocked_component_keys: bundle.blocked_component_keys ?? [],
+          blocked_template_keys: bundle.blocked_template_keys ?? [],
+          blocked_model_keys: [],
+          reason: "environment-policy-authority: attempt to clear",
+        },
+      });
+
+      try {
+        await test.step("the write is refused", async () => {
+          expect(attempt.ok()).toBe(false);
+        });
+
+        await test.step("the bundle still carries the declared model", async () => {
+          const after = await readPolicyBundle(request, auth);
+          expect(after.blocked_model_keys).toContain(BLOCKED_MODEL);
+        });
+      } finally {
+        if (attempt.ok()) {
+          const current = await readPolicyBundle(request, auth);
+          await request.put("/api/v1/policy-bundle", {
+            headers: { Authorization: auth },
+            data: {
+              expected_revision: current.revision,
+              approved_provider_ids: current.approved_provider_ids ?? [],
+              blocked_component_keys: current.blocked_component_keys ?? [],
+              blocked_template_keys: current.blocked_template_keys ?? [],
+              blocked_model_keys: bundle.blocked_model_keys ?? [],
+              reason: "environment-policy-authority: restore",
+            },
           });
         }
       }


### PR DESCRIPTION
Closes #1510

## What changed

The environment-policy spec asserted its invariant against **one** of the four governance
knobs an Enterprise deployment declares at boot. It now asserts all four, each on the
surface a user would notice, and a second spec pins the admin component inventory.

| Knob | Surface asserted |
|---|---|
| Component blocklist | the palette |
| Template blocklist | the template listing |
| Provider allowlist | the provider listing |
| Model blocklist | the policy bundle |

The model blocklist reads the bundle deliberately rather than a listing: `GET
/api/v1/models` filters by provider and never by model — its handler calls the policy's
`allows`/`filter`, while the only consumer of the per-model predicate is the option
builder behind a component's model dropdown. Asserting absence from the REST listing
would assert something the product never promised there.

The new `admin-catalog-inventory` spec is **expected to pass**. It pins an exact
relationship: the inventory is the palette plus exactly what policy blocks. Both
directions matter — a blocked component must stay listed there or it could not be
unblocked from the screen that blocked it, and nothing may be hidden that the declared
policy does not account for.

## Three fixes the work surfaced

**`requireEnvironmentPolicy()` documented a precondition it did not enforce.** It accepted
a policy written through the admin API, which is the OSS path already covered — so a
stale container would be reported as a product defect. It now reads the deployment's own
history revision. Two simpler shapes were tried and are worth recording because both look
correct: reading the live `source` field made the first failing test skip every test after
it (the override attempt flips it to `api` permanently, so the specs would have reported
the defect on one surface and stayed silent about three); memoising the first observation
in a module variable did not survive either, because Playwright recycles the worker
process after a failed test. The history row is durable, carries the key lists the
deployment declared, and a fresh container starts a fresh history.

**`readCatalogTypes()` folds in `component_display_names`**, which is a metadata map and
not a category. Harmless for the membership and relative-size assertions its callers make;
wrong for set algebra, where it doubles the set and reports 160 phantom absences. Added
`readPaletteComponentTypes()` rather than changing the shared helper — the existing
callers compare against a baseline they captured themselves, so silently moving what that
baseline counts would change their meaning rather than fix their helper.

**`start-langflow-enterprise.sh` probed the wrong thing.** It decided whether to rotate the
bootstrap password by trying `login`, which is *not* gated by `must_change_password` — it
mints a token for a user who may not use it. With `LANGFLOW_EE_PASSWORD` set to the
bootstrap password the login succeeded, the script concluded the rotation had already
happened, and returned an instance answering `403` on **every** authenticated route. The
probe is an authenticated route now, and the matching-passwords case says so explicitly
rather than attempting a change whose acceptance would consume the pending state the
credential-lifecycle spec asks for.

## Verification

Run against a locally built Enterprise image (`1.12.0` from `IBM-Langflow@release-1.12.0`),
fresh container per measurement:

- `admin-catalog-inventory` — **3 passed**. Force-failed by inverting the set-difference
  assertion: fails as expected, reverted, green again.
- `environment-policy-authority` — **5 tests all run**, all failing on the same step. That
  failing state is the known one the spec header describes and is tracked outside this
  repo; the point of this PR is that the question is now asked of four surfaces instead of
  one. Before the gate fix the same run reported 2 failed / 3 skipped.
- Gate skip path — pointed at an instance with no environment-declared policy: **8
  skipped, zero failures**, which is the verdict that keeps a wrong instance from reading
  as a product defect.
- `npm run typecheck`, `npm run lint` (0 errors), `npm run test:units` (712 pass / 0 fail),
  `npm run test:scripts` (0 fail), checklist guard and coverage guard all clean.

## Notes

No `@stable` — there is no scheduled Enterprise lane, so a `@stable` test here would
silently never run (#1010). These specs run only under `PW_ENTERPRISE=1`.

Two open questions are recorded as unchecked checklist bullets rather than asserted in
either direction: whether the model blocklist should also filter `GET /api/v1/models`, and
provenance surviving a restart (which needs a second container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)