### PR TITLE
test(flow-functionality): suppress the onboarding overlay and re-anchor the Run Flow node (#1548)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -706,7 +706,7 @@
 - [x] Save flow components as template → `core-components/saveComponents.spec.ts`
 
 #### 12.6 Flow Execution
-- [x] Run Flow component executes another flow — `@stable` restored 2026-08-11 (#966). The upstream `New Flow` dead-click defect ([LE-2019](https://datastax.jira.com/browse/LE-2019)) is fixed by langflow#14349, present on the nightly line; the shared helper still gates on the flows list having rendered, and the spec was re-validated on `1.12.0.dev23` → `flow-functionality/run-flow.spec.ts`
+- [x] Run Flow component executes another flow — `@stable` restored 2026-08-11 (#966). The upstream `New Flow` dead-click defect ([LE-2019](https://datastax.jira.com/browse/LE-2019)) is fixed by langflow#14349, present on the nightly line; the shared helper still gates on the flows list having rendered. Hardened for #1548 (daily 2026-08-21 flow-selector click intercepted by two overlays): the spec now seeds the assistant-onboarding suppression (#1220) and drags the Run Flow node to the upper-right canvas region so the flow-name popup stays clear of the canvas-controls band; re-validated on `1.12.0.dev33` → `flow-functionality/run-flow.spec.ts`
 - [x] Run a flow from the canvas — terminal-node run builds the whole graph; all nodes reach build success and output is produced → `flow-functionality/flow-execution-canvas.spec.ts`
 - [x] Stop building flow → `flow-functionality/stop-building.spec.ts`
 - [ ] A cyclic graph is refused with a cycle-specific error, and the flow stays editable afterwards (the engine's own contract; a total engine failure is caught indirectly by the 63 `@stable` specs that trigger a run, a subtle one by nothing)

--- a/docs/flow-functionality/run-flow.md
+++ b/docs/flow-functionality/run-flow.md
@@ -47,6 +47,13 @@ If this breaks, users cannot compose flows via the Run Flow component — a core
 - Step 5 (return to the main page, then open the templates modal again) reaches the
   templates modal — the flake fixed in #966 died here, before the second flow was
   ever created
+- The flow-name dropdown interaction (step 7: open → refresh → "Loading" →
+  "Select an option") completes with no overlay interception: the spec seeds
+  `langflow-assistant-discovered` before its first load (#1220 mechanism), so the
+  assistant-onboarding tooltip never arms on either editor entry, and the refresh
+  click lands on a hit point clear of the `main_canvas_controls` band even when
+  the instance's flow list is long enough to reposition the dropdown popup
+  (see the #1548 section below)
 
 ---
 
@@ -144,6 +151,52 @@ The recovery-by-page-load that helper also offers is deliberately
 **not** enabled here: everything the rest of this spec asserts lives in the flow
 built on the canvas, so discarding it would trade a clean failure at the exit for
 an inscrutable one at the Run Flow dropdown.
+
+---
+
+## Flake history — #1548 (daily 2026-08-21): flow-selector click intercepted by two overlays
+
+Hard-failed all three attempts on shard 1 — the shard that run's own liveness
+recorder measured **clean** (0 outages, 0 gunicorn `WORKER TIMEOUT`), so this is
+not the day's backend wedge. The click on
+`refresh-dropdown-list-flow_name_selected` (step 7) retried for the full 20 s
+actionability window; every retry was refused by an overlay Playwright named in
+the call log. Two distinct interceptors appeared, and per the issue they are
+attributed **separately**:
+
+**(A) `main_canvas_controls` / `canvas_controls_dropdown` — popup geometry, not
+the tooltip.** The dropdown popup is anchored to the Run Flow node and grows
+downward as the flow list populates; the refresh row rides it. Measured on
+`1.12.0.dev33` (fresh profile, the spec's own entry path): with the list not yet
+loaded the refresh row sits at y≈424, well clear of the controls bar (y 665–705);
+once the instance's list populated (56 flows) the same row landed at y≈741 —
+*past* the 720-viewport, i.e. the row crosses the controls-bar band on its way
+out as the list grows. On an instance holding a mid-size list the row parks
+inside the bar's band and the bar intercepts the click. This is the #576 overlay
+class, independent of the onboarding tooltip, and it explains why the failure is
+rare: it needs the shared CI instance's flow count to put the row in that band at
+the moment of the click.
+
+**(B) `assistant-onboarding-tooltip` — a known, already-solved suite hazard this
+spec never opted into.** NOT new upstream behaviour: the mechanism was measured
+to the millisecond in #1220 on `1.12.0.dev15` and re-confirmed identical on
+`1.12.0.dev33` for this issue (282×32 px, z-40, anchored over the controls bar
+at the bar's mount position + 10 000 ms whenever
+`localStorage["langflow-assistant-discovered"]` is unset — a fresh Playwright
+context always meets it; dismissal persists the flag per user). The suite's
+standing answer is `seedAssistantDiscovered` (`helpers/ui/assistant-onboarding.ts`,
+PR #1282) seeded **before the first navigation** — a post-load dismissal cannot
+disarm the timer (measured in #1220). This spec predates the helper and never
+adopted it, and it enters the editor **twice**, arming the 10 s timer twice per
+run. The issue's premise that the testid "is referenced nowhere in this
+repository" was stale on arrival: seven specs plus `openFlowById` already seed,
+and `expandFocusedNode` hard-fails unseeded callers.
+
+Fix shape: adopt the seed (kills B on both entries), and keep the step-7 hit
+point clear of the controls-bar band regardless of instance flow count (kills A).
+Blast radius of B beyond this spec is any fresh-context spec that mounts the
+canvas-controls bar and still interacts ≥10 s later without seeding — recorded on
+issue #1548 rather than widened here.
 
 ---
 

--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -9,6 +9,16 @@ import { zoomOut } from "../../../helpers/ui/zoom-out";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { renameFlow } from "../../../helpers/flows/rename-flow";
 import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-templates-modal";
+import { seedAssistantDiscovered } from "../../../helpers/ui/assistant-onboarding";
+
+// Before the first document load — the only moment it can work (#1220): upstream
+// snapshots the flag at canvas-controls mount and arms a 10 s timer, so a fresh
+// context meets the assistant-onboarding tooltip on EVERY editor entry, and this
+// spec enters twice. Its popper intercepted the flow-selector click in the
+// 2026-08-21 daily (#1548).
+test.beforeEach(async ({ page }) => {
+  await seedAssistantDiscovered(page);
+});
 
 // `test.fixme` lifted in #966 — the spec runs again. The recurrent flake (dailies
 // 2026-07-16 / 07-27) was the mid-test `openNewFlowTemplatesModal` call below: after
@@ -152,11 +162,16 @@ test(
         timeout: 30000,
       });
 
+      // Drag to the upper-right canvas region instead of the one-click add,
+      // which drops the node where the flow-name popup's refresh row lands in
+      // the canvas-controls band (x 668–892, y 665–705 at 1280×720) once the
+      // instance's flow list is long enough — the bar then intercepts the
+      // click (#1548, the #576 overlay class). Anchored up here, every popup
+      // hit point stays clear of that band regardless of list size.
       await page
         .getByTestId("flow_controlsRun Flow")
-        .hover()
-        .then(async () => {
-          await page.getByTestId("add-component-button-run-flow").click();
+        .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+          targetPosition: { x: 550, y: 60 },
         });
 
       await page


### PR DESCRIPTION
**Closes #1548.**

## Problem

The 2026-08-21 daily (#1544, run 32464002123) hard-failed `flow-functionality/run-flow.spec.ts` on all three attempts, on **shard 1 — the shard the run's own liveness recorder measured clean** (0 outages, 0 gunicorn `WORKER TIMEOUT`), so this is not that day's backend wedge. The click on `refresh-dropdown-list-flow_name_selected` retried for the full 20 s actionability window; every retry was refused by an overlay Playwright named in the call log. Two distinct interceptors appeared, and they are attributed **separately** (issue deliverable):

- **(A) `main_canvas_controls` / `canvas_controls_dropdown` — popup geometry, independent of the tooltip.** The flow-name popup anchors to the Run Flow node and grows downward as the flow list populates. Measured on `1.12.0.dev33` (fresh profile, the spec's own entry path): refresh row at y≈424 with the list not yet loaded → y≈741 once 56 flows populated — crossing the controls-bar band (y 665–705 at 1280×720) on its way out. A mid-size list parks the row inside the band and the bar intercepts. This is the #576 overlay class, and it explains the rarity: it needs the shared CI instance's flow count to put the row in the band at the moment of the click.
- **(B) `assistant-onboarding-tooltip` — a known, already-solved suite hazard this spec never opted into.** NOT new upstream behaviour: the mechanism #1220 measured on `1.12.0.dev15` is byte-identical on `1.12.0.dev33` (282×32 px, z-40, anchored over the controls bar at canvas-controls mount + 10 000 ms whenever `localStorage["langflow-assistant-discovered"]` is unset; dismissal persists per user, so every fresh Playwright context meets it). This spec enters the editor **twice**, arming the 10 s timer twice per run. The issue's premise that the testid "is referenced nowhere in this repository" was stale on arrival: `helpers/ui/assistant-onboarding.ts` (PR #1282) plus seven seeding specs and the `expandFocusedNode` guard already exist.

Two more issue premises corrected on the record:
- No quarantine ever landed on `main` for this failure — the spec still carried `@stable` with no `test.fixme`, so there is **nothing to lift** (the deliverable's "nothing to lift if nothing was quarantined" arm).
- `recurrence.same_signature = 1` stands: the 2026-07-27 failure was the different (already fixed, #966/LE-2019) signature.

## Fix

- **Seed the onboarding suppression** (kills B on both entries): `test.beforeEach` → `seedAssistantDiscovered(page)`, the repo-standard #1220 mechanism, registered before the first navigation. A post-load dismissal is not an alternative — upstream snapshots the flag at mount, measured in #1220.
- **Re-anchor the Run Flow node** (kills A by construction): the node now enters via sidebar `dragTo` with `targetPosition {x: 550, y: 60}` (upper-right canvas region) — the same pattern the spec already uses for Chat Input — instead of the one-click add that drops it where the popup's hit points land in the controls-bar band. Anchored up there, every dropdown hit point stays clear of the band regardless of instance flow count.

Rejected alternatives: post-load tooltip dismissal (measurably cannot disarm the timer, #1220); a shared "canvas clear of overlays" barrier (re-litigates the #1220 decision — seed-per-spec + hard-fail guard in click-heavy helpers — without new evidence).

## Scope note

No assertion changed: the pipeline build, `built successfully` toast, output-inspection echo assert, unique-name dropdown selection (#340), `leaveFlowEditor` exit (#1153) and the id-scoped API cleanup are all untouched. Tags unchanged (`@stable` stays — nothing was quarantined). Blast radius of (B) beyond this spec: any fresh-context spec that mounts the canvas-controls bar and still interacts ≥10 s later without seeding — recorded on #1548; the #1220 policy (opt-in seed + helper guard) stands, this PR is this spec adopting it.

## Validation (nightly `1.12.0.dev33`, `--retries=0 --workers=1`)

- typecheck ✅ · eslint ✅ · QA-CHECKLIST guard rules ✅ (manual bullet only)
- 3-run VALIDATE burst: `clean expected=1 unexpected=0 flaky=0 backendErrors=false` ×3 ✅
- Design run green against an **82-flow** instance list — worse geometric stress than the failing daily ✅
- Force-fail: final `toHaveValue` mutated to a wrong echo string → **failed (unexpected=1)**; revert verified (no `FF-MUTATION` marker in diff) + final green run ✅
- Zero `🚨 Backend Error:` across all runs ✅
- Scout residue cleaned: 3 scout flows deleted via API (one transient id 404 = already gone); 0 orphaned `Run Flow Target` flows on the instance ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
