### PR TITLE
test(auth): promote the §4 tail to @stable — API-driven rewrite after upstream removed the OSS Admin Page (#1542, #1543)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -287,23 +287,31 @@
 ### core-functionality/auth/ — Authentication and User Management
 
 #### 4.1 Login / Logout
-- [-] Login with valid credentials
-- [-] Login with invalid credentials — should display error message
+- [x] Login with valid credentials — through the form with auto-login mocked off; every form login rides `helpers/auth/sign-in-through-form.ts`, which absorbs the endpoint's per-IP 5/min budget → `core-functionality/auth/auto-login-off.spec.ts`
+- [x] Login with invalid credentials — should display error message → `core-functionality/auth/login-invalid-credentials.spec.ts`
 - [x] Logout — should redirect to login screen → `core-functionality/auth/logout-flow.spec.ts`
-- [-] Auto-login enabled — should skip login screen
-- [-] Auto-login disabled — should display login screen
-- [-] Expired session — should redirect to login
+- [x] Auto-login enabled — should skip login screen (and `/login`, `/admin`, `/admin/login` do not break the auto-logged app) → `core-functionality/auth/autoLogin.spec.ts`
+- [x] Auto-login disabled — should display login screen → `core-functionality/auth/auto-login-off.spec.ts`
+- [x] Expired session — should redirect to login: invalid/absent token refused at the API plus the UI falling back to the form, with a valid-token control → `core-functionality/auth/session-expired.spec.ts`
 - [x] Session cleanup after logout — after logging out, navigating to `/` and reloading both stay on the login screen → `core-functionality/auth/logout-flow.spec.ts`
 - [-] `POST /api/v1/login` is rate-limited: repeated attempts are refused `429` with a `retry_after` body field and a matching `retry-after` header, a **successful** login does not reset the counter (the check runs before authentication, so brute force cannot be made free by interleaving a good login), and the limiter reopens after the window it advertised. **`@destructive`**: the budget is keyed on the client address and is instance-global, so exhausting it would hand a `429` to the eight specs that authenticate through this endpoint — which also means it does not run in the daily → `core-functionality/auth/login-rate-limit.spec.ts`
 
 #### 4.2 User Management (Admin)
-- [-] Admin creates new user
-- [-] Admin deactivates user
-- [-] Admin activates inactive user
-- [-] Admin renames user
-- [-] Admin changes user password
-- [-] Admin changes password — old password does not work after change
-- [-] Isolation flow: user A cannot see user B's flows
+
+> **The OSS Admin Page is gone** (`langflow-ai/langflow#14276`, 2026-08-05) — user
+> management in OSS is the API, `/api/v1/users/`, and the specs below drive it
+> there. `admin-user-management.spec.ts` also pins the removal itself (no menu
+> item, no admin route), so an Enterprise admin UI leaking back into the OSS
+> bundle is a named failure.
+
+- [x] Admin creates new user — `201`, inactive by default, and the pending user's login is refused `400 "Waiting for approval"` → `core-functionality/auth/admin-user-management.spec.ts`
+- [x] Admin deactivates user — the identical credentials flip back to refused, `401 "Inactive user"` (the deactivated-after-use branch, distinct from the pending one) → `core-functionality/auth/admin-user-management.spec.ts`
+- [x] Admin activates inactive user — the identical login flips to `200` with an `access_token` → `core-functionality/auth/admin-user-management.spec.ts`
+- [x] Admin renames user — the new username logs in with the unchanged password and the old one is refused → `core-functionality/auth/admin-user-management.spec.ts`
+- [x] Admin changes user password → `core-functionality/auth/admin-password-change.spec.ts`
+- [x] Admin changes password — old password does not work after change (with a works-before control) → `core-functionality/auth/admin-password-change.spec.ts`
+- [x] Isolation flow: user A cannot see user B's flows — both directions, exact random names → `core-functionality/auth/auto-login-off.spec.ts`
+- [x] The OSS build offers no Admin Page — menu and `/admin` route both, pinning `langflow-ai/langflow#14276` → `core-functionality/auth/admin-user-management.spec.ts`
 
 #### 4.3 Global Variables (API Keys)
 - [x] Create global variable

--- a/docs/core-functionality/auth/admin-password-change.md
+++ b/docs/core-functionality/auth/admin-password-change.md
@@ -1,0 +1,78 @@
+# Auth — admin changes a user's password
+
+**Last validated:** Langflow 1.12.x (validated on nightly `1.12.0.dev33`)
+
+---
+
+## What this test validates *(required)*
+
+That a superuser setting another user's password via
+`PATCH /api/v1/users/{id}` really moves the credential — proven at the login
+endpoint from both sides.
+
+1. **should let the user log in with the new password** — after the PATCH, the
+   new password answers `200` with an `access_token` at `POST /api/v1/login`,
+   and the same credentials sign in through the real login form to the
+   workspace (`new-project-btn`).
+2. **should refuse the old password after the change** — the old password is
+   proven live *before* the change (`200`, the control assertion) and refused
+   *after* it (`401`) — without the control, a login endpoint that refused
+   everything would pass.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@regression` `@auth`
+
+`@stable` after the full-directory validation runs: API-driven with one UI
+login, no LLM, no provider, per-test user cleanup by id.
+
+---
+
+## Validation criterion *(required)*
+
+- **Both directions at the login endpoint.** "New works" and "old stops
+  working" are separate failures with separate causes; each test owns one,
+  and the old-password test carries its before/after control pair.
+- **User creation and password change happen via API on purpose** — the OSS
+  Admin Page is gone (`langflow-ai/langflow#14276`), and the API was already
+  this spec's vehicle before that (the admin UI's search-only-filters-current-
+  page pagination bug is noted in the spec's own comments).
+- **Logins go through `postLogin` (`tests/helpers/auth/login-request.ts`)**,
+  absorbing the endpoint's per-IP 5/min fixed-window budget so a `401` is
+  always a credential verdict — this file alone spends five login calls in
+  ~30 s, which is exactly the collision profile the helper exists for.
+- **The UI login half keeps the client-side auto-login mock**, with the known
+  caveat documented in the spec: a failed UI login under the mock resets the
+  page before the error toast can be read, so failure paths are asserted at
+  the API and only the success path at the UI.
+
+---
+
+## External dependencies *(required)*
+
+- A running Langflow instance; superuser token via
+  `helpers/auth/get-auth-token.ts`.
+- `POST /api/v1/users/`, `PATCH /api/v1/users/{id}` (password and activation),
+  `DELETE /api/v1/users/{id}`.
+- `POST /api/v1/login` and its rate limiter — absorbed by
+  `helpers/auth/login-request.ts`.
+
+---
+
+## Cleanup *(required)*
+
+Each test deletes its random-named user by id in a `finally` block, pass or
+fail. No flows are created.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Self-service password change (Settings → General password form — hidden
+  under `LANGFLOW_AUTO_LOGIN=true`).
+- Whether a password change invalidates previously minted tokens (measured on
+  the Enterprise side: it does not, self-service — see the `enterprise/` auth
+  specs).
+- Activation/deactivation/rename — `admin-user-management.spec.ts`.

--- a/docs/core-functionality/auth/admin-user-management.md
+++ b/docs/core-functionality/auth/admin-user-management.md
@@ -1,0 +1,124 @@
+# Auth — admin user management
+
+**Last validated:** Langflow 1.12.x (measured on nightly `1.12.0.dev33`)
+
+---
+
+## What this test validates *(required)*
+
+The admin's user-management surface — which in OSS is the **API**,
+`/api/v1/users/`, since upstream removed the Admin Page
+(`langflow-ai/langflow#14276`, 2026-08-05). Every lifecycle state is proven at
+the observable that matters: whether the managed user can log in.
+
+1. **should create a user inactive by default — the inactive user cannot log
+   in** — `POST /api/v1/users/` answers `201` with `is_active: false`, and the
+   new user's correct credentials are refused `400 "Waiting for approval"` (the
+   product's dedicated never-logged-in branch).
+2. **should flip the same credentials between refused and accepted via
+   activation** — `PATCH {is_active: true}` makes the identical login succeed
+   (`200` + `access_token`); `PATCH {is_active: false}` refuses it again, now
+   `401 "Inactive user"` (the deactivated-after-use branch — a different branch
+   from test 1's, deliberately).
+3. **should move the login to the new username on rename** — after
+   `PATCH {username}`, the new name logs in with the unchanged password and the
+   old name is refused `401` (gone, not aliased).
+4. **should offer no Admin Page in the OSS build — menu and route both** — the
+   user menu renders no `Admin Page` item, and `/admin` falls through to the
+   workspace with the old page's own marker (the `Search Username` field)
+   absent.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@regression` `@auth` (+ `@ui-ux` on test 4, the
+one that drives the browser)
+
+`@stable` after the full-directory validation runs: API-driven, no LLM, no
+provider, each test creates and deletes its own user.
+
+---
+
+## Validation criterion *(required)*
+
+- **Login is the observable, never the user record.** `is_active: false` read
+  back from `GET /users` is what the admin *wrote*; the refused login is what
+  it *means*. Every state transition here ends at `POST /api/v1/login`.
+- **The two refusal branches are pinned separately because the product ships
+  two.** `authenticate_user` (read from the shipped source inside the running
+  container) refuses a never-logged-in inactive user with
+  `400 "Waiting for approval"` and a previously-logged-in one with
+  `401 "Inactive user"`. Test 1 lands in the first branch, test 2's
+  deactivation half in the second — asserting one blanket 401 would have been
+  wrong on dev33 (it was: the first run of this rewrite failed exactly there).
+- **Activation is asserted as a pair** — refused, then accepted, then refused
+  again. A lone success is equivocal: a login endpoint that ignored
+  `is_active` entirely would pass the activation half alone.
+- **Creation asserts `is_active: false` in the 201 body**, so the "inactive
+  cannot log in" test cannot pass by accident against an API that started
+  activating on create.
+- **Every login goes through `postLogin`
+  (`tests/helpers/auth/login-request.ts`)**, which absorbs the endpoint's
+  per-IP rate limit (5/min, fixed window, every attempt counts — measured for
+  `login-rate-limit.spec.ts`). A `401` in these tests is therefore always a
+  credential verdict, never the suite's own traffic. The helper never hides a
+  verdict: only `429` is retried, after waiting out the window the server
+  names in `retry_after` (a string, not a number — the helper converts).
+- **Test 4 opens the menu before asserting the absence** — an unopened menu
+  also contains no Admin Page. The route half asserts the old page's own
+  marker (`Search Username`) absent rather than where the fall-through lands,
+  so a redirect-target rename cannot fake a pass.
+
+---
+
+## External dependencies *(required)*
+
+- A running Langflow instance; the superuser token via
+  `helpers/auth/get-auth-token.ts` (auto-login endpoint — spends no login-form
+  budget).
+- `POST/PATCH/DELETE /api/v1/users/` — the admin API that replaced the OSS
+  Admin Page.
+- `POST /api/v1/login` and its rate limiter (5/min per client IP, fixed
+  window) — absorbed by `helpers/auth/login-request.ts`.
+- `src/backend/base/langflow/services/auth/` (upstream) — `authenticate_user`
+  and its two inactive branches; the `#510` legacy-password refusal this
+  rewrite also buried (the old spec logged in with the hardcoded legacy
+  password `"langflow"`, refused since nightly `1.11.0.dev29` —
+  `helpers/auth/credentials.ts` exists for exactly that).
+- `src/frontend/src/routes.tsx` (upstream) — after #14276,
+  `pages/AdminPage/` holds only the `/login/admin` LoginPage; no admin route
+  registers, which is what test 4 pins.
+
+---
+
+## Cleanup *(required)*
+
+Each test creates its own user with a random name and deletes it by id in
+`afterEach` (`DELETE /api/v1/users/{id}`), pass or fail. No flows are created.
+Never name-based, never delete-all.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Password change and old-password invalidation —
+  `admin-password-change.spec.ts`.
+- Per-user flow isolation — `auto-login-off.spec.ts` (§4.2's isolation bullet).
+- The login rate limiter itself — `login-rate-limit.spec.ts` (`@destructive`).
+- The Enterprise admin UI, which is where the removed page went
+  (`enterprise/` specs, `@enterprise` lane).
+
+---
+
+## Notes *(optional)*
+
+- **History.** Until this rewrite the spec drove the OSS Admin Page UI and
+  carried two stacked defects: the hardcoded legacy password (#510) made every
+  admin login fail on any current nightly, and even with that fixed, the
+  `Admin Page` menu click had nothing to click after #14276. Baseline on
+  `1.12.0.dev33`: 0/3.
+- **Why test 4 earns its place**: the Admin Page moved behind the
+  Enterprise/OSS build split. An EE surface leaking back into the OSS bundle
+  is a regression a human would only notice by diffing menus — this pins it to
+  a named upstream decision instead.

--- a/docs/core-functionality/auth/auto-login-off.md
+++ b/docs/core-functionality/auth/auto-login-off.md
@@ -1,0 +1,107 @@
+# Auth — login screen and per-user flow isolation
+
+**Last validated:** Langflow 1.12.x (measured on nightly `1.12.0.dev33`)
+
+---
+
+## What this test validates *(required)*
+
+One journey, two guarantees: when auto-login cannot establish a session the
+**login form** is what the user gets, and two users signing in through it each
+see **only their own flows**.
+
+1. **should show the login screen when auto-login is off** — with
+   `/api/v1/auto_login` refused client-side, `/` renders `Sign in to Langflow`.
+2. **should isolate flows per user, both directions** — the superuser signs in
+   and creates a named flow; a second (API-provisioned) user signs in and sees
+   neither that flow nor anything else of the superuser's; the second user
+   creates their own named flow; back as the superuser, the second user's flow
+   is invisible and the superuser's own is still there. Both names are exact
+   and random per run, so a prefix collision cannot fake either verdict.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@database` `@mainpage` `@auth`
+
+`@stable` after the full-directory validation runs. The test is one journey on
+purpose — the isolation claim is only meaningful across the same two accounts
+in the same run.
+
+---
+
+## Validation criterion *(required)*
+
+- **The auto-login kill switch is client-side** (`page.route` on
+  `/api/v1/auto_login` → 500): the server keeps `LANGFLOW_AUTO_LOGIN=true`,
+  which is exactly what lets the standalone `request` fixture keep
+  authenticating — the second user is provisioned through
+  `POST /api/v1/users/` + activation while the browser sees a password-first
+  instance. (The OSS Admin Page this test used to drive for that is gone —
+  `langflow-ai/langflow#14276`; the CRUD coverage lives in
+  `admin-user-management.spec.ts`.)
+- **Isolation is asserted in both directions with exact random names.** One
+  direction alone would also pass on a workspace that simply shows nothing; the
+  superuser's return visit must still SEE their own flow while NOT seeing the
+  other user's, which pins "filtered by owner" rather than "empty".
+- **Form logins go through `signInThroughForm`
+  (`tests/helpers/auth/sign-in-through-form.ts`)**, the browser side of the
+  429-absorbing login helper: the endpoint budget is 5/min per client IP,
+  fixed window, and this one test spends three form logins — the measured
+  collision that used to fail the NEXT file in the run (`logout-flow`, timing
+  out on `mainpage_title` through no fault of its own). The helper captures
+  the `POST /api/v1/login` response registered before the click, waits out a
+  `429`'s `retry_after`, and resubmits; any other status is returned for the
+  caller to assert.
+- **Flow creation returns the id from the editor URL**, which is what makes
+  the cleanup id-scoped instead of name-based.
+
+---
+
+## External dependencies *(required)*
+
+- A running Langflow instance under `LANGFLOW_AUTO_LOGIN=true` (the suite's
+  standard state) — the mock only affects the browser context.
+- Superuser credentials from `helpers/auth/credentials.ts`
+  (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) — the legacy default
+  password `"langflow"` is refused since `1.11.0.dev29` (#510).
+- `POST /api/v1/users/` + `PATCH` (provision/activate the second user),
+  `DELETE /api/v1/users/{id}` and `DELETE /api/v1/flows/{id}` (cleanup).
+- The Basic Prompting starter template (flow creation vehicle) and
+  `helpers/flows/rename-flow.ts`.
+- `POST /api/v1/login` and its per-IP rate limiter — absorbed by
+  `helpers/auth/sign-in-through-form.ts`.
+
+---
+
+## Cleanup *(required)*
+
+A `finally` block deletes, with the superuser token: both created flows by the
+ids captured at creation (the superuser can delete any user's flow), then the
+second user by id. The old version leaked its user and both flows on every
+run; this one leaves nothing. Never name-based, never delete-all.
+
+---
+
+## What this test does not cover *(optional)*
+
+- User lifecycle (create/activate/deactivate/rename) —
+  `admin-user-management.spec.ts`.
+- Logout mechanics and session cleanup — `logout-flow.spec.ts`.
+- Invalid and empty credentials — `login-invalid-credentials.spec.ts`.
+- API-level enforcement of flow ownership (a user A token reading user B's
+  flow by id) — a worthwhile future `@api` spec; this test pins the UI listing.
+
+---
+
+## Notes *(optional)*
+
+- **History.** The previous version carried an Admin-Page-driven user CRUD
+  section between the two halves; it died at the `Admin Page` menu click after
+  upstream removed the page (#14276) and, before that, leaked one user and two
+  flows per run. The surgery moved provisioning to the API, added the missing
+  cleanup, and kept the two guarantees that were always this file's subject.
+- The empty-workspace state a brand-new user lands on renders
+  `mainpage_title` too — the isolation asserts do not depend on the second
+  user having any flows yet.

--- a/docs/core-functionality/auth/autoLogin.md
+++ b/docs/core-functionality/auth/autoLogin.md
@@ -1,0 +1,65 @@
+# Auth — auto-login
+
+**Last validated:** Langflow 1.12.x (validated on nightly `1.12.0.dev33`)
+
+---
+
+## What this test validates *(required)*
+
+The suite's own ground state: under `LANGFLOW_AUTO_LOGIN=true` the app signs
+the superuser in with no form, and the auth-adjacent routes do not break that.
+
+1. **should sign in automatically** — `/` reaches the workspace
+   (`mainpage_title`, `new-project-btn`) and the templates modal opens; no
+   login form is ever shown.
+2. **should keep working across the auth routes** — visiting `/login`, `/admin`
+   and `/admin/login` under auto-login, the app returns to a working workspace
+   each time (each visit re-proven by opening the templates modal, not just by
+   the absence of an error).
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@database` `@auth`
+
+`@stable` after the full-directory validation runs. This is the assumption the
+other ~230 specs stand on — every one of them enters through auto-login — so
+its failure mode is "everything is red"; having it named keeps that day's
+triage a one-liner.
+
+---
+
+## Validation criterion *(required)*
+
+- **"Signed in" is proven by doing, not by URL**: the templates modal opening
+  requires the authenticated workspace to be interactive, which a stuck
+  spinner or a half-rendered shell would fail.
+- **The `/admin` visit doubles as a fall-through check** since upstream removed
+  the OSS Admin Page (`langflow-ai/langflow#14276`): no admin route registers,
+  so the SPA lands back on the workspace. The dedicated absence assertions
+  (menu item, the old page's own marker) live in
+  `admin-user-management.spec.ts`.
+
+---
+
+## External dependencies *(required)*
+
+- A running Langflow instance with `LANGFLOW_AUTO_LOGIN=true` (the start
+  scripts' and CI's default).
+- `GET /api/v1/auto_login` — the endpoint the app bootstraps its session from.
+
+---
+
+## Cleanup *(required)*
+
+Nothing is created. `awaitBootstrapTest` may create a starter flow on a
+completely empty workspace (shared bootstrap behaviour, not this spec's own
+state); the templates modal is only opened, never submitted.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The password-first path (auto-login off) — `auto-login-off.spec.ts`.
+- Session expiry and token validity — `session-expired.spec.ts`.

--- a/docs/core-functionality/auth/login-invalid-credentials.md
+++ b/docs/core-functionality/auth/login-invalid-credentials.md
@@ -1,0 +1,68 @@
+# Auth — login with invalid credentials
+
+**Last validated:** Langflow 1.12.x (validated on nightly `1.12.0.dev33`)
+
+---
+
+## What this test validates *(required)*
+
+The login form's refusal path: bad input is told apart from a broken form.
+
+1. **should show an error and stay on the login page for wrong credentials** —
+   a nonexistent username/password pair produces the `Error signing in`
+   alert, no navigation to the workspace, and the form still present for a
+   retry.
+2. **should not navigate on an empty submit** — submitting with both fields
+   empty leaves the login page in place (client-side validation; no workspace,
+   form still visible).
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@regression` `@auth`
+
+`@stable` after the full-directory validation runs: no LLM, no provider,
+nothing created.
+
+---
+
+## Validation criterion *(required)*
+
+- **Three assertions per refusal, because each fails differently**: the error
+  surface appears (a silent refusal is itself a defect), the workspace is NOT
+  reached (`mainpage_title` absent — the security half), and the form remains
+  usable (a dead-end refusal is a UX defect).
+- **The wrong-credentials attempt spends one unit of the login endpoint's
+  per-IP budget** (5/min fixed window — the limiter counts before
+  authentication). One attempt per test keeps this file's footprint minimal;
+  the budget-collision absorption for the specs that log in successfully lives
+  in `helpers/auth/sign-in-through-form.ts` / `login-request.ts`.
+- **The auto-login kill switch is client-side** (`page.route` → 500 on
+  `/api/v1/auto_login`), the directory's shared pattern — the server is
+  untouched.
+
+---
+
+## External dependencies *(required)*
+
+- A running Langflow instance (server-side auto-login state irrelevant — the
+  mock forces the form).
+- `POST /api/v1/login` — one deliberately failing call.
+
+---
+
+## Cleanup *(required)*
+
+Nothing is created; the browser context and its mock are discarded with the
+test.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The rate-limited refusal (`429`) — `login-rate-limit.spec.ts`
+  (`@destructive`: the budget is instance-global).
+- Valid-credential journeys — `auto-login-off.spec.ts`, `logout-flow.spec.ts`.
+- The inactive-user refusals (`400 "Waiting for approval"` /
+  `401 "Inactive user"`) — `admin-user-management.spec.ts`.

--- a/docs/core-functionality/auth/logout-flow.md
+++ b/docs/core-functionality/auth/logout-flow.md
@@ -1,6 +1,6 @@
 # Logout flow
 
-**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev29`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev33`)
 
 ---
 
@@ -60,6 +60,11 @@ credentials.
 
 - `src/frontend/src/pages/LoginPage/**` — the login form (Username/Password
   fields, **Sign In** button). A markup change breaks the credential fill.
+- `tests/helpers/auth/sign-in-through-form.ts` — every form login here goes
+  through the 429-absorbing helper: `POST /api/v1/login` is limited to 5/min
+  per client IP (fixed window, counted before authentication), and this
+  file's three logins used to be the ones that met a window exhausted by
+  the auth specs running before it.
 - `src/frontend/src/pages/MainPage/components/header/**` — renders
   `data-testid="mainpage_title"`, the post-login landing assertion.
 - `src/backend/base/langflow/api/v1/login.py` — `/api/v1/login` and

--- a/docs/core-functionality/auth/session-expired.md
+++ b/docs/core-functionality/auth/session-expired.md
@@ -1,0 +1,69 @@
+# Auth — expired and absent sessions
+
+**Last validated:** Langflow 1.12.x (validated on nightly `1.12.0.dev33`)
+
+---
+
+## What this test validates *(required)*
+
+That a request without a live session is refused at the API and recoverable at
+the UI — four small tests, one boundary each.
+
+1. **should refuse an invalid token** — `GET /api/v1/flows/` with a garbage
+   bearer answers `401`/`403`.
+2. **should refuse the absence of a token** — the same call with no
+   `Authorization` header is refused the same way.
+3. **should fall back to the login screen when a session cannot be
+   established** — with `/api/v1/auto_login` answering 500 (client-side mock:
+   auth backend down, or an expired session that cannot re-establish), the UI
+   renders the login form with both fields and the submit button — a
+   recoverable state, not a blank page.
+4. **should accept a valid token** — the control assertion: the same protected
+   route answers `200` with a real token, so tests 1–2 cannot pass against an
+   API that refuses everything.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@regression` `@auth`
+
+`@stable` after the full-directory validation runs: no LLM, no provider,
+nothing created, no login-form attempts (the token comes from
+`get-auth-token`, which uses the auto-login endpoint).
+
+---
+
+## Validation criterion *(required)*
+
+- **The refusal pair plus the acceptance control.** Refusals alone are
+  equivocal (a dead API also refuses); the valid-token `200` is what makes
+  them evidence of *auth*, specifically.
+- **`401`/`403` are both accepted** for the refusals: which one the backend
+  picks has moved between versions and is not this spec's subject — the
+  boundary existing is.
+- **Test 3's mock is client-side**, so it simulates the *browser's* view of an
+  expired/unavailable session without touching the shared instance.
+
+---
+
+## External dependencies *(required)*
+
+- A running Langflow instance; `helpers/auth/get-auth-token.ts` for the valid
+  token.
+- `GET /api/v1/flows/` as the protected route under test.
+
+---
+
+## Cleanup *(required)*
+
+Nothing is created.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Real token expiry by clock (no spec advances a clock past a JWT's `exp`).
+- Logout-driven session teardown — `logout-flow.spec.ts`.
+- Re-authentication through the form after the fallback —
+  `auto-login-off.spec.ts`.

--- a/tests/helpers/auth/login-request.test.ts
+++ b/tests/helpers/auth/login-request.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { postLogin, retryAfterMs } from "./login-request";
+
+/** Minimal APIResponse stand-in — only what postLogin reads. */
+function response(status: number, body: unknown = null) {
+  return {
+    status: () => status,
+    json: async () => {
+      if (body === null) throw new Error("no body");
+      return body;
+    },
+  };
+}
+
+/** A requester scripted with a queue of responses; records its calls. */
+function requester(queue: ReturnType<typeof response>[]) {
+  const calls: Array<Record<string, string>> = [];
+  return {
+    calls,
+    post: async (_url: string, options: { form: Record<string, string> }) => {
+      calls.push(options.form);
+      const next = queue.shift();
+      if (!next) throw new Error("requester queue exhausted");
+      return next as never;
+    },
+  };
+}
+
+test("a non-429 response is returned untouched, first try, no sleep", async () => {
+  const slept: number[] = [];
+  const r = requester([response(401)]);
+  const res = await postLogin(r, "u", "wrong", {
+    sleep: async (ms) => void slept.push(ms),
+  });
+  assert.equal(res.status(), 401);
+  assert.equal(r.calls.length, 1);
+  assert.deepEqual(slept, []);
+});
+
+test("a 429 waits the advertised retry_after and retries — the retry's verdict wins", async () => {
+  const slept: number[] = [];
+  const r = requester([response(429, { retry_after: 7 }), response(200)]);
+  const res = await postLogin(r, "u", "p", {
+    sleep: async (ms) => void slept.push(ms),
+  });
+  assert.equal(res.status(), 200);
+  assert.equal(r.calls.length, 2);
+  // +1s over the server's figure — the window edge is exclusive.
+  assert.deepEqual(slept, [8000]);
+});
+
+test("an unparseable 429 body falls back to a full window", async () => {
+  const slept: number[] = [];
+  const r = requester([response(429, null), response(401)]);
+  const res = await postLogin(r, "u", "p", {
+    sleep: async (ms) => void slept.push(ms),
+  });
+  assert.equal(res.status(), 401);
+  assert.deepEqual(slept, [61_000]);
+});
+
+test("the budget is two retries — a third consecutive 429 is returned, not retried forever", async () => {
+  const r = requester([
+    response(429, { retry_after: 1 }),
+    response(429, { retry_after: 1 }),
+    response(429, { retry_after: 1 }),
+  ]);
+  const res = await postLogin(r, "u", "p", { sleep: async () => {} });
+  assert.equal(res.status(), 429);
+  assert.equal(r.calls.length, 3);
+});
+
+test("retryAfterMs: seconds are converted with the +1s edge margin", () => {
+  assert.equal(retryAfterMs({ retry_after: 42 }), 43_000);
+  assert.equal(retryAfterMs({ retry_after: "9" }), 10_000);
+});
+
+test("retryAfterMs: zero, negative, NaN and missing all fall back", () => {
+  for (const body of [
+    { retry_after: 0 },
+    { retry_after: -3 },
+    { retry_after: "soon" },
+    {},
+    null,
+    "429",
+  ]) {
+    assert.equal(retryAfterMs(body), 61_000, JSON.stringify(body));
+  }
+});

--- a/tests/helpers/auth/login-request.ts
+++ b/tests/helpers/auth/login-request.ts
@@ -1,0 +1,98 @@
+import type { APIRequestContext, APIResponse } from "@playwright/test";
+
+/**
+ * `POST /api/v1/login` with the shared-budget collision absorbed.
+ *
+ * The login endpoint is rate-limited per CLIENT IP — 5/min, fixed window,
+ * counted before authentication, so every attempt spends budget whether it
+ * succeeds or fails (measured for `login-rate-limit.spec.ts`, which is the spec
+ * that owns asserting the limiter itself). Every auth spec in a sequential run
+ * shares that budget: `admin-password-change` alone spends five calls in ~30 s,
+ * so the file that runs next can meet a refused window through no fault of its
+ * own — a 429 red pointing nowhere near its cause.
+ *
+ * This helper turns that collision into a wait: on a 429 it sleeps out the
+ * window the server names in `retry_after` (falling back to a full window when
+ * the body does not parse) and retries. Anything that is not a 429 is returned
+ * as-is — including 401, which several callers assert deliberately — so the
+ * helper never hides a verdict, it only removes the one status that is about
+ * the SUITE's traffic rather than the credentials under test.
+ *
+ * Deliberately NOT used by `login-rate-limit.spec.ts`: there the 429 is the
+ * subject, and absorbing it would assert nothing.
+ */
+
+/** One extra full window over the advertised wait absorbs clock skew. */
+const FALLBACK_WINDOW_MS = 61_000;
+const MAX_BUDGET_RETRIES = 2;
+
+interface LoginRequester {
+  post(
+    url: string,
+    options: {
+      form: Record<string, string>;
+      failOnStatusCode: boolean;
+    },
+  ): Promise<APIResponse>;
+}
+
+export interface PostLoginOptions {
+  /** Unit tests only — a spec must not pass it (same contract as getAuthToken). */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Reads the wait the server asked for, in ms. Exported for its unit test.
+ *
+ * The refusal body carries `retry_after` in seconds (the header `retry-after`
+ * exists too, but has been observed truncated — the body field is the one the
+ * product's own spec asserts). A missing or unparseable value falls back to a
+ * full window: over-waiting costs seconds on a path already refused, while
+ * under-waiting spends the retry on a still-closed window.
+ */
+export function retryAfterMs(body: unknown): number {
+  if (body !== null && typeof body === "object" && "retry_after" in body) {
+    const seconds = Number((body as { retry_after: unknown }).retry_after);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      // +1s: the server rounds down and the window edge is exclusive.
+      return (seconds + 1) * 1000;
+    }
+  }
+  return FALLBACK_WINDOW_MS;
+}
+
+/**
+ * POST the login form, waiting out up to two rate-limit windows.
+ *
+ * Returns the first non-429 response — the caller owns asserting its status
+ * (200 for a live credential, 401 for a refused one, …).
+ */
+export async function postLogin(
+  request: APIRequestContext | LoginRequester,
+  username: string,
+  password: string,
+  options: PostLoginOptions = {},
+): Promise<APIResponse> {
+  const sleep =
+    options.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  let response = await request.post("/api/v1/login", {
+    form: { username, password },
+    failOnStatusCode: false,
+  });
+
+  for (let retry = 0; retry < MAX_BUDGET_RETRIES; retry++) {
+    if (response.status() !== 429) return response;
+
+    const body = await response.json().catch(() => null);
+    await sleep(retryAfterMs(body));
+
+    response = await request.post("/api/v1/login", {
+      form: { username, password },
+      failOnStatusCode: false,
+    });
+  }
+
+  return response;
+}

--- a/tests/helpers/auth/sign-in-through-form.ts
+++ b/tests/helpers/auth/sign-in-through-form.ts
@@ -1,0 +1,58 @@
+import type { Page, Response } from "@playwright/test";
+import { retryAfterMs } from "./login-request";
+
+/**
+ * Fills the login form, submits, and absorbs the endpoint's per-IP rate limit.
+ *
+ * The browser side of `postLogin` (see login-request.ts): `POST /api/v1/login`
+ * is limited to 5/min per client address, fixed window, counted before
+ * authentication — so a UI login can be refused purely because of the SUITE's
+ * own earlier traffic (the auth directory spends ~15 form+API logins in ~3
+ * minutes; measured collision: `logout-flow` timing out on `mainpage_title`
+ * right after `auto-login-off`'s three form logins). On a 429 this waits out
+ * the window the server names in `retry_after` and clicks again — the form
+ * keeps its values. Any other status is the caller's verdict: 200 callers gate
+ * on the workspace, 401 callers on the error toast, and neither is hidden.
+ *
+ * The response is captured via `waitForResponse` registered BEFORE the click,
+ * so the status read cannot race the navigation that a 200 triggers.
+ *
+ * Returns the final HTTP status, for callers that want to assert it directly.
+ */
+export async function signInThroughForm(
+  page: Page,
+  username: string,
+  password: string,
+  options: { sleep?: (ms: number) => Promise<void> } = {},
+): Promise<number> {
+  const sleep =
+    options.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  await page.getByPlaceholder("Username").fill(username);
+  await page.getByPlaceholder("Password").fill(password);
+  // The client-side auto-login mock's flag: removed so the login the user just
+  // typed is the one the app performs (same contract as the specs had inline).
+  await page.evaluate(() => {
+    sessionStorage.removeItem("testMockAutoLogin");
+  });
+
+  const submitOnce = async (): Promise<Response> => {
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname.endsWith("/api/v1/login") &&
+        response.request().method() === "POST",
+      { timeout: 30000 },
+    );
+    await page.getByRole("button", { name: "Sign In" }).click();
+    return responsePromise;
+  };
+
+  let response = await submitOnce();
+  for (let retry = 0; retry < 2 && response.status() === 429; retry++) {
+    const body = await response.json().catch(() => null);
+    await sleep(retryAfterMs(body));
+    response = await submitOnce();
+  }
+  return response.status();
+}

--- a/tests/tests-automations/regression/core-functionality/auth/admin-password-change.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/admin-password-change.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { postLogin } from "../../../../helpers/auth/login-request";
+import { signInThroughForm } from "../../../../helpers/auth/sign-in-through-form";
 
 // NOTE: When login fails with 401 (wrong credentials), the Langflow frontend re-calls
 // /api/v1/auto_login. With the auto_login mock returning 500, the page resets before
@@ -23,7 +25,7 @@ async function enableLoginScreen(page: any) {
 
 test(
   "admin changes user password — user can log in with new password",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ page, request }) => {
     const username = `pwdtest_${Math.random().toString(36).substring(5)}`;
     const originalPassword = `pass_${Math.random().toString(36).substring(5)}`;
@@ -59,17 +61,11 @@ test(
       expect(patchRes.status()).toBe(200);
 
       // Assert: old password must be rejected by the login endpoint
-      const oldLoginRes = await request.post("/api/v1/login", {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        data: `username=${username}&password=${originalPassword}`,
-      });
+      const oldLoginRes = await postLogin(request, username, originalPassword);
       expect(oldLoginRes.status()).toBe(401);
 
       // Assert: new password must be accepted by the login endpoint
-      const newLoginRes = await request.post("/api/v1/login", {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        data: `username=${username}&password=${newPassword}`,
-      });
+      const newLoginRes = await postLogin(request, username, newPassword);
       expect(newLoginRes.status()).toBe(200);
       const loginBody = await newLoginRes.json();
       expect(loginBody).toHaveProperty("access_token");
@@ -82,10 +78,12 @@ test(
         timeout: 30000,
       });
 
-      await page.getByPlaceholder("Username").fill(username);
-      await page.getByPlaceholder("Password").fill(newPassword);
-      await page.evaluate(() => sessionStorage.removeItem("testMockAutoLogin"));
-      await page.getByRole("button", { name: "Sign In" }).click();
+      // 429-absorbing: by this point the test has already spent four login
+      // calls, so the UI attempt is the one most likely to meet a hot window.
+      const uiStatus = await signInThroughForm(page, username, newPassword);
+      expect(uiStatus, "the new password should sign in through the form").toBe(
+        200,
+      );
 
       await page.waitForSelector('[id="new-project-btn"]', { timeout: 30000 });
       await expect(page.locator('[id="new-project-btn"]')).toBeVisible();
@@ -104,7 +102,7 @@ test(
 
 test(
   "admin changes user password — old password no longer works after change",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ page, request }) => {
     const username = `pwdold_${Math.random().toString(36).substring(5)}`;
     const originalPassword = `orig_${Math.random().toString(36).substring(5)}`;
@@ -129,10 +127,7 @@ test(
       expect(activateRes.status()).toBe(200);
 
       // Verify old password works BEFORE the change (control assertion)
-      const beforeChangeRes = await request.post("/api/v1/login", {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        data: `username=${username}&password=${originalPassword}`,
-      });
+      const beforeChangeRes = await postLogin(request, username, originalPassword);
       expect(beforeChangeRes.status()).toBe(200);
 
       // Change password via API
@@ -143,10 +138,7 @@ test(
       expect(patchRes.status()).toBe(200);
 
       // Assert: old password must NOW be rejected
-      const afterChangeRes = await request.post("/api/v1/login", {
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        data: `username=${username}&password=${originalPassword}`,
-      });
+      const afterChangeRes = await postLogin(request, username, originalPassword);
       expect(afterChangeRes.status()).toBe(401);
     } finally {
       // Cleanup via API

--- a/tests/tests-automations/regression/core-functionality/auth/admin-user-management.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/admin-user-management.spec.ts
@@ -1,284 +1,208 @@
+import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { postLogin } from "../../../../helpers/auth/login-request";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 
-// Helper: mock auto_login to show the login screen
-async function enableLoginScreen(page: any) {
-  await page.route("**/api/v1/auto_login", (route: any) => {
-    route.fulfill({
-      status: 500,
-      contentType: "application/json",
-      body: JSON.stringify({ detail: { auto_login: false } }),
-    });
-  });
+// Auth — admin user management (QA-CHECKLIST §4.2).
+// Spec doc: docs/core-functionality/auth/admin-user-management.md
+//
+// API-driven on purpose. Upstream removed the OSS Admin Page in
+// langflow-ai/langflow#14276 (2026-08-05, "SSO foundations, login seams, and
+// remove OSS Admin Page"): on 1.12.0.dev33 the user menu renders no Admin Page
+// item (the slot between Settings and Docs compiles to a null stub) and the SPA
+// router registers no admin path. User management in OSS is /api/v1/users/ —
+// the same surface the previous UI drove, asserted at the same observable that
+// matters: whether the managed user can log in. The last test pins the removal
+// itself, so an admin UI leaking back into OSS is caught here and not by a
+// human diffing menus.
+//
+// This rewrite also buries a second, older defect the removal was masking: the
+// old spec logged in with the hardcoded legacy password "langflow", refused
+// since nightly 1.11.0.dev29 (#510) — helpers/auth/credentials.ts existed for
+// exactly that and was never imported here.
+//
+// Every login verdict goes through postLogin, which absorbs the endpoint's
+// per-IP rate-limit window (5/min, fixed, every attempt counts) — see
+// helpers/auth/login-request.ts. A 401 is always a credential verdict, never
+// budget.
 
-  await page.addInitScript(() => {
-    sessionStorage.setItem("testMockAutoLogin", "true");
+/** Creates a user via the admin API and registers its cleanup. */
+async function createUser(
+  request: APIRequestContext,
+  token: string,
+  username: string,
+  password: string,
+): Promise<string> {
+  const res = await request.post("/api/v1/users/", {
+    headers: { Authorization: token },
+    data: { username, password },
   });
+  expect(res.status(), "user creation should answer 201").toBe(201);
+  const user = await res.json();
+  // POST /api/v1/users/ creates users INACTIVE by default — asserted here so
+  // the "inactive cannot log in" test below cannot pass by accident on an API
+  // that started activating on create.
+  expect(user.is_active, "a freshly created user ships inactive").toBe(false);
+  return user.id as string;
 }
 
-async function loginAs(page: any, username: string, password: string) {
-  await page.evaluate(() => {
-    sessionStorage.removeItem("testMockAutoLogin");
+async function patchUser(
+  request: APIRequestContext,
+  token: string,
+  userId: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const res = await request.patch(`/api/v1/users/${userId}`, {
+    headers: { Authorization: token },
+    data,
   });
-  await page.getByPlaceholder("Username").fill(username);
-  await page.getByPlaceholder("Password").fill(password);
-  await page.getByRole("button", { name: "Sign In" }).click();
+  expect(res.status(), `PATCH ${JSON.stringify(data)} should answer 200`).toBe(
+    200,
+  );
 }
 
-async function logoutAndShowLogin(page: any) {
-  await page.evaluate(() => {
-    sessionStorage.setItem("testMockAutoLogin", "true");
+async function deleteUser(
+  request: APIRequestContext,
+  token: string,
+  userId: string | null,
+): Promise<void> {
+  if (!userId) return;
+  await request
+    .delete(`/api/v1/users/${userId}`, { headers: { Authorization: token } })
+    .catch(() => {});
+}
+
+test.describe("Auth — admin user management over /api/v1/users/", () => {
+  let token: string;
+  let userId: string | null = null;
+
+  test.beforeEach(async ({ request }) => {
+    token = await getAuthToken(request);
+    userId = null;
   });
-  await page.getByTestId("user-profile-settings").click();
-  await page.getByText("Logout", { exact: true }).click();
-  await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
-}
 
-// Filter the admin user list by username — resolves pagination issues
-async function searchForUser(page: any, username: string) {
-  const searchInput = page.getByPlaceholder("Search Username");
-  await expect(searchInput).toBeVisible({ timeout: 5000 });
-  await searchInput.fill(username);
-  await page.waitForTimeout(500);
-  await expect(page.getByText(username, { exact: true })).toBeVisible({
-    timeout: 5000,
+  test.afterEach(async ({ request }) => {
+    await deleteUser(request, token, userId);
   });
-}
 
-// Cleanup: navigate to admin page and delete user by username.
-// Called in finally blocks to guarantee cleanup even on test failure.
-async function deleteUserIfExists(page: any, username: string) {
-  try {
-    // Ensure we're on a page with navigation (not login screen)
-    const isLoginPage = await page
-      .getByRole("button", { name: "Sign In" })
-      .isVisible({ timeout: 2000 })
-      .catch(() => false);
+  test(
+    "admin creates a user inactive by default — the inactive user cannot log in",
+    { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
+    async ({ request }) => {
+      const username = `user_${Math.random().toString(36).substring(5)}`;
+      const password = `pw_${Math.random().toString(36).substring(5)}`;
 
-    if (isLoginPage) {
-      await loginAs(page, "langflow", "langflow");
-      await page.waitForSelector('[data-testid="mainpage_title"]', {
-        timeout: 30000,
-      });
-    }
-
-    // Navigate to Admin Page if not already there
-    const isAdminPage = await page
-      .getByPlaceholder("Search Username")
-      .isVisible({ timeout: 2000 })
-      .catch(() => false);
-
-    if (!isAdminPage) {
-      await page.getByTestId("user-profile-settings").click();
-      await page.getByText("Admin Page", { exact: true }).click();
-    }
-
-    // Search and delete if found
-    const searchInput = page.getByPlaceholder("Search Username");
-    await searchInput.fill(username);
-    await page.waitForTimeout(500);
-
-    const userVisible = await page
-      .getByText(username, { exact: true })
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-
-    if (userVisible) {
-      await page.getByTestId("icon-Trash2").last().click();
-      await page.getByText("Delete", { exact: true }).last().click();
-      await page.waitForSelector("text=user deleted", { timeout: 10000 });
-    }
-  } catch {
-    // Cleanup best-effort — do not fail the test report on cleanup errors
-  }
-}
-
-test(
-  "admin creates inactive user — inactive user cannot log in",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
-  async ({ page }) => {
-    const randomName = `user_${Math.random().toString(36).substring(5)}`;
-    const randomPassword = Math.random().toString(36).substring(5);
-
-    try {
-      await enableLoginScreen(page);
-      await page.goto("/");
-      await page.waitForSelector("text=sign in to langflow", {
-        timeout: 30000,
+      await test.step("create the user, without activating", async () => {
+        userId = await createUser(request, token, username, password);
       });
 
-      // Log in as admin
-      await loginAs(page, "langflow", "langflow");
-      await page.waitForSelector('[data-testid="mainpage_title"]', {
-        timeout: 30000,
+      await test.step("the inactive user's correct credentials are refused as pending approval", async () => {
+        // The login endpoint is the observable, not the user record: is_active
+        // false is what the admin WROTE, the refused login is what it MEANS.
+        // A never-logged-in inactive user is its own branch in the product
+        // (authenticate_user: last_login_at unset -> 400 "Waiting for
+        // approval"); the deactivated-after-use branch (401 "Inactive user")
+        // is the sibling test's subject.
+        const res = await postLogin(request, username, password);
+        expect(res.status(), "a pending user must not authenticate").toBe(400);
+        expect((await res.json()).detail).toBe("Waiting for approval");
+      });
+    },
+  );
+
+  test(
+    "activation and deactivation flip the same credentials between refused and accepted",
+    { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
+    async ({ request }) => {
+      const username = `user_${Math.random().toString(36).substring(5)}`;
+      const password = `pw_${Math.random().toString(36).substring(5)}`;
+      userId = await createUser(request, token, username, password);
+
+      await test.step("activating the user makes the identical login succeed", async () => {
+        await patchUser(request, token, userId as string, { is_active: true });
+        const res = await postLogin(request, username, password);
+        expect(res.status(), "an activated user must authenticate").toBe(200);
+        expect(await res.json()).toHaveProperty("access_token");
       });
 
-      // Navigate to Admin Page
-      await page.getByTestId("user-profile-settings").click();
-      await page.getByText("Admin Page", { exact: true }).click();
-
-      // Create new user WITHOUT activating (default is inactive)
-      await page.getByText("New User", { exact: true }).click();
-      await page.getByPlaceholder("Username").last().fill(randomName);
-      await page.locator('input[name="password"]').fill(randomPassword);
-      await page.locator('input[name="confirmpassword"]').fill(randomPassword);
-      // Note: NOT clicking #is_active — user remains inactive
-
-      await page.getByText("Save", { exact: true }).click();
-      await page.waitForSelector("text=new user added", { timeout: 30000 });
-
-      // Search for the user to handle pagination
-      await searchForUser(page, randomName);
-
-      // Log out as admin
-      await page.getByTestId("icon-ChevronLeft").first().click();
-      await page.waitForSelector('[data-testid="user-profile-settings"]', {
-        timeout: 30000,
+      await test.step("deactivating the user refuses the identical login again", async () => {
+        // The pair is the assertion: without this half, a login endpoint that
+        // ignores is_active entirely would pass the activation step (#1010's
+        // "a lone success is equivocal" reasoning, applied to auth).
+        await patchUser(request, token, userId as string, { is_active: false });
+        const res = await postLogin(request, username, password);
+        // 401 "Inactive user", not 400: this user HAS logged in, so it takes
+        // the deactivated branch rather than the pending-approval one.
+        expect(res.status(), "a deactivated user must be refused").toBe(401);
+        expect((await res.json()).detail).toBe("Inactive user");
       });
-      await logoutAndShowLogin(page);
+    },
+  );
 
-      // Try to log in as inactive user — should fail
-      await page.getByPlaceholder("Username").fill(randomName);
-      await page.getByPlaceholder("Password").fill(randomPassword);
-      await page.evaluate(() => {
-        sessionStorage.removeItem("testMockAutoLogin");
-      });
-      await page.getByRole("button", { name: "Sign In" }).click();
+  test(
+    "renaming a user moves the login to the new username",
+    { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
+    async ({ request }) => {
+      const username = `user_${Math.random().toString(36).substring(5)}`;
+      const renamed = `renamed_${Math.random().toString(36).substring(5)}`;
+      const password = `pw_${Math.random().toString(36).substring(5)}`;
+      userId = await createUser(request, token, username, password);
+      await patchUser(request, token, userId, { is_active: true });
 
-      await page.waitForSelector("text=Error signing in", { timeout: 10000 });
-      await expect(page.getByText("Error signing in")).toBeVisible();
-
-      // Navigate back to admin to prepare cleanup
-      await loginAs(page, "langflow", "langflow");
-      await page.waitForSelector('[data-testid="mainpage_title"]', {
-        timeout: 30000,
-      });
-      await page.getByTestId("user-profile-settings").click();
-      await page.getByText("Admin Page", { exact: true }).click();
-    } finally {
-      // Always delete the created user — even if the test fails midway
-      await deleteUserIfExists(page, randomName);
-    }
-  },
-);
-
-test(
-  "admin activates previously inactive user — user can log in after activation",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
-  async ({ page }) => {
-    const randomName = `user_${Math.random().toString(36).substring(5)}`;
-    const randomPassword = Math.random().toString(36).substring(5);
-
-    try {
-      await enableLoginScreen(page);
-      await page.goto("/");
-      await page.waitForSelector("text=sign in to langflow", {
-        timeout: 30000,
+      await test.step("rename via PATCH", async () => {
+        await patchUser(request, token, userId as string, {
+          username: renamed,
+        });
       });
 
-      // Log in as admin
-      await loginAs(page, "langflow", "langflow");
-      await page.waitForSelector('[data-testid="mainpage_title"]', {
-        timeout: 30000,
+      await test.step("the new username logs in with the unchanged password", async () => {
+        const res = await postLogin(request, renamed, password);
+        expect(res.status(), "the renamed user must authenticate").toBe(200);
       });
 
-      // Go to Admin Page and create inactive user
-      await page.getByTestId("user-profile-settings").click();
-      await page.getByText("Admin Page", { exact: true }).click();
-
-      await page.getByText("New User", { exact: true }).click();
-      await page.getByPlaceholder("Username").last().fill(randomName);
-      await page.locator('input[name="password"]').fill(randomPassword);
-      await page.locator('input[name="confirmpassword"]').fill(randomPassword);
-      await page.getByText("Save", { exact: true }).click();
-      await page.waitForSelector("text=new user added", { timeout: 30000 });
-
-      // Search to find the user regardless of pagination, then activate via Pencil
-      await searchForUser(page, randomName);
-      await page.getByTestId("icon-Pencil").last().click();
-      await page.waitForSelector("#is_active", { timeout: 5000 });
-      await page.locator("#is_active").click();
-      await page.getByText("Save", { exact: true }).click();
-      await page.waitForSelector("text=user edited", { timeout: 30000 });
-
-      // Log out as admin
-      await page.getByTestId("icon-ChevronLeft").first().click();
-      await page.waitForSelector('[data-testid="user-profile-settings"]', {
-        timeout: 30000,
+      await test.step("the old username no longer authenticates", async () => {
+        const res = await postLogin(request, username, password);
+        expect(
+          res.status(),
+          "the pre-rename username must be gone, not aliased",
+        ).toBe(401);
       });
-      await logoutAndShowLogin(page);
+    },
+  );
 
-      // Try to log in as now-active user — should succeed
-      await page.getByPlaceholder("Username").fill(randomName);
-      await page.getByPlaceholder("Password").fill(randomPassword);
-      await page.evaluate(() => {
-        sessionStorage.removeItem("testMockAutoLogin");
-      });
-      await page.getByRole("button", { name: "Sign In" }).click();
+  test(
+    "the OSS build offers no Admin Page — menu and route both",
+    { tag: ["@stable", "@regression", "@auth", "@ui-ux"] },
+    async ({ page }) => {
+      // Pins langflow-ai/langflow#14276. If an admin UI ever ships back into
+      // the OSS bundle — an EE surface leaking across the build split — this is
+      // the test that names it, instead of a human noticing a new menu item.
+      await awaitBootstrapTest(page, { skipModal: true });
 
-      await page.waitForSelector('[id="new-project-btn"]', { timeout: 30000 });
-      await expect(page.locator('[id="new-project-btn"]')).toBeVisible();
-
-      // Log out the activated user and re-enter as admin for cleanup
-      await logoutAndShowLogin(page);
-      await loginAs(page, "langflow", "langflow");
-      await page.waitForSelector('[data-testid="mainpage_title"]', {
-        timeout: 30000,
-      });
-      await page.getByTestId("user-profile-settings").click();
-      await page.getByText("Admin Page", { exact: true }).click();
-    } finally {
-      await deleteUserIfExists(page, randomName);
-    }
-  },
-);
-
-test(
-  "admin renames user — renamed user can log in with new username",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
-  async ({ page }) => {
-    const randomName = `user_${Math.random().toString(36).substring(5)}`;
-    const updatedName = `renamed_${Math.random().toString(36).substring(5)}`;
-    const randomPassword = Math.random().toString(36).substring(5);
-
-    try {
-      await enableLoginScreen(page);
-      await page.goto("/");
-      await page.waitForSelector("text=sign in to langflow", {
-        timeout: 30000,
+      await test.step("the user menu renders, without an Admin Page item", async () => {
+        await page.getByTestId("user-profile-settings").click();
+        // The menu itself must be open before the absence means anything — an
+        // unopened menu also contains no Admin Page.
+        await expect(page.getByTestId("menu_settings_button")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByText("Admin Page", { exact: true })).toHaveCount(
+          0,
+        );
+        await page.keyboard.press("Escape");
       });
 
-      // Log in as admin
-      await loginAs(page, "langflow", "langflow");
-      await page.waitForSelector('[data-testid="mainpage_title"]', {
-        timeout: 30000,
+      await test.step("/admin does not land on an admin UI", async () => {
+        await page.goto("/admin");
+        // The router registers no admin path, so the SPA falls through to the
+        // workspace. The old page's own marker (the user-search field) is the
+        // absence asserted — a redirect target rename would not fake a pass.
+        await page.waitForSelector('[data-testid="mainpage_title"]', {
+          timeout: 30000,
+        });
+        await expect(page.getByPlaceholder("Search Username")).toHaveCount(0);
       });
-
-      // Create and activate user
-      await page.getByTestId("user-profile-settings").click();
-      await page.getByText("Admin Page", { exact: true }).click();
-
-      await page.getByText("New User", { exact: true }).click();
-      await page.getByPlaceholder("Username").last().fill(randomName);
-      await page.locator('input[name="password"]').fill(randomPassword);
-      await page.locator('input[name="confirmpassword"]').fill(randomPassword);
-      await page.waitForSelector("#is_active", { timeout: 1500 });
-      await page.locator("#is_active").click(); // activate
-      await page.getByText("Save", { exact: true }).click();
-      await page.waitForSelector("text=new user added", { timeout: 30000 });
-
-      // Search to find the user before editing
-      await searchForUser(page, randomName);
-      await page.getByTestId("icon-Pencil").last().click();
-      await page.getByPlaceholder("Username").last().fill(updatedName);
-      await page.getByText("Save", { exact: true }).click();
-      await page.waitForSelector("text=user edited", { timeout: 30000 });
-
-      // Search for the renamed user to confirm rename succeeded
-      await searchForUser(page, updatedName);
-    } finally {
-      // Try to delete by updated name first, then original name as fallback
-      await deleteUserIfExists(page, updatedName);
-      await deleteUserIfExists(page, randomName);
-    }
-  },
-);
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/auth/auto-login-off.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/auto-login-off.spec.ts
@@ -1,280 +1,190 @@
+import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import {
   SUPERUSER_PASSWORD,
   SUPERUSER_USERNAME,
 } from "../../../../helpers/auth/credentials";
-import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { signInThroughForm } from "../../../../helpers/auth/sign-in-through-form";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { openNewFlowTemplatesModal } from "../../../../helpers/flows/open-new-flow-templates-modal";
 import { renameFlow } from "../../../../helpers/flows/rename-flow";
-import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+
+// Auth — login screen and per-user flow isolation (QA-CHECKLIST §4.1 + the
+// §4.2 isolation bullet). Spec doc: docs/core-functionality/auth/auto-login-off.md
+//
+// The auto_login mock is CLIENT-side (page.route): the server keeps
+// LANGFLOW_AUTO_LOGIN=true, so the standalone `request` fixture still
+// authenticates normally — which is what lets the second user be provisioned
+// through /api/v1/users/ while the BROWSER sees a password-first instance.
+//
+// History: this test used to drive the OSS Admin Page for its user CRUD.
+// Upstream removed that page in langflow-ai/langflow#14276 (2026-08-05), which
+// is where the old version died. The CRUD coverage lives in
+// admin-user-management.spec.ts (API-driven); what THIS test owns is the
+// login screen appearing when auto-login is off, and that two users see only
+// their own flows.
+
+/** Client-side auto-login kill switch — the server itself is untouched. */
+async function enableLoginScreen(page: Page): Promise<void> {
+  await page.route("**/api/v1/auto_login", (route) => {
+    route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: { auto_login: false } }),
+    });
+  });
+  await page.addInitScript(() => {
+    sessionStorage.setItem("testMockAutoLogin", "true");
+  });
+}
+
+/** Signs in through the form (429-absorbing) and waits for the workspace. */
+async function signIn(
+  page: Page,
+  username: string,
+  password: string,
+): Promise<void> {
+  const status = await signInThroughForm(page, username, password);
+  expect(status, "the form login should authenticate").toBe(200);
+  await page.waitForSelector('[data-testid="mainpage_title"]', {
+    timeout: 30000,
+  });
+}
+
+/** Logs out through the user menu and lands back on the login screen. */
+async function signOut(page: Page): Promise<void> {
+  await page.getByTestId("user-profile-settings").click();
+  await page.evaluate(() => {
+    sessionStorage.setItem("testMockAutoLogin", "true");
+  });
+  await page.getByText("Logout", { exact: true }).click();
+  await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
+}
+
+/**
+ * Creates a flow from the Basic Prompting template and renames it, returning
+ * the flow id read from the editor URL — the id the cleanup deletes.
+ */
+async function createNamedFlow(page: Page, flowName: string): Promise<string> {
+  await openNewFlowTemplatesModal(page);
+  await page.getByTestId("side_nav_options_all-templates").click();
+  await page.getByRole("heading", { name: "Basic Prompting" }).click();
+  await page.waitForURL(/\/flow\/[^/?#]+/, { timeout: 30000 });
+  await adjustScreenView(page, { numberOfZoomOut: 1 });
+  await renameFlow(page, { flowName });
+  const id = page.url().match(/\/flow\/([^/?#]+)/)?.[1];
+  expect(id, "the editor URL should carry the created flow's id").toBeTruthy();
+
+  await page.getByTestId("icon-ChevronLeft").first().click();
+  await page.waitForSelector('[data-testid="mainpage_title"]', {
+    timeout: 30000,
+  });
+  await expect(page.getByText(flowName, { exact: true })).toBeVisible({
+    timeout: 15000,
+  });
+  return id as string;
+}
+
+async function deleteUserIfCreated(
+  request: APIRequestContext,
+  token: string,
+  userId: string | null,
+): Promise<void> {
+  if (!userId) return;
+  await request
+    .delete(`/api/v1/users/${userId}`, { headers: { Authorization: token } })
+    .catch(() => {});
+}
 
 test(
-  "when auto_login is false, admin can CRUD user's and should see just your own flows",
-  { tag: ["@release", "@api", "@database", "@mainpage", "@auth"] },
-  async ({ page }) => {
-    await page.route("**/api/v1/auto_login", (route) => {
-      route.fulfill({
-        status: 500,
-        contentType: "application/json",
-        body: JSON.stringify({
-          detail: { auto_login: false },
-        }),
-      });
-    });
+  "when auto_login is off, users sign in through the form and see only their own flows",
+  { tag: ["@stable", "@release", "@api", "@database", "@mainpage", "@auth"] },
+  async ({ page, request }) => {
+    const secondUsername = `user_${Math.random().toString(36).substring(5)}`;
+    const secondPassword = `pw_${Math.random().toString(36).substring(5)}`;
+    const superuserFlow = `flow_a_${Math.random().toString(36).substring(5)}`;
+    const secondUserFlow = `flow_b_${Math.random().toString(36).substring(5)}`;
 
-    await page.addInitScript(() => {
-      window.process = window.process || {};
+    const token = await getAuthToken(request);
+    let secondUserId: string | null = null;
+    const createdFlowIds: string[] = [];
 
-      const newEnv = { ...window.process.env, LANGFLOW_AUTO_LOGIN: "false" };
-
-      Object.defineProperty(window.process, "env", {
-        value: newEnv,
-        writable: true,
-        configurable: true,
+    try {
+      await test.step("the login screen appears when auto-login cannot log in", async () => {
+        await enableLoginScreen(page);
+        await page.goto("/");
+        await page.waitForSelector("text=sign in to langflow", {
+          timeout: 30000,
+        });
       });
 
-      sessionStorage.setItem("testMockAutoLogin", "true");
-    });
-
-    const randomName = Math.random().toString(36).substring(5);
-    const randomPassword = Math.random().toString(36).substring(5);
-    const secondRandomName = Math.random().toString(36).substring(5);
-    const randomFlowName = Math.random().toString(36).substring(5);
-    const secondRandomFlowName = Math.random().toString(36).substring(5);
-
-    await page.goto("/");
-
-    await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
-
-    await page.getByPlaceholder("Username").fill(SUPERUSER_USERNAME);
-    await page.getByPlaceholder("Password").fill(SUPERUSER_PASSWORD);
-
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
-
-    await page.getByRole("button", { name: "Sign In" }).click();
-
-    await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
-
-    await page.waitForSelector('[id="new-project-btn"]', {
-      timeout: 30000,
-    });
-
-    await page.getByTestId("user-profile-settings").click();
-
-    await page.getByText("Admin Page", { exact: true }).click();
-
-    //CRUD an user
-    await page.getByText("New User", { exact: true }).click();
-
-    await page.getByPlaceholder("Username").last().fill(randomName);
-    await page.locator('input[name="password"]').fill(randomPassword);
-    await page.locator('input[name="confirmpassword"]').fill(randomPassword);
-
-    await page.waitForSelector("#is_active", {
-      timeout: 1500,
-    });
-
-    await page.locator("#is_active").click();
-
-    await page.getByText("Save", { exact: true }).click();
-
-    await page.waitForSelector("text=new user added", { timeout: 30000 });
-
-    await expect(page.getByText(randomName, { exact: true })).toBeVisible({
-      timeout: 2000,
-    });
-
-    await page.getByTestId("icon-Trash2").last().click();
-    await page.getByText("Delete", { exact: true }).last().click();
-
-    await page.waitForSelector("text=user deleted", { timeout: 30000 });
-
-    await expect(page.getByText(randomName, { exact: true })).toBeVisible({
-      timeout: 2000,
-      visible: false,
-    });
-
-    await page.getByText("New User", { exact: true }).click();
-
-    await page.getByPlaceholder("Username").last().fill(randomName);
-    await page.locator('input[name="password"]').fill(randomPassword);
-    await page.locator('input[name="confirmpassword"]').fill(randomPassword);
-
-    await page.waitForSelector("#is_active", {
-      timeout: 1500,
-    });
-
-    await page.locator("#is_active").click();
-
-    await page.getByText("Save", { exact: true }).click();
-
-    await page.waitForSelector("text=new user added", { timeout: 30000 });
-
-    await page.getByPlaceholder("Username").last().fill(randomName);
-
-    await page.getByTestId("icon-Pencil").last().click();
-
-    await page.getByPlaceholder("Username").last().fill(secondRandomName);
-
-    await page.getByText("Save", { exact: true }).click();
-
-    await page.waitForSelector("text=user edited", { timeout: 30000 });
-
-    await expect(page.getByText(secondRandomName, { exact: true })).toBeVisible(
-      {
-        timeout: 2000,
-      },
-    );
-
-    //user must see just your own flows
-    await page.waitForSelector('[data-testid="icon-ChevronLeft"]', {
-      timeout: 100000,
-    });
-
-    await page.getByTestId("icon-ChevronLeft").first().click();
-
-    await page.waitForSelector('[id="new-project-btn"]', {
-      timeout: 30000,
-    });
-
-    await awaitBootstrapTest(page, { skipGoto: true });
-
-    await page.getByTestId("side_nav_options_all-templates").click();
-    await page.getByRole("heading", { name: "Basic Prompting" }).click();
-
-    await adjustScreenView(page, { numberOfZoomOut: 1 });
-
-    await renameFlow(page, { flowName: randomFlowName });
-
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 100000,
-      state: "visible",
-    });
-
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 1500,
-    });
-
-    await page.getByTestId("icon-ChevronLeft").first().click();
-
-    await page.waitForSelector('[data-testid="search-store-input"]:enabled', {
-      timeout: 30000,
-      state: "visible",
-    });
-
-    await expect(page.getByText(randomFlowName, { exact: true })).toBeVisible({
-      timeout: 2000,
-    });
-
-    await page.waitForSelector("[data-testid='user-profile-settings']", {
-      timeout: 1500,
-    });
-
-    await page.getByTestId("user-profile-settings").click();
-
-    await page.evaluate(() => {
-      sessionStorage.setItem("testMockAutoLogin", "true");
-    });
-
-    await page.getByText("Logout", { exact: true }).click();
-
-    await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
-
-    await page.getByPlaceholder("Username").fill(secondRandomName);
-    await page.getByPlaceholder("Password").fill(randomPassword);
-
-    await page.waitForSelector("text=Sign in", {
-      timeout: 1500,
-    });
-
-    await page.getByRole("button", { name: "Sign In" }).click();
-
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
-
-    await page.waitForSelector('[id="new-project-btn"]', {
-      timeout: 30000,
-    });
-
-    await expect(page.getByText("Welcome to LangFlow")).toBeVisible({
-      timeout: 30000,
-    });
-
-    await page.waitForTimeout(2000);
-
-    await awaitBootstrapTest(page, { skipGoto: true });
-
-    await page.getByTestId("side_nav_options_all-templates").click();
-    await page.getByRole("heading", { name: "Basic Prompting" }).click();
-
-    await adjustScreenView(page, { numberOfZoomOut: 2 });
-
-    await renameFlow(page, { flowName: secondRandomFlowName });
-
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 100000,
-    });
-
-    await page.getByTestId("icon-ChevronLeft").first().click();
-
-    await page.waitForSelector('[data-testid="search-store-input"]:enabled', {
-      timeout: 30000,
-    });
-
-    await expect(
-      page.getByText(secondRandomFlowName, { exact: true }),
-    ).toBeVisible({
-      timeout: 2000,
-    });
-
-    await expect(page.getByText(randomFlowName, { exact: true })).toBeVisible({
-      timeout: 2000,
-      visible: false,
-    });
-
-    await page.getByTestId("user-profile-settings").click();
-
-    await page.evaluate(() => {
-      sessionStorage.setItem("testMockAutoLogin", "true");
-    });
-
-    await page.getByText("Logout", { exact: true }).click();
-
-    await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
-
-    await page.getByPlaceholder("Username").fill(SUPERUSER_USERNAME);
-    await page.getByPlaceholder("Password").fill(SUPERUSER_PASSWORD);
-
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
-
-    await page.getByRole("button", { name: "Sign In" }).click();
-
-    await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
-
-    await page.waitForSelector('[data-testid="search-store-input"]:enabled', {
-      timeout: 30000,
-    });
-
-    expect(
-      await page.getByText(secondRandomFlowName, { exact: true }).isVisible(),
-    ).toBe(false);
-
-    await expect(page.getByText(randomFlowName, { exact: true })).toBeVisible({
-      timeout: 2000,
-    });
-
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
+      await test.step("provision the second user via the admin API", async () => {
+        // The OSS Admin Page is gone (langflow-ai/langflow#14276) — user
+        // provisioning is API-only, and the API path also spends no login-form
+        // attempts against the endpoint's per-IP budget.
+        const createRes = await request.post("/api/v1/users/", {
+          headers: { Authorization: token },
+          data: { username: secondUsername, password: secondPassword },
+        });
+        expect(createRes.status()).toBe(201);
+        secondUserId = (await createRes.json()).id;
+        const activateRes = await request.patch(
+          `/api/v1/users/${secondUserId}`,
+          {
+            headers: { Authorization: token },
+            data: { is_active: true },
+          },
+        );
+        expect(activateRes.status()).toBe(200);
+      });
+
+      await test.step("the superuser signs in through the form and creates a flow", async () => {
+        await signIn(page, SUPERUSER_USERNAME, SUPERUSER_PASSWORD);
+        createdFlowIds.push(await createNamedFlow(page, superuserFlow));
+      });
+
+      await test.step("the second user signs in and does not see the superuser's flow", async () => {
+        await signOut(page);
+        await signIn(page, secondUsername, secondPassword);
+        // The isolation assertion proper: the OTHER user's flow, by its exact
+        // name, absent from this workspace.
+        await expect(
+          page.getByText(superuserFlow, { exact: true }),
+        ).toHaveCount(0);
+      });
+
+      await test.step("the second user creates their own flow and sees only it", async () => {
+        createdFlowIds.push(await createNamedFlow(page, secondUserFlow));
+        await expect(
+          page.getByText(secondUserFlow, { exact: true }),
+        ).toBeVisible({ timeout: 15000 });
+        await expect(
+          page.getByText(superuserFlow, { exact: true }),
+        ).toHaveCount(0);
+      });
+
+      await test.step("back as the superuser, the second user's flow is invisible", async () => {
+        await signOut(page);
+        await signIn(page, SUPERUSER_USERNAME, SUPERUSER_PASSWORD);
+        await expect(page.getByText(superuserFlow, { exact: true })).toBeVisible(
+          { timeout: 15000 },
+        );
+        await expect(
+          page.getByText(secondUserFlow, { exact: true }),
+        ).toHaveCount(0);
+      });
+    } finally {
+      // Id-scoped cleanup, superuser token — the old version leaked its user
+      // and both flows on every run. The second user's flow is deletable by
+      // the superuser; the user record goes last.
+      for (const id of createdFlowIds) {
+        await deleteFlow(request, id, {
+          headers: { Authorization: token },
+        }).catch(() => {});
+      }
+      await deleteUserIfCreated(request, token, secondUserId);
+    }
   },
 );

--- a/tests/tests-automations/regression/core-functionality/auth/autoLogin.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/autoLogin.spec.ts
@@ -9,7 +9,7 @@ test.describe(
   () => {
     test(
       "auto_login sign in",
-      { tag: ["@release", "@api", "@database", "@auth"] },
+      { tag: ["@stable", "@release", "@api", "@database", "@auth"] },
       async ({ page }) => {
         await awaitBootstrapTest(page, {
           skipModal: true,
@@ -20,7 +20,7 @@ test.describe(
 
     test(
       "auto_login block_admin",
-      { tag: ["@release", "@api", "@database", "@auth"] },
+      { tag: ["@stable", "@release", "@api", "@database", "@auth"] },
       async ({ page }) => {
         await awaitBootstrapTest(page, {
           skipModal: true,

--- a/tests/tests-automations/regression/core-functionality/auth/login-invalid-credentials.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/login-invalid-credentials.spec.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "../../../../fixtures/fixtures";
+import { signInThroughForm } from "../../../../helpers/auth/sign-in-through-form";
 
 test(
   "login with invalid credentials must show error and stay on login page",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ page }) => {
     // Mock auto_login to force login screen
     await page.route("**/api/v1/auto_login", (route) => {
@@ -30,15 +31,14 @@ test(
 
     await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
 
-    // Fill with invalid credentials
-    await page.getByPlaceholder("Username").fill("wronguser");
-    await page.getByPlaceholder("Password").fill("wrongpassword");
-
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
-
-    await page.getByRole("button", { name: "Sign In" }).click();
+    // Invalid credentials, with the shared-budget 429 absorbed first: under a
+    // hot window the app shows the SAME "Error signing in" toast for a 429,
+    // which would make a title-only assertion pass for the wrong reason. The
+    // helper returns the final status, so the credential verdict is pinned.
+    const status = await signInThroughForm(page, "wronguser", "wrongpassword");
+    expect(status, "wrong credentials must be refused as credentials").toBe(
+      401,
+    );
 
     // Error alert must appear — title is "Error signing in"
     await page.waitForSelector("text=Error signing in", { timeout: 10000 });
@@ -65,7 +65,7 @@ test(
 
 test(
   "login with empty credentials must not redirect to main page",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ page }) => {
     await page.route("**/api/v1/auto_login", (route) => {
       route.fulfill({

--- a/tests/tests-automations/regression/core-functionality/auth/logout-flow.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/logout-flow.spec.ts
@@ -3,6 +3,7 @@ import {
   SUPERUSER_PASSWORD,
   SUPERUSER_USERNAME,
 } from "../../../../helpers/auth/credentials";
+import { signInThroughForm } from "../../../../helpers/auth/sign-in-through-form";
 
 function setupAutoLoginMock(page: any) {
   return Promise.all([
@@ -37,15 +38,9 @@ test(
     await page.goto("/");
     await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
 
-    // Login with valid credentials
-    await page.getByPlaceholder("Username").fill(SUPERUSER_USERNAME);
-    await page.getByPlaceholder("Password").fill(SUPERUSER_PASSWORD);
-
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
-
-    await page.getByRole("button", { name: "Sign In" }).click();
+    // Login with valid credentials (429-absorbing — the endpoint budget is
+    // shared with every other auth spec in the run)
+    await signInThroughForm(page, SUPERUSER_USERNAME, SUPERUSER_PASSWORD);
 
     await page.waitForSelector('[data-testid="mainpage_title"]', {
       timeout: 30000,
@@ -88,14 +83,8 @@ test(
     await page.goto("/");
     await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
 
-    await page.getByPlaceholder("Username").fill(SUPERUSER_USERNAME);
-    await page.getByPlaceholder("Password").fill(SUPERUSER_PASSWORD);
-
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
-
-    await page.getByRole("button", { name: "Sign In" }).click();
+    // 429-absorbing — the login budget is shared with every auth spec
+    await signInThroughForm(page, SUPERUSER_USERNAME, SUPERUSER_PASSWORD);
 
     await page.waitForSelector('[data-testid="mainpage_title"]', {
       timeout: 30000,
@@ -132,14 +121,8 @@ test(
     await page.goto("/");
     await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
 
-    await page.getByPlaceholder("Username").fill(SUPERUSER_USERNAME);
-    await page.getByPlaceholder("Password").fill(SUPERUSER_PASSWORD);
-
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
-
-    await page.getByRole("button", { name: "Sign In" }).click();
+    // 429-absorbing — the login budget is shared with every auth spec
+    await signInThroughForm(page, SUPERUSER_USERNAME, SUPERUSER_PASSWORD);
 
     await page.waitForSelector('[data-testid="mainpage_title"]', {
       timeout: 30000,

--- a/tests/tests-automations/regression/core-functionality/auth/session-expired.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/session-expired.spec.ts
@@ -3,7 +3,7 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 test(
   "API request with invalid token returns 401 or 403",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ request }) => {
     const response = await request.get("/api/v1/flows/", {
       headers: { Authorization: "Bearer invalid.expired.token" },
@@ -15,7 +15,7 @@ test(
 
 test(
   "API request with no token returns 401 or 403",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ request }) => {
     const response = await request.get("/api/v1/flows/");
 
@@ -26,7 +26,7 @@ test(
 
 test(
   "UI shows login page when auto_login is unavailable (session cannot be established)",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ page }) => {
     // Simulate a scenario where the session cannot be established
     // (auto_login returns 500 = auth server down or session expired)
@@ -57,7 +57,7 @@ test(
 
 test(
   "valid token grants access to protected resources",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ request }) => {
     const authToken = await getAuthToken(request);
 


### PR DESCRIPTION
Closes #1542. Closes #1543.

Moves the auth tail — the `ROADMAP.md` pool item "ready to date" — to `@stable`: 13 `QA-CHECKLIST.md` §4.1/§4.2 bullets `[-]` → `[x]`, plus one new bullet the audit earned. Six spec docs authored (none existed). Everything measured on nightly `1.12.0.dev33`.

## The audit that reshaped the batch

Baseline (`--retries=0 --workers=1`): **13/17 pass**. The 4 reds decomposed into two product facts and one suite defect:

1. **Upstream removed the OSS Admin Page** — [langflow-ai/langflow#14276](https://github.com/langflow-ai/langflow/pull/14276) (2026-08-05, *"SSO foundations, login seams, and remove OSS Admin Page"*). On dev33 the user-menu slot compiles to a `null` stub and the SPA router registers no admin path (`pages/AdminPage/` upstream holds only the `/login/admin` LoginPage). `admin-user-management` and `auto-login-off` died at the `Admin Page` click.
2. **The legacy-password defect underneath it**: `admin-user-management` logged in with hardcoded `"langflow"`, refused since `1.11.0.dev29` (#510) — `helpers/auth/credentials.ts` exists for exactly this and was never imported. Every admin login failed before even reaching the removed page.
3. **Login-budget collisions between specs** (suite defect, measured twice): `POST /api/v1/login` is limited to **5/min per client IP, fixed window, counted before authentication**. `logout-flow` (already `@stable`) timed out on `mainpage_title` right after `auto-login-off`'s three form logins; later `admin-password-change`'s UI login met the window its own four API calls had just spent — snapshot shows the form submitted and parked.

## 1. Covered tests (18 in the directory, 13 promoted + 1 new)

| File | Tests | What changed |
|---|---|---|
| `admin-user-management.spec.ts` | 4 | **Rewritten API-driven** over `/api/v1/users/`, proving every state at the login endpoint: created-inactive → `400 "Waiting for approval"`; activate → `200` + `access_token`; deactivate → `401 "Inactive user"`; rename → new username `200`, old `401`. The two refusal branches are the product's own (read from the shipped `authenticate_user`: never-logged-in vs deactivated-after-use) and each test pins one — the first run of this rewrite failed on exactly that distinction. **New 4th test** pins #14276 itself: menu open + no `Admin Page` item, `/admin` falls through with the old page's own marker (`Search Username`) absent — an EE admin surface leaking back into OSS fails by name |
| `auto-login-off.spec.ts` | 1 | **Surgery**: keeps its two real subjects — login screen when auto-login is off, and **two-way** flow isolation with exact random names (A invisible to B, B invisible to A, while each still sees their own — pinning "filtered by owner", not "empty") — provisions the second user via API, and gains the id-scoped cleanup it never had (old version leaked 1 user + 2 flows per run) |
| `admin-password-change.spec.ts` | 2 | Passing already; its 5 login calls now ride the 429-absorbing helpers (its UI login was the measured victim), promoted |
| `logout-flow.spec.ts` | 3 | Already `@stable`; its 3 raw form logins swapped to the helper — it was the other measured victim |
| `autoLogin.spec.ts` | 2 | Promoted as-is |
| `login-invalid-credentials.spec.ts` | 2 | Promoted, with one tightening: under a hot window the app shows the same `Error signing in` toast for a 429, so the title-only assert could pass for the wrong reason — the refusal is now pinned to a **401 status** through the helper |
| `session-expired.spec.ts` | 4 | Promoted as-is (refusal pair + valid-token control) |

Out of scope, stated: `login-rate-limit.spec.ts` stays `[-]` — `@destructive` (instance-global budget), `@stable` forbidden on it (#1010), bullet carries the lane. It also deliberately does **not** use the new helpers: there the 429 is the subject.

## 2. How it was built

- **New shared helpers** (`tests/helpers/auth/`): `login-request.ts` (`postLogin` — API side) and `sign-in-through-form.ts` (browser side, response captured via `waitForResponse` registered before the click, so the status read cannot race the navigation). Both absorb only `429`, waiting out the server-named `retry_after` — **a string, not a number**, converted with a +1 s edge margin — and return every other status untouched, so no credential verdict is ever hidden. Unit-tested (6 cases, `npm run test:units`).
- **Backend semantics read from the shipped source inside the running container** (`services/auth/service.py::authenticate_user`), not guessed: the 400-vs-401 inactive branches above.
- **Live-confirmed surface**: the Admin Page absence was established from the shipped frontend bundle (menu slot `const H_i = e => null`, router path table with no `admin` entry, zero `Search Username` occurrences) and upstream refs (`pages/AdminPage/` = LoginPage only on `release-1.12.0`).
- **Cleanup**: every created user deleted by id in `afterEach`/`finally`; both isolation flows deleted by ids captured from the editor URL. Nothing name-based, nothing delete-all.

## 3. Dependencies

- **None — no LLM, no provider key.** Superuser token via `get-auth-token` (auto-login endpoint, spends no form budget).
- Runs `--workers=1` as the auth directory always has (shared login budget is per-IP); parallel-safe against the rest of the suite.

## Validation (nightly `1.12.0.dev33`, `--retries=0 --workers=1`)

- **Final burst 3× back-to-back with deliberately hot windows** (~45 logins in ~13 min): **18/18 · 18/18 · 18/18**, 0 flaky, 0 skipped, **0 `🚨 Backend Error`**. Run 3 shows +60 s — one absorbed 429, visible and green: the in-vivo proof of the helper, stronger than a mocked one.
- **Two defect-simulating force-fails**, both red with the designed message, then reverted: the pending-approval detail assert (`Expected "Pending review" · Received "Waiting for approval"`) and the isolation count flip (`Expected 1 · Received 0`).
- JSON-reporter stats throughout, never `\r` progress lines.
- `typecheck` 0 errors · `lint` 0 errors · `test:units` green (incl. the new helper's 6 cases) · checklist guard + coverage guard + `validate:specs` green.
- `--trace=on` skipped deliberately: hangs UI specs on this local Docker VM (Colima) — known constraint; CI captures trace on first retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
