### PR TITLE
test(enterprise): prove an unlicensed instance is unavailable rather than open

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -1103,6 +1103,14 @@
 - [ ] Actually using break-glass records the use — needs an SSO-only state, which needs a connection, which is entitlement-gated
 - [ ] A created SSO connection is disabled by default, plan limits are enforced server-side, and the client secret is masked on read — all blocked without a licence (issue #1501)
 
+#### 22.5 Entitlement Fail-Closed (no licence)
+
+- [-] The gated read and the gated write both answer `503` with **one** message, asserted exactly and carrying a `detail` and nothing else — a licence failure is where a stack trace, an internal host or a key identifier would escape, and no other test here would notice → `enterprise/auth/entitlement-fail-closed.spec.ts`
+- [-] The refusal is **total**: creation is refused, so no connection comes into existence and none is left half-created for a later request to find — this is the assertion that separates "unavailable" from "open" → `enterprise/auth/entitlement-fail-closed.spec.ts`
+- [-] Authentication is answered **before** entitlement: an anonymous caller gets `403`, never the `503`, so the licence gate cannot be used to enumerate which Enterprise surfaces a deployment has → `enterprise/auth/entitlement-fail-closed.spec.ts`
+- [-] The blast radius is bounded — flows, the component catalog, projects and identity all answer `200`. An unlicensed Enterprise is missing its entitled features, not broken → `enterprise/auth/entitlement-fail-closed.spec.ts`
+- [ ] The entitled behaviour itself (a valid licence unlocks exactly the entitled surfaces and nothing else; an invalid, expired or wrong-signature licence is refused, naming which of the three) — blocked on a licence key
+
 ---
 
 ---

--- a/docs/enterprise/auth/entitlement-fail-closed.md
+++ b/docs/enterprise/auth/entitlement-fail-closed.md
@@ -1,0 +1,103 @@
+# Enterprise — Without a Licence, the Entitled Surface Fails Closed
+
+**Last validated:** Langflow Enterprise 1.12.0 (image built from `IBM-Langflow@release-1.12.0`)
+
+---
+
+## What this test validates *(required)*
+
+An Enterprise instance that cannot validate a licence has to be **unavailable**, not
+**open**. Those two words describe the same HTTP outcome to a casual reader and opposite
+outcomes to an operator: one means the entitled feature cannot be used, the other means it
+is being served without the check that governs it.
+
+Most of the SSO surface is blocked on entitlement validation, which is why the rest of
+session 5 of the Enterprise plan is unreachable without a licence key. The half that *is*
+reachable is the one that matters most, because it is the difference above — and nothing
+covers it.
+
+Four properties, measured on an instance with no licence:
+
+1. **The gated routes refuse, with one stable message.** `GET /api/v1/sso/entitlements`
+   and `POST /api/v1/sso/connections` both answer `503` with the identical body
+   `{"detail":"Enterprise license validation is unavailable"}`.
+2. **The refusal is total.** The creation route is refused, so no connection can come into
+   existence — `GET /api/v1/sso/connections` stays empty, and there is no half-created
+   connection for a later request to trip over.
+3. **Authentication runs first.** An anonymous caller gets `403 No authentication
+   credentials provided`, not the `503`. The licence gate never answers before the auth
+   gate, so it cannot be used to enumerate which Enterprise surfaces a deployment has.
+4. **The blast radius is bounded.** Flows, the component catalog, projects and identity all
+   answer `200`. An unlicensed Enterprise is a product missing its entitled features, not a
+   product that stopped working.
+
+### What the message must not become
+
+The failure text is asserted **exactly**, not with a loose `toContain`. A licence failure is
+a natural place for a stack trace, an internal hostname, a signing-key identifier or a
+vendor URL to escape into a response body an unauthenticated-adjacent caller can read — and
+each of those would be a leak that no other test in this suite would notice. Measured today
+the body is 57 bytes and carries a `detail` and nothing else.
+
+Pinning the string has a cost worth naming: a product decision to reword it fails this
+test. That is the intended trade. The reword is a one-line update here, while a silently
+widened message is exactly what an exact assertion exists to catch.
+
+## Relationship to the neighbouring specs
+
+`login-surface.spec.ts` already covers the other half of the fail-closed story — that
+password login survives SSO being switched on but unusable, and that break-glass ships
+disabled. This spec does not repeat it; between them, "SSO is unavailable" is proven to
+mean the organisation is neither locked out nor let in.
+
+## Tags *(required)*
+
+`@enterprise` `@api` `@auth` `@sso`
+
+Reuses the pairing `login-surface.spec.ts` established rather than introducing licensing
+vocabulary: the licence is what gates this surface, but the surface is SSO, and a reader
+filtering for `@sso` wants this test.
+
+No `@stable`: there is no scheduled Enterprise lane, so a `@stable` test here would
+silently never run (#1010).
+
+## Step by step *(required)*
+
+Every test first requires the instance to have **no** licence — `GET /api/v1/sso/entitlements`
+answering `503`. A licensed instance skips, naming why, because every assertion below
+describes the unlicensed state and would otherwise report a correctly licensed deployment
+as a defect.
+
+1. **The gated read and the gated write refuse identically.** Both answer `503`; the two
+   bodies are compared to each other, not just to a literal, so a per-route message
+   divergence is caught.
+2. **The body carries a `detail` and nothing else** — no traceback, no path, no host, no
+   key identifier.
+3. **No connection exists.** `GET /api/v1/sso/connections` returns an empty list after the
+   refused creation attempt.
+4. **An anonymous call is refused by authentication**, not by entitlement: `403`, and the
+   body does not mention the licence.
+5. **The rest of the product answers `200`:** `flows/`, `all`, `projects/`,
+   `users/whoami`.
+
+## Validation criterion *(required)*
+
+Fails when an unlicensed instance is permissive rather than unavailable — a gated route
+that answers anything but `503`, a connection that comes into existence, a licence refusal
+reaching an unauthenticated caller, or a message that grows beyond its single `detail`.
+Also fails when the blast radius widens: a core product endpoint that stops working because
+a licence is absent.
+
+## External dependencies *(required)*
+
+- A Langflow **Enterprise** instance with no licence configured:
+  `./scripts/start-langflow-enterprise.sh` (the default — the script configures none).
+- No LLM provider and no network egress.
+- **One** unauthenticated request, which spends nothing from the login budget. This spec
+  performs no password login of its own beyond the cached lane token.
+
+## Notes
+
+The creation attempt is a real `POST`, not a dry run, because the property being tested is
+that it is refused. On an instance that ever does carry a licence the gate skips the whole
+file before the attempt is made, so the destructive reading of this test never occurs.

--- a/tests/helpers/enterprise/entitlement-gate.ts
+++ b/tests/helpers/enterprise/entitlement-gate.ts
@@ -1,0 +1,43 @@
+import { test, type APIRequestContext } from "@playwright/test";
+
+/** The route whose answer decides whether this instance can validate a licence. */
+const ENTITLEMENTS = "/api/v1/sso/entitlements";
+
+/** What an instance that cannot validate a licence answers, everywhere. */
+export const LICENCE_UNAVAILABLE_STATUS = 503;
+
+/**
+ * Skip unless the instance has **no** licence.
+ *
+ * The mirror of `requireEnvironmentPolicy()`: an Enterprise spec cannot create
+ * the state it needs, so it asserts against the instance it was handed. Here the
+ * needed state is the absence of an entitlement, which is the default for a
+ * locally built image and the reason most of the SSO surface is untestable.
+ *
+ * The gate matters in the direction people forget. Every assertion in the
+ * fail-closed spec describes the UNLICENSED behaviour — a `503`, an empty
+ * connection list, a refused creation. Run them against a correctly licensed
+ * deployment and they all fail, reporting a working instance as broken, which is
+ * the failure mode this lane is most exposed to (a red about the environment
+ * wearing the clothes of a red about the product).
+ *
+ * Skipping rather than failing, for that same reason: "this instance has a
+ * licence" is a statement about the environment, not about Langflow.
+ */
+export async function requireNoEnterpriseLicence(
+  request: APIRequestContext,
+  auth: string,
+): Promise<void> {
+  const response = await request.get(ENTITLEMENTS, {
+    headers: { Authorization: auth },
+  });
+
+  test.skip(
+    response.status() !== LICENCE_UNAVAILABLE_STATUS,
+    `${ENTITLEMENTS} answered ${response.status()}, not ${LICENCE_UNAVAILABLE_STATUS} — ` +
+      `this instance can validate a licence. This spec describes what an ` +
+      `instance WITHOUT one must do, so every assertion in it would fail here ` +
+      `for the wrong reason. The entitled behaviour is a separate spec, and the ` +
+      `plan records it as blocked on a licence key.`,
+  );
+}

--- a/tests/tests-automations/regression/enterprise/auth/entitlement-fail-closed.spec.ts
+++ b/tests/tests-automations/regression/enterprise/auth/entitlement-fail-closed.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getEnterpriseAuthToken } from "../../../../helpers/enterprise/enterprise-auth";
+import {
+  LICENCE_UNAVAILABLE_STATUS,
+  requireNoEnterpriseLicence,
+} from "../../../../helpers/enterprise/entitlement-gate";
+
+/**
+ * An Enterprise instance that cannot validate a licence has to be UNAVAILABLE,
+ * not OPEN.
+ *
+ * Those two words describe the same HTTP outcome to a casual reader and opposite
+ * outcomes to an operator: one means the entitled feature cannot be used, the
+ * other means it is being served without the check that governs it. Most of the
+ * SSO surface is blocked on entitlement validation — which is why the rest of
+ * that area is untestable without a licence key — and the reachable half is the
+ * one that decides which of those two words applies.
+ *
+ * `login-surface.spec.ts` covers the other half: password login survives SSO
+ * being switched on but unusable, and break-glass ships disabled. Between them,
+ * "SSO is unavailable" is proven to mean the organisation is neither locked out
+ * nor let in. This file does not repeat that.
+ *
+ * The creation attempt below is a real POST rather than a dry run, because the
+ * property under test is that it is refused. The gate skips the whole file on an
+ * instance that can validate a licence, so the destructive reading never occurs.
+ */
+const GATED_READ = "/api/v1/sso/entitlements";
+const GATED_WRITE = "/api/v1/sso/connections";
+
+/**
+ * Asserted exactly, not with a substring match.
+ *
+ * A licence failure is a natural place for a stack trace, an internal hostname,
+ * a signing-key identifier or a vendor URL to escape into a response body — and
+ * each of those would be a leak no other test in this suite would notice. The
+ * cost of pinning it is real and intended: rewording the message fails this
+ * test, which is a one-line update here, while a silently widened message is
+ * exactly what an exact assertion exists to catch.
+ */
+const LICENCE_MESSAGE = "Enterprise license validation is unavailable";
+
+/** Endpoints that must keep working — an unlicensed EE is not a broken EE. */
+const CORE_ENDPOINTS = [
+  "/api/v1/flows/",
+  "/api/v1/all",
+  "/api/v1/projects/",
+  "/api/v1/users/whoami",
+];
+
+test.describe("Enterprise — without a licence, the entitled surface fails closed", () => {
+  test(
+    "the gated read and the gated write refuse with one stable, non-leaking message",
+    { tag: ["@enterprise", "@api", "@auth", "@sso"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      await requireNoEnterpriseLicence(request, auth);
+
+      const read = await request.get(GATED_READ, {
+        headers: { Authorization: auth },
+      });
+      const write = await request.post(GATED_WRITE, {
+        headers: { Authorization: auth },
+        data: {
+          display_name: "entitlement-fail-closed probe",
+          protocol: "oidc",
+          provider: "generic",
+          config: {
+            issuer: "https://example.invalid",
+            client_id: "probe",
+            client_secret: "probe",
+          },
+        },
+      });
+
+      await test.step("both answer 503", async () => {
+        expect(read.status()).toBe(LICENCE_UNAVAILABLE_STATUS);
+        expect(write.status()).toBe(LICENCE_UNAVAILABLE_STATUS);
+      });
+
+      const readBody = (await read.json()) as Record<string, unknown>;
+      const writeBody = (await write.json()) as Record<string, unknown>;
+
+      await test.step("with the same message on both", async () => {
+        // Compared to each other as well as to the literal: a per-route
+        // divergence is a message that grew somewhere, which is the shape of a
+        // leak.
+        expect(readBody.detail).toBe(LICENCE_MESSAGE);
+        expect(writeBody.detail).toBe(LICENCE_MESSAGE);
+      });
+
+      await test.step("and nothing besides that message", async () => {
+        expect(Object.keys(readBody)).toEqual(["detail"]);
+        expect(Object.keys(writeBody)).toEqual(["detail"]);
+      });
+    },
+  );
+
+  test(
+    "the refusal is total: no connection comes into existence",
+    { tag: ["@enterprise", "@api", "@auth", "@sso"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      await requireNoEnterpriseLicence(request, auth);
+
+      // The assertion that separates "unavailable" from "open". A 503 on the
+      // creation route means nothing if a connection is left half-created for a
+      // later request to find.
+      const connections = await request.get(GATED_WRITE, {
+        headers: { Authorization: auth },
+      });
+      expect(connections.status()).toBe(200);
+      expect(await connections.json()).toEqual([]);
+    },
+  );
+
+  test(
+    "authentication is answered before entitlement, so the gate enumerates nothing",
+    { tag: ["@enterprise", "@api", "@auth", "@sso"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      await requireNoEnterpriseLicence(request, auth);
+
+      // Deliberately no Authorization header. If the licence gate ran first, an
+      // anonymous caller could map which Enterprise surfaces a deployment has by
+      // reading which ones answer 503 rather than 403.
+      const anonymous = await request.get(GATED_READ);
+
+      expect(anonymous.status()).toBe(403);
+      expect(await anonymous.text()).not.toContain("license");
+    },
+  );
+
+  test(
+    "an unlicensed instance is missing its entitled features, not broken",
+    { tag: ["@enterprise", "@api", "@auth", "@sso"] },
+    async ({ request }) => {
+      const auth = await getEnterpriseAuthToken(request);
+      await requireNoEnterpriseLicence(request, auth);
+
+      for (const path of CORE_ENDPOINTS) {
+        const response = await request.get(path, {
+          headers: { Authorization: auth },
+        });
+        expect(
+          response.status(),
+          `${path} answered ${response.status()} on an instance whose only ` +
+            `missing piece is a licence — the entitlement gate has a wider blast ` +
+            `radius than the entitled surface`,
+        ).toBe(200);
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #1514

## What changed

Four tests over the half of the Enterprise entitlement surface that is reachable **without**
a licence — which is the half that decides whether an unlicensed instance is *unavailable* or
*open*. Those two words describe the same HTTP outcome to a casual reader and opposite
outcomes to an operator.

| Property | Assertion |
|---|---|
| Gated read + gated write refuse identically | both `503`, bodies compared to **each other** as well as to a literal |
| The refusal is total | creation refused ⇒ connection list stays empty |
| Auth answered before entitlement | anonymous gets `403`, never the `503` |
| Blast radius bounded | flows, catalog, projects, identity all `200` |

The second is what separates the two words: a `503` on the creation route means nothing if a
connection is left half-created for a later request to find.

The third is a security property in its own right. If the licence gate answered first, an
anonymous caller could map which Enterprise surfaces a deployment has by reading which ones
answer `503` rather than `403`.

## Why the message is pinned exactly

A licence failure is a natural place for a stack trace, an internal hostname, a signing-key
identifier or a vendor URL to escape into a response body, and no other test in this suite
would notice. Measured today the body is 57 bytes carrying a `detail` and nothing else, and
the spec asserts exactly that.

The cost is real and intended: a product decision to reword the message fails this test. That
is a one-line update here, while a silently widened message is precisely what an exact
assertion exists to catch.

## The gate skips rather than fails

Every assertion describes the **unlicensed** state. Run them against a correctly licensed
deployment and they all fail, reporting a working instance as broken — the failure mode this
lane is most exposed to, a red about the environment wearing the clothes of a red about the
product. So `requireNoEnterpriseLicence()` skips, naming why, and points at the plan's record
that the entitled behaviour is blocked on a key.

It also means the real `POST` this spec makes — a real one, because the property under test is
that it is refused — never runs on an instance where it could succeed.

## Verification

Against a locally built Enterprise image (`1.12.0` from `IBM-Langflow@release-1.12.0`) with no
licence configured:

- **4 passed.**
- Force-failed the two assertions the spec argues hardest for, in one run: appending a period
  to the pinned message, and expecting the anonymous caller to get `503` instead of `403`.
  Result **2 failed / 2 passed** — each mutation failed its own test and neither disturbed the
  others. Reverted, green again.
- `npm run typecheck`, `npm run lint` (0 errors), `npm run test:units` (712 pass / 0 fail),
  `npm run test:scripts` (827 pass / 0 fail), spec-doc dependency guard (exit 0), checklist
  guard and coverage guard all clean.

## Notes

No `@stable` — there is no scheduled Enterprise lane (#1010). Tags reuse the
`@auth` + `@sso` pairing `login-surface.spec.ts` established: the licence is what gates this
surface, but the surface is SSO, and a reader filtering for `@sso` wants this test.

Does not repeat `login-surface.spec.ts` (password login surviving an unusable SSO, break-glass
defaults). Between them, "SSO is unavailable" is proven to mean the organisation is neither
locked out nor let in.

Costs nothing from the per-IP login budget beyond the cached lane token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)