### PR TITLE
test(security): quarantine the export-binding test — upstream #14639 nulls load_from_db bindings on flow download (#1546)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -890,7 +890,7 @@
 - [x] A flow run using a Credential-type global variable does **not** render the secret value
       in the trace detail (`langflow-ai/langflow#7313` — TracingService exposing secrets)
       → security/credential-secret-exposure.spec.ts
-- [x] The same secret is absent from the exported flow JSON
+- [!] The same secret is absent from the exported flow JSON
       → security/credential-secret-exposure.spec.ts
 - [x] The same secret is absent from the API response of a run
       → security/credential-secret-exposure.spec.ts

--- a/REGRESSIONS.md
+++ b/REGRESSIONS.md
@@ -107,8 +107,9 @@ moment a ticket is filed. Not counted in the indicator.
 
 | Found | Area / Test | Regression | Severity | Report |
 |-------|-------------|------------|----------|--------|
+| 2026-08-21 | security · credential-secret-exposure.spec.ts | `POST /api/v1/flows/download/` nulls `load_from_db` bindings alongside literal secrets (upstream PR #14639): exported `SecretStrInput` comes back `value: null` with the variable name absent, so export→import silently unbinds every credential. `GET /api/v1/flows/{id}` keeps the binding. | Medium | [#1546](https://github.com/oriontech-me/langflow-e2e/issues/1546) · `docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md` |
 
-*(none — the file-attachment wipe was promoted to the Ledger on 2026-08-13 when
+*(the file-attachment wipe was promoted to the Ledger on 2026-08-13 when
 LE-2208 was filed; the project-delete 500 on 2026-07-28 when LE-2020 was.)*
 
 ## Not listed — validated non-regression

--- a/docs/security/credential-secret-exposure.md
+++ b/docs/security/credential-secret-exposure.md
@@ -27,6 +27,8 @@ No **functional** tag applies: the tag table has no security area, and the sibli
 
 `@stable` ships with the first delivery, mirroring the sibling security spec: the file is pure API (no browser, no LLM, no provider key, ~10 s for all three tests), so it costs the daily almost nothing and cannot fail for a provider-outage reason. It is **not** `@destructive` — it creates and deletes only its own flow, its own two global variables and its own API key.
 
+**Test 2 currently runs without `@stable`** — quarantined via `test.fixme` against the upstream export regression tracked by issue #1546 (see the note on Test 2 below). Tests 1 and 3 keep `@stable`.
+
 The three `QA-CHECKLIST.md` §17.3 bullets therefore become `[x]`.
 
 ---
@@ -63,6 +65,21 @@ The spec runs **3 tests** in a serial describe via Playwright's `request` fixtur
 6. Assert the same on `GET /api/v1/monitor/transactions?flow_id={flowId}` — the per-vertex record the same Traces panel renders alongside the spans. Neither sentinel appears there either. The masking on that path is name-based and therefore *different* (`secret_token` reads `***R...D***`; `gateway_pin` shows the unresolved variable **name**), so the assertion is on the sentinel's absence, not on a mask shape that would drift.
 
 **Test 2 — the export carries the binding, never the secret** *(`@api @regression`)*
+
+> **Quarantined (`test.fixme`, `@stable` removed) — upstream regression, tracked by issue #1546.**
+> Since upstream PR `langflow-ai/langflow#14639` (merged 2026-08-19 into `release-1.12.0`),
+> `POST /api/v1/flows/download/` nulls **every** `password=True` field — including a
+> `load_from_db` binding, whose `value` is the global-variable *name*, not the secret.
+> The exported flow comes back `{"load_from_db": true, "value": null}` and the variable
+> name is absent from the whole payload, so step 2 below fails deterministically
+> (5/5 on `1.12.0.dev33`) while `GET /api/v1/flows/{id}` keeps the binding.
+> This spec's expectation is **unchanged**: the export contract this doc pins is the
+> round-trippable one (binding preserved), and the scrubber itself has a
+> binding-preserving mode (`variable_references`, used by deployment packaging) that
+> the export call site does not use. Full analysis and reproduction:
+> `docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md`.
+> Lifting the quarantine (remove `test.fixme`, restore `@stable`) is a deliverable of
+> #1546, due when the upstream fix lands in `langflowai/langflow-nightly:latest`.
 
 1. `POST /api/v1/flows/download/` with `[flowId]` — the endpoint behind the UI's Export/Download action — and assert `200`.
 2. Assert the exported payload contains **both variable names**. The export must keep the *binding* — a flow exported without it would import as a broken flow, so this is the control that step 3 is not passing because the field vanished. The check is textual here because a multi-id export answers with an archive rather than a flow object, and the variable name is the binding's observable in both shapes.

--- a/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
@@ -1,0 +1,117 @@
+# `POST /api/v1/flows/download/` drops the credential variable binding — exported flows no longer import with their secrets bound
+
+| Field | Value |
+|---|---|
+| **Filed upstream** | _pending_ (draft below; owner: QA team) |
+| **Repo issue** | [oriontech-me/langflow-e2e#1546](https://github.com/oriontech-me/langflow-e2e/issues/1546) (spun out of daily triage #1544) |
+| **Affected builds** | `langflowai/langflow-nightly:latest` since `2026-08-20` (first nightly cut after the causing merge); reproduced 5/5 on `1.12.0.dev33` |
+| **Introduced by** | [langflow-ai/langflow#14639](https://github.com/langflow-ai/langflow/pull/14639) — *fix(security): scrub all secret fields on flow and project export* (commit `fc3810da0`, merged 2026-08-19T17:36Z into `release-1.12.0`) |
+| **Component** | `src/backend/base/langflow/api/v1/flows_helpers.py` → `_build_flows_download_response` → `langflow/utils/flow_secrets.py` (`strip_flow_secrets` / `strip_secret_field_values_in_place`) |
+| **Sibling surfaces** | `GET /api/v1/projects/download/{project_id}` and `flow_version.strip_version_data` were moved onto the same scrubber by the same PR and share the defect |
+| **Severity** | Medium. Data-fidelity regression, **not** a secret leak: every exported flow that binds a Credential global variable to a `SecretStrInput` imports back with the binding silently destroyed (`load_from_db: true`, `value: null`), so the re-imported flow cannot resolve its credentials until each field is re-bound by hand. Backup/share/round-trip workflows are all affected; nothing in the UI warns. |
+| **Discovered by** | Langflow E2E regression suite — `tests/tests-automations/regression/security/credential-secret-exposure.spec.ts` (test: *the exported flow carries the credential binding, never the secret*), hard-failing on the dailies of 2026-08-20 and 2026-08-21 |
+
+---
+
+## 1. Summary
+
+A `SecretStrInput` field bound to a Credential-type global variable stores the
+variable's **name** in `value` with `load_from_db: true` — the name, not the
+secret, is what the stored flow carries, and it is what an import needs to
+re-resolve the credential. Since PR #14639, `POST /api/v1/flows/download/`
+(the endpoint behind the UI's Export action) nulls that name:
+
+```json
+"secret_token": {
+  "_input_type": "SecretStrInput",
+  "load_from_db": true,
+  "password": true,
+  "type": "str",
+  "value": null
+}
+```
+
+The field is still marked DB-bound while the reference it is bound to is gone
+from the entire payload. `GET /api/v1/flows/{id}` returns the same field with
+`value: "<variable name>"` — only the export path loses it.
+
+The scrub itself is the right move (#14639 fixed real literal-secret leaks:
+`password: true` fields under non-API-key names, credential-bearing connection
+strings). The regression is that the export call site uses the scrubber's
+**anonymous-consumer default**, which — per its own docstring — nulls
+"including the names of global variables bound via `load_from_db`" and is "the
+right contract for anonymous consumers such as the public-flow endpoint". The
+owner exporting their own flow is not an anonymous consumer, and the variable
+name is not a secret (the stored flow and `GET /api/v1/flows/{id}` have always
+carried it).
+
+## 2. Why this looks unintended rather than a contract change
+
+1. **The PR's stated scope is literal secrets.** The body describes the two
+   leaking classes (`password: true` fields with ordinary names; connection
+   strings). Variable bindings / `load_from_db` are not mentioned anywhere.
+2. **The PR's test file never covers the bound case.** `src/backend/tests/unit/api/v1/test_export_secret_sanitization.py`
+   (212 lines) contains zero occurrences of `load_from_db` — the case where
+   `value` holds a variable *name* was never pinned in either direction.
+3. **The scrubber already has the correct mode.** `strip_secret_field_values_in_place`
+   accepts `variable_references`; when passed, fields the runtime resolves from
+   the database keep their variable-name values (and the names are collected
+   for a required-variables manifest). Deployment packaging (#14437) uses it
+   for exactly the round-trip reason: "a deployment target can re-resolve the
+   credential it provisions under that name". The export call site simply does
+   not pass it.
+
+## 3. Reproduction (API, deterministic)
+
+Against any nightly ≥ 2026-08-20 (reproduced on `1.12.0.dev33`,
+`LANGFLOW_AUTO_LOGIN=true`):
+
+```bash
+BASE=http://localhost:7860
+TOKEN=$(curl -s $BASE/api/v1/auto_login | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')
+AUTH="Authorization: Bearer $TOKEN"
+
+# 1. Credential-type global variable
+VAR_ID=$(curl -s -X POST $BASE/api/v1/variables/ -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"name":"repro-binding","value":"not-the-point","type":"Credential","default_fields":[]}' \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])')
+
+# 2. Any flow whose template carries a SecretStrInput bound to it, e.g.:
+#    "my_secret": { "_input_type": "SecretStrInput", "password": true,
+#                   "load_from_db": true, "value": "repro-binding", ... }
+#    (in the UI: drop any provider component, click the key icon on its secret
+#     field, pick the variable — then grab the flow id from the URL)
+
+# 3. Compare the two read surfaces
+curl -s $BASE/api/v1/flows/$FLOW_ID -H "$AUTH" | grep -c repro-binding          # -> 1  (binding kept)
+curl -s -X POST $BASE/api/v1/flows/download/ -H "$AUTH" \
+  -H 'Content-Type: application/json' -d "[\"$FLOW_ID\"]" | grep -c repro-binding  # -> 0  (binding gone)
+```
+
+Observed on `1.12.0.dev33`: the download body carries
+`"load_from_db": true, "value": null` and the string `repro-binding` appears
+nowhere in it; the flow read returns `"value": "repro-binding"`. Import of the
+downloaded JSON therefore produces a flow whose secret fields are unbound.
+
+UI-level equivalent: create any flow with a provider component, bind a
+Credential global variable to its API-key field, use **Export** — open the
+downloaded JSON and the binding is gone.
+
+## 4. Expected behavior
+
+The export keeps the variable **name** for `load_from_db` fields (as it did
+before #14639, and as `GET /api/v1/flows/{id}` still does) while continuing to
+null literal secrets. That is precisely the scrubber's `variable_references`
+mode; the fix is plausibly one line per call site
+(`_build_flows_download_response`, `download_project_flows`,
+`strip_version_data` — plus test coverage for the bound case).
+
+## 5. Suite impact while open
+
+- `security/credential-secret-exposure.spec.ts` — test *"the exported flow
+  carries the credential binding, never the secret"* is quarantined
+  (`test.fixme`, `@stable` removed) referencing this document and issue #1546.
+  The spec's contract is unchanged; the quarantine lifts when the upstream fix
+  lands in `langflowai/langflow-nightly:latest`.
+- The serial sibling *"the run resolves the credential without echoing it"*
+  resumes running (it was cascade-skipped while the export test hard-failed).

--- a/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
+++ b/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
@@ -296,9 +296,23 @@ test.describe("Credential secret exposure", () => {
     },
   );
 
-  test(
+  // Quarantined at #1546 (dailies of 2026-08-20 and 08-21): upstream PR
+  // langflow-ai/langflow#14639 (fc3810da0, merged 2026-08-19 into
+  // release-1.12.0) moved POST /api/v1/flows/download/ onto the metadata-driven
+  // scrubber WITHOUT its binding-preserving `variable_references` mode, so every
+  // password=True field is nulled — including a load_from_db binding, whose
+  // value is the variable NAME, not the secret. The export comes back
+  // `{load_from_db: true, value: null}` and the round-trip breaks; GET
+  // /api/v1/flows/{id} keeps the binding (asserted below, still green). The
+  // spec's contract is unchanged — this is a product regression, 5/5 on
+  // 1.12.0.dev33: see docs/upstream-bugs/
+  // UPSTREAM-BUG-flow-export-drops-credential-binding.md. Being `fixme` (a
+  // skip, not a failure) lets the serial sibling below run again. Lifting the
+  // quarantine (remove test.fixme + restore @stable) is a deliverable of #1546,
+  // due when the upstream fix lands in langflowai/langflow-nightly:latest.
+  test.fixme(
     "the exported flow carries the credential binding, never the secret",
-    { tag: ["@stable", "@api", "@regression"] },
+    { tag: ["@api", "@regression"] },
     async ({ request }) => {
       const surfaces: Array<{ label: string; body: string }> = [];
 


### PR DESCRIPTION
## Context

Dedicated daily-failure issue #1546 (spun out of triage #1544): `security/credential-secret-exposure.spec.ts` test *"the exported flow carries the credential binding, never the secret"* hard-failed 3/3 on the 2026-08-20 and 2026-08-21 dailies with the same non-transport signature — `POST /api/v1/flows/download/` answers a complete flow JSON whose `SecretStrInput` reads `{load_from_db: true, value: null}`, with the bound variable's name absent from the whole payload.

**This PR does not close #1546** — the issue stays open until the upstream fix lands in `langflowai/langflow-nightly:latest` and the quarantine is lifted. Tracked by #1546.

## Verdict: langflow-regression (user-confirmed)

- **Cause:** upstream [langflow-ai/langflow#14639](https://github.com/langflow-ai/langflow/pull/14639) (*fix(security): scrub all secret fields on flow and project export*, commit `fc3810da0`, merged 2026-08-19T17:36Z into `release-1.12.0`). The export call site moved onto `strip_flow_secrets()` → `strip_secret_field_values_in_place()` **without** `variable_references` — the scrubber's binding-preserving mode (used by deployment packaging). In that default mode every `password=True` field is nulled, including `load_from_db` bindings whose `value` is the variable **name**, not the secret.
- **Why unintended, not a contract change:** the PR's stated scope is literal secrets (oddly-named `password` fields, credential-bearing connection strings); its 212-line test file has **zero** `load_from_db` coverage; and the scrubber already ships the correct mode that the call site does not use. Consequence: export→import silently unbinds every credential.
- **Divergence:** `GET /api/v1/flows/{id}` keeps the binding (the spec's structural assert on it still passes) — only the download path loses it. Sibling surfaces from the same PR (`GET /api/v1/projects/download/{project_id}`, `strip_version_data`) share the pattern.
- **Timeline:** first nightly after the merge = 2026-08-20 = first failure; explains both occurrences.
- Full analysis + reproduction + upstream-ticket draft: `docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md`. Upstream ticket will be filed by the team from that draft (REGRESSIONS.md row stays under Candidates until then).

## Evidence

- Manual API repro on `1.12.0.dev33` and re-confirmed on `1.12.0.dev34` (today's nightly): download body `value=None`, variable name absent; flow read `value='<varname>'`.
- Pre-fix baseline via pipeline `repro-run`: **5/5 failed (100%)**, 0 environment voids — deterministic, matching the daily's 3/3.

## Change

- `credential-secret-exposure.spec.ts`: the export test goes `test.fixme` with `@stable` removed (`["@api", "@regression"]` kept), quarantine comment naming cause, signature and lift deliverable — the #1552 pattern. `fixme` is a skip, not a failure, so the serial sibling *"the run resolves the credential without echoing it"* (cascade-skipped since 08-20) **resumes running**.
- `docs/security/credential-secret-exposure.md`: quarantine note on Test 2 (contract unchanged).
- `docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md`: new — the ticket text.
- `QA-CHECKLIST.md`: §17.3 manual bullet → `[!]` (generated Phase 0 line self-removes on merge when `@stable` drops).
- `REGRESSIONS.md`: Candidates row (indicator block untouched, `npm run regressions:summary` reports up to date).

## Validation

- VALIDATE burst (pipeline): 3× `--retries=0 --workers=1` on the touched spec against a tracing-enabled dev34 probe — **3/3 clean, `expected=2 unexpected=0`** (tests 1 and 3 green, test 2 fixme-skipped). No `🚨 Backend Error` logged.
- Force-fail (both active tests, mutation + verified red + revert): test 1 trace-mask assert mutated to `"WRONG-MASK"` → failed on exactly that assert; test 3 `resolved_len` expectation off-by-one → failed on exactly that assert. `grep -c FF-MUTATION` = 0 after revert.
- `npm run typecheck` 0 errors; `npm run lint` 0 errors.
- Cleanup audit: `GET /api/v1/flows/` and `/variables/` on both instances after all runs — zero orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)