### PR TITLE
test(security): quarantine the credential-export binding test for #1546

### DIFF
--- a/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
+++ b/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
@@ -296,9 +296,16 @@ test.describe("Credential secret exposure", () => {
     },
   );
 
-  test(
+  // Quarantined at triage (daily #1544): hard failure on all three attempts —
+  // `POST /api/v1/flows/download/` returns the SecretStrInput field as
+  // `load_from_db: true` with `value: null`, so the variable name the binding
+  // points at is absent from the export (the secret itself is not leaked). Same
+  // signature on the 2026-08-20 and 08-21 dailies, both outside every measured
+  // outage window. Lifting the quarantine (remove test.fixme + restore @stable)
+  // is a deliverable of #1546.
+  test.fixme(
     "the exported flow carries the credential binding, never the secret",
-    { tag: ["@stable", "@api", "@regression"] },
+    { tag: ["@api", "@regression"] },
     async ({ request }) => {
       const surfaces: Array<{ label: string; body: string }> = [];
 


### PR DESCRIPTION
Quarantines one `@stable` test at triage of daily #1544, as prevention. Not a fix — the investigation is #1546.

## What was quarantined

`tests/tests-automations/regression/security/credential-secret-exposure.spec.ts:299` — *the exported flow carries the credential binding, never the secret*

Both edits, together: `@stable` removed **and** `test.fixme` added. Tag removal alone only stops the daily; the test would keep going red on the `pr-validation.yml` impacted-specs gate, which selects by file diff rather than by tag (#871).

## Why

Hard failure on all three attempts of run [32464002123](https://github.com/oriontech-me/langflow-e2e/actions/runs/32464002123) (2026-08-21), same signature as 2026-08-20:

```
Error: POST /api/v1/flows/download/ lost the variable binding
```

The exported `SecretStrInput` field returns `load_from_db: true` with `value: null` — DB-bound, but the variable name is gone from the payload. The secret is **not** leaked (`expect(body).not.toContain(sentinel)` never fired).

The 2026-08-21 daily tripped the mass-failure guard, so the workflow auto-removed nothing. This test is on the non-environmental side of the day's mixed verdict: it ran on shard 2, which did carry the wedge, but its three attempts ran at 09:07:05 / 09:07:08 / 09:07:12 UTC — over four minutes after shard 2's last outage window closed (09:02:56) — each in under a second, each receiving a complete flow JSON and failing a `toContain` on its contents.

## Not closing #1546

Lifting the quarantine (remove `test.fixme` + restore `@stable`) is a deliverable **of** #1546, so this PR deliberately carries no auto-close keyword.

Refs #1546, #1544

🤖 Generated with [Claude Code](https://claude.com/claude-code)