### PR TITLE
fix(core-components): unbreak the TableInput "Open table" trigger and settle its refresh (#1488)

### DIFF
--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -1,6 +1,6 @@
 # API Request Component — Rendering, Inspector, HTTP Methods, cURL Mode and Error Paths
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev10`; the cURL test re-validated on `1.11.1` as well, which already carries langflow#14312)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev32`, #1488; the cURL test re-validated on `1.11.1` as well, which already carries langflow#14312)
 
 ---
 
@@ -66,7 +66,7 @@ For each of GET, POST, PUT, PATCH, DELETE:
   via the inspector (`addTableFieldToBody(page, "headers")`: select node →
   `parameters-button` → `inspector-add-headers` → `inspection-panel-close`). The
   `div-table_headers` widget then renders on the node body.
-- Opens `div-table_headers` → `Open table` button → table dialog opens.
+- Opens `div-table_headers` → its trigger button (`tableFieldTrigger`, role-only inside the field container — **not** matched by accessible name, see Notes) → table dialog opens.
 - Adds a row, then fills BOTH the `[col-id="key"]` cell with `X-E2E-Header` and the `[col-id="value"]` cell with `test-header-value` via the `fillViewTextCell` helper. The helper asserts each cell value renders as a button inside the table dialog after Save (this is the in-session validation; the test does not assert table-modal-level persistence — see "What this test does not cover").
 - Closes the dialog with `btn-cancel-modal` and asserts canvas integrity.
 
@@ -81,13 +81,15 @@ For each of GET, POST, PUT, PATCH, DELETE:
 
 ### 14. `body table accepts key + value cell entries when method is POST`
 - The body field is marked `advanced=True` AND is hidden whenever `method.value === "GET"`. The test switches the method dropdown to `POST` first so `body` becomes available in the inspector. dev46: `body` is then added to the node body via `addTableFieldToBody(page, "body")` (select node → `parameters-button` → `inspector-add-body` → `inspection-panel-close`), which makes the `div-table_body` widget render on the node body.
-- The method switch triggers a `real_time_refresh` round-trip (`POST /api/v1/custom_component/update`). The test waits for that response BEFORE opening the body table so the `[value]` useEffect in `TableNodeComponent` finishes resetting `tempValue`. Without this wait, a click on `add-row-button` can land during the reset window and the new row is immediately wiped.
-- Finds `div-table_body`, clicks `Open table`, adds a row, then fills BOTH the `[col-id="key"]` cell with `payload` and the `[col-id="value"]` cell with `e2e-body-value` via the `fillViewTextCell` helper. The helper asserts each cell value renders as a button INSIDE that specific cell after Save (cell-scoped — not dialog-wide).
+- The method switch triggers a `real_time_refresh` round-trip (`POST /api/v1/custom_component/update`). The test waits for that response BEFORE opening the body table so the `[value]` useEffect in `TableNodeComponent` finishes resetting `tempValue`. Without this wait, a click on `add-row-button` can land during the reset window and the new row is immediately wiped. **One response is not enough** — one method switch is answered by TWO round-trips on 1.12.0.dev32 (request +228 ms after the click, answered +286 ms; a second at +565 ms, answered +610 ms, with no interaction in between), so `addTableFieldToBody` watches that traffic from its first line and waits for it to go QUIET (`watchNodeRefresh(page)` → `refresh.untilQuiet()`) before the caller opens the modal (#1488).
+- Finds `div-table_body`, clicks its trigger via `tableFieldTrigger` (role-only inside the field container — see Notes), adds a row, then fills BOTH the `[col-id="key"]` cell with `payload` and the `[col-id="value"]` cell with `e2e-body-value` via the `fillViewTextCell` helper. The helper asserts each cell value renders as a button INSIDE that specific cell after Save (cell-scoped — not dialog-wide).
+- Unlike tests 11 and 15, this one keeps `.last()` for both cell edits with no re-anchor and no row-count guard, and that is deliberate: `body` ships with **zero** default rows (`body value = []` in the catalog), so a dropped row leaves `.last()` resolving to nothing and the fill fails loudly. The re-anchor exists to stop a dropped row from silently redirecting an edit onto a surviving DEFAULT row — a state `body` does not have.
 - Closes the dialog with `btn-cancel-modal` — this test asserts in-session edit behavior only. End-to-end body persistence through reload is intentionally NOT covered (see "What this test does not cover").
 
 ### 15. `flow state persists in database after autosave (URL, method, headers)`
 - Configures URL (`https://postman-echo.com/get?persist=true`), method (`POST`) and a headers row (`X-Persist-Header` / `persisted-value`) on a freshly created flow; the `flowId` is the one `setupBlankFlow` returned (it created the flow), and the test asserts the editor URL carries that same id before polling it.
-- Like test 14, waits for the `POST /api/v1/custom_component/update` response after the method switch so the headers `[value]` useEffect settles before adding a new row.
+- Like test 14, waits for the `POST /api/v1/custom_component/update` response after the method switch, and then for the refresh traffic to go quiet (`watchNodeRefresh`, inside `addTableFieldToBody`), so the headers `[value]` useEffect settles before adding a new row.
+- The value cell is filled on the row **re-anchored by the key just written**, not on `.last()`: that locator is live, and a refresh landing between the two edits makes it resolve to the DEFAULT header row, so both edits would land there and the persistence assertion below would still pass — on an overwritten default row. A `toHaveCount(2)` check right before Save asserts the added row sits alongside the default one (#1488).
 - Clicks the dialog-level **Save** button (not Cancel, which discards `tempValue` via `handleCancel` in `TableNodeComponent`) so the row commits before autosave fires.
 - Polls `GET /api/v1/flows/{id}` (using `page.request` which inherits the session cookie) until the autosave has written the URL, method and matching header row into the saved flow JSON. Polling the API directly proves the autosave reached the database — not just in-memory React state. The match key is `node.data.type === "APIRequest"` (Python class name, not the `"API Request"` display name).
 - Reloads the page and re-asserts: URL field still holds the saved URL, method dropdown still reads `POST`, and reopening the headers table still shows the saved key/value buttons. dev46: the headers field added to the node body in step 1 persists across the reload, so `div-table_headers` renders directly (no inspector re-open needed); the test just clicks the canvas node to focus it. The reload check covers UI rehydration end-to-end.
@@ -222,3 +224,56 @@ The suite must:
 - **Default endpoint moved to postman-echo.com (issue #407).** The retry above only survives a transient blip *within* a single test window. `httpbin.org` returned `503` (AWS ELB) on **all** retry attempts in the weekly runs of 2026-06-08, 2026-06-15 (#383) and 2026-06-22 (#407) — a sustained outage the retry cannot absorb. After the third recurrence the default echo endpoint moved from `httpbin.org` to `postman-echo.com`, empirically verified as a near drop-in: `/get`, `/post`, `/put`, `/patch`, `/delete` each 200 only for the matching verb, `/status/{code}` is a deliberate status endpoint, query params echo in `args`, and the response body echoes `host`/`url`. The one difference — a wrong verb returns `404` instead of httpbin's `405` — is immaterial to the verb tests, which assert the output contains `200` (and `404` is just as much "not 200"). The env knob was renamed `ECHO_BASE_URL` (the old `HTTPBIN_BASE_URL` is still honored as a fallback) and the constants are now `ECHO_BASE` / `ECHO_HOST`.
 - **cURL pre-fill anti-pattern (fixed).** The previous version of test 13 pre-populated `url_input` before switching to the cURL tab. The run would then succeed via the URL-tab path even if the cURL parser was broken. The current test switches to the cURL tab first and waits for the parser to auto-populate `url_input` — the run is genuinely driven by the cURL command.
 - **Headers table value-cell gap (fixed).** The previous version of test 11 only filled the key cell and closed the dialog with Cancel. It would have passed even if the value column was non-functional. The current version fills both key and value cells via `fillViewTextCell`, which asserts each cell renders as a button after Save inside the table dialog — closing the gap.
+- **`Open table` trigger: accessible name flipped (upstream a11y, #1488).** All four
+  tests in the repo that open a node `TableInput` (tests 11, 14, 15 here and
+  `parameters-panel-field-types.spec.ts`'s table row) broke on the same day —
+  `getByRole("button", { name: "Open table" })` stopped matching. Upstream PR
+  langflow#14461 (`13bb21ce26`, `release-1.12.0`, 2026-08-18, first shipped in
+  nightly `1.12.0.dev32`) added `aria-labelledby={ariaLabelledBy}` to that button
+  in `TableNodeComponent/index.tsx`, pointing at the field's visible label
+  (`node-<id>-field-<name>-label`). `aria-labelledby` outranks an element's own
+  contents in the accessible-name computation, so the name became **`Headers`** /
+  **`Body`** while the visible text stayed `Open table` and the button, its
+  behaviour and its `type` were unchanged. Not a product regression — the widget
+  works; the locator described a name the product no longer exposes. The trigger
+  carries no `data-testid` of its own, so the replacement (`tableFieldTrigger`)
+  anchors on the field container's testid plus the role, with no name match at
+  all; the container holds exactly one button, so a second one appearing there
+  fails strict mode loudly rather than clicking the wrong control.
+- **Refresh traffic must go quiet, not arrive once (#1488).** Root-causing the
+  trigger break surfaced the mechanism behind this file's oldest table flake
+  (#868). Two properties of the `real_time_refresh` traffic were measured on
+  `1.12.0.dev32`, and either one alone reopens the race:
+  - **one interaction, two round-trips** — switching `method` to POST issues the
+    request at +228 ms after the click (answered +286 ms) and a SECOND at
+    +565 ms (answered +610 ms), with no interaction in between. A test that
+    awaits the first response resumes ~280 ms before the node re-renders again.
+  - **the round-trip is deferred and unbounded** — the refresh for the
+    `inspector-add-<field>` click starts ~336 ms AFTER the click, so a call site
+    that waits for nothing has an open gap, and ~100 ms on an idle box says
+    nothing about a shared CI container.
+
+  A refresh landing after the modal opens makes `TableNodeComponent`'s `[value]`
+  effect re-sync `tempValue` and drop the row just added. Measured here: with the
+  row re-anchored by its key and a `toHaveCount(2)` guard added, test 15 failed
+  once in three runs on a healthy local nightly — the same accident that
+  previously produced a GREEN run over a corrupted grid, because both cell edits
+  had landed on the default row and the persistence assertion could not tell the
+  two apart. `watchNodeRefresh` closes it: quiet means nothing in flight AND no
+  refresh activity for the window, and the watch is attached at the FIRST line of
+  `addTableFieldToBody` rather than after the click — a wait that only attaches
+  when called cannot see a request already issued, so a slow refresh in flight is
+  invisible to it and the window elapses right over it. 3 × 15 green at
+  `--retries=0` afterwards.
+- **Unsaved table rows are discarded by a node refresh — reported, not just
+  worked around (#1488).** The mechanism above is a product behaviour, not a test
+  race: `TableNodeComponent/index.tsx` runs
+  `useEffect(() => { setTempValue(cloneDeep(value)); }, [value])` unconditionally,
+  *including while the modal is open*, and a component refresh replaces the
+  template object so `value` always changes identity. Any row typed and not yet
+  saved is lost. Why this is recorded here rather than filed as a regression: the
+  modal is blocking, so a user cannot trigger a refresh from another field while
+  it is open — reaching the loss requires opening the table inside the ~300 ms
+  window after editing a `real_time_refresh` field, which is real but narrow, and
+  `REGRESSIONS.md` admits a row only on adversarial validation plus an upstream
+  ticket. Neither exists yet; it is raised on #1488 for the team to decide.

--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -68,6 +68,7 @@ For each of GET, POST, PUT, PATCH, DELETE:
   `div-table_headers` widget then renders on the node body.
 - Opens `div-table_headers` → its trigger button (`tableFieldTrigger`, role-only inside the field container — **not** matched by accessible name, see Notes) → table dialog opens.
 - Adds a row, then fills BOTH the `[col-id="key"]` cell with `X-E2E-Header` and the `[col-id="value"]` cell with `test-header-value` via the `fillViewTextCell` helper. The helper asserts each cell value renders as a button inside the table dialog after Save (this is the in-session validation; the test does not assert table-modal-level persistence — see "What this test does not cover").
+- Like test 15, the value cell is filled on the row **re-anchored by the key just written**, with a `toHaveCount(2)` guard on either side of the add. `headers` ships with a default `User-Agent` row, so a late `real_time_refresh` landing between the two edits would re-sync `tempValue` and make a `.last()` locator resolve to that default row — both edits would land on it, both cell-scoped assertions inside `fillViewTextCell` would still pass, and the test would report green having asserted nothing about the added row. The data-row locator is scoped with `[row-id]` for the same reason: unscoped, the grid's own header row is in the set and a total drop resolves `.last()` onto it instead of resolving empty (#1488).
 - Closes the dialog with `btn-cancel-modal` and asserts canvas integrity.
 
 ### 12. `cURL tab switches mode and field accepts a cURL command`

--- a/docs/core-components/parameters-panel-field-types.md
+++ b/docs/core-components/parameters-panel-field-types.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts`
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev32`, #1488)
 
 ---
 
@@ -69,7 +69,7 @@ matches what a reload would load.
 | 6 | Edit toggle field | `BoolInput` | Save File | `append_mode` | click `toggle_bool_append_mode` | phase 1 ✓ |
 | 7 | Edit slider | `SliderInput` | Language Model | `temperature` | click `slider_thumb` + `ArrowRight` | **phase 2 (this PR)** |
 | 8 | Edit code field | `CodeInput` | Python Function *(legacy)* | `function_code` | open `codearea_code_function_code` → set ACE value → `checkAndSaveBtn` | **phase 3 (this PR)** |
-| 9 | Edit table input | `TableInput` | API Request | `headers` *(advanced)* | show-or-reveal `div-table_headers` → settle (method→POST refresh) → Open table → `add-row-button` (retried until the row lands) → fill key/value cells | **phase 3**; flake-hardened #868 |
+| 9 | Edit table input | `TableInput` | API Request | `headers` *(advanced)* | show-or-reveal `div-table_headers` → settle (method→POST refresh, then `watchNodeRefresh` → `untilQuiet`) → `tableFieldTrigger` → `add-row-button` (retried until the row lands) → fill key cell → **re-anchor the row by that key** → fill value cell | **phase 3**; flake-hardened #868, #1488 |
 | 10 | Edit key-pair list | `NestedDictInput` | Alter Metadata *(legacy)* | `metadata` | `dict_nesteddict_metadata` → Edit Dictionary (text mode) → fill JSON → Save | **phase 3 (this PR)** |
 | 11 | Edit input list | `SortableListInput` | Read File | `storage_location` *(advanced)* | show-or-reveal the field → remove the `Local` chip (build-robust) → `button_open_list_selection_…` → `list_item_aws` | **phase 4 (#806)** |
 | 12 | Edit float field | `FloatInput` | Semantic Text Splitter | `breakpoint_threshold_amount` | fill `float_float_breakpoint_threshold_amount` | **phase 2 (this PR)** |
@@ -118,6 +118,14 @@ the panel's handling of that specific field type.
 
 - `tests/helpers/flows/create-flow.ts`, `delete-flow.ts`, `auth/get-auth-token.ts`,
   `add-component-from-sidebar.ts`.
+- `tests/helpers/ui/table-field-trigger.ts`, `tests/helpers/ui/watch-node-refresh.ts`
+  — the table row's trigger locator and the component-refresh settle (#1488).
+- `src/frontend/src/components/core/parameterRenderComponent/components/TableNodeComponent/index.tsx`
+  — upstream source the table row is written against: the trigger button and the
+  `[value]` → `setTempValue` effect (#1488).
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeInputField/index.tsx`
+  — supplies the `labelId` passed to that button as `ariaLabelledBy`, which is
+  what took over its accessible name.
 - `tests/helpers/flows/add-legacy-components.ts` — phase 3's code and key-pair
   tests add `legacy` components (Python Function, Alter Metadata), hidden from the
   sidebar unless the **Legacy** feature toggle is on; this helper flips it.
@@ -164,3 +172,42 @@ phase 3 (`codearea_code_function_code` + `checkAndSaveBtn`, `div-table_headers` 
   (per field type), each observed failing then reverted — documented in the PR
   Validation block.
 - Every test creates exactly one flow and deletes it id-scoped in `afterEach`.
+- **`Open table` trigger: anchored on the field container, never on the accessible
+  name (#1488).** Upstream a11y PR langflow#14461 (`13bb21ce26`, `release-1.12.0`,
+  2026-08-18, first shipped in nightly `1.12.0.dev32`) added
+  `aria-labelledby={ariaLabelledBy}` to `TableNodeComponent`'s trigger button,
+  pointing at the field's visible label. `aria-labelledby` outranks an element's
+  own contents in the accessible-name computation, so the button's name flipped
+  from the backend `trigger_text` (`Open table`) to the field's display name
+  (`Headers`) while its visible text, behaviour and `type` were unchanged — and
+  every spec clicking it by name stopped matching on the same day. The button
+  carries no `data-testid`, so `tableFieldTrigger` (`tests/helpers/ui/`) resolves
+  it from the field container's testid plus the role, with no name match at all.
+  Not a product regression: the widget works.
+- **The `[value]` re-sync is not settled by ONE refresh response (#1488).** This
+  test's `method → POST` step exists to settle `TableNodeComponent`'s `[value]`
+  effect before the grid is touched (see #868). It waited for the first
+  `POST /api/v1/custom_component/update` response — but a single interaction is
+  answered by more than one (two ~300 ms apart on 1.12.0.dev32), and the second
+  lands while the table modal is open, re-syncing `tempValue` and dropping the row
+  just added. Measured locally at `--retries=0`: 2 failures in 5 runs, matching
+  this test's `flaky` entries in the daily on 2026-07-20, 07-21, 07-27 and 08-04.
+  The underlying behaviour — `TableNodeComponent`'s unconditional
+  `useEffect(… , [value])` resetting `tempValue` while the modal is open, which
+  discards unsaved rows — is a product one; it is raised on #1488 rather than
+  filed, see the same note in `api-request-component-regression.md`.
+  `watchNodeRefresh` waits for the refresh traffic to go quiet instead of
+  counting responses, so a build emitting a third cannot reopen the race: 5/5
+  green after the change. Precise timing on `1.12.0.dev32`: request at +228 ms
+  after the POST click, answered +286 ms; a second request at +565 ms, answered
+  +610 ms, with no interaction in between. It is a *watcher* attached before the
+  interaction, not a wait called after it, because a wait that attaches on call
+  cannot see a refresh already issued and still in flight — the window would
+  elapse right over it.
+- **The value cell is filled on a row re-anchored by its key, not on `.last()`.**
+  `dataRows.last()` is a live locator: when the added row is dropped between the
+  two cell edits it resolves to the DEFAULT `User-Agent` row, so the value lands
+  there and the key edit is lost — and the final `some()` assertion could still be
+  satisfied by a row that was overwritten rather than added. One such run passed
+  green on a corrupted grid during the #1488 investigation. Anchoring on the key
+  plus a `toHaveCount(2)` check before Save turns that accident into a failure.

--- a/tests/helpers/ui/table-field-trigger.ts
+++ b/tests/helpers/ui/table-field-trigger.ts
@@ -1,0 +1,24 @@
+import type { Locator } from "@playwright/test";
+
+/**
+ * The trigger that opens a node TableInput's editing dialog, resolved from the
+ * field's container (`div-table_<field>`, e.g. `div-table_headers`).
+ *
+ * Anchored on the container's `data-testid` plus the role — deliberately NOT on
+ * the accessible name. Upstream a11y PR #14461 (`13bb21ce26`, landed on
+ * `release-1.12.0` 2026-08-18, first shipped in nightly `1.12.0.dev32`) added
+ * `aria-labelledby={ariaLabelledBy}` to this button, pointing at the field's
+ * visible label. `aria-labelledby` outranks an element's own contents in the
+ * accessible-name computation, so the name flipped from the backend
+ * `trigger_text` ("Open table") to the field's display name ("Headers",
+ * "Body") — while the button, its visible text and its behaviour are
+ * unchanged. Every spec clicking it as `getByRole("button", { name: "Open
+ * table" })` stopped matching on the same day (#1488).
+ *
+ * `TableNodeComponent` renders exactly one button inside that container, so the
+ * role alone is unambiguous; a second one appearing there fails strict mode
+ * loudly rather than clicking the wrong control.
+ */
+export function tableFieldTrigger(fieldContainer: Locator): Locator {
+  return fieldContainer.getByRole("button");
+}

--- a/tests/helpers/ui/watch-node-refresh.test.ts
+++ b/tests/helpers/ui/watch-node-refresh.test.ts
@@ -25,6 +25,8 @@ const REFRESH_URL = `http://localhost:7860${COMPONENT_REFRESH_PATH}`;
 /** A Page stand-in exposing only what the helper touches. */
 function fakePage() {
   const handlers = new Map<string, Set<Handler>>();
+  /** Every `waitForTimeout` the helper asked for, in order. */
+  const sleeps: number[] = [];
   const page = {
     on(event: string, handler: Handler) {
       if (!handlers.has(event)) handlers.set(event, new Set());
@@ -34,6 +36,7 @@ function fakePage() {
       handlers.get(event)?.delete(handler);
     },
     async waitForTimeout(ms: number) {
+      sleeps.push(ms);
       await new Promise((resolve) => setTimeout(resolve, ms));
     },
   };
@@ -42,6 +45,12 @@ function fakePage() {
   };
   return {
     page: page as unknown as Page,
+    /**
+     * Every `page.waitForTimeout` the helper issued. In the E2E context each one
+     * is a traced Playwright call, so the count is what makes the poll rate an
+     * assertable property rather than a comment.
+     */
+    sleeps,
     /** Total listeners still attached, across every event. */
     get listeners() {
       return [...handlers.values()].reduce((n, set) => n + set.size, 0);
@@ -180,4 +189,67 @@ test("throws naming the endpoint when the traffic never goes quiet", async () =>
   }
 
   assert.equal(fake.listeners, 0, "every listener must be removed");
+});
+
+test("polls at a floor instead of spinning while a refresh is in flight", async () => {
+  // The sleep is derived from the REMAINING quiet window, which goes negative
+  // once `quietFor` passes `quietMs` with a request still in flight — the
+  // `inFlight === 0` conjunct correctly blocks the return, so without a floor
+  // the loop turns over every 1 ms. Measured at 5655 iterations for a request
+  // in flight for 8 s, each one a traced Playwright call landing in the trace
+  // someone opens to diagnose the throw.
+  const fake = fakePage();
+  const watch = watchNodeRefresh(fake.page);
+  fake.request(); // in flight for the whole window, never answered
+
+  await assert.rejects(() =>
+    watch.untilQuiet({ quietMs: 20, timeout: 400 }),
+  );
+
+  // 400 ms at the 50 ms floor is ~8 turns; at 1 ms it would be in the hundreds.
+  assert.ok(
+    fake.sleeps.length <= 40,
+    `must not spin while in flight (issued ${fake.sleeps.length} sleeps, expected <= 40)`,
+  );
+  assert.ok(
+    fake.sleeps.every((ms) => ms >= 20),
+    `every sleep must respect the floor (got ${JSON.stringify(fake.sleeps)})`,
+  );
+});
+
+test("a second untilQuiet() throws instead of reporting a quiet it cannot observe", async () => {
+  // The listeners are detached once the first call settles, so a second one
+  // would find `inFlight === 0` and a stale `lastActivityAt` and return on its
+  // first iteration — indistinguishable from an observed quiet, and the exact
+  // #1012 failure mode the timeout path refuses. The way in is a caller wrapping
+  // interaction + settle in `expect(async () => {…}).toPass()`.
+  const fake = fakePage();
+  const watch = watchNodeRefresh(fake.page);
+  await watch.untilQuiet({ quietMs: 20, timeout: 1000 });
+
+  const started = Date.now();
+  await assert.rejects(
+    () => watch.untilQuiet({ quietMs: 5000, timeout: 1000 }),
+    (error: Error) => {
+      assert.match(error.message, /single-use/);
+      return true;
+    },
+  );
+  assert.ok(
+    Date.now() - started < 500,
+    "the refusal must be immediate, not a timeout",
+  );
+});
+
+test("dispose() detaches the listeners on the abort path", async () => {
+  // If the interaction between `watchNodeRefresh(page)` and `untilQuiet()`
+  // throws, nothing else would ever remove these three listeners.
+  const fake = fakePage();
+  const watch = watchNodeRefresh(fake.page);
+  assert.equal(fake.listeners, 3, "three listeners attach up front");
+
+  watch.dispose();
+  assert.equal(fake.listeners, 0, "dispose() must remove all of them");
+  watch.dispose();
+  assert.equal(fake.listeners, 0, "dispose() must be idempotent");
 });

--- a/tests/helpers/ui/watch-node-refresh.test.ts
+++ b/tests/helpers/ui/watch-node-refresh.test.ts
@@ -1,0 +1,183 @@
+// Unit tests for watchNodeRefresh (#1488).
+// Run with: npm run test:units
+//
+// Why this helper is unit-tested: what it guarantees is a NEGATIVE — that no
+// component refresh is in flight and none has landed for `quietMs` — and a
+// watcher that releases too early is indistinguishable from a correct one on a
+// green E2E run. The flake it removes only reproduces when a late refresh
+// happens to land inside the table modal's edit window, so an E2E run cannot pin
+// the boundary. These tests drive the timing directly instead.
+//
+// Timings are deliberately small (tens of ms) so the suite stays fast; the
+// helper reads the real clock, so assertions are on ORDER and on generous lower
+// bounds, never on exact durations.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Page } from "@playwright/test";
+import {
+  COMPONENT_REFRESH_PATH,
+  watchNodeRefresh,
+} from "./watch-node-refresh";
+
+type Handler = (event: { url(): string }) => void;
+const REFRESH_URL = `http://localhost:7860${COMPONENT_REFRESH_PATH}`;
+
+/** A Page stand-in exposing only what the helper touches. */
+function fakePage() {
+  const handlers = new Map<string, Set<Handler>>();
+  const page = {
+    on(event: string, handler: Handler) {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)!.add(handler);
+    },
+    off(event: string, handler: Handler) {
+      handlers.get(event)?.delete(handler);
+    },
+    async waitForTimeout(ms: number) {
+      await new Promise((resolve) => setTimeout(resolve, ms));
+    },
+  };
+  const emit = (event: string, url: string) => {
+    for (const handler of handlers.get(event) ?? []) handler({ url: () => url });
+  };
+  return {
+    page: page as unknown as Page,
+    /** Total listeners still attached, across every event. */
+    get listeners() {
+      return [...handlers.values()].reduce((n, set) => n + set.size, 0);
+    },
+    request: (url = REFRESH_URL) => emit("request", url),
+    finished: (url = REFRESH_URL) => emit("requestfinished", url),
+    failed: (url = REFRESH_URL) => emit("requestfailed", url),
+  };
+}
+
+test("releases once the refresh traffic has been quiet for quietMs", async () => {
+  const fake = fakePage();
+  const watch = watchNodeRefresh(fake.page);
+  const started = Date.now();
+
+  await watch.untilQuiet({ quietMs: 120, timeout: 2000 });
+
+  assert.ok(
+    Date.now() - started >= 100,
+    "must observe the quiet window rather than releasing immediately",
+  );
+  assert.equal(fake.listeners, 0, "every listener must be removed");
+});
+
+test("a refresh landing inside the window restarts it — the second round-trip of #1488", async () => {
+  // Measured on 1.12.0.dev32: one method switch produces a request at +228 ms
+  // (answered at +286 ms) and a SECOND at +565 ms, with no interaction between.
+  // Waiting for the first response only is what let the second land inside the
+  // open table modal.
+  const fake = fakePage();
+  const watch = watchNodeRefresh(fake.page);
+  const started = Date.now();
+  setTimeout(() => {
+    fake.request();
+    fake.finished();
+  }, 100);
+
+  await watch.untilQuiet({ quietMs: 150, timeout: 4000 });
+
+  const waited = Date.now() - started;
+  assert.ok(
+    waited >= 240,
+    `must wait quietMs AFTER the late refresh (waited ${waited} ms, expected >= 240)`,
+  );
+});
+
+test("does not report quiet while a refresh is still IN FLIGHT", async () => {
+  // This is why the helper is a watcher attached BEFORE the interaction rather
+  // than a wait called after it: the refresh is deferred (~336 ms after the
+  // inspector-add click) and its duration is not bounded on a shared CI
+  // container, so a response-only wait would let the window elapse over a
+  // request that was issued and never answered — straight into the race.
+  const fake = fakePage();
+  const watch = watchNodeRefresh(fake.page);
+  fake.request(); // issued, never answered within the window
+
+  await assert.rejects(
+    () => watch.untilQuiet({ quietMs: 50, timeout: 250 }),
+    (error: Error) => {
+      assert.match(error.message, /1 request\(s\) in flight/);
+      return true;
+    },
+  );
+  assert.equal(fake.listeners, 0, "listeners must be removed on the throwing path");
+});
+
+test("an in-flight refresh that lands is waited out, then quiet is reported", async () => {
+  const fake = fakePage();
+  const watch = watchNodeRefresh(fake.page);
+  const started = Date.now();
+  fake.request();
+  setTimeout(() => fake.finished(), 120);
+
+  await watch.untilQuiet({ quietMs: 100, timeout: 4000 });
+
+  assert.ok(
+    Date.now() - started >= 210,
+    "the quiet window must start when the in-flight request settles",
+  );
+});
+
+test("a FAILED refresh releases the wait — an aborted request must not wedge it", async () => {
+  const fake = fakePage();
+  const watch = watchNodeRefresh(fake.page);
+  fake.request();
+  setTimeout(() => fake.failed(), 60);
+
+  await watch.untilQuiet({ quietMs: 60, timeout: 3000 });
+});
+
+test("ignores traffic from any other endpoint", async () => {
+  const fake = fakePage();
+  const watch = watchNodeRefresh(fake.page);
+  const started = Date.now();
+  // Flow autosaves and event polls fire constantly during these specs; if they
+  // counted, the wait would block until its timeout on every call. The asset
+  // path is the `url.includes("/build/")` trap, one directory over.
+  const noise = setInterval(() => {
+    fake.request("http://localhost:7860/api/v1/flows/abc");
+    fake.request("http://localhost:7860/assets/api/v1/custom_component/update.js");
+    fake.finished("http://localhost:7860/api/v1/flows/abc");
+    fake.finished("http://localhost:7860/assets/api/v1/custom_component/update.js");
+  }, 20);
+
+  try {
+    await watch.untilQuiet({ quietMs: 120, timeout: 2000 });
+  } finally {
+    clearInterval(noise);
+  }
+
+  assert.ok(
+    Date.now() - started < 1000,
+    "unrelated traffic must not extend the wait",
+  );
+});
+
+test("throws naming the endpoint when the traffic never goes quiet", async () => {
+  const fake = fakePage();
+  const watch = watchNodeRefresh(fake.page);
+  const noise = setInterval(() => {
+    fake.request();
+    fake.finished();
+  }, 20);
+
+  try {
+    await assert.rejects(
+      () => watch.untilQuiet({ quietMs: 200, timeout: 300 }),
+      (error: Error) => {
+        assert.match(error.message, /custom_component\/update/);
+        assert.match(error.message, /never stopped re-rendering/);
+        return true;
+      },
+    );
+  } finally {
+    clearInterval(noise);
+  }
+
+  assert.equal(fake.listeners, 0, "every listener must be removed");
+});

--- a/tests/helpers/ui/watch-node-refresh.ts
+++ b/tests/helpers/ui/watch-node-refresh.ts
@@ -21,8 +21,22 @@ export interface NodeRefreshWatch {
    * Resolve once no component refresh is in flight AND none has been seen for
    * `quietMs`. Throws if the traffic is still going at `timeout`. Detaches its
    * listeners either way.
+   *
+   * **Single-use.** Detaching is what makes a second call unsafe: with no
+   * listeners attached, `inFlight` can never rise and `lastActivityAt` is
+   * already stale, so the second call would return on its first iteration and
+   * report a quiet it never observed — the #1012 failure mode the timeout path
+   * below refuses. It therefore throws instead. Wrap the interaction in a
+   * `toPass()` retry and you need a fresh `watchNodeRefresh(page)` per attempt.
    */
   untilQuiet(opts?: { quietMs?: number; timeout?: number }): Promise<void>;
+  /**
+   * Detach the listeners without waiting. Only needed on the abort path: if the
+   * interaction between `watchNodeRefresh(page)` and `untilQuiet()` throws, the
+   * listeners would otherwise stay attached for the rest of the test. Idempotent,
+   * and safe to call after `untilQuiet()` (which detaches on its own).
+   */
+  dispose(): void;
 }
 
 /**
@@ -88,6 +102,7 @@ export function watchNodeRefresh(page: Page): NodeRefreshWatch {
   page.on("requestfinished", onSettled);
   page.on("requestfailed", onSettled);
 
+  let spent = false;
   const detach = () => {
     page.off("request", onRequest);
     page.off("requestfinished", onSettled);
@@ -95,7 +110,21 @@ export function watchNodeRefresh(page: Page): NodeRefreshWatch {
   };
 
   return {
+    dispose: detach,
     async untilQuiet({ quietMs = 1500, timeout = 20000 } = {}) {
+      // Refuse the second call rather than answering it wrongly: the listeners
+      // are gone, so this one would see `inFlight === 0` and a stale
+      // `lastActivityAt` and return at once, claiming a quiet it cannot have
+      // observed (#1012).
+      if (spent) {
+        throw new Error(
+          "watchNodeRefresh: untilQuiet() is single-use — its listeners are " +
+            "detached once it settles, so a second call would report quiet it " +
+            "never observed. Call watchNodeRefresh(page) again before the next " +
+            "interaction.",
+        );
+      }
+      spent = true;
       try {
         const deadline = Date.now() + timeout;
         for (;;) {
@@ -112,7 +141,16 @@ export function watchNodeRefresh(page: Page): NodeRefreshWatch {
                 `never stopped re-rendering.`,
             );
           }
-          await page.waitForTimeout(Math.min(100, Math.max(1, quietMs - quietFor)));
+          // The sleep is derived from the quiet window, so with a request in
+          // flight past `quietMs` the remaining-window figure goes negative and
+          // a bare `Math.max(1, …)` collapses the loop to 1 ms per turn — a
+          // request in flight for 8 s measured 5655 iterations, and each one is
+          // a traced Playwright call, so the very trace someone opens to
+          // diagnose the throw is the one buried in them. Poll at a fixed 50 ms
+          // whenever there is nothing to wait out but the in-flight request.
+          const sleepMs =
+            inFlight > 0 ? 50 : Math.min(100, Math.max(1, quietMs - quietFor));
+          await page.waitForTimeout(sleepMs);
         }
       } finally {
         detach();

--- a/tests/helpers/ui/watch-node-refresh.ts
+++ b/tests/helpers/ui/watch-node-refresh.ts
@@ -1,0 +1,122 @@
+import type { Page, Request, Response } from "@playwright/test";
+
+/** Pathname of the component-refresh endpoint a `real_time_refresh` edit posts to. */
+export const COMPONENT_REFRESH_PATH = "/api/v1/custom_component/update";
+
+/**
+ * Anchored on the PATHNAME, never on a substring of the whole URL — the repo has
+ * been bitten by `url.includes("/build/")` matching `/assets/build/index.js`
+ * (see `tests/fixtures/flow-error-policy.ts`).
+ */
+function isComponentRefresh(url: string): boolean {
+  try {
+    return new URL(url).pathname === COMPONENT_REFRESH_PATH;
+  } catch {
+    return false;
+  }
+}
+
+export interface NodeRefreshWatch {
+  /**
+   * Resolve once no component refresh is in flight AND none has been seen for
+   * `quietMs`. Throws if the traffic is still going at `timeout`. Detaches its
+   * listeners either way.
+   */
+  untilQuiet(opts?: { quietMs?: number; timeout?: number }): Promise<void>;
+}
+
+/**
+ * Start watching the node's component-refresh traffic. Call this BEFORE the
+ * interaction that triggers it, then `await watch.untilQuiet()` after.
+ *
+ * Touching a field the component declares `real_time_refresh` on — the API
+ * Request `method` dropdown, or the inspector toggle that adds an advanced field
+ * to the node body — posts `/api/v1/custom_component/update`. Two measured
+ * properties of that traffic make "wait for the response" the wrong wait, and
+ * each of them alone is enough to reopen the race:
+ *
+ *  - **One interaction produces more than one round-trip.** Timed on
+ *    `1.12.0.dev32`, switching `method` to POST: request at +228 ms after the
+ *    click, answered at +286 ms — then a SECOND request at +565 ms, answered at
+ *    +610 ms, with no further interaction in between. A test awaiting the first
+ *    response resumes at +286 ms and has ~280 ms before the node re-renders
+ *    again.
+ *  - **The round-trip is deferred, and its duration is not bounded.** The
+ *    refresh for the `inspector-add-<field>` click starts ~336 ms AFTER the
+ *    click, and an update answered in ~100 ms on an idle box says nothing about
+ *    a shared CI container.
+ *
+ * Either way, a refresh landing while a `TableInput` modal is open makes
+ * `TableNodeComponent`'s `[value]` effect re-sync `tempValue` from the node and
+ * DROP the row the test had just added. That is the mechanism behind
+ * `api-request-component-regression`'s oldest table flake (#868) and behind
+ * `parameters-panel-field-types`' table test flaking in the daily on 2026-07-20
+ * / 07-21 / 07-27 / 08-04 — reproduced locally at 2 runs in 5 and root-caused on
+ * #1488. In the api-request persistence test the same accident used to pass
+ * GREEN: both cell edits then land on the default header row, which its
+ * assertion cannot tell apart from the added one.
+ *
+ * Quiet therefore means BOTH: nothing in flight, and `quietMs` since the last
+ * refresh activity of any kind. Counting responses would move the race to the
+ * next build that emits one more; ignoring in-flight requests would let the
+ * window elapse over a refresh already issued and not yet answered.
+ *
+ * **Why a watcher and not a plain wait:** a helper that attaches its listeners
+ * only when it is called cannot see a request issued before that moment, so a
+ * slow refresh already in flight is invisible to it and the window elapses right
+ * over the thing it is waiting for. Attaching first is what makes the guarantee
+ * true rather than likely.
+ */
+export function watchNodeRefresh(page: Page): NodeRefreshWatch {
+  let inFlight = 0;
+  let lastActivityAt = Date.now();
+
+  const onRequest = (request: Request) => {
+    if (!isComponentRefresh(request.url())) return;
+    inFlight += 1;
+    lastActivityAt = Date.now();
+  };
+  // `requestfailed` counts too: an aborted refresh (navigation, teardown) would
+  // otherwise leave `inFlight` stuck above zero and turn the wait into a throw.
+  const onSettled = (event: Request | Response) => {
+    if (!isComponentRefresh(event.url())) return;
+    inFlight = Math.max(0, inFlight - 1);
+    lastActivityAt = Date.now();
+  };
+
+  page.on("request", onRequest);
+  page.on("requestfinished", onSettled);
+  page.on("requestfailed", onSettled);
+
+  const detach = () => {
+    page.off("request", onRequest);
+    page.off("requestfinished", onSettled);
+    page.off("requestfailed", onSettled);
+  };
+
+  return {
+    async untilQuiet({ quietMs = 1500, timeout = 20000 } = {}) {
+      try {
+        const deadline = Date.now() + timeout;
+        for (;;) {
+          const quietFor = Date.now() - lastActivityAt;
+          if (inFlight === 0 && quietFor >= quietMs) return;
+          if (Date.now() >= deadline) {
+            // Never report quiet it did not observe (#1012): a caller that opens
+            // the table modal anyway hits exactly the race this closes, and the
+            // failure would surface as a dropped row somewhere else entirely.
+            throw new Error(
+              `watchNodeRefresh: ${COMPONENT_REFRESH_PATH} was still busy after ` +
+                `${timeout} ms (${inFlight} request(s) in flight, last activity ` +
+                `${quietFor} ms ago, needed ${quietMs} ms of quiet) — the node ` +
+                `never stopped re-rendering.`,
+            );
+          }
+          await page.waitForTimeout(Math.min(100, Math.max(1, quietMs - quietFor)));
+        }
+      } finally {
+        detach();
+      }
+    },
+  };
+}

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -8,6 +8,8 @@ import {
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { tableFieldTrigger } from "../../../helpers/ui/table-field-trigger";
+import { watchNodeRefresh } from "../../../helpers/ui/watch-node-refresh";
 
 // Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
 test.describe.configure({ mode: "serial" });
@@ -75,10 +77,17 @@ const ECHO_HOST = new URL(ECHO_BASE).host;
 // on the node body. `body` only appears in the inspector once the method is a
 // verb that carries a payload (e.g. POST), so switch the method first for it.
 async function addTableFieldToBody(page: Page, field: "headers" | "body") {
+  // Watch from the FIRST line: adding the field re-renders the node, and so does
+  // any `real_time_refresh` edit made just before this call (the `method`
+  // switch), whose second round-trip may still be in flight here. A refresh
+  // landing after the caller opens the table modal drops the row it adds — see
+  // watchNodeRefresh for the measurements.
+  const refresh = watchNodeRefresh(page);
   await page.getByTestId("title-API Request").click();
   await openAdvancedOptions(page);
   await page.getByTestId(`inspector-add-${field}`).click();
   await closeAdvancedOptions(page);
+  await refresh.untilQuiet();
 }
 
 // Helper: create a blank flow and add the API Request component to the canvas.
@@ -611,10 +620,8 @@ test("API Request component — query parameters embedded in URL are sent and ec
 // Headers / Body / cURL tests
 // =============================================================================
 
-// Quarantined for #1488 — same `Open table` trigger as
-// parameters-panel-field-types.spec.ts:415.
-test.fixme("API Request component — inspector headers table accepts key + value cell entries",
-  { tag: ["@regression", "@components"] },
+test("API Request component — inspector headers table accepts key + value cell entries",
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 
@@ -622,7 +629,7 @@ test.fixme("API Request component — inspector headers table accepts key + valu
 
     const headersDiv = page.getByTestId("div-table_headers");
     await expect(headersDiv).toBeVisible({ timeout: 10000 });
-    await headersDiv.getByRole("button", { name: "Open table" }).click();
+    await tableFieldTrigger(headersDiv).click();
 
     const headersDialog = tableDialog(page, "Headers");
     await expect(headersDialog).toBeVisible({ timeout: 10000 });
@@ -749,12 +756,8 @@ test("API Request component — cURL mode parses command, auto-fills URL, execut
   },
 );
 
-// Quarantined for #1488 — the same `Open table` trigger, on the sibling
-// `body` field. It never ran on daily 2026-08-19 (the serial cascade behind
-// the failure above skipped it); quarantining that test let it execute on
-// PR #1491's impacted-specs lane, where it failed 3/3 on a healthy backend.
-test.fixme("API Request component — body table accepts key + value cell entries when method is POST",
-  { tag: ["@regression", "@components"] },
+test("API Request component — body table accepts key + value cell entries when method is POST",
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 
@@ -786,7 +789,7 @@ test.fixme("API Request component — body table accepts key + value cell entrie
 
     const bodyDiv = page.getByTestId("div-table_body");
     await expect(bodyDiv).toBeVisible({ timeout: 10000 });
-    await bodyDiv.getByRole("button", { name: "Open table" }).click();
+    await tableFieldTrigger(bodyDiv).click();
 
     const bodyDialog = tableDialog(page, "Body");
     await expect(bodyDialog).toBeVisible({ timeout: 10000 });
@@ -827,11 +830,8 @@ test.fixme("API Request component — body table accepts key + value cell entrie
   },
 );
 
-// Quarantined for #1488 — the same `Open table` trigger again, reached from
-// the autosave-persistence path. Failed 3/3 on PR #1491's lane once :750 was
-// quarantined and the serial cascade cleared.
-test.fixme("API Request component — flow state persists in database after autosave (URL, method, headers)",
-  { tag: ["@regression", "@components"] },
+test("API Request component — flow state persists in database after autosave (URL, method, headers)",
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     const expectedUrl = `${ECHO_BASE}/get?persist=true`;
     const headerKey = "X-Persist-Header";
@@ -880,7 +880,7 @@ test.fixme("API Request component — flow state persists in database after auto
 
       const headersDiv = page.getByTestId("div-table_headers");
       await expect(headersDiv).toBeVisible({ timeout: 10000 });
-      await headersDiv.getByRole("button", { name: "Open table" }).click();
+      await tableFieldTrigger(headersDiv).click();
 
       const headersDialog = tableDialog(page, "Headers");
       await expect(headersDialog).toBeVisible({ timeout: 10000 });
@@ -903,11 +903,22 @@ test.fixme("API Request component — flow state persists in database after auto
         lastRow.locator('[col-id="key"]'),
         headerKey,
       );
+
+      // Re-anchor on the key just written rather than reusing `.last()`, which
+      // is a live locator: if a late component refresh drops the added row
+      // between the two cell edits, `.last()` resolves to the DEFAULT row and
+      // both edits land there — leaving the persistence assertion below
+      // satisfied by an overwritten default row instead of the added one. That
+      // silent-green path was measured on the sibling table test in #1488.
+      const editedRow = headersDataRows.filter({ hasText: headerKey });
+      await expect(editedRow).toHaveCount(1, { timeout: 5000 });
       await fillViewTextCell(
         page,
-        lastRow.locator('[col-id="value"]'),
+        editedRow.locator('[col-id="value"]'),
         headerValue,
       );
+      // The added row must sit ALONGSIDE the default header row.
+      await expect(headersDataRows).toHaveCount(2, { timeout: 5000 });
       // Click the dialog-level Save button — Cancel discards `tempValue`
       // (see `handleCancel` in TableNodeComponent). The persistence test must
       // commit the row so autosave can write it to the database.
@@ -1000,7 +1011,7 @@ test.fixme("API Request component — flow state persists in database after auto
         // the row survived the reload via the UI, not just the API.
         const headersDiv = page.getByTestId("div-table_headers");
         await expect(headersDiv).toBeVisible({ timeout: 10000 });
-        await headersDiv.getByRole("button", { name: "Open table" }).click();
+        await tableFieldTrigger(headersDiv).click();
         const headersDialog = tableDialog(page, "Headers");
         await expect(headersDialog).toBeVisible({ timeout: 10000 });
         await expect(

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -634,24 +634,41 @@ test("API Request component — inspector headers table accepts key + value cell
     const headersDialog = tableDialog(page, "Headers");
     await expect(headersDialog).toBeVisible({ timeout: 10000 });
 
+    // Scoped with `[row-id]` so only DATA rows match: without it the grid's own
+    // header row is in the set, and a total row drop leaves `.last()` resolving
+    // to that header instead of resolving empty — an edit that fails somewhere
+    // unrelated rather than here.
+    const headersDataRows = headersDialog.locator(
+      '[role="treegrid"] [role="row"][row-id]',
+    );
+    await expect(headersDataRows).toHaveCount(1, { timeout: 5000 });
     await headersDialog.getByTestId("add-row-button").click();
-
-    const lastRow = headersDialog
-      .locator('[role="treegrid"] [role="row"]')
-      .last();
+    await expect(headersDataRows).toHaveCount(2, { timeout: 5000 });
 
     // fillViewTextCell asserts the cell value renders as a button inside the table dialog after Save —
     // verifying both key AND value cells closes the gap where only the key was previously asserted.
     await fillViewTextCell(
       page,
-      lastRow.locator('[col-id="key"]'),
+      headersDataRows.last().locator('[col-id="key"]'),
       "X-E2E-Header",
     );
+
+    // Re-anchor on the key just written rather than reusing `.last()`, which is
+    // a live locator. `headers` ships with a DEFAULT row (`User-Agent`), so a
+    // late component refresh landing between the two edits re-syncs `tempValue`
+    // and makes `.last()` resolve to that default row: both edits then land on
+    // it, both cell-scoped assertions inside fillViewTextCell still pass, and
+    // the test reports green having asserted nothing about the added row. Same
+    // silent-green path measured on the sibling tests in #1488.
+    const editedRow = headersDataRows.filter({ hasText: "X-E2E-Header" });
+    await expect(editedRow).toHaveCount(1, { timeout: 5000 });
     await fillViewTextCell(
       page,
-      lastRow.locator('[col-id="value"]'),
+      editedRow.locator('[col-id="value"]'),
       "test-header-value",
     );
+    // The added row must sit ALONGSIDE the default header row.
+    await expect(headersDataRows).toHaveCount(2, { timeout: 5000 });
 
     await headersDialog.getByTestId("btn-cancel-modal").click();
     await expect(headersDialog).not.toBeVisible({ timeout: 5000 });

--- a/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
+++ b/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
@@ -5,6 +5,8 @@ import { createFlow } from "../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
 import { addLegacyComponents } from "../../../helpers/flows/add-legacy-components";
+import { tableFieldTrigger } from "../../../helpers/ui/table-field-trigger";
+import { watchNodeRefresh } from "../../../helpers/ui/watch-node-refresh";
 
 // §2.1 Parameters Panel — field-type edit matrix. For each input type, a
 // representative component is added, the field is edited in the panel, and the
@@ -412,12 +414,9 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
     },
   );
 
-  // Quarantined for #1488 — the `Open table` trigger of the API Request
-  // `headers` TableInput never becomes clickable (3/3 attempts on a shard
-  // measured at 0% backend downtime, daily 2026-08-19).
-  test.fixme(
+  test(
     "table field edit persists",
-    { tag: ["@components", "@regression"] },
+    { tag: ["@stable", "@components", "@regression"] },
     async ({ page, request }) => {
       const bearer = await getAuthToken(request);
       const flowId = await openFlowWithComponent(
@@ -436,6 +435,9 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
       // the grid: switch method to POST and wait for the component-refresh POST.
       // Without this, the grid drops the add-row click / fails to commit cells
       // (mirrors the settle in api-request-component-regression).
+      // Watch before the interaction, so a refresh already issued and not yet
+      // answered cannot slip through the quiet window (see watchNodeRefresh).
+      const nodeRefresh = watchNodeRefresh(page);
       await page.getByTestId("dropdown_str_method").click();
       const refresh = page.waitForResponse(
         (r) =>
@@ -444,11 +446,14 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
         { timeout: 15000 },
       );
       await page.getByTestId("POST-1-option").click();
+      // Awaiting the first response proves the switch registered at all; the
+      // watcher then waits out every refresh that follows it.
       await refresh;
+      await nodeRefresh.untilQuiet();
 
       const headersDiv = page.getByTestId("div-table_headers");
       await expect(headersDiv).toBeVisible({ timeout: 15000 });
-      await headersDiv.getByRole("button", { name: "Open table" }).click();
+      await tableFieldTrigger(headersDiv).click();
 
       const dialog = dialogByHeading(page, "Headers");
       await expect(dialog).toBeVisible({ timeout: 10000 });
@@ -471,11 +476,25 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
         newRow.locator('[col-id="key"]'),
         "X-E2E-Header",
       );
+
+      // Re-anchor on the key that was just written instead of reusing
+      // `dataRows.last()`. That locator is live: if a late re-render drops the
+      // added row between the two cell edits, `.last()` silently resolves to the
+      // DEFAULT row and the value lands there — overwriting `User-Agent`'s value
+      // and, when the key edit is lost the same way, still satisfying the final
+      // `some()` assertion. That is a green run over a corrupted grid, measured
+      // on 1.12.0.dev32 (#1488). Anchored, the same accident fails here instead.
+      const editedRow = dataRows.filter({ hasText: "X-E2E-Header" });
+      await expect(editedRow).toHaveCount(1, { timeout: 5000 });
       await fillTableTextCell(
         page,
-        newRow.locator('[col-id="value"]'),
+        editedRow.locator('[col-id="value"]'),
         "e2e-header-value",
       );
+
+      // The added row must sit ALONGSIDE the component's default header row —
+      // two rows, not one edited in place.
+      await expect(dataRows).toHaveCount(2, { timeout: 5000 });
       // Save (not Cancel) commits the edited rows so autosave persists them.
       await dialog.getByRole("button", { name: "Save", exact: true }).click();
       await expect(dialog).not.toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
**Fixes #1488.**

## Problem

The four tests in the repo that open a node `TableInput` all failed on the same
day, on `getByRole("button", { name: "Open table" })`:

| Test | Field | Evidence |
|---|---|---|
| `parameters-panel-field-types.spec.ts` — table field edit persists | `headers` | daily 2026-08-19, shard 4 (0 % backend down), 3/3 |
| `api-request-component-regression.spec.ts` — inspector headers table | `headers` | daily 2026-08-19, shard 2, 1 attempt |
| `api-request-component-regression.spec.ts` — body table | `body` | PR #1491 lane, 3/3 |
| `api-request-component-regression.spec.ts` — flow state persists after autosave | `headers` | PR #1491 lane, 3/3 |

**Root cause: the trigger's accessible name, not the trigger.** Upstream a11y PR
langflow#14461 (`13bb21ce26`, `release-1.12.0`, 2026-08-18 22:51 UTC, first
shipped in nightly `1.12.0.dev32`, built 2026-08-19 03:30 UTC — the daily ran at
08:4x) added `aria-labelledby={ariaLabelledBy}` to the button in
`TableNodeComponent/index.tsx`, fed from `NodeInputField`'s `labelId`.
`aria-labelledby` outranks an element's own contents in the accessible-name
computation, so the name flipped from the backend `trigger_text` (`Open table`)
to the field's display name (`Headers` / `Body`). Measured live on dev32:

```json
{"testid":"div-table_headers","buttonCount":1,
 "buttons":[{"text":"Open table","aria-labelledby":"node-APIRequest-…-field-headers-label","labelText":"Headers"}]}
```

The visible text, the behaviour and the `type` are unchanged — **not a product
regression**; the locator described a name the product no longer exposes.

**Second defect, found while validating.** The `parameters-panel` table test
failed 2 runs in 5 at `--retries=0` on a healthy local nightly — matching its
`flaky` entries in the daily on 2026-07-20, 07-21, 07-27 and 08-04. Timing the
refresh traffic per step on dev32:

```
+0     click POST
+228   REQ  /api/v1/custom_component/update
+286   RESP                                   ← the only response the test awaited
+565   REQ  /api/v1/custom_component/update   ← second round-trip, no interaction between
+610   RESP
```

The second refresh lands with the table modal open, `TableNodeComponent`'s
`useEffect(…, [value])` re-syncs `tempValue`, and the row just added is dropped.
Because `dataRows.last()` is a live locator, the value cell then lands on the
DEFAULT `User-Agent` row — which in the api-request persistence test **passed
green over a corrupted grid**, since its assertion cannot tell an added row from
an overwritten default one.

## Fix

- **`tests/helpers/ui/table-field-trigger.ts`** — the trigger resolved from the
  field container's `data-testid` plus the role, with **no accessible-name
  match**. The button carries no testid of its own; the container renders exactly
  one button (verified in the upstream source and measured live), so a second one
  appearing there fails strict mode loudly instead of clicking the wrong control.
- **`tests/helpers/ui/watch-node-refresh.ts`** (+ unit tests) — quiet means
  **nothing in flight AND no refresh activity for the window**, matched on the
  **pathname** (the `url.includes("/build/")` → `/assets/build/index.js` trap).
  It is a *watcher attached before the interaction*, not a wait called after it:
  a wait that attaches on call cannot see a request already issued and still
  pending, so the window would elapse right over it. Throws naming the endpoint
  rather than reporting quiet it never observed (#1012).
- **Row re-anchored by the key just written**, plus a `toHaveCount(2)` guard
  before Save, so a dropped row fails instead of silently overwriting the default
  row.
- **Quarantine lifted** on all four tests: `test.fixme` removed and `@stable`
  restored, byte-identical to the pre-#1491 tag arrays.

**Rejected alternatives.** Matching the new name (`Headers` / `Body`) — it would
break again on any display-name change, and a required field's label resolves to
`"<name>*required"`. Counting refresh responses — that only moves the race to the
next build emitting one more. Retrying the whole edit block — it hides the cause
and leaves the silent-corruption path open.

**Reported, not silently worked around:** the underlying behaviour — unsaved
table rows discarded by a node refresh, since that `useEffect` runs
unconditionally including while the modal is open — is a product one. It is
argued in both spec docs and raised on #1488 rather than added to
`REGRESSIONS.md`: the modal is blocking, so reaching the loss requires opening
the table inside the ~300 ms window after editing a `real_time_refresh` field —
real but narrow, and the ledger admits a row only on adversarial validation plus
an upstream ticket.

## Scope note

No assertion was weakened. Every existing observable is unchanged; the two
guards added (`toHaveCount(2)`, the key-anchored row) only make previously
silent corruption fail. The `body` test deliberately keeps `.last()` with no
re-anchor — `body` ships with zero default rows, so a dropped row makes `.last()`
resolve to nothing and the fill fails loudly; that asymmetry is now documented.
No other repo call site is affected by `13bb21ce26`: every other widget it
touched is reached by testid.

## Validation (nightly `1.12.0.dev32`, `--retries=0`, `--workers=1`)

- `npm run typecheck` ✅ · `npm run lint` 0 errors ✅ · `npm run test:units`
  719/719 ✅ · `npm run test:scripts` 828/828 ✅
- QA-CHECKLIST guards ✅ (`check-checklist-guard`, `check:checklist-coverage`) —
  no generated block edited, no bullet change needed (#1491 touched none)
- `npm run validate:specs` ✅ — the `src/` paths added to the parameters-panel
  doc resolve on `release-1.12.0`
- **4 clean bursts of both files: 27/27, 27/27, 27/27, 27/27**; the
  parameters-panel table test alone 5/5 (was 3/5 before the settle)
- Zero leaked flows (`GET /api/v1/flows/` → only the 26 factory templates)
- Zero `🚨 Backend Error`. One ADVISORY flow error remains on the invalid-URL
  test — the error that test provokes on purpose.
- `--trace=on` skipped per the documented local hang (CONTRIBUTING/#518); step
  verification came from the `--retries=0` bursts, the force-fails and live DOM
  scouting.

### Force-fail (executed, observed failing, reverted — 0 mutation markers in the diff)

- `FF-A` locator reverted to the accessible-name match → **4/4 tests fail**
- `FF-B1` expected persisted key mutated (parameters-panel) → fails
- `FF-B2/B3` cell-content assertion in `fillViewTextCell` mutated → 2 tests fail
- `FF-B4` expected persisted value mutated (autosave test) → fails
- `FF-C1` row re-anchor pointed at a nonexistent key → fails
- `FF-U1` in-flight tracking removed from the watcher → 2 unit tests fail
- `FF-U2` late refresh no longer restarts the window → 1 unit test fails
- `FF-U3` timeout returns instead of throwing → 2 unit tests fail

An independent review with clean context ran over the diff; its two substantive
findings — the watcher's in-flight hole and an over-claimed measurement in the
docs — are fixed here, not carried.
