### PR TITLE
test(i18n): language selection and locale resilience — the §18 batch #1400 unblocked (#1539, #1540)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -905,32 +905,42 @@
 > asserts that the **Language group renders** with its description. Nothing asserts that
 > **changing** the language works, and that is exactly where the reported failures are.
 >
-> **Blocked on a prerequisite, by the project's own rule.** `CONTRIBUTING.md` →
-> *Browser locale is pinned to `en-US`* fixes the context locale and `Accept-Language`
-> for every test in every project, because the suite asserts English strings throughout,
-> and it states that non-English coverage *"is a separate, parameterised concern — raise
-> it as its own issue rather than editing the shared default."* §18.2 in particular
-> cannot run under that pin. These bullets therefore need that parameterisation issue
-> opened and resolved **first**; writing them against a per-test `locale` override would
-> violate the rule they depend on.
+> **The prerequisite has landed.** `CONTRIBUTING.md` used to pin the context locale to
+> `en-US` for every test with no sanctioned override, which made these bullets unwritable
+> — the exact parameterisation issue it asked for is #1400 (`tests/fixtures/locale.ts`,
+> `withLocale()`), merged 2026-08-11. The batch below is written against it.
 
 #### 18.1 Language Selection
 
-- [ ] Changing the display language in Settings → General actually re-renders the interface
+- [x] Changing the display language in Settings → General actually re-renders the interface
       in the selected language (the seam immediately past `settings-general-section.spec.ts`)
-- [ ] The selected language persists across a reload and a new session
-- [ ] Every language offered in the selector has a locale bundle that loads
+      → i18n/language-selection.spec.ts
+- [x] The selected language persists across a reload and a new session — a reload and a
+      second tab of the same browser context; a fresh context correctly does **not**
+      inherit it (the preference is `localStorage`, not server state)
+      → i18n/language-selection.spec.ts
+- [x] Every language offered in the selector has a locale bundle that loads
       (`langflow-ai/langflow#12738`, `#12740` — shipped selector entries with missing `ru`
-      and `ko` bundles)
+      and `ko` bundles; the options are enumerated at run time so a new entry is covered
+      the day it appears, and English is asserted as the inverse case — no chunk at all)
+      → i18n/language-selection.spec.ts
 
 #### 18.2 Locale Resilience
 
-- [ ] The application boots without a blank screen when the browser language is one Langflow
+- [x] The application boots without a blank screen when the browser language is one Langflow
       does not ship a bundle for — **the product's known total-failure mode**: a missing
       Chinese bundle (`#12923`, `#13477`) and Norwegian Bokmål `nb-NO` (`#13196`) each render
-      a black screen, so the product does not open at all for those users
-- [ ] A locale bundle missing individual keys falls back to English for those keys instead of
-      failing the render
+      a black screen, so the product does not open at all for those users. Covered on both
+      axes: the stored `languagePreference` (nine-seed normaliser table) and the browser
+      locale under `withLocale("nb-NO")`, which also pins that `navigator.language` never
+      becomes a preference
+      → i18n/locale-resilience.spec.ts
+- [x] A locale bundle missing individual keys falls back to English for those keys instead of
+      failing the render — asserted in the Create Memory modal under `pt`, on the two
+      `memory.dbProvider*` keys only `en` carries (`shortcuts.modifierOnly` is a decoy: its
+      call site passes an inline `defaultValue`, so it renders English even with the
+      fallback broken)
+      → i18n/locale-resilience.spec.ts
 
 ---
 

--- a/docs/i18n/language-selection.md
+++ b/docs/i18n/language-selection.md
@@ -1,0 +1,172 @@
+# i18n — Language selection
+
+**Last validated:** Langflow 1.12.x (measured on nightly `1.12.0.dev33`)
+
+---
+
+## What this test validates *(required)*
+
+The **display-language selector** in Settings → General: that choosing a
+language actually re-renders the interface in it, that the choice survives a
+reload, and that **every** language the selector offers is backed by a
+translation bundle that loads. This is the seam immediately past
+`ui-ux/settings-general-section.spec.ts`, which asserts the Language card
+exists and stops there.
+
+1. **should re-render the interface when the display language changes** —
+   picking `Português` in the Settings → General language selector switches
+   `document.documentElement.lang` from `en` to `pt`, retitles the settings
+   header from `General` to `Geral`, leaves the selector reading `Português`,
+   and writes `pt` to `localStorage.languagePreference`.
+2. **should keep the selected language across a reload and a second tab of the
+   same browser session** — after switching to `Português`, a `page.reload()`
+   and a second page opened in the **same browser context** both come up in
+   Portuguese, with no second visit to the selector.
+3. **should load a translation bundle for every language the selector offers** —
+   the selector's options are enumerated at run time; each one is selected in
+   turn and must (a) set `<html lang>` to a language code, (b) for every
+   non-English code, fetch `/assets/<code>-<hash>.js` with a `200`, and (c)
+   change the settings header away from the English `General`. English is the
+   inverse case and is asserted as such: it fetches **no** bundle (its
+   translations are inlined in the app bundle) and restores `General`.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@ui-ux` `@settings`
+
+`@regression` because the batch exists to pin fixed upstream defects, not to
+describe a new feature — see **Notes**. `@ui-ux` and `@settings` are the
+existing functional tags for this surface; **no new `@i18n` tag is introduced**,
+following the rule that a new functional tag is only warranted when there is no
+OSS area to reuse (the `@authz` precedent in `CLAUDE.md`).
+
+`@stable` from the first PR on the same grounds as the `memory` specs: every
+assertion is LLM-free and provider-free, nothing is created server-side so there
+is nothing to leak, and the whole file measured **20.6 s** in the scout that
+walked all seven languages. Subject to the VALIDATE burst passing at
+`--retries=0 --workers=1`.
+
+Not `@release`: switching display language is not a pre-deploy happy path.
+
+---
+
+## Validation criterion *(required)*
+
+- **`document.documentElement.lang` is the primary observable, not a translated
+  string.** The frontend sets it at boot and again on every `languageChanged`
+  event (measured in the shipped bundle:
+  `hRn = e => {document.documentElement.lang = e}`, registered as the
+  `languageChanged` handler). It is a machine value that upstream cannot
+  reword, so it survives a translation edit that would break a string
+  assertion — while still being *product* state, not test state.
+- **The combobox is resolved by role and pinned to exactly one match, never by
+  its accessible name.** The trigger carries **no `id` and no `data-testid`**
+  (measured in the bundle and live) — only
+  `aria-label={t("settings.languageSelectAriaLabel")}`, which is itself
+  translated: it reads `Select language` in English, `Selecionar idioma` in
+  Portuguese, `言語の選択` in Japanese. A `getByRole("combobox", { name: "Select
+  language" })` therefore works exactly once and then resolves zero elements —
+  the trap that makes test 3 unwritable if taken naively. Settings → General
+  renders **exactly one** combobox in all seven languages (measured), so the
+  spec resolves `getByRole("combobox")` and asserts `toHaveCount(1)` first: if a
+  second one ever appears, the test fails naming that, instead of silently
+  driving the wrong control.
+- **The option labels are the stable half and are used as such.** They are
+  hardcoded native names in the frontend (`English (Recommended)`, `Français`,
+  `Español`, `Deutsch`, `Português`, `日本語`, `中文`) and do **not** move when
+  the interface language changes — only the `(Recommended)` suffix is
+  translated, which is why the English option is matched on `/English/` rather
+  than on its full label.
+- **Test 3 enumerates the selector rather than asserting a fixed list of
+  seven.** The bullet's claim is *"every language offered in the selector has a
+  bundle that loads"* — a hardcoded list would pass unchanged on the exact
+  defect it exists to catch, which is a **new selector entry shipped without a
+  bundle** (upstream `#12738`/`#12740` shipped `ru` and `ko` that way). Reading
+  the options at run time means an eighth entry is covered the day it appears.
+- **"The bundle loads" is asserted as a `200` on the chunk request, and "the UI
+  re-rendered" separately.** They are different failures: a missing bundle
+  `404`s the dynamic import and leaves the interface silently English (the
+  `#12738` shape), so asserting only "the text changed" would report the right
+  verdict for the wrong reason, and asserting only the request would not notice
+  a bundle that loads but is never applied. Both, per language.
+- **English is asserted as the inverse case, not skipped.** Its translations are
+  inlined in the app bundle and the loader short-circuits on `e !== "en"`, so
+  selecting English must produce **no** locale chunk request at all. Asserting
+  that pins the optimisation; a test that merely skipped English would also pass
+  if English started fetching a chunk that does not exist.
+- **Persistence is asserted in the two places it is real, and the third is
+  documented as out of scope.** The preference lives in `localStorage`, so it
+  survives a reload and a second tab of the same browser context, and is
+  **correctly** absent from a fresh `browser.newContext()`. The spec must
+  therefore never open a new context to check "a new session" — that reads
+  designed behaviour as a bug.
+
+---
+
+## External dependencies *(required)*
+
+- A running Langflow instance reachable at `PLAYWRIGHT_BASE_URL`. **No provider
+  key, no LLM call, no flow.** The whole surface is client-side.
+- The seven locale chunks the image ships under
+  `langflow/frontend/assets/` (`de`, `es`, `fr`, `ja`, `pt`, `zh-Hans`, plus
+  `en` inlined). Their presence is the subject of test 3, not a precondition of
+  it.
+- Settings → General must be reachable through `user-profile-settings` →
+  `menu_settings_button` → the `General` link, the same path
+  `ui-ux/settings-general-section.spec.ts` uses.
+- `src/frontend/src/i18n.ts` — the module that reads
+  `localStorage.languagePreference`, registers the `languageChanged` →
+  `document.documentElement.lang` handler, and holds the dynamic-import map of
+  locale chunks the bundle-loads test observes.
+- `src/frontend/src/locales/` — the shipped translation bundles; the selector's
+  option list must stay 1:1 with this directory (the upstream defect class).
+- `src/frontend/src/pages/SettingsPage/pages/GeneralPage/` — the Language card:
+  the hardcoded option labels, the translated `aria-label`, and the change
+  handler (`changeLanguage` + `localStorage` write + `useGetTypes`
+  invalidation).
+
+---
+
+## Cleanup *(required)*
+
+Nothing is created server-side, so there is nothing to delete. The only state
+the tests write is `localStorage.languagePreference` in their own browser
+context, which Playwright discards with the context after each test — no test
+inherits another's language.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The **browser** locale axis and the missing-key fallback — `locale-resilience.md`
+  (§18.2), the sibling in this batch.
+- The quality or completeness of any individual translation.
+- The language selector in the app header, if one exists there — this spec
+  drives the Settings → General one named by the checklist bullet.
+- The side effect that switching language invalidates the component-types query
+  (`setTypes({})` + `invalidateQueries(["useGetTypes"])` in the change handler):
+  real, measured in the bundle, but a catalog concern rather than an i18n one.
+
+---
+
+## Notes *(optional)*
+
+- **Where the facts come from.** Every selector and every string below was
+  harvested twice: from the shipped frontend bundle inside the running container
+  (`langflow/frontend/assets/index-d_5OgSTc.js`) and then confirmed live against
+  `1.12.0.dev33` with a throwaway scout. The scout is what produced the
+  translated-`aria-label` trap above, which reading the bundle alone would have
+  missed.
+- **The upstream defects this pins.** `langflow-ai/langflow#12738` and `#12740`
+  shipped selector entries (`ru`, `ko`) with no corresponding bundle. On
+  `1.12.0.dev33` the selector offers exactly the seven languages the image ships
+  a bundle for, so the defect is **fixed** and test 3 is a regression guard, not
+  a reproduction.
+- **Measured behaviour of the change handler**, for whoever debugs this next:
+  selecting a language `await`s the dynamic import of its chunk, calls
+  `i18n.changeLanguage`, writes `localStorage.languagePreference`, then clears
+  the component-types store and invalidates `useGetTypes`. The last step means a
+  language switch also triggers a catalog refetch — expect a `GET /api/v1/all`
+  in the network log that has nothing to do with i18n.

--- a/docs/i18n/locale-resilience.md
+++ b/docs/i18n/locale-resilience.md
@@ -1,0 +1,195 @@
+# i18n — Locale resilience
+
+**Last validated:** Langflow 1.12.x (measured on nightly `1.12.0.dev33`)
+
+---
+
+## What this test validates *(required)*
+
+That an unsupported language **degrades instead of breaking the product**. Two
+independent failure modes: a stored language preference Langflow ships no bundle
+for (the upstream **black-screen** class), and a bundle that ships but is missing
+individual keys.
+
+1. **should boot into a shipped language for every unsupported or regional
+   preference** — `localStorage.languagePreference` is seeded before the first
+   navigation with each of `nb-NO`, `ru`, `ko`, `xx`, `zh-CN`, `zh-SG`, `pt-BR`,
+   `de-AT` and an unset value. In every case the application reaches
+   `mainpage_title` with a non-empty body, and `document.documentElement.lang`
+   settles on the language the frontend's normaliser resolves — `en` for the
+   four it cannot place, `zh-Hans` for both Chinese regionals, `pt` for `pt-BR`,
+   `de` for `de-AT`.
+2. **should boot in English under a browser locale Langflow ships no bundle
+   for** — the whole test runs under `withLocale("nb-NO")`. The application
+   renders, `navigator.language` reads `nb-NO`, `document.documentElement.lang`
+   reads `en`, and `localStorage.languagePreference` is **unset** — the browser
+   locale never becomes a language preference.
+3. **should fall back to English for a key the active bundle lacks, next to
+   siblings it translates** — with the interface in Portuguese, the flow
+   editor's Create Memory modal renders `Criar Memória`, `Nome` and
+   `Tamanho do lote` in Portuguese while the `Vector Database` label and its
+   description — two keys the Portuguese bundle does not carry — render their
+   English text. No raw i18n key (`memory.dbProviderLabel`) appears anywhere in
+   the dialog.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@ui-ux` `@workspace`
+
+`@regression` is the load-bearing tag: test 1 pins three fixed upstream
+black-screen defects (see **Notes**). `@workspace` covers the flow editor and
+its Memories panel, which test 3 has to reach; `@ui-ux` covers the rest. No new
+`@i18n` functional tag — see the sibling doc.
+
+`@stable` from the first PR: LLM-free and provider-free (test 3 never selects an
+embedding model, so it does not inherit `memory-base-panel.spec.ts`'s
+provider-dependent branch), and the one flow test 3 creates is deleted
+id-scoped.
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1 asserts the frontend's normaliser, and the expected value per seed is
+  measured, not assumed.** The shipped bundle resolves the stored preference
+  through a three-step ladder before i18next ever sees it: exact match against
+  the seven shipped codes → the `zh-hans`/`zh-cn`/`zh-sg` special case → the
+  primary subtag (`pt-BR` → `pt`) → `en`. Each row of the table asserts one
+  branch of that ladder, so a regression that flattens it to "unknown ⇒ en"
+  would still be caught by the `zh-CN` and `de-AT` rows, and a regression that
+  drops the final `en` fallback — the black-screen shape — by the `nb-NO`, `ru`,
+  `ko` and `xx` rows.
+- **"Boots" is asserted as three things, because a blank screen satisfies one of
+  them.** The defect being pinned renders a black page with a live document: the
+  navigation resolves and the URL is right. So each row requires
+  `mainpage_title` to become visible **and** the body to carry text **and**
+  `<html lang>` to hold the expected code. A bare `waitForURL` or a
+  `toBeVisible()` on the app shell would pass on the very failure this exists
+  to catch.
+- **The seed is written with `addInitScript` before the first navigation.**
+  `localStorage.languagePreference` is read once, at module evaluation
+  (`normalize(localStorage.getItem("languagePreference") || "en")`), so a value
+  written after the page loads changes nothing until the next load — a test that
+  seeded post-navigation would assert the default and pass for the wrong
+  reason.
+- **Test 2 exists because the checklist bullet says "browser language" and the
+  product does not read it.** Langflow's `i18n.ts` consults
+  `localStorage.languagePreference` and has no language-detector plugin, so
+  `navigator.language` is inert (measured for #1400 and re-measured here). Test 2
+  pins that independence: it is the only assertion in the suite that would fail
+  if upstream added detection, at which point every unshipped browser locale
+  becomes a boot risk again and test 1's table becomes reachable from the
+  browser. It uses `withLocale()` — the sanctioned opt-in — never a bare
+  `test.use({ locale })`.
+- **Test 3's vehicle is chosen, not convenient — and one obvious candidate is a
+  decoy.** On `1.12.0.dev33` all six non-English bundles are missing the **same
+  five** keys that `en` carries: `shortcuts.modifierOnly`, `memory.backendLabel`,
+  `memory.dbProviderLabel`, `memory.dbProviderDescription` and
+  `memory.dbProviderNotConfigured`. `shortcuts.modifierOnly` **must not be
+  used**: its call site passes an inline
+  `{ defaultValue: "Add at least one non-modifier key…" }`, so it renders English
+  whether or not `fallbackLng` works, and a test built on it would pass against a
+  broken fallback. The three `memory.*` keys are called with no `defaultValue` at
+  all, so English there can only come from `fallbackLng: "en"`. `memory.backendLabel`
+  needs an existing memory base; `memory.dbProviderLabel` and its description
+  render unconditionally in the Create Memory modal, on an instance with nothing
+  configured — which is why that modal is the vehicle.
+- **Test 3 asserts translated siblings in the same dialog, not just the English
+  string.** "This label is in English" is also true of an instance that never
+  switched language at all. The falsifiable form is the pair: `Criar Memória` /
+  `Nome` / `Tamanho do lote` in Portuguese **and** `Vector Database` in English,
+  read from one screenshot of one dialog.
+- **A raw-key check backs it up**, because i18next's other failure mode is to
+  render the key itself: the dialog's text must not contain
+  `memory.dbProviderLabel`. Two different broken states — key echoed, or empty
+  string — are excluded by the pair of assertions.
+- **This test has a known expiry and says so in its own failure.** If upstream
+  translates those keys, the English assertion goes red on a healthy product.
+  The assertion therefore carries a message naming that possibility and pointing
+  at how to re-measure (diff the `en` translation object in
+  `assets/index-*.js` against `assets/pt-*.js`), so the next reader is not left
+  diagnosing a phantom i18n regression.
+
+---
+
+## External dependencies *(required)*
+
+- A running Langflow instance reachable at `PLAYWRIGHT_BASE_URL`. **No provider
+  key and no LLM call** — test 3 opens the Create Memory modal and never selects
+  an embedding model, so the provider-dependent control that
+  `memory-base-panel.spec.ts` branches on is irrelevant here.
+- `POST /api/v1/flows/` and `DELETE /api/v1/flows/{id}` for test 3's own flow —
+  the Memories nav item requires a flow to be open.
+- `withLocale()` from `tests/fixtures/locale.ts` (#1400) for test 2. Without it
+  the browser-locale axis cannot be exercised at all: `CONTRIBUTING.md` bans a
+  bare `test.use({ locale })`, which is what made these bullets unwritable
+  before that fixture landed.
+- The `pt` locale chunk shipped by the image, for test 3.
+- `src/frontend/src/i18n.ts` — the normaliser ladder test 1 transcribes, the
+  `fallbackLng: "en"` configuration test 3 exercises, and the absence of a
+  language-detector plugin that test 2 pins.
+- `src/frontend/src/locales/pt.json` — the bundle whose five-key gap against
+  `en` is test 3's subject; if upstream fills it, the test says how to
+  re-measure (see Validation criterion).
+
+---
+
+## Cleanup *(required)*
+
+Test 3 creates one flow through `POST /api/v1/flows/` and deletes it id-scoped
+in `afterEach`, leaving the editor first via `unmountEditorForCleanup` so the
+deleted flow's editor polls cannot 404 into the fixture's HTTP log. No memory
+base is ever created — the modal is cancelled. Tests 1 and 2 create nothing;
+their only state is `localStorage` inside their own browser context, which
+Playwright discards with it.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The Settings → General selector itself — `language-selection.md` (§18.1), the
+  sibling in this batch.
+- Whether the **backend** localises. It does — `GET /api/v1/flows/basic_examples/`
+  answers `Sugestões básicas` under `Accept-Language: pt` — but that is a third
+  axis reached by an explicit header, not by either mechanism here
+  (`CONTRIBUTING.md` → *Browser locale*).
+- The other two en-only keys (`memory.backendLabel`,
+  `memory.dbProviderNotConfigured`), which need a registered memory base and a
+  half-configured DB provider respectively.
+- Right-to-left layout: Langflow ships no RTL bundle, so there is nothing to
+  assert.
+
+---
+
+## Notes *(optional)*
+
+- **The upstream defects test 1 pins.** A missing Chinese bundle
+  (`langflow-ai/langflow#12923`, `#13477`) and Norwegian Bokmål `nb-NO`
+  (`#13196`) each rendered a **black screen** — the product did not open at all
+  for those users. On `1.12.0.dev33` every one of those inputs boots, so this is
+  a regression guard rather than a reproduction. `nb-NO` and `zh-CN` are in the
+  table specifically because they are those reports.
+- **Measured normaliser**, transcribed from the shipped bundle so the table above
+  is auditable:
+
+  ```js
+  const SUPPORTED = ["en", "de", "es", "fr", "ja", "pt", "zh-Hans"];
+  const normalize = (e) => {
+    if (SUPPORTED.includes(e)) return e;
+    if (["zh-hans", "zh-cn", "zh-sg"].includes(e.toLowerCase())) return "zh-Hans";
+    const primary = e.split("-")[0];
+    return SUPPORTED.includes(primary) ? primary : "en";
+  };
+  ```
+
+  i18next is then initialised with `fallbackLng: "en"`, `returnNull: false` and
+  `returnEmptyString: false` — the configuration test 3 exercises.
+- **Where the facts come from.** The five-key gap was produced by diffing the
+  `en` translation object inside `assets/index-*.js` against each locale chunk
+  (2387 English keys, 2382 in each of the six bundles, identical gap in all
+  six), then confirmed live: the Create Memory modal under `pt` renders
+  `Vector Database` and `Where this memory base stores vectors. Configured
+  providers come from DB Providers settings.` in English amid an otherwise
+  Portuguese dialog.

--- a/tests/tests-automations/regression/i18n/language-selection.spec.ts
+++ b/tests/tests-automations/regression/i18n/language-selection.spec.ts
@@ -1,0 +1,330 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+
+// i18n — Language selection (QA-CHECKLIST §18.1).
+// Spec doc: docs/i18n/language-selection.md
+//
+// The seam immediately past ui-ux/settings-general-section.spec.ts, which
+// asserts the Language card exists and stops there. Nothing here needs a
+// provider, an LLM or a flow — the whole surface is client-side.
+//
+// Sibling coverage, deliberately not duplicated: i18n/locale-resilience.spec.ts
+// (§18.2) owns the browser-locale axis and the missing-key fallback.
+
+/**
+ * The primary observable, in preference to any translated string.
+ *
+ * The frontend assigns it at boot and again on every `languageChanged` event
+ * (measured in the shipped bundle: the handler is
+ * `e => {document.documentElement.lang = e}`). It is product state that upstream
+ * cannot reword, so it survives a translation edit that would break a string
+ * assertion.
+ */
+function documentLanguage(page: Page): Locator {
+  return page.locator("html");
+}
+
+/**
+ * The language selector, resolved by role and pinned to a single match.
+ *
+ * NOT by accessible name. The trigger carries no `id` and no `data-testid` —
+ * only `aria-label={t("settings.languageSelectAriaLabel")}`, which is itself
+ * translated: `Select language` in English, `Selecionar idioma` in Portuguese,
+ * `言語の選択` in Japanese (all measured on 1.12.0.dev33). A name-based handle
+ * therefore resolves exactly once and matches nothing after the first switch,
+ * which is what makes the "every offered language" test unwritable if taken
+ * naively.
+ *
+ * Settings → General renders exactly one combobox in all seven languages
+ * (measured). Asserting the count first is what turns a second one appearing
+ * into a named failure instead of a click on the wrong control.
+ */
+async function languageSelect(page: Page): Promise<Locator> {
+  const select = page.getByRole("combobox");
+  await expect(select).toHaveCount(1);
+  return select;
+}
+
+/** Settings → General, the same path ui-ux/settings-general-section.spec.ts uses. */
+async function openSettingsGeneral(page: Page): Promise<void> {
+  await page.getByTestId("user-profile-settings").click();
+  await page.getByTestId("menu_settings_button").click();
+  await page.waitForSelector('[data-testid="settings_menu_header"]', {
+    timeout: 15000,
+  });
+  await page.getByRole("link", { name: "General", exact: true }).click();
+  await expect(page.getByTestId("settings_menu_header")).toContainText(
+    "General",
+    { timeout: 10000 },
+  );
+}
+
+/**
+ * An option's label with its trailing parenthetical removed.
+ *
+ * The option labels are hardcoded native names and do NOT move with the
+ * interface language — except the `(Recommended)` suffix on the English entry,
+ * which does (`(Recommandé)`, `(推荐)`). Since the round trip back to English
+ * happens last, by which point the interface is in some other language, the
+ * English option has to be matched on its stable prefix.
+ */
+function stableOptionPrefix(label: string): string {
+  return label.replace(/\s*\(.*\)\s*$/, "").trim();
+}
+
+function prefixMatcher(label: string): RegExp {
+  const escaped = stableOptionPrefix(label).replace(
+    /[.*+?^${}()|[\]\\]/g,
+    "\\$&",
+  );
+  return new RegExp(`^${escaped}`);
+}
+
+/** Opens the selector and returns every option's visible label, in order. */
+async function readOfferedLanguages(page: Page): Promise<string[]> {
+  const select = await languageSelect(page);
+  await select.click();
+  const options = page.getByRole("option");
+  await expect(options.first()).toBeVisible({ timeout: 10000 });
+  const labels = (await options.allTextContents()).map((l) => l.trim());
+  await page.keyboard.press("Escape");
+  await expect(options).toHaveCount(0);
+  return labels;
+}
+
+/**
+ * Selects one option and waits for the switch to land.
+ *
+ * Gated on `<html lang>` actually moving off its previous value rather than on
+ * a fixed wait: the change handler awaits a dynamic import of the locale chunk
+ * before it calls `changeLanguage`, so the interface is briefly still in the old
+ * language after the click.
+ */
+async function selectLanguage(
+  page: Page,
+  label: string,
+  previousLanguage: string,
+): Promise<string> {
+  const option = page.getByRole("option", { name: prefixMatcher(label) });
+  await (await languageSelect(page)).click();
+  // Exactly one match, so a future selector entry sharing a prefix with another
+  // fails here by name instead of resolving to whichever came first.
+  await expect(option).toHaveCount(1);
+  await option.click();
+  await expect(documentLanguage(page)).not.toHaveAttribute(
+    "lang",
+    previousLanguage,
+    { timeout: 15000 },
+  );
+  return (await documentLanguage(page).getAttribute("lang")) ?? "";
+}
+
+/** The locale chunk a given language code would be served from, if any. */
+function localeChunkPattern(language: string): RegExp {
+  const escaped = language.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`/assets/${escaped}-[A-Za-z0-9_-]+\\.js$`);
+}
+
+test.describe("i18n — the Settings display-language selector", () => {
+  test.beforeEach(async ({ page }) => {
+    await awaitBootstrapTest(page, { skipModal: true });
+    await openSettingsGeneral(page);
+  });
+
+  test(
+    "changing the display language re-renders the interface",
+    { tag: ["@stable", "@regression", "@ui-ux", "@settings"] },
+    async ({ page }) => {
+      await test.step("the interface starts in English with no stored preference", async () => {
+        await expect(documentLanguage(page)).toHaveAttribute("lang", "en");
+        // Null, not "en": the default is applied without ever being written, so
+        // a stored value here would mean some earlier state leaked into the test.
+        expect(
+          await page.evaluate(() =>
+            localStorage.getItem("languagePreference"),
+          ),
+        ).toBeNull();
+      });
+
+      await test.step("selecting Português switches the document language", async () => {
+        await selectLanguage(page, "Português", "en");
+        await expect(documentLanguage(page)).toHaveAttribute("lang", "pt");
+      });
+
+      await test.step("the interface renders in the selected language", async () => {
+        // The settings header is the closest translated string to the control
+        // that changed it, so a switch that writes the preference without
+        // re-rendering cannot pass.
+        await expect(page.getByTestId("settings_menu_header")).toHaveText(
+          "Geral",
+          { timeout: 15000 },
+        );
+        await expect(await languageSelect(page)).toHaveText("Português");
+      });
+
+      await test.step("the choice is stored as the language preference", async () => {
+        await expect
+          .poll(
+            () =>
+              page.evaluate(() =>
+                localStorage.getItem("languagePreference"),
+              ),
+            { timeout: 10000 },
+          )
+          .toBe("pt");
+      });
+    },
+  );
+
+  test(
+    "the selected language survives a reload and a second tab of the same session",
+    { tag: ["@stable", "@regression", "@ui-ux", "@settings"] },
+    async ({ page }) => {
+      await test.step("switch the interface to Português", async () => {
+        await selectLanguage(page, "Português", "en");
+        await expect(page.getByTestId("settings_menu_header")).toHaveText(
+          "Geral",
+          { timeout: 15000 },
+        );
+      });
+
+      await test.step("a reload comes back in Portuguese", async () => {
+        await page.reload();
+        await expect(documentLanguage(page)).toHaveAttribute("lang", "pt", {
+          timeout: 30000,
+        });
+        await expect(page.getByTestId("settings_menu_header")).toHaveText(
+          "Geral",
+          { timeout: 30000 },
+        );
+      });
+
+      await test.step("a second tab of the same browser session comes up in Portuguese", async () => {
+        // A second PAGE, never a second CONTEXT. The preference lives in
+        // localStorage, so a fresh context correctly does not inherit it —
+        // checking "a new session" that way would read designed behaviour as a
+        // regression.
+        const secondTab = await page.context().newPage();
+        try {
+          await secondTab.goto("/");
+          await secondTab.waitForSelector('[data-testid="mainpage_title"]', {
+            timeout: 30000,
+          });
+          await expect(secondTab.locator("html")).toHaveAttribute("lang", "pt", {
+            timeout: 15000,
+          });
+          expect(
+            await secondTab.evaluate(() =>
+              localStorage.getItem("languagePreference"),
+            ),
+          ).toBe("pt");
+        } finally {
+          await secondTab.close();
+        }
+      });
+    },
+  );
+
+  test(
+    "every language the selector offers loads a translation bundle",
+    { tag: ["@stable", "@regression", "@ui-ux", "@settings"] },
+    async ({ page }) => {
+      const chunkRequests: Array<{ path: string; status: number }> = [];
+      page.on("response", (response) => {
+        chunkRequests.push({
+          path: new URL(response.url()).pathname,
+          status: response.status(),
+        });
+      });
+
+      const startLanguage =
+        (await documentLanguage(page).getAttribute("lang")) ?? "";
+      const startHeader =
+        (await page.getByTestId("settings_menu_header").textContent())?.trim() ??
+        "";
+      const offered = await readOfferedLanguages(page);
+
+      await test.step("the selector offers a choice at all", async () => {
+        // Without this a selector reduced to one entry would satisfy the loop
+        // below vacuously.
+        expect(offered.length).toBeGreaterThanOrEqual(2);
+      });
+
+      // The option matching the current selection is the starting language. It
+      // is identified from the product's own state rather than by hardcoding
+      // "English", and it is walked LAST so that its own switch is observable —
+      // selecting the already-active language changes nothing.
+      const startLabel =
+        (await (await languageSelect(page)).textContent())?.trim() ?? "";
+      const startOption = offered.find(
+        (label) => stableOptionPrefix(label) === stableOptionPrefix(startLabel),
+      );
+      expect(
+        startOption,
+        `the selector's current value ${JSON.stringify(startLabel)} matches none of its options ${JSON.stringify(offered)}`,
+      ).toBeDefined();
+
+      const walkOrder = [
+        ...offered.filter((label) => label !== startOption),
+        startOption as string,
+      ];
+
+      let previousLanguage = startLanguage;
+      for (const label of walkOrder) {
+        const isStartLanguage = label === startOption;
+        await test.step(`"${label}" ${isStartLanguage ? "restores the inlined bundle" : "loads its bundle and re-renders"}`, async () => {
+          const seenBefore = chunkRequests.length;
+          const language = await selectLanguage(page, label, previousLanguage);
+          previousLanguage = language;
+
+          expect(
+            language,
+            `selecting ${JSON.stringify(label)} left <html lang> empty`,
+          ).not.toBe("");
+
+          const newChunks = chunkRequests.slice(seenBefore);
+          const localeChunks = newChunks.filter((chunk) =>
+            localeChunkPattern(language).test(chunk.path),
+          );
+
+          if (isStartLanguage) {
+            // The starting language is the one whose translations are inlined
+            // in the app bundle — the loader short-circuits on `!== "en"`, so
+            // there is no chunk to fetch. Asserted rather than skipped: a test
+            // that merely skipped this case would also pass if it started
+            // fetching a chunk that does not exist.
+            expect(
+              localeChunks,
+              `${JSON.stringify(label)} resolved to "${language}" and fetched a locale chunk, which the inlined language should never do`,
+            ).toHaveLength(0);
+            await expect(page.getByTestId("settings_menu_header")).toHaveText(
+              startHeader,
+              { timeout: 15000 },
+            );
+            return;
+          }
+
+          // Two separate failures, asserted separately: a selector entry with no
+          // bundle 404s the dynamic import and leaves the interface silently in
+          // the previous language (the upstream #12738/#12740 shape), so the
+          // request alone and the re-render alone each report the right verdict
+          // for the wrong reason.
+          expect(
+            localeChunks.map((chunk) => `${chunk.status} ${chunk.path}`),
+            `${JSON.stringify(label)} resolved to "${language}" but fetched no /assets/${language}-<hash>.js — the selector offers a language the image ships no bundle for`,
+          ).not.toHaveLength(0);
+          expect(
+            localeChunks.every((chunk) => chunk.status === 200),
+            `${JSON.stringify(label)} fetched its bundle with a non-200: ${JSON.stringify(localeChunks)}`,
+          ).toBe(true);
+
+          await expect(
+            page.getByTestId("settings_menu_header"),
+            `${JSON.stringify(label)} loaded its bundle but the interface still reads ${JSON.stringify(startHeader)}`,
+          ).not.toHaveText(startHeader, { timeout: 15000 });
+        });
+      }
+    },
+  );
+});

--- a/tests/tests-automations/regression/i18n/locale-resilience.spec.ts
+++ b/tests/tests-automations/regression/i18n/locale-resilience.spec.ts
@@ -1,0 +1,310 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { withLocale } from "../../../fixtures/locale";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { openFlowById } from "../../../helpers/flows/open-flow-by-id";
+import { unmountEditorForCleanup } from "../../../helpers/flows/unmount-editor-for-cleanup";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+
+// i18n — Locale resilience (QA-CHECKLIST §18.2).
+// Spec doc: docs/i18n/locale-resilience.md
+//
+// That an unsupported language degrades instead of breaking the product. The
+// upstream reports this pins are total-failure ones: a missing Chinese bundle
+// (langflow-ai/langflow#12923, #13477) and Norwegian Bokmål (#13196) each
+// rendered a BLACK SCREEN — the product did not open at all. Measured fixed on
+// 1.12.0.dev33, so this is a regression guard, not a reproduction.
+//
+// Sibling coverage, deliberately not duplicated: i18n/language-selection.spec.ts
+// (§18.1) owns the Settings selector itself.
+
+/**
+ * The language ladder the frontend applies to the stored preference before
+ * i18next ever sees it, transcribed from the shipped bundle:
+ *
+ * ```js
+ * const SUPPORTED = ["en", "de", "es", "fr", "ja", "pt", "zh-Hans"];
+ * const normalize = (e) => {
+ *   if (SUPPORTED.includes(e)) return e;
+ *   if (["zh-hans", "zh-cn", "zh-sg"].includes(e.toLowerCase())) return "zh-Hans";
+ *   const primary = e.split("-")[0];
+ *   return SUPPORTED.includes(primary) ? primary : "en";
+ * };
+ * ```
+ *
+ * Each row exercises one branch, so a regression that flattens the ladder to
+ * "unknown ⇒ en" is still caught by the `zh-CN`/`de-AT` rows, and one that drops
+ * the final `en` fallback — the black-screen shape — by the first four.
+ */
+const PREFERENCE_LADDER: Array<{
+  seed: string | null;
+  expected: string;
+  branch: string;
+}> = [
+  {
+    seed: "nb-NO",
+    expected: "en",
+    branch: "no bundle, no primary subtag match — upstream #13196 black-screened on this exact tag",
+  },
+  {
+    seed: "ru",
+    expected: "en",
+    branch: "no bundle — upstream #12738 offered it in the selector without one",
+  },
+  {
+    seed: "ko",
+    expected: "en",
+    branch: "no bundle — upstream #12740, the same defect",
+  },
+  {
+    seed: "xx",
+    expected: "en",
+    branch: "well-formed but not a language Langflow ships",
+  },
+  {
+    seed: "zh-CN",
+    expected: "zh-Hans",
+    branch: "the Chinese special case — upstream #12923/#13477 black-screened on it",
+  },
+  {
+    seed: "zh-SG",
+    expected: "zh-Hans",
+    branch: "the second arm of the same special case",
+  },
+  {
+    seed: "pt-BR",
+    expected: "pt",
+    branch: "primary-subtag fallback",
+  },
+  {
+    seed: "de-AT",
+    expected: "de",
+    branch: "primary-subtag fallback, a second language",
+  },
+  {
+    seed: null,
+    expected: "en",
+    branch: "no preference stored at all",
+  },
+];
+
+/**
+ * Writes the preference and reloads, because the frontend reads it exactly once.
+ *
+ * `normalize(localStorage.getItem("languagePreference") || "en")` runs at module
+ * evaluation, so a value written after the page has loaded changes nothing until
+ * the next load — a test that seeded and then asserted without reloading would
+ * read the default and pass for the wrong reason.
+ */
+async function reloadWithPreference(
+  page: Page,
+  seed: string | null,
+): Promise<void> {
+  await page.evaluate((value) => {
+    if (value === null) {
+      localStorage.removeItem("languagePreference");
+    } else {
+      localStorage.setItem("languagePreference", value);
+    }
+  }, seed);
+  await page.reload();
+}
+
+test.describe("i18n — a stored language preference Langflow cannot place", () => {
+  test(
+    "the application boots into a shipped language for every unsupported or regional preference",
+    { tag: ["@stable", "@regression", "@ui-ux"] },
+    async ({ page }) => {
+      // Nine reloads of the home screen; measured at ~30 s in total.
+      test.setTimeout(180000);
+      await awaitBootstrapTest(page, { skipModal: true });
+
+      for (const { seed, expected, branch } of PREFERENCE_LADDER) {
+        const label = seed === null ? "(unset)" : JSON.stringify(seed);
+        await test.step(`${label} → "${expected}" (${branch})`, async () => {
+          await reloadWithPreference(page, seed);
+
+          // Soft, so one broken branch reports itself without hiding the other
+          // eight — the value of a table test is seeing which rows moved.
+          //
+          // "Boots" is three assertions because the defect being pinned renders
+          // a black page with a LIVE document: the navigation resolves and the
+          // URL is right, so a waitForURL or a bare shell check passes on the
+          // very failure this exists to catch.
+          await expect
+            .soft(
+              page.getByTestId("mainpage_title"),
+              `${label}: the application never reached its main page`,
+            )
+            .toBeVisible({ timeout: 30000 });
+
+          await expect
+            .soft(
+              page.locator("html"),
+              `${label}: expected the ladder to resolve to "${expected}"`,
+            )
+            .toHaveAttribute("lang", expected, { timeout: 15000 });
+
+          const rendered = (
+            await page.locator("body").innerText().catch(() => "")
+          ).trim();
+          expect
+            .soft(
+              rendered.length,
+              `${label}: the document rendered but its body is empty — this is the black-screen failure mode`,
+            )
+            .toBeGreaterThan(0);
+        });
+      }
+    },
+  );
+});
+
+test.describe("i18n — an unshipped browser locale", () => {
+  // The sanctioned opt-in (#1400), never a bare `test.use({ locale })`:
+  // CONTRIBUTING.md bans that spelling, and the ban is what made this bullet
+  // unwritable before the fixture landed.
+  test.use(withLocale("nb-NO"));
+
+  test(
+    "the application boots in English and never adopts the browser locale as a preference",
+    { tag: ["@stable", "@regression", "@ui-ux"] },
+    async ({ page }) => {
+      await awaitBootstrapTest(page, { skipModal: true });
+
+      await test.step("the browser really is running under the unshipped locale", async () => {
+        // Without this the rest of the test would pass on a context that quietly
+        // stayed en-US, which is exactly the false negative to avoid.
+        expect(await page.evaluate(() => navigator.language)).toBe("nb-NO");
+      });
+
+      await test.step("the interface renders, in English", async () => {
+        await expect(page.getByTestId("mainpage_title")).toBeVisible({
+          timeout: 30000,
+        });
+        await expect(page.locator("html")).toHaveAttribute("lang", "en");
+      });
+
+      await test.step("the browser locale did not become a language preference", async () => {
+        // The load-bearing half. Langflow's i18n reads only
+        // localStorage.languagePreference and ships no language-detector, so
+        // navigator.language is inert — this is the one assertion in the suite
+        // that fails if upstream ever adds detection, at which point every
+        // unshipped browser locale becomes a boot risk again.
+        expect(
+          await page.evaluate(() =>
+            localStorage.getItem("languagePreference"),
+          ),
+        ).toBeNull();
+      });
+    },
+  );
+});
+
+test.describe("i18n — a key the active bundle does not carry", () => {
+  let token: string;
+  let flowId: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    token = await getAuthToken(request);
+    flowId = await createFlow(
+      request,
+      {
+        name: `i18n-fallback-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        description: "Empty flow for the §18.2 missing-key fallback test",
+        data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+        is_component: false,
+      },
+      { headers: { Authorization: token } },
+    );
+
+    // Seeded before the first navigation: the preference is read once, at module
+    // evaluation. openFlowById performs that navigation.
+    await page.addInitScript(() =>
+      localStorage.setItem("languagePreference", "pt"),
+    );
+    await openFlowById(page, flowId);
+    await expect(page.locator("html")).toHaveAttribute("lang", "pt", {
+      timeout: 30000,
+    });
+  });
+
+  test.afterEach(async ({ page, request }) => {
+    // Leave the editor BEFORE deleting: an editor mounted over a deleted flow
+    // 404s its own polls into the fixture's HTTP log.
+    await unmountEditorForCleanup(page);
+    await deleteFlow(request, flowId, { headers: { Authorization: token } });
+  });
+
+  test(
+    "a missing key falls back to English beside siblings the bundle translates",
+    { tag: ["@stable", "@regression", "@ui-ux", "@workspace"] },
+    async ({ page }) => {
+      // On 1.12.0.dev33 all six non-English bundles are missing the same five
+      // keys `en` carries (2387 vs 2382). Two of them render unconditionally in
+      // this modal, on an instance with nothing configured.
+      //
+      // A third, `shortcuts.modifierOnly`, is a DECOY and must not be used: its
+      // call site passes an inline `defaultValue`, so it renders English whether
+      // or not `fallbackLng` works. These two are called with no defaultValue at
+      // all, so English here can only come from the fallback.
+      const FALLBACK_LABEL = "Vector Database";
+      const FALLBACK_DESCRIPTION =
+        "Where this memory base stores vectors. Configured providers come from DB Providers settings.";
+      const FALLBACK_KEY = "memory.dbProviderLabel";
+      const EXPIRY_HINT =
+        `if upstream has translated ${FALLBACK_KEY}, re-measure by diffing the en translation ` +
+        `object in the container's langflow/frontend/assets/index-*.js against assets/pt-*.js and ` +
+        `pick another key present only in en`;
+
+      await page.getByTestId("sidebar-nav-memories").click();
+      // `/^Mem/` covers the English and Portuguese headings alike, so the
+      // navigation does not itself depend on the translation under test.
+      const panel = page
+        .locator("aside")
+        .filter({ has: page.getByRole("heading", { name: /^Mem/ }) });
+      await expect(panel).toBeVisible({ timeout: 20000 });
+
+      await panel.getByRole("button", { name: /^(Criar|Create)$/ }).click();
+      const dialog = page.getByRole("dialog");
+      await expect(dialog).toBeVisible({ timeout: 15000 });
+
+      await test.step("the dialog's translated keys render in Portuguese", async () => {
+        // The half that makes the English assertion falsifiable: "this label is
+        // in English" is also true of an instance that never switched language.
+        await expect(
+          dialog.getByRole("heading", { name: /Criar Memória/ }),
+        ).toBeVisible({ timeout: 15000 });
+        await expect(
+          dialog.getByText("Tamanho do lote", { exact: false }).first(),
+        ).toBeVisible();
+      });
+
+      await test.step("the two keys the bundle lacks render their English text", async () => {
+        await expect(
+          dialog.getByText(FALLBACK_LABEL, { exact: false }).first(),
+          `${FALLBACK_LABEL} did not fall back to English — ${EXPIRY_HINT}`,
+        ).toBeVisible({ timeout: 15000 });
+        await expect(
+          dialog.getByText(FALLBACK_DESCRIPTION, { exact: false }),
+          `the description did not fall back to English — ${EXPIRY_HINT}`,
+        ).toBeVisible();
+      });
+
+      await test.step("no raw i18n key leaks into the dialog", async () => {
+        // i18next's other failure mode: with the fallback gone it echoes the key
+        // itself. Excluded explicitly so "missing" cannot pass as "handled".
+        expect(
+          await dialog.innerText(),
+          `the dialog rendered the raw key instead of a string — fallbackLng is not doing its job`,
+        ).not.toContain(FALLBACK_KEY);
+      });
+
+      // Nothing is created: the modal is only read, then dismissed.
+      await page.keyboard.press("Escape");
+      await expect(dialog).toBeHidden({ timeout: 10000 });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1539. Closes #1540.

Closes the five `[ ]` gaps in `QA-CHECKLIST.md` §18.1 (Language Selection) and §18.2 (Locale Resilience) — the batch `ROADMAP.md` names as schedulable after Wave 6, unblocked by #1400 (`withLocale()` / the parameterised browser locale). Distinct from `ui-ux/settings-general-section.spec.ts`, which asserts the Language card *renders* and stops there: everything here is about the language actually *changing*, surviving, degrading.

Everything below was measured on nightly `1.12.0.dev33` — the shipped frontend bundle read inside the container, then confirmed live with throwaway scouts (deleted).

## 1. Covered tests

`i18n/language-selection.spec.ts` (§18.1, spec doc `docs/i18n/language-selection.md`):

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `changing the display language re-renders the interface` | Selecting `Português` in Settings → General flips `html[lang]` `en`→`pt`, retitles the settings header to `Geral`, and writes `localStorage.languagePreference` — a switch that stores without re-rendering (or renders without storing) fails on the specific missing half |
| 2 | `the selected language survives a reload and a second tab of the same session` | Reload and a second **page of the same context** both come up Portuguese. Deliberately never a fresh context: the preference is `localStorage`, so a new context correctly does not inherit it — checking "a new session" that way would read designed behaviour as a bug |
| 3 | `every language the selector offers loads a translation bundle` | Options **enumerated at run time**, each switched to and required to (a) move `html[lang]`, (b) fetch `/assets/<code>-<hash>.js` with a `200`, (c) re-render the header. English walked **last** and asserted as the inverse case — no chunk at all (its translations are inlined). Pins the `langflow-ai/langflow#12738`/`#12740` class: a selector entry shipped without a bundle (`ru`, `ko`) — a hardcoded list of seven would pass unchanged on exactly that defect |

`i18n/locale-resilience.spec.ts` (§18.2, spec doc `docs/i18n/locale-resilience.md`):

| # | Test | What it validates |
|---|------|-------------------|
| 4 | `the application boots into a shipped language for every unsupported or regional preference` | Nine seeds through the frontend's normaliser ladder, one row per branch: `nb-NO`/`ru`/`ko`/`xx` → `en`, `zh-CN`/`zh-SG` → `zh-Hans`, `pt-BR` → `pt`, `de-AT` → `de`, unset → `en`. Pins the **black-screen** class (`#12923`/`#13477` missing Chinese bundle, `#13196` `nb-NO`) — the product did not open at all for those users. "Boots" is three assertions (`mainpage_title` visible + `html[lang]` + non-empty body) because the defect renders a black page with a *live* document, so a `waitForURL` passes on it. Soft expects, so one broken branch reports itself without hiding the other eight |
| 5 | `the application boots in English and never adopts the browser locale as a preference` | Under `withLocale("nb-NO")` (#1400's sanctioned opt-in — the first spec to use it): `navigator.language` reads `nb-NO`, the app renders in English, and `languagePreference` stays **unset**. The load-bearing half is the last one — the only assertion in the suite that fails if upstream ever adds language detection, at which point every unshipped browser locale becomes a boot risk again |
| 6 | `a missing key falls back to English beside siblings the bundle translates` | Interface in `pt`, Create Memory modal: `Criar Memória`/`Nome`/`Tamanho do lote` translated **and** `Vector Database` + its description in English — the pair is what makes it falsifiable ("this label is in English" is also true of an instance that never switched). Raw-key leak (`memory.dbProviderLabel`) excluded explicitly, covering i18next's other failure mode |

## 2. How the tests were built

- **Primary observable is `document.documentElement.lang`, not translated strings.** The bundle assigns it at boot and on every `languageChanged` event — product state upstream cannot reword, so it survives translation edits.
- **Live-confirmed selectors, including one trap that decided the design:** the language combobox carries **no `id` and no `data-testid`** — only `aria-label={t("settings.languageSelectAriaLabel")}`, which is itself translated (`Select language` → `Selecionar idioma` → `言語の選択`). A name-based handle resolves exactly once and then matches nothing. Resolved by role with `toHaveCount(1)` asserted first (measured: exactly one combobox on Settings → General in all seven languages). Option labels are the stable half (hardcoded native names) — except the `(Recommended)` suffix, so the English option matches on its stable prefix.
- **Key-gap measurement for test 6:** diffing the `en` translation object in `assets/index-*.js` against each locale chunk gives 2387 vs 2382 keys — all six non-English bundles miss the **same five**. `shortcuts.modifierOnly` is a **decoy**: its call site passes an inline `defaultValue`, so it renders English even with `fallbackLng` broken. The `memory.dbProvider*` keys are called with no `defaultValue` — English there can only come from the fallback. **Known expiry, named in the assert itself:** if upstream translates those keys the test goes red on a healthy product, and its failure message says how to re-measure.
- **Seeding order matters and is encoded:** `languagePreference` is read once, at module evaluation, so test 4 seeds + reloads and test 6 seeds via `addInitScript` before the first navigation — a post-load write asserts the default and passes for the wrong reason.
- **Force-failures simulated the real defects, not broken asserts:** (a) `route.abort()` on the `pt` chunk → red naming the missing bundle (the #12738 shape); (b) wrong ladder expectation → soft expect names the `zh-CN` row (`Expected "zh" · Received "zh-Hans"`); (c) nonexistent fallback label → red carrying the expiry hint. All three reverted.

## 3. Dependencies

- **None — pure UI.** No LLM, no provider key, no `models.json`. Test 6 creates one empty flow via API and deletes it id-scoped in `afterEach` (leaving the editor first via `unmountEditorForCleanup`); the Create Memory modal is only read, then dismissed — nothing registered.
- **Parallel-safe.** `languagePreference` is per-browser-context; no shared server state. Validated both serial and parallel.
- Upstream deps declared in both spec docs with paths verified on `langflow-ai/langflow@main` (4× HTTP 200): `src/frontend/src/i18n.ts`, `src/frontend/src/locales/`, `src/frontend/src/pages/SettingsPage/pages/GeneralPage/`.

## Validation (nightly `1.12.0.dev33`)

- **4 runs green, 6/6 each**: burst 3× `--retries=0 --workers=1` (37.1 s / 35.6 s / 38.7 s) + one parallel-workers run (27.8 s). JSON-reporter stats, not `\r` progress lines.
- **3 defect-simulating force-fails red** with the designed messages (above), then reverted.
- **0 `🚨 Backend Error`** across all runs.
- `typecheck` 0 errors · `lint` 0 errors (7 warnings, same classes as the repo's existing 1430) · `test:units` green · checklist guard + coverage guard + `validate:specs` green.
- `--trace=on` skipped deliberately: it hangs UI specs on this local Docker VM (Colima) — known project constraint; CI captures trace on first retry.

**Tags:** `@stable @regression` + `@ui-ux`/`@settings`/`@workspace`. No new `@i18n` functional tag — the `@authz` precedent: a new functional tag only when no OSS area tag can be reused. Not `@release`: switching display language is not a pre-deploy happy path. `@stable` from the first PR on the same grounds as the memory specs: LLM-free, provider-free, id-scoped cleanup, burst-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
