### PR TITLE
test(regression): quarantine the four sidebar-entry tests for #1518

### DIFF
--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -73,9 +73,13 @@ async function addLoopComponent(page: Page) {
 // UI / Canvas — rendering, handles and output inspection in a single test
 // =============================================================================
 
-test(
+// Quarantined at triage (daily #1517): recurrent flake — `add-component-button-loop`
+// never enters the DOM after sidebar-search-input.fill("Loop"). Same signature on
+// the 2026-08-19 and 08-20 dailies. Lifting the quarantine (remove test.fixme +
+// restore @stable) is a deliverable of #1518.
+test.fixme(
   "Loop component — renders correctly with all handles and output inspection buttons",
-  { tag: ["@stable", "@release", "@components"] },
+  { tag: ["@release", "@components"] },
   async ({ page }) => {
     await addLoopComponent(page);
 

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/limit-file-size-upload.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/limit-file-size-upload.spec.ts
@@ -38,9 +38,13 @@ test.afterEach(async ({ request }) => {
   }
 });
 
-test(
+// Quarantined at triage (daily #1517): recurrent flake — `input_outputChat Input`
+// never becomes visible after sidebar-search-input.fill("chat input"). Same
+// signature on the 2026-08-19 and 08-20 dailies. Lifting the quarantine (remove
+// test.fixme + restore @stable) is a deliverable of #1518.
+test.fixme(
   "user should not be able to upload a file larger than the limit",
-  { tag: ["@stable", "@release", "@api", "@files"] },
+  { tag: ["@release", "@api", "@files"] },
   async ({ page }) => {
     // A tiny upload ceiling (0.001 MB ≈ 1.02 KB) so any real asset is rejected.
     const maxFileSizeUpload = 0.001;

--- a/tests/tests-automations/regression/ui-ux/langflowShortcuts.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/langflowShortcuts.spec.ts
@@ -44,9 +44,15 @@ test.afterEach(async ({ request }) => {
   }
 });
 
-test(
+// Quarantined at triage (daily #1517): the sidebar never renders the filtered
+// entry after sidebar-search-input.fill, so `add-component-button-chat-output`
+// never becomes clickable. Hard failure on a guard-tripped day, judged
+// non-environmental (recurrent 2026-08-18 / 08-20, failed after the shard-1
+// outage closed). Lifting the quarantine (remove test.fixme + restore @stable)
+// is a deliverable of #1518.
+test.fixme(
   "LangflowShortcuts",
-  { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+  { tag: ["@release", "@workspace", "@ui-ux"] },
   async ({ page }) => {
     const nodes = page.getByTestId(NODE_TITLE_TESTID);
     const selectedNodes = page.locator(".react-flow__node.selected");

--- a/tests/tests-automations/regression/ui-ux/notifications.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/notifications.spec.ts
@@ -26,9 +26,13 @@ test.describe("Notifications tab", () => {
     }
   });
 
-  test(
+  // Quarantined at triage (daily #1517): recurrent flake — `input_outputChat Input`
+  // never becomes hoverable after sidebar-search-input.fill("chat input"). Same
+  // signature on the 2026-08-18 and 08-20 dailies. Lifting the quarantine (remove
+  // test.fixme + restore @stable) is a deliverable of #1518.
+  test.fixme(
     "User should be able to interact notifications tab",
-    { tag: ["@stable", "@release", "@ui-ux"] },
+    { tag: ["@release", "@ui-ux"] },
     async ({ page }) => {
       await awaitBootstrapTest(page);
 


### PR DESCRIPTION
Quarantines the four `@stable` tests of the sidebar-entry cluster filed as #1518, as prevention at triage of daily 2026-08-20 (run [32349515682](https://github.com/oriontech-me/langflow-e2e/actions/runs/32349515682)).

All four fail on the same three-step opening sequence — open a blank flow, fill `sidebar-search-input`, wait for the filtered component entry (or its `+` button). None reaches the click; the entry never renders.

| Spec (line) | Waits for | Signature |
|---|---|---|
| `tests/tests-automations/regression/ui-ux/langflowShortcuts.spec.ts:47` | `add-component-button-chat-output` | `TimeoutError: locator.click: Timeout 20000ms exceeded.` |
| `tests/tests-automations/regression/core-components/loop-component-regression.spec.ts:76` | `add-component-button-loop` | `TimeoutError: page.waitForSelector: Timeout 10000ms exceeded.` |
| `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/limit-file-size-upload.spec.ts:41` | `input_outputChat Input` | `Error: expect(locator).toBeVisible() failed` |
| `tests/tests-automations/regression/ui-ux/notifications.spec.ts:29` | `input_outputChat Input` | `TimeoutError: locator.hover: Timeout 20000ms exceeded.` |

Each is `test.fixme` **plus** `@stable` removed, together: removing the tag alone only stops the daily, leaving the tests red on the impacted-specs gate, which selects by file diff rather than by tag (#871).

The daily tripped the mass-failure guard, so the workflow removed no tag and this is the manual quarantine the triage owes. The cluster is on the non-environmental side of the day's mixed verdict — two members failed seven to nine minutes **before** the shard-1 outage opened, and the cluster recurs on three consecutive dailies (08-18, 08-19, 08-20). Full evidence in #1518.

Investigation and the fix stay with #1518; lifting the quarantine (remove `test.fixme` + restore `@stable`) is a deliverable there, so this PR does not close it.

Refs #1518
