### PR TITLE
fix(mcp): authenticate the MCP transport with an API key, not the auto_login session (#1522)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -739,7 +739,7 @@
 - [x] MCP Server tab in flow → `mcp/server/mcp-server-tab.spec.ts`
 - [x] Add MCP server via modal → `mcp/server/mcp-server-tab.spec.ts`
 - [x] Starter project with MCP → `mcp/server/mcp-server-starter-projects.spec.ts`
-- [x] Flow exposed as MCP server — verify generated endpoint → `mcp/server/mcp-server-protocol.spec.ts`
+- [x] Flow exposed as MCP server — verify generated endpoint, and that the transport takes an API key: the same `initialize` with no credential is refused `403` (#1522) → `mcp/server/mcp-server-protocol.spec.ts`
 - [x] Execute MCP server tool via MCP protocol → `mcp/server/mcp-server-protocol.spec.ts`
 - [x] Register an external MCP server through the stdio form — `command` + `args` resolves the server's real tools into the MCPTools node → `mcp/server/mcp-server.spec.ts`
 - [x] Add-server modal fields persist across save → reopen-for-edit — stdio (name, command, 4 args, 2 env pairs) and HTTP/SSE (name, URL, 2 headers, 2 env pairs) → `mcp/server/mcp-server.spec.ts`

--- a/docs/mcp/server/mcp-server-install.md
+++ b/docs/mcp/server/mcp-server-install.md
@@ -71,6 +71,13 @@ one property from each side: the UI's origin rule, and agreement on the path.
   works — the spec deliberately does not require it to match the backend's configured
   `host:port` (see *The mechanism*); verified green against both
   `http://localhost:7860/` and `http://127.0.0.1:7860/`.
+- **An API key is the transport credential.** The specs mint one with
+  `createApiKey` (`tests/helpers/auth/create-api-key.ts`) and send it as
+  `x-api-key`; the `auto_login` session JWT is refused with `403` by
+  `/api/v1/mcp/project/{id}/streamable` (measured on 1.12.0.dev33 — the table in
+  `tests/tests-automations/regression/mcp/CLAUDE.md` → *Authenticating against the
+  MCP transport*). The key is deleted in teardown. No lane sets
+  `LANGFLOW_SKIP_AUTH_AUTO_LOGIN`, on purpose.
 - At least one project exists (the default `Starter Project` satisfies this).
 - Clipboard read/write permission — already granted to every context by
   `playwright.config.ts`.
@@ -108,9 +115,12 @@ selects by default.
    rule, and the property that makes the URL usable by whoever copied it.
 5. Assert the copied URL's **path** equals the path the API published: the two
    independent derivations agree on where the project is served.
-6. **Resolve it:** run the MCP handshake **against the copied URL** and assert
+6. **Resolve it:** run the MCP handshake **against the copied URL**, carrying the
+   minted API key as `x-api-key`, and assert
    `serverInfo.name === langflow-mcp-project-{id}`. Reachable by construction, since
-   its origin is the page's own.
+   its origin is the page's own; the credential is the one the JSON the tab copies
+   names (`"x-api-key": "YOUR_API_KEY"`), so this resolves the URL the way the user's
+   own client will.
 
 ### 2 — `the auto-install list reflects the install state the page was given`
 
@@ -177,6 +187,11 @@ The button is only asserted to be offered. It is never clicked — that would
   developer box full of leftovers and failed all three tests in CI, where the home page
   renders the empty state. Every change here is now validated against a disposable
   container as well as the local one.
+- **The URL is resolved with a real credential, never with the check turned off.**
+  `LANGFLOW_SKIP_AUTH_AUTO_LOGIN=true` would make step 6 pass on an instance where a
+  keyed client is refused — it resolves the URL for a caller presenting nothing,
+  which is exactly the user this test speaks for. That is why #1522 was fixed by
+  keying the handshake on an API key rather than by setting the bypass on the lanes.
 - **Force-failure check** (CONTRIBUTING §2) executed per assertion during VERIFY.
 
 ---

--- a/docs/mcp/server/mcp-server-project-config.md
+++ b/docs/mcp/server/mcp-server-project-config.md
@@ -60,6 +60,13 @@ Test 1: `@stable` `@api` `@mcp` · Test 2: `@stable` `@regression` `@api` `@mcp`
 ## Preconditions *(optional)*
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`; auto-login superuser.
+- **An API key is the transport credential.** The specs mint one with
+  `createApiKey` (`tests/helpers/auth/create-api-key.ts`) and send it as
+  `x-api-key`; the `auto_login` session JWT is refused with `403` by
+  `/api/v1/mcp/project/{id}/streamable` (measured on 1.12.0.dev33 — the table in
+  `tests/tests-automations/regression/mcp/CLAUDE.md` → *Authenticating against the
+  MCP transport*). The key is deleted in teardown. No lane sets
+  `LANGFLOW_SKIP_AUTH_AUTO_LOGIN`, on purpose.
 - No provider key, no npm registry, no external MCP server: the flow under test is a
   Chat Input → Chat Output passthrough created from
   `tests/assets/flows/chat-io-ok-trace-fixture.json`.

--- a/docs/mcp/server/mcp-server-protocol.md
+++ b/docs/mcp/server/mcp-server-protocol.md
@@ -58,6 +58,13 @@ server area; `@regression` — guards a server-exposure/execution regression.
 ## Preconditions *(optional)*
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`; auto-login superuser.
+- **An API key is the transport credential.** The specs mint one with
+  `createApiKey` (`tests/helpers/auth/create-api-key.ts`) and send it as
+  `x-api-key`; the `auto_login` session JWT is refused with `403` by
+  `/api/v1/mcp/project/{id}/streamable` (measured on 1.12.0.dev33 — the table in
+  `tests/tests-automations/regression/mcp/CLAUDE.md` → *Authenticating against the
+  MCP transport*). The key is deleted in teardown. No lane sets
+  `LANGFLOW_SKIP_AUTH_AUTO_LOGIN`, on purpose.
 - A default project exists (`GET /api/v1/projects/` → the "Starter Project"); its
   id is the MCP project id.
 - Passthrough fixture `tests/assets/flows/chat-io-ok-trace-fixture.json`
@@ -73,9 +80,11 @@ server area; `@regression` — guards a server-exposure/execution regression.
 **Setup (API only)**
 
 1. Resolve the default project id (`GET /api/v1/projects/`).
-2. Create a passthrough runnable flow via `createRunnableChatFlowViaApi(request, headers)`
+2. Mint an API key (`createApiKey`) — every call to the streamable transport below
+   carries it as `x-api-key`, and it is deleted in `afterAll`.
+3. Create a passthrough runnable flow via `createRunnableChatFlowViaApi(request, headers)`
    — ChatInput → ChatOutput, echoes `input_value`.
-3. Expose it as an MCP tool: `PATCH /api/v1/mcp/project/{projectId}` with
+4. Expose it as an MCP tool: `PATCH /api/v1/mcp/project/{projectId}` with
    `{ settings: [{ id: <flowId>, mcp_enabled: true, action_name: <unique>, action_description }] }`.
    The action name is unique per run (`e2e_echo_<suffix>`) to avoid colliding with
    other tools in the shared project.
@@ -91,6 +100,12 @@ server area; `@regression` — guards a server-exposure/execution regression.
      endpoint is generated for this project).
    - MCP `initialize` on the streamable endpoint returns
      `serverInfo.name === "langflow-mcp-project-{projectId}"`.
+   - The **same `initialize` carrying no credential is refused with `403`**, and
+     the body names the API-key gate. The negative half of the credential
+     assertion: 1.12.0.dev31 answered `200` to a keyless caller, so every other
+     assertion here passed on a transport that authenticated nobody. On a build
+     that predates the gate this step fails — that is the finding it exists to
+     report, not a false positive.
    - `tools/list` includes a tool whose `name` equals the unique `action_name`
      just enabled — the flow is exposed by the generated server.
 
@@ -128,6 +143,10 @@ server area; `@regression` — guards a server-exposure/execution regression.
   satisfy it.
 - **Deterministic tool (no LLM):** the passthrough flow removes model
   non-determinism entirely, so a failure is a real protocol/exposure regression.
+- **The credential is asserted in both directions.** The positive assertions
+  key on an API key sent as `x-api-key`; the paired keyless `initialize` must be
+  `403`. Either half alone is passable by an endpoint that asks for nothing —
+  which is exactly what the transport did until 1.12.0.dev33 (#1522).
 - **Force-failure check** (CONTRIBUTING §2) is run during VERIFY on each hard
   assertion.
 
@@ -152,7 +171,12 @@ server area; `@regression` — guards a server-exposure/execution regression.
   (`/api/v1/mcp/project/{id}`, `/composer-url`, `/streamable`, `/sse`) and the
   protocol handlers.
 - `src/backend/base/langflow/api/v1/mcp_projects.py` — the per-project generated
-  endpoint this spec calls.
+  endpoint this spec calls, **and its credential gate**: the transport takes an
+  API key (`x-api-key` header or query param) and resolves a keyless caller to the
+  superuser only under `LANGFLOW_SKIP_AUTH_AUTO_LOGIN`. A change here is what
+  turned these specs red in #1522.
+- `src/backend/base/langflow/services/auth/constants.py` — carries the
+  `AUTO_LOGIN_ERROR` body that refusal answers with.
 - `src/backend/base/langflow/api/v1/mcp_utils.py` — the shared request/response
   plumbing both routers use.
 - `src/lfx/src/lfx/services/mcp_composer/` (or equivalent) — the MCP server

--- a/docs/mcp/server/mcp-server-resources.md
+++ b/docs/mcp/server/mcp-server-resources.md
@@ -142,6 +142,13 @@ capture the server-assigned (timestamp-prefixed) filename from the response
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`, `auto_login` mode (the fixture's
   `request` context is authenticated via `getAuthToken`).
+- **An API key is the transport credential.** The specs mint one with
+  `createApiKey` (`tests/helpers/auth/create-api-key.ts`) and send it as
+  `x-api-key`; the `auto_login` session JWT is refused with `403` by
+  `/api/v1/mcp/project/{id}/streamable` (measured on 1.12.0.dev33 — the table in
+  `tests/tests-automations/regression/mcp/CLAUDE.md` → *Authenticating against the
+  MCP transport*). The key is deleted in teardown. No lane sets
+  `LANGFLOW_SKIP_AUTH_AUTO_LOGIN`, on purpose.
 - No LLM or API key required.
 
 ---

--- a/docs/mcp/server/mcp-server.md
+++ b/docs/mcp/server/mcp-server.md
@@ -70,6 +70,15 @@ read-back/update tests)
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`; auto-login superuser.
 - The default MCP starter project exists (`lf-starter_project`).
+- **An API key is the transport credential.** The specs mint one with
+  `createApiKey` (`tests/helpers/auth/create-api-key.ts`) and send it as
+  `x-api-key`; the `auto_login` session JWT is refused with `403` by
+  `/api/v1/mcp/project/{id}/streamable` (measured on 1.12.0.dev33 — the table in
+  `tests/tests-automations/regression/mcp/CLAUDE.md` → *Authenticating against the
+  MCP transport*). The key is deleted in teardown. No lane sets
+  `LANGFLOW_SKIP_AUTH_AUTO_LOGIN`, on purpose. Test 6 is the one that needs it: it registers Langflow's **own**
+  transport endpoint, so the stored server config must carry the header for
+  Langflow to connect to itself.
 - **Network egress to the npm registry** — the stdio tests run real MCP servers
   via `npx`. A cold container downloads the package on first use; see the
   timeout budgets below. **Tests 8 and 9 are exempt**: registration is
@@ -175,8 +184,17 @@ failure unattributed. See the note below.
 ### 6 — `Streamable HTTP MCP server with server-everything should load tools correctly`
 
 Unchanged by #1091 (no stdio surface). Derives the project's own
-`/api/v1/mcp/project/{id}/streamable` URL, registers it via the HTTP tab, polls
-`toolsCount`, and asserts ≥1 tool option; cleans up via the API.
+`/api/v1/mcp/project/{id}/streamable` URL, registers it via the HTTP tab **with an
+`x-api-key` header** (`http-headers-key-0` / `popover-anchor-http-headers-value-0`),
+polls `toolsCount`, and asserts ≥1 tool option; cleans up the server and the key via
+the API.
+
+The header is what makes the poll meaningful rather than a wait on a value that can
+never arrive: Langflow connects out to that URL itself, so with no credential stored
+`GET /api/v2/mcp/servers?action_count=true` answers `toolsCount: null` with
+`rejected the request with HTTP 403: the configured credential was refused`
+(measured, #1522). The failure this test is here to catch — the endpoint not serving
+its project's flows — and a missing credential both used to read as the same null.
 
 ### 7 — `stdio command with an embedded argument is refused, and command plus args is accepted` *(new)*
 

--- a/tests/helpers/mcp/mcp-streamable-client.ts
+++ b/tests/helpers/mcp/mcp-streamable-client.ts
@@ -15,7 +15,39 @@ import type { APIRequestContext } from "@playwright/test";
  * required between calls), so each request is independent. We send
  * `Accept: application/json, text/event-stream` (the transport requires the SSE
  * media type) and parse the `data:` line back into the JSON-RPC object.
+ *
+ * **The credential is an API key, sent as `x-api-key` — never a session token**
+ * (#1522). Langflow's gate (`langflow/api/v1/mcp_projects.py`) reads the key from
+ * the `x-api-key` header or a query param of the same name, and resolves a caller
+ * that presented nothing to the superuser only under
+ * `LANGFLOW_SKIP_AUTH_AUTO_LOGIN`; its own comment states the intent — *"AUTO_LOGIN
+ * alone is not a credential"*. Measured on the same endpoint, same project:
+ *
+ * | Credential on `initialize` | 1.12.0.dev31 | 1.12.0.dev33 |
+ * |---|---|---|
+ * | `Authorization: Bearer <auto_login JWT>` | 200 | **403** |
+ * | `x-api-key: <API key>` | 200 | **200** |
+ * | `Authorization: Bearer <API key>` | 200 | **403** |
+ * | no credential at all | 200 | **403** |
+ *
+ * dev31 answering 200 to a request carrying *nothing* is why this went unnoticed:
+ * the specs asserted the protocol without exercising auth at all. An API key works
+ * on both builds, so keying on it needs no lane change — and no lane sets the
+ * bypass, on purpose (it would turn off the control these specs exercise).
+ *
+ * The credential is an object rather than a header string so a bearer token cannot
+ * be passed by accident: it would compile and then 403 at run time, which is the
+ * failure this signature exists to make impossible.
  */
+
+/**
+ * The transport's credential: a plaintext Langflow API key. Mint one with
+ * `createApiKey` (`tests/helpers/auth/create-api-key.ts`) and delete it in
+ * teardown — a key outlives the test that created it.
+ */
+export interface McpTransportCredential {
+  apiKey: string;
+}
 
 export interface JsonRpcResponse {
   jsonrpc: string;
@@ -42,18 +74,18 @@ function parseSseData(body: string): JsonRpcResponse {
 
 /**
  * Send one JSON-RPC request to a streamable MCP endpoint and return the parsed
- * response. `authorization` is the full header value (e.g. `Bearer <token>`).
+ * response. `credential` carries the API key the transport requires (see header).
  */
 export async function mcpCall(
   request: APIRequestContext,
   url: string,
-  authorization: string,
+  credential: McpTransportCredential,
   method: string,
   params?: Record<string, unknown>,
   id = 1,
 ): Promise<JsonRpcResponse> {
   const res = await request.post(url, {
-    headers: { ...MCP_HEADERS, Authorization: authorization },
+    headers: { ...MCP_HEADERS, "x-api-key": credential.apiKey },
     data: { jsonrpc: "2.0", id, method, ...(params ? { params } : {}) },
   });
   if (!res.ok()) {
@@ -70,9 +102,9 @@ export async function mcpCall(
 export async function mcpHandshake(
   request: APIRequestContext,
   url: string,
-  authorization: string,
+  credential: McpTransportCredential,
 ): Promise<any> {
-  const init = await mcpCall(request, url, authorization, "initialize", {
+  const init = await mcpCall(request, url, credential, "initialize", {
     protocolVersion: "2024-11-05",
     capabilities: {},
     clientInfo: { name: "langflow-e2e", version: "0.1" },
@@ -81,7 +113,7 @@ export async function mcpHandshake(
   // an (empty) SSE frame or 202 — fire it and ignore the body.
   await request
     .post(url, {
-      headers: { ...MCP_HEADERS, Authorization: authorization },
+      headers: { ...MCP_HEADERS, "x-api-key": credential.apiKey },
       data: { jsonrpc: "2.0", method: "notifications/initialized" },
     })
     .catch(() => {});

--- a/tests/tests-automations/regression/mcp/CLAUDE.md
+++ b/tests/tests-automations/regression/mcp/CLAUDE.md
@@ -57,6 +57,57 @@ Tests that only validate MCP server/client configuration (UI, endpoints, modal) 
 
 ---
 
+## Authenticating against the MCP transport
+
+The project transport endpoints (`/api/v1/mcp/project/{id}/streamable` and
+`/sse`) accept an **API key and nothing else** — `x-api-key` as a header or as a
+query parameter of the same name. Mint one with
+`tests/helpers/auth/create-api-key.ts` and delete it in teardown; the
+`auto_login` session JWT every other helper uses is **not** a credential here.
+
+Measured on two live nightly containers while fixing #1522 (`initialize` on the
+same endpoint, same project):
+
+| Credential on `initialize` | 1.12.0.dev31 | 1.12.0.dev33 |
+|---|---|---|
+| `Authorization: Bearer <auto_login JWT>` | 200 | **403** |
+| `x-api-key: <API key>` | 200 | **200** |
+| `Authorization: Bearer <API key>` | 200 | **403** |
+| no credential at all | 200 | **403** |
+
+Three things that column pair settles:
+
+- **The 403 is deliberate, not a regression.** The gate in
+  `langflow/api/v1/mcp_projects.py` says so in the source: *"AUTO_LOGIN parity
+  with the non-MCP entrypoints (`_api_key_security_impl`, `ws_api_key_security`,
+  `authenticate_with_credentials`): AUTO_LOGIN alone is not a credential."* Only
+  an explicit `LANGFLOW_SKIP_AUTH_AUTO_LOGIN=true` lets a caller with no key
+  resolve to the superuser. The product agrees with itself: the JSON the MCP
+  Server tab copies for a client carries `"x-api-key": "YOUR_API_KEY"`.
+- **The dev31 column is why this was invisible.** That build answered `200` to a
+  request carrying *no credential*, so every transport assertion passed without
+  exercising auth at all — a spec could not tell a working credential from none.
+- **An API key works on both builds**, so keying on it is version-robust and
+  needs no lane change.
+
+**We deliberately do not set `LANGFLOW_SKIP_AUTH_AUTO_LOGIN` on any lane or
+start script.** The bypass turns off the control these specs exercise, and it is
+weakest exactly where it would be most tempting: `mcp-server-install.spec.ts`
+asserts that *the URL the UI copies resolves*, which the bypass makes
+unconditionally true — including for a user whose real, keyed client would be
+refused.
+
+**Registering a Langflow endpoint as an MCP server** (`POST
+/api/v2/mcp/servers/{name}`, or the HTTP tab's `http-headers-key-0` /
+`popover-anchor-http-headers-value-0` fields) is the same contract seen from the
+server side: Langflow connects out to that URL itself, so the stored config must
+carry the `x-api-key` header. Without it, `GET
+/api/v2/mcp/servers?action_count=true` reports `toolsCount: null` with
+`rejected the request with HTTP 403: the configured credential was refused`;
+with it, `toolsCount` is a number (measured).
+
+---
+
 ## References
 
 - `SimpleAgentTemplatePage` → `tests/pages/SimpleAgentTemplatePage.ts`

--- a/tests/tests-automations/regression/mcp/server/mcp-server-install.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-install.spec.ts
@@ -1,5 +1,9 @@
 import type { Page, Response } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  createApiKey,
+  deleteApiKey,
+} from "../../../../helpers/auth/create-api-key";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { mcpHandshake } from "../../../../helpers/mcp/mcp-streamable-client";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
@@ -283,12 +287,27 @@ test.describe("MCP Server — connect a project to a client", () => {
       await test.step("the copied URL is a live MCP endpoint for THIS project", async () => {
         // Asserted against the protocol, on the string a user would actually
         // paste. Reachable by construction: its origin is the page's own.
-        const info = await mcpHandshake(
-          page.request,
-          copied.toString(),
-          authorization,
-        );
-        expect(info.serverInfo.name).toBe(`langflow-mcp-project-${projectId}`);
+        //
+        // The credential is an API key, which is what the JSON this tab copies
+        // names (`"x-api-key": "YOUR_API_KEY"`) — so this resolves the URL the
+        // way the user's own client will. The alternative unblock for #1522,
+        // `LANGFLOW_SKIP_AUTH_AUTO_LOGIN=true` on the lanes, would satisfy this
+        // step for a caller presenting NOTHING, i.e. it would keep passing on an
+        // instance where the copied URL is refused for every real client. The key
+        // is deleted before the step returns, whether the assertion holds or not.
+        const key = await createApiKey(page.request, { Authorization: authorization }, {
+          namePrefix: "e2e-mcp-install",
+        });
+        try {
+          const info = await mcpHandshake(page.request, copied.toString(), {
+            apiKey: key.key,
+          });
+          expect(info.serverInfo.name).toBe(`langflow-mcp-project-${projectId}`);
+        } finally {
+          await deleteApiKey(page.request, key.id, {
+            Authorization: authorization,
+          }).catch(() => {});
+        }
       });
     },
   );

--- a/tests/tests-automations/regression/mcp/server/mcp-server-project-config.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-project-config.spec.ts
@@ -1,11 +1,16 @@
 import { readFileSync } from "fs";
 import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  createApiKey,
+  deleteApiKey,
+} from "../../../../helpers/auth/create-api-key";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createFlow } from "../../../../helpers/flows/create-flow";
 import { createProjectViaApi } from "../../../../helpers/flows/create-project-via-api";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
+  type McpTransportCredential,
   mcpCall,
   mcpHandshake,
 } from "../../../../helpers/mcp/mcp-streamable-client";
@@ -86,6 +91,10 @@ async function createChatFlowInProject(
 test.describe("MCP Server — per-project tool exposure", () => {
   let authorization: string;
   let headers: Record<string, string>;
+  // The MCP transport takes an API key and nothing else; `headers` still
+  // authenticates the REST calls in this spec (#1522).
+  let credential: McpTransportCredential;
+  let apiKeyId: string;
   let projectId: string;
   let deleteProjectFn: (req?: APIRequestContext) => Promise<void>;
   let flowId: string;
@@ -117,6 +126,12 @@ test.describe("MCP Server — per-project tool exposure", () => {
         "reason rather than for the contract",
     ).toBeTruthy();
     headers = { Authorization: authorization };
+
+    const created = await createApiKey(request, headers, {
+      namePrefix: "e2e-mcp-project-config",
+    });
+    credential = { apiKey: created.key };
+    apiKeyId = created.id;
 
     // Fixture guard, not product coverage: the assertions below compare the
     // served tool name to `actionName` for equality, which holds only while the
@@ -184,6 +199,11 @@ test.describe("MCP Server — per-project tool exposure", () => {
     if (deleteProjectFn) {
       await deleteProjectFn(request).catch((e) =>
         failures.push(`project ${projectId}: ${e}`),
+      );
+    }
+    if (apiKeyId) {
+      await deleteApiKey(request, apiKeyId, headers).catch((e) =>
+        failures.push(`api key ${apiKeyId}: ${e}`),
       );
     }
     expect(
@@ -261,7 +281,7 @@ test.describe("MCP Server — per-project tool exposure", () => {
       await test.step("the handshake identifies THIS project's MCP server", async () => {
         // Asserted first: a misdirected endpoint would otherwise produce an
         // empty tools/list that reads exactly like correct de-selection.
-        const info = await mcpHandshake(request, streamableUrl, authorization);
+        const info = await mcpHandshake(request, streamableUrl, credential);
         expect(info.serverInfo.name).toBe(`langflow-mcp-project-${projectId}`);
       });
 
@@ -269,7 +289,7 @@ test.describe("MCP Server — per-project tool exposure", () => {
         const resp = await mcpCall(
           request,
           streamableUrl,
-          authorization,
+          credential,
           "tools/list",
           undefined,
           2,
@@ -303,7 +323,7 @@ test.describe("MCP Server — per-project tool exposure", () => {
         const resp = await mcpCall(
           request,
           streamableUrl,
-          authorization,
+          credential,
           "tools/call",
           { name: actionName, arguments: { input_value: sentinel } },
           3,
@@ -335,7 +355,7 @@ test.describe("MCP Server — per-project tool exposure", () => {
         const resp = await mcpCall(
           request,
           streamableUrl,
-          authorization,
+          credential,
           "tools/list",
           undefined,
           4,
@@ -364,7 +384,7 @@ test.describe("MCP Server — per-project tool exposure", () => {
         const resp = await mcpCall(
           request,
           streamableUrl,
-          authorization,
+          credential,
           "tools/call",
           { name: actionName, arguments: { input_value: sentinel } },
           5,

--- a/tests/tests-automations/regression/mcp/server/mcp-server-protocol.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-protocol.spec.ts
@@ -1,11 +1,19 @@
 import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  createApiKey,
+  deleteApiKey,
+} from "../../../../helpers/auth/create-api-key";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import {
   createRunnableChatFlowViaApi,
   type RunnableChatFlow,
 } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
-import { mcpCall, mcpHandshake } from "../../../../helpers/mcp/mcp-streamable-client";
+import {
+  type McpTransportCredential,
+  mcpCall,
+  mcpHandshake,
+} from "../../../../helpers/mcp/mcp-streamable-client";
 
 /**
  * MCP Server — flow-as-server endpoint & tool execution over the MCP protocol
@@ -34,6 +42,10 @@ test.describe.configure({ mode: "serial" });
 
 test.describe("MCP Server — flow-as-server protocol", () => {
   let authorization: string;
+  // The transport takes an API key and nothing else — the `authorization` bearer
+  // above still authenticates every other API call here (#1522).
+  let credential: McpTransportCredential;
+  let apiKeyId: string;
   let projectId: string;
   let streamableUrl: string;
   let flow: RunnableChatFlow;
@@ -42,6 +54,12 @@ test.describe("MCP Server — flow-as-server protocol", () => {
   test.beforeAll(async ({ request }) => {
     authorization = await getAuthToken(request);
     const headers = { Authorization: authorization };
+
+    const created = await createApiKey(request, headers, {
+      namePrefix: "e2e-mcp-protocol",
+    });
+    credential = { apiKey: created.key };
+    apiKeyId = created.id;
 
     // Default project ("Starter Project") — its id is the MCP project id.
     const projectsRes = await request.get("/api/v1/projects/", { headers });
@@ -81,6 +99,11 @@ test.describe("MCP Server — flow-as-server protocol", () => {
         headers: { Authorization: authorization },
       }).catch(() => {});
     }
+    if (apiKeyId) {
+      await deleteApiKey(request, apiKeyId, {
+        Authorization: authorization,
+      }).catch(() => {});
+    }
   });
 
   test(
@@ -103,15 +126,49 @@ test.describe("MCP Server — flow-as-server protocol", () => {
       });
 
       await test.step("initialize identifies this project's MCP server", async () => {
-        const info = await mcpHandshake(request, streamableUrl, authorization);
+        const info = await mcpHandshake(request, streamableUrl, credential);
         expect(info.serverInfo.name).toBe(`langflow-mcp-project-${projectId}`);
+      });
+
+      await test.step("the same initialize with no credential is refused", async () => {
+        // The negative half of the credential assertion, and the reason it is
+        // here at all: 1.12.0.dev31 answered 200 to a request carrying NO
+        // credential, so every assertion above passed on a transport that
+        // authenticated nobody (#1522). Without this step the spec cannot tell a
+        // working key from an endpoint that never asks for one.
+        const res = await request.post(streamableUrl, {
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+          },
+          data: {
+            jsonrpc: "2.0",
+            id: 99,
+            method: "initialize",
+            params: {
+              protocolVersion: "2024-11-05",
+              capabilities: {},
+              clientInfo: { name: "langflow-e2e-no-credential", version: "0.1" },
+            },
+          },
+        });
+        expect(
+          res.status(),
+          "a keyless caller must be refused: the transport takes an API key, and " +
+            "resolves nobody to the superuser unless LANGFLOW_SKIP_AUTH_AUTO_LOGIN " +
+            "is set — which no lane sets, on purpose",
+        ).toBe(403);
+        expect(
+          (await res.text()).toLowerCase(),
+          "the refusal must be the API-key gate, not an unrelated 403",
+        ).toContain("api key");
       });
 
       await test.step("tools/list exposes the enabled flow", async () => {
         const resp = await mcpCall(
           request,
           streamableUrl,
-          authorization,
+          credential,
           "tools/list",
           undefined,
           2,
@@ -132,12 +189,12 @@ test.describe("MCP Server — flow-as-server protocol", () => {
       // string, so a pass proves the call round-tripped through the flow.
       const sentinel = `mcp-echo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
-      await mcpHandshake(request, streamableUrl, authorization);
+      await mcpHandshake(request, streamableUrl, credential);
 
       const resp = await mcpCall(
         request,
         streamableUrl,
-        authorization,
+        credential,
         "tools/call",
         { name: actionName, arguments: { input_value: sentinel } },
         3,

--- a/tests/tests-automations/regression/mcp/server/mcp-server-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-regression.spec.ts
@@ -1,4 +1,9 @@
 import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  createApiKey,
+  deleteApiKey,
+} from "../../../../helpers/auth/create-api-key";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
@@ -76,26 +81,44 @@ test.describe("MCP Server – Flow Exposed as MCP Tool", () => {
           : (projectsRaw.folders ?? []);
         expect(projects.length).toBeGreaterThan(0);
 
-        const initResp = await page.request.post(
-          `/api/v1/mcp/project/${projects[0].id}/streamable`,
-          {
-            headers: {
-              "Content-Type": "application/json",
-              Accept: "application/json, text/event-stream",
-            },
-            data: {
-              jsonrpc: "2.0",
-              id: 1,
-              method: "initialize",
-              params: {
-                protocolVersion: "2024-11-05",
-                capabilities: {},
-                clientInfo: { name: "langflow-e2e-test", version: "1" },
+        // The transport takes an API key as `x-api-key` and nothing else (#1522):
+        // this POST used to carry no credential at all and assert 200, which
+        // 1.12.0.dev31 answered — that build served the transport to anyone, so
+        // the assertion passed without exercising auth. On 1.12.0.dev33 a keyless
+        // caller is refused with 403.
+        const authorization = await getAuthToken(page.request);
+        const apiKey = await createApiKey(
+          page.request,
+          { Authorization: authorization },
+          { namePrefix: "e2e-mcp-regression" },
+        );
+        try {
+          const initResp = await page.request.post(
+            `/api/v1/mcp/project/${projects[0].id}/streamable`,
+            {
+              headers: {
+                "Content-Type": "application/json",
+                Accept: "application/json, text/event-stream",
+                "x-api-key": apiKey.key,
+              },
+              data: {
+                jsonrpc: "2.0",
+                id: 1,
+                method: "initialize",
+                params: {
+                  protocolVersion: "2024-11-05",
+                  capabilities: {},
+                  clientInfo: { name: "langflow-e2e-test", version: "1" },
+                },
               },
             },
-          },
-        );
-        expect(initResp.status()).toBe(200);
+          );
+          expect(initResp.status()).toBe(200);
+        } finally {
+          await deleteApiKey(page.request, apiKey.id, {
+            Authorization: authorization,
+          }).catch(() => {});
+        }
       });
     },
   );

--- a/tests/tests-automations/regression/mcp/server/mcp-server-resources.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-resources.spec.ts
@@ -1,11 +1,19 @@
 import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  createApiKey,
+  deleteApiKey,
+} from "../../../../helpers/auth/create-api-key";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import {
   createRunnableChatFlowViaApi,
   type RunnableChatFlow,
 } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
-import { mcpCall, mcpHandshake } from "../../../../helpers/mcp/mcp-streamable-client";
+import {
+  type McpTransportCredential,
+  mcpCall,
+  mcpHandshake,
+} from "../../../../helpers/mcp/mcp-streamable-client";
 
 /**
  * MCP Server — flow-file resources over the MCP protocol (QA-CHECKLIST §14.1
@@ -57,6 +65,10 @@ test.describe.configure({ mode: "serial" });
 
 test.describe("MCP Server — flow-file resources protocol", () => {
   let authorization: string;
+  // The MCP transport takes an API key and nothing else; `authorization` still
+  // authenticates every other API call here (#1522).
+  let credential: McpTransportCredential;
+  let apiKeyId: string;
   let projectId: string;
   let streamableUrl: string;
   let flow: RunnableChatFlow;
@@ -68,6 +80,12 @@ test.describe("MCP Server — flow-file resources protocol", () => {
   test.beforeAll(async ({ request }) => {
     authorization = await getAuthToken(request);
     const headers = { Authorization: authorization };
+
+    const created = await createApiKey(request, headers, {
+      namePrefix: "e2e-mcp-resources",
+    });
+    credential = { apiKey: created.key };
+    apiKeyId = created.id;
 
     // Create the flow first, then scope to the project it actually lives in
     // (its folder_id), so resources/list on that project is guaranteed to
@@ -121,13 +139,18 @@ test.describe("MCP Server — flow-file resources protocol", () => {
         headers: { Authorization: authorization },
       }).catch(() => {});
     }
+    if (apiKeyId) {
+      await deleteApiKey(request, apiKeyId, {
+        Authorization: authorization,
+      }).catch(() => {});
+    }
   });
 
   test(
     "resources/list surfaces the uploaded flow file as a resource",
     { tag: ["@stable", "@regression", "@api", "@mcp"] },
     async ({ request }) => {
-      await mcpHandshake(request, streamableUrl, authorization);
+      await mcpHandshake(request, streamableUrl, credential);
 
       // resources/list can lag a moment behind the upload — poll until this
       // flow's file appears, matching on its exact URI path (the project list
@@ -139,7 +162,7 @@ test.describe("MCP Server — flow-file resources protocol", () => {
             const resp = await mcpCall(
               request,
               streamableUrl,
-              authorization,
+              credential,
               "resources/list",
               {},
               2,
@@ -171,12 +194,12 @@ test.describe("MCP Server — flow-file resources protocol", () => {
     "resources/read returns the uploaded file content by URI",
     { tag: ["@regression", "@api", "@mcp"] },
     async ({ request }) => {
-      await mcpHandshake(request, streamableUrl, authorization);
+      await mcpHandshake(request, streamableUrl, credential);
 
       const resp = await mcpCall(
         request,
         streamableUrl,
-        authorization,
+        credential,
         "resources/read",
         { uri: resourceUri },
         3,

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -9,6 +9,10 @@ import {
 } from "../../../../helpers/mcp/open-add-mcp-server-modal";
 import { addComponentFromSidebarWithoutSearch } from "../../../../helpers/flows/add-component-from-sidebar";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import {
+  createApiKey,
+  deleteApiKey,
+} from "../../../../helpers/auth/create-api-key";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { openFlowById } from "../../../../helpers/flows/open-flow-by-id";
@@ -54,6 +58,10 @@ const TOOL_LIST_TIMEOUT = 120_000;
 // transient id 404s harmlessly — `deleteFlow` treats 404 as done.
 const createdFlowIds: string[] = [];
 const registeredServers: string[] = [];
+// API keys minted by a test, deleted id-scoped in `afterEach` — a key outlives
+// the test that created it and would otherwise accumulate on the shared
+// superuser account (#1522).
+const createdApiKeyIds: string[] = [];
 
 /** Server names currently registered on the instance. */
 async function listMcpServerNames(page: Page): Promise<string[]> {
@@ -111,6 +119,7 @@ async function selectMcpServerOnNode(page: Page, name: string) {
 test.beforeEach(async ({ page }) => {
   createdFlowIds.length = 0;
   registeredServers.length = 0;
+  createdApiKeyIds.length = 0;
   page.on("response", (resp) => {
     if (
       resp.url().includes("/api/v1/flows") &&
@@ -133,7 +142,8 @@ test.beforeEach(async ({ page }) => {
 test.afterEach(async ({ request }) => {
   const names = registeredServers.splice(0);
   const ids = createdFlowIds.splice(0);
-  if (names.length === 0 && ids.length === 0) return;
+  const keyIds = createdApiKeyIds.splice(0);
+  if (names.length === 0 && ids.length === 0 && keyIds.length === 0) return;
 
   const bearer = await getAuthToken(request);
   const options = bearer ? { headers: { Authorization: bearer } } : undefined;
@@ -167,6 +177,13 @@ test.afterEach(async ({ request }) => {
   // 404s, which it treats as done, so this only fires on a real failure.
   for (const id of ids) {
     await deleteFlow(request, id, options);
+  }
+
+  // `deleteApiKey` tolerates a 404 and throws on anything else, for the same
+  // reason as the flows above: a swallowed failure is how keys pile up on the
+  // shared superuser account.
+  for (const keyId of keyIds) {
+    await deleteApiKey(request, keyId, { Authorization: bearer });
   }
 });
 
@@ -1239,6 +1256,27 @@ test("Streamable HTTP MCP server with server-everything should load tools correc
 
     await page.getByTestId("http-name-input").fill(testName);
     await page.getByTestId("http-url-input").fill(server);
+
+    // The credential Langflow needs to call ITSELF (#1522). This registration is
+    // the one case where the server under test and the client are the same
+    // instance: Langflow connects out to `server` to enumerate its tools, and the
+    // transport takes an API key as `x-api-key` and nothing else. Without the
+    // header the poll below can only ever see `toolsCount: null` — reported as
+    // `rejected the request with HTTP 403: the configured credential was refused`
+    // — which is indistinguishable from the endpoint failing to serve its
+    // project's flows, the regression this test exists to catch.
+    const apiKey = await createApiKey(
+      page.request,
+      { Authorization: await getAuthToken(page.request) },
+      { namePrefix: "e2e-mcp-streamable" },
+    );
+    createdApiKeyIds.push(apiKey.id);
+    await page.getByTestId("http-headers-key-0").fill("x-api-key");
+    await page
+      .getByTestId("popover-anchor-http-headers-value-0")
+      .first()
+      .fill(apiKey.key);
+
     await page.getByTestId("add-mcp-server-button").click();
 
     await expect(


### PR DESCRIPTION
**Fixes #1522.** Closes #1522

## Problem

Five `@stable` MCP Server specs hard-failed on the 2026-08-20 daily ([run 32349515682](https://github.com/oriontech-me/langflow-e2e/actions/runs/32349515682)), 3 of 3 attempts each, four of them in 0 s — a refusal, not a timeout:

```
MCP initialize HTTP 403: {"detail":"Since v1.5, LANGFLOW_AUTO_LOGIN requires a valid API key.
Set LANGFLOW_SKIP_AUTH_AUTO_LOGIN=true to skip this check."}
```

The issue's step 1 asked for a probe before any PR, to decide between "our client is wrong" and "upstream regression". **The probe selected the first, and the product change is deliberate.** Measured live on two containers, same endpoint, same project:

| Credential on `initialize` | 1.12.0.dev31 | 1.12.0.dev33 |
|---|---|---|
| `Authorization: Bearer <auto_login JWT>` | 200 | **403** |
| `x-api-key: <API key>` | 200 | **200** |
| `Authorization: Bearer <API key>` | 200 | **403** |
| **no credential at all** | **200** | **403** |

Diffing `mcp_projects.py` between the two running containers shows the change and its stated reason: *"AUTO_LOGIN parity with the non-MCP entrypoints (`_api_key_security_impl`, `ws_api_key_security`, `authenticate_with_credentials`): AUTO_LOGIN alone is not a credential."* Only `LANGFLOW_SKIP_AUTH_AUTO_LOGIN` resolves a keyless caller to the superuser. The product agrees with itself — the JSON the MCP Server tab copies for a client carries `"x-api-key": "YOUR_API_KEY"`, already asserted by `mcp-server-tab.spec.ts:265`.

**The dev31 column is the finding behind the finding.** That build answered 200 to a request carrying *nothing*, so these specs asserted the protocol without exercising auth at all; they could not tell a working credential from an endpoint that never asks for one.

**Row 5 (`mcp-server.spec.ts:1189`, `toolsCount: null`) is the same cause, proven by mechanism.** Registering the project's own streamable URL via `POST /api/v2/mcp/servers/{name}`:

- no `headers` → `toolsCount: null`, error `rejected the request with HTTP 403: the configured credential was refused`
- `headers: {"x-api-key": <key>}` → `toolsCount` is a number

**Baseline on unmodified `origin/main`** (whole file, dev33, `--retries=0`): **3/3 red**, every time on that same test — `toolsCount: null` twice and one `socket hang up`. The defect reproduces locally on `main` and does not on this branch.

**A sixth spec carried the same defect invisibly.** `mcp-server-regression.spec.ts:68` POSTs `initialize` with **no credential** and asserts `200`. It is `@mcp @regression` without `@stable`, so the daily never ran it — red and unreported. Its inclusion here was authorized.

## Fix

- `tests/helpers/mcp/mcp-streamable-client.ts` — the third parameter changes from an `authorization` header string to a typed `McpTransportCredential = { apiKey: string }`, and the client sends `x-api-key`. The object shape is deliberate: a bearer string would still compile and then 403 at run time, which is precisely the failure this signature makes impossible. The measurement table lives in the header.
- The four handshake specs mint a key with the existing `createApiKey` (`tests/helpers/auth/create-api-key.ts`) in their existing setup hook and delete it in teardown. Every *other* API call in those specs keeps the `auto_login` bearer — those endpoints still accept it (measured 200 on dev33).
- `mcp-server.spec.ts` test 6 registers Langflow's **own** endpoint, so the stored config must carry the credential: it fills the HTTP tab's existing header fields (`http-headers-key-0` / `popover-anchor-http-headers-value-0`, already exercised by test 4 in the same file — no new selectors). Minted keys are reclaimed by the file's id-scoped `afterEach`, alongside servers and flows.
- `mcp-server-regression.spec.ts` sends the same header on its inline `initialize`.
- **New negative control** in `mcp-server-protocol.spec.ts`: the same `initialize` with no credential must answer `403`, with a body naming the API-key gate. Without it the whole spec passes on a build that serves the transport unauthenticated — which is what dev31 did. On a build predating the gate this step fails; that is the finding it exists to report, and the spec doc says so.
- Docs: the measurement, the two-flavour contract and the reasoning live once in `tests/tests-automations/regression/mcp/CLAUDE.md` → *Authenticating against the MCP transport*, referenced from the five spec docs.

### Rejected alternative — the bypass, and why not even as a temporary unblock

`LANGFLOW_SKIP_AUTH_AUTO_LOGIN=true` in `services.langflow.env` is one line per lane and has in-repo precedent (`migration-test.yml` since `02e84b2`). It is **not** used here, on any of the five lanes or either start script.

It turns off the control these specs exercise, and it is weakest exactly where it would be most tempting: `mcp-server-install.spec.ts` asserts that *the URL the UI copies resolves*. With the bypass on, it resolves for a caller presenting **nothing** — so the test would stay green on an instance where every real, keyed client is refused. An API key answered 200 on **both** builds, so keying on it needs no lane change at all. This is recorded in that spec's *Guarding against false positives* section, per the issue's own deliverable.

## Scope note

No assertion was weakened and no tag changed. All six specs keep their existing tags; the `test.fixme` in `mcp-server.spec.ts` belongs to #1266 (a transport-level flake, different cause) and is deliberately left in place. Lanes, workflows and start scripts are untouched.

Two things stay out of scope and are reported rather than acted on:

- `resources/read returns the uploaded file content by URI` — the test blocked by **LE-2012** — passed 3/3 on dev33. The upstream fix appears to have landed; promoting it to `@stable` belongs in its own issue.
- The `mcp-server.spec.ts` burst needed three attempts: two rounds failed on a **different**, untouched test (`STDIO … fields should persist`, hanging on `sidebar-nav-MCP Servers`) plus one `socket hang up`. Pre-existing local instability, not this change — the same test failed once in the 2026-08-13 daily, the same file already carries #1266's quarantine for that class, and baseline run 1 on unmodified `main` also produced a `socket hang up`.

## Validation (nightly 1.12.0.dev33, `--workers=1 --retries=0`)

```
run 1..3/3 mcp-server-install.spec.ts         clean expected=3 unexpected=0 flaky=0 backendErrors=false
run 1..3/3 mcp-server-project-config.spec.ts  clean expected=2 unexpected=0 flaky=0 backendErrors=false
run 1..3/3 mcp-server-protocol.spec.ts        clean expected=2 unexpected=0 flaky=0 backendErrors=false
run 1..3/3 mcp-server-regression.spec.ts      clean expected=1 unexpected=0 flaky=0 backendErrors=false
run 1..3/3 mcp-server-resources.spec.ts       clean expected=2 unexpected=0 flaky=0 backendErrors=false
run 1..3/3 mcp-server.spec.ts                 clean expected=8 unexpected=0 flaky=0 backendErrors=false
typecheck=0 · lint=0 · final green run after reverts ✓
```

- **Force-fail: 18/18 tests in the six touched files**, each with a real mutation on its primary assertion (not a trivial `expect(1).toBe(2)`), each verified to fail, each reverted — `grep -c FF-MUTATION` = 0 and a final green run confirms the reverts. Examples: the echoed sentinel compared against `sentinel + "-ff"`; `serverInfo.name` suffixed; `composer-url` required to answer 418; the streamable test required to find >999 tool options; the persisted server name compared against `testName + "-ff"`.
- Zero `🚨 Backend Error` across every run (checklist step 4, the gate #1084 exists for).
- **Cleanup audited before reporting**, on both instances: 26 flows (all starter templates), no orphaned flow, no leftover MCP server beyond the product's own `lf-starter_project`, no leftover API key beyond Langflow's own. Every key, server and flow these specs create is reclaimed id-scoped.
- `QA-CHECKLIST.md`: only the manual §14.1 bullet was edited (records that the transport takes an API key and that a keyless `initialize` is refused); both checklist guards pass — no generated block touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
