### PR TITLE
test(core-components): quarantine the Human Input custom-action test for #1547

### DIFF
--- a/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
+++ b/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
@@ -191,8 +191,14 @@ test.describe("Human Input node configuration (HITL branch handles)", () => {
     },
   );
 
-  test("adding a custom User Action creates its branch handle without a reload",
-    { tag: ["@stable", "@components", "@ui-ux"] },
+  // Quarantined at triage (daily #1544): recurrent flake — the custom action's
+  // own edit row `action-edit-<name>` never enters the DOM (the call log reads
+  // "element(s) not found", not hidden), so the test never reaches the branch
+  // handle it is named for. Same signature on the 2026-08-13 and 08-21 dailies;
+  // on 08-21 it ran on shard 3, which measured zero backend outages. Lifting the
+  // quarantine (remove test.fixme + restore @stable) is a deliverable of #1547.
+  test.fixme("adding a custom User Action creates its branch handle without a reload",
+    { tag: ["@components", "@ui-ux"] },
     async ({ page }) => {
       await test.step("Add a Human Input node with its two default branches", async () => {
         await addHumanInputNode(page);


### PR DESCRIPTION
Quarantines one recurrent flake at triage of daily #1544, as prevention. Not a fix — the investigation is #1547.

## What was quarantined

`tests/tests-automations/regression/core-components/human-input-node-config.spec.ts:194` — *adding a custom User Action creates its branch handle without a reload*

Both edits, together: `@stable` removed **and** `test.fixme` added. Tag removal alone only stops the daily; the test would keep going red on the `pr-validation.yml` impacted-specs gate, which selects by file diff rather than by tag (#871).

## Why

Recurrent under the same signature on 2026-08-13 and 2026-08-21 (run [32464002123](https://github.com/oriontech-me/langflow-e2e/actions/runs/32464002123)), failing attempt 0 and passing on retry both times:

```
Locator: getByTestId('action-edit-Request Changes')
Expected: visible
Timeout: 15000ms
Error: element(s) not found
```

`element(s) not found` rather than hidden — the row never entered the DOM, so the test never reached the branch handle it exists to check.

The 2026-08-21 daily tripped the mass-failure guard, but the guard suppresses the automatic `@stable` removal that applies to **hard failures**; the flake criterion has no guard-day exemption (`CONTRIBUTING.md` → *Triage protocol*). The day's environmental verdict does not cover this test either way: it ran on **shard 3**, measured at 0 outages / 0 % down, with no gunicorn `WORKER TIMEOUT` in its job log.

The recorded signature is the most generic string Playwright emits, so the recurrence claim rests on the second shared dimension — both occurrences are the same test at the same line in the same file. On 2026-08-13 the file's sibling at `:223` flaked with the same signature in the same run; #1547 is directed to check that rather than assume it.

## Not closing #1547

Lifting the quarantine (remove `test.fixme` + restore `@stable`) is a deliverable **of** #1547, so this PR deliberately carries no auto-close keyword.

Refs #1547, #1544

🤖 Generated with [Claude Code](https://claude.com/claude-code)