### PR TITLE
test(flow-functionality): quarantine the Run Flow test for #1548

### DIFF
--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -22,9 +22,16 @@ import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-
 // the product fix itself landed upstream in langflow#14349 (*stop flow route request
 // storm*), whose files are present on `release-1.12.0`, so `@stable` is restored here
 // after re-validation on `1.12.0.dev23` (#966). See docs/flow-functionality/run-flow.md.
-test(
+// Quarantined at triage (daily #1544): hard failure on all three attempts — the
+// click on `refresh-dropdown-list-flow_name_selected` is refused by two overlays
+// taking the pointer events, `main_canvas_controls` and an
+// `assistant-onboarding-tooltip` popper this repository references nowhere. It
+// ran on shard 1, which the in-run liveness recorder measured at zero outages,
+// so the day's mass-failure verdict does not cover it. Lifting the quarantine
+// (remove test.fixme + restore @stable) is a deliverable of #1548.
+test.fixme(
   "user should be able to use Run Flow without any issues",
-  { tag: ["@stable", "@release", "@workspace", "@api", "@regression"] },
+  { tag: ["@release", "@workspace", "@api", "@regression"] },
   async ({ page, request }) => {
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });


### PR DESCRIPTION
Quarantines one `@stable @release` test at triage of daily #1544, as prevention. Not a fix — the investigation is #1548.

## What was quarantined

`tests/tests-automations/regression/flow-functionality/run-flow.spec.ts:25` — *user should be able to use Run Flow without any issues*

Both edits, together: `@stable` removed **and** `test.fixme` added. Tag removal alone only stops the daily; the test would keep going red on the `pr-validation.yml` impacted-specs gate, which selects by file diff rather than by tag (#871).

**Read this one before approving: the test is `@release`, so `test.fixme` takes it out of the release lane too**, not just the daily. That is what the primitive does, and it is why lifting the quarantine is a deliverable of #1548 rather than a nice-to-have.

## Why

Hard failure on all three attempts of run [32464002123](https://github.com/oriontech-me/langflow-e2e/actions/runs/32464002123) (2026-08-21):

```
TimeoutError: locator.click: Timeout 20000ms exceeded.
```

The element was never the problem — `refresh-dropdown-list-flow_name_selected` resolved and reported visible, enabled and stable. Every click retry was refused by an overlay Playwright named, and there were **two** of them in one call log:

- `<div data-testid="main_canvas_controls"> subtree intercepts pointer events` — the hazard #576 recorded;
- `<div role="dialog" data-state="open" data-testid="assistant-onboarding-tooltip">` from a `data-radix-popper-content-wrapper` subtree.

`grep -rn "onboarding" tests/ scripts/` returns nothing: the second overlay is a Langflow surface this suite has never accounted for.

## Why it was filed on a guard day at all

The 2026-08-21 daily tripped the mass-failure guard, so the workflow auto-removed nothing, and the guard-day rule would ordinarily **note** a today-only cluster rather than file it. That rule's premise — a mass-failure day is environment-wide, so a today-only failure is collateral — is measurably false here: the test ran on **shard 1**, the one shard the in-run liveness recorder measured at **0 outages / 0 % down**, with **zero** gunicorn `WORKER TIMEOUT` lines against four in each of shards 2 and 4. Nothing timed out waiting for the backend; the click was refused, repeatedly, by something rendered on top of it.

Context, recorded so it is not mistaken for the cause: shard 1's `Collect models` step did fail (the `openai` collector never reached the configured state within 60 s of Save). This test declares no provider and resolves no model.

## Not closing #1548

Lifting the quarantine (remove `test.fixme` + restore `@stable`) is a deliverable **of** #1548, so this PR deliberately carries no auto-close keyword.

Refs #1548, #1544

🤖 Generated with [Claude Code](https://claude.com/claude-code)