### PR TITLE
test(core-components): quarantine the Requires Approval persistence test for #1519

### DIFF
--- a/tests/tests-automations/regression/core-components/edit-tools.spec.ts
+++ b/tests/tests-automations/regression/core-components/edit-tools.spec.ts
@@ -75,9 +75,13 @@ async function openFlowWithUrlComponent(
 }
 
 test.describe("Edit tools (Tool Mode)", () => {
-  test(
+  // Quarantined at triage (daily #1517): recurrent flake — `requires-approval-toggle`
+  // stays aria-checked="false" after the edit (9 stable resolutions in 5 s, so not a
+  // wait-strategy race). Same signature on the 2026-07-30 and 08-20 dailies. Lifting
+  // the quarantine (remove test.fixme + restore @stable) is a deliverable of #1519.
+  test.fixme(
     "user can edit a URL tool action in Tool Mode and the edits persist",
-    { tag: ["@stable", "@release", "@components"] },
+    { tag: ["@release", "@components"] },
     async ({ page, request }) => {
       const bearer = await getAuthToken(request);
 


### PR DESCRIPTION
Quarantines the recurrent flake filed as #1519, as prevention at triage of daily 2026-08-20 (run [32349515682](https://github.com/oriontech-me/langflow-e2e/actions/runs/32349515682)).

| Spec (line) | Waits for | Signature |
|---|---|---|
| `tests/tests-automations/regression/core-components/edit-tools.spec.ts:78` | `getByTestId('requires-approval-toggle').first()` | `Error: expect(locator).toHaveAttribute(expected) failed` |

Recurrent under the same signature on the 2026-07-30 and 2026-08-20 dailies. The call log rules out a wait-strategy race: the locator resolved **9 times** over the 5 s budget, every time to the same `<button role="switch" aria-checked="false" data-state="unchecked">`. The element is present and settled — the edit did not persist.

`test.fixme` **plus** `@stable` removed, together: removing the tag alone only stops the daily, leaving the test red on the impacted-specs gate, which selects by file diff rather than by tag (#871).

The daily tripped the mass-failure guard, so the workflow removed no tag. This item is on the non-environmental side of the day's mixed verdict — it failed nine minutes before the shard-1 outage opened, and its earlier hit was on a different daily entirely.

Investigation and the fix stay with #1519; lifting the quarantine (remove `test.fixme` + restore `@stable`) is a deliverable there, so this PR does not close it.

Refs #1519
