### PR TITLE
test(security): cover the tweaks floor on the graph run path (#1567)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -900,6 +900,24 @@
 - [x] Tweak values passed to `POST /api/v1/run/{id}` cannot reach template fields as
       executable input (`langflow-ai/langflow#9319`, `#8672`)
       → security/tweaks-injection.spec.ts
+- [-] The floor holds on the **graph run path** — `POST /api/v2/workflows` `mode=stream` refuses a
+      `global_imports` and a `python_code` tweak on a code-execution node, and the refusal is
+      **named** in the stream (an `event: "error"` frame carrying `TweakRefusedError` and the
+      refused key) rather than being a bare failure. Both failure directions are asserted because
+      they are opposite: acceptance is caught causally (the author's code branches on whether the
+      widened module is in scope) and an unattributable refusal by requiring the frame to name the
+      key. This is the path `langflow-ai/langflow#14538` says previously accepted tweaks the sync
+      mode refused → security/tweaks-graph-path-floor.spec.ts
+- [-] The same on `mode=background`, read from `GET /api/v2/workflows/{job_id}/events` — kept as
+      its own bullet because `#14538` names both modes and they can regress independently
+      → security/tweaks-graph-path-floor.spec.ts
+- [-] `mode=sync` refuses a protected tweak **without ever answering 2xx**, and the refused request
+      leaves the flow still running the author's code. Asserted shape-agnostically on purpose: the
+      status body is a generic `500` on `1.12.0.dev37` where `POST /api/v1/run` returns
+      `422 TWEAKS_REFUSED` naming the field, and the property pinned here holds under both, while
+      still catching the failure that matters — a refusal answering `200` because the tweak took
+      effect or was dropped and the run proceeded anyway. The shape difference is recorded in the
+      spec doc → security/tweaks-graph-path-floor.spec.ts
 
 ---
 

--- a/docs/security/tweaks-graph-path-floor.md
+++ b/docs/security/tweaks-graph-path-floor.md
@@ -1,0 +1,156 @@
+# Tweaks — the protected-field floor on the graph run path
+
+**Last validated:** Langflow 1.12.0.dev37 — `langflowai/langflow-nightly@sha256:b672ab7e91981c6f1719b2932bfa7e2255324d4cfac18b7fedf0dbf5722761de`, the digest both `:latest` and `:1.12.0.dev37` resolve to (`docker manifest inspect`); upstream revision `50340f2a4322eca624b7ef5684237d87f863fc1b`.
+
+---
+
+## What this test validates *(required)*
+
+Validates that **the protected-field floor is a property of the tweaks contract, not of one endpoint**, and that **a refusal is attributable on the surface the caller is using**.
+
+`security/tweaks-injection.spec.ts` covers the floor on `POST /api/v1/run/{flow_id}`, where tweaks are applied to the graph *payload* before construction. Langflow has a second, structurally different path: the **streaming** and **background** run modes build the `Graph` first and then push overrides onto built vertices (`process_tweaks_on_graph` / `apply_tweaks_on_vertex`). Upstream `langflow-ai/langflow#14538` (`4f3b9f3772`, 2026-08-21) records that this path *"filtered only the literal key `code` in `api/build.py`, so it accepted tweaks the sync mode refused: a `global_imports` override widening the exec sandbox was applied"*, and adds the enforcement plus `except TweakRefusedError` re-raises at three call sites *"because both call sites previously swallowed the refusal into a 500"*. Nothing in this suite exercises that path.
+
+Two registered protections are asserted (`CODE_EXECUTION_FIELD_NAMES` on a `CODE_EXECUTION_COMPONENT_TYPES` node), and they fail independently:
+
+- **`python_code`** — the Python Interpreter's executable input. A run-time override never passes through the build-time sanitizer that governs whose component source may execute (`prepare_flow_build_for_user`).
+- **`global_imports`** — the documented sandbox boundary. `get_globals()` builds the exec namespace from it and `validate_code_safety()` rejects inline `import`, so a module is reachable from the author's code **only** if it is on this list. Widening it is an escalation, not a configuration change.
+
+The floor is asserted in **both** directions on every covered surface, because the two failure modes are opposite and a spec catching one can miss the other:
+
+- **acceptance** — the tweak takes effect. Caught causally: the author's `python_code` branches on whether the widened module is in scope and prints one of two sentinels, so the run itself names which value was in effect.
+- **an unattributable refusal** — the value is dropped, or the request fails, without the caller being told which key was refused and why. On a security path that is a reporting failure with teeth: a caller who cannot tell a refused tweak from a server fault retries, and believes a value took effect when it did not.
+
+Every refusal is paired with a **benign** tweak on the same surface and the same request shape, because a spec asserting only "the sentinel is absent" passes just as well when the tweaks mechanism is dead altogether.
+
+---
+
+## Tags *(required)*
+
+`@api` `@regression`
+
+No **functional** tag applies: the tag table has no security area, and the sibling `security/` specs (`tweaks-injection`, `code-execution-endpoints`, `ssrf-url-validation`) also carry only cross-cutting tags. `@api` marks the layer; `@regression` is what issue #1567 asks for.
+
+**No `@stable` in this delivery**, for the ordinary reason: it is a new spec awaiting a validation cycle, so its checklist bullets are `[-]`. The lane profile is a good fit and promotion is a one-line follow-up — pure API, no browser, no LLM, no provider key, three tests in ~4 s, and it cannot fail for a provider-outage reason. Nothing in the file is quarantined.
+
+Not `@destructive`: the file creates and deletes only its own two flows and sets no instance-wide state. (A spec for `LANGFLOW_TWEAKS_POLICY` *would* be instance-global — that surface is scoped out below.)
+
+---
+
+## Measured contract — one table, four surfaces *(required reading)*
+
+Measured on the digest above, against the container's **own** published port with the identity asserted (`GET /api/v1/version` → `1.12.0.dev37` / `Langflow Nightly`) before every run. Flow: `Python Interpreter -> Chat Output`, author `global_imports = "math"`, author `python_code` = the two-sentinel probe.
+
+| tweak on the interpreter node | `POST /api/v1/run/{id}` | `/api/v2/workflows` `sync` | `/api/v2/workflows` `stream` | `/api/v2/workflows` `background` |
+|---|---|---|---|---|
+| `global_imports: ["os"]` (protected) | `422` · `code: TWEAKS_REFUSED` · `fields: ["global_imports"]` | **`500` · `code: INTERNAL_SERVER_ERROR` · `"An unexpected error occurred."`** | `200` + an `event: "error"` frame naming `TweakRefusedError` and the refused key | `200` + the same frame on `GET /{job_id}/events` |
+| `python_code` (protected) | `422` · `fields: ["python_code"]` | **`500`, same generic body** | same as above | same as above |
+| `sender_name` (benign control) | `200`, applied | `200`, applied | `200`, applied | `200`, applied |
+| none (control) | `200`, author value | `200`, author value | `200`, author value | `200`, author value |
+
+**The floor holds on all four surfaces** — no protected tweak was ever applied, on any surface, in any policy state. The graph path enforces it, which is what `#14538` claims and what this spec pins so a regression cannot return it silently.
+
+**`mode=sync` refuses, but reports it as a generic `500`.** The `TWEAKS_REFUSED` code and the refused field names — which the v1 endpoint returns for the identical request, and which the app-level handler exists to produce — are gone, so the caller cannot separate "my request was refused" from "the server failed" and will retry a request that can never succeed. Mechanism: `TweakRefusedError` is deliberately not an `HTTPException` (`lfx/exceptions/tweaks.py` says so — library callers see a plain Python exception), so it lands in the catch-all `except Exception -> 500` arm of `langflow/api/v2/workflow.py`'s inline sync handler and never reaches the app-level handler in `main.py`. The re-raise `#14538` added at `workflow_execution.py:704` is present and correct; it hands the exception to a router that swallows it.
+
+**Test 3 asserts this surface shape-agnostically, and that is a deliberate scope choice rather than a gap.** The property it pins — a refusal must never answer `2xx` — is true under the current `500` and equally true under the `422` the code intends, so the test is green in both worlds while still catching the failure this file exists for: a refusal that answers `200`, whether because the tweak took effect or because it was dropped and the run proceeded anyway. Pinning `422` would ship a red test for a reporting difference; pinning `500` would bless it. The difference between the two statuses is real but it is an API-contract cost, not a security one, and it is recorded here rather than asserted.
+
+The graph path's `200`-plus-error-event is **not** a defect and is deliberately asserted as-is: `langflow/api/build.py`'s own comment records that streaming and background callers run the build in their own task, so a refusal is reported as an error event on an already-committed `200`. Enforcement holds either way. The frame carries the refusal in `content_blocks[0].text` (`Refused tweak keys ['global_imports']: The field is protected and keeps the value set by the flow author.`) and again under `reason` (`**TweakRefusedError**`), which is what makes it attributable rather than a bare failure.
+
+### Two further measurements, recorded because they answer #1567 and cost more to repeat than to keep
+
+- **`LANGFLOW_TWEAKS_POLICY` is enforced, and the floor outranks the flow author's allowlist.** With `off`, *every* tweak is refused — including the benign one — with `message: "This deployment does not accept tweaks."`. With `declared` on a flow that marks fields `api_editable`, a marked **benign** field (`sender_name`) is applied while a marked **protected** field (`global_imports`) is still refused. That is the security-relevant half of the feature: an author cannot opt a code or sandbox field into the API by toggling a flag. One observation, not asserted anywhere: the refusal `message` is chosen by policy rather than by which layer refused, so under `declared` a floor refusal is explained as *"This flow declares which fields the API may set"* even when the field **is** marked editable.
+- **An invalid value fails closed.** `LANGFLOW_TWEAKS_POLICY=bogus-typo` raises `ValidationError: … tweaks_policy Input should be 'permissive', 'declared' or 'off'`; the container exits `1` after ~10 s and never serves. The `_resolve_tweak_policy()` fallback to `permissive` is real in code but unreachable through the environment, because pydantic rejects the value first — it applies only to a library caller that sets the setting programmatically. This refutes the premise in #1567 that a typo silently widens the policy.
+
+### A measurement trap this spec was written through, worth carrying
+
+The first pass of this work was measured against `http://localhost:7866`, which on this machine is **not** the container that `docker run -p 7866:7860` published: an SSH tunnel from a parallel session holds `*:7860`, `*:7865`, `*:7866` and `*:7891`, and another process holds `127.0.0.1:7866`, so `localhost` resolved to a different Langflow entirely. Every conclusion from that pass was wrong in the same direction — it reported the floor unenforced on the graph path, the policy inert, and source instrumentation never executing. Three signals said so and were each explained away individually: `GET /api/v1/version` answered `1.12.0` / `package: "Langflow"` where the nightly must answer `.devNN` / `"Langflow Nightly"`; a container that had exited `1` still "answered" on its port; and the instance held flows nobody in this session created. **Check `lsof -iTCP:<port> -sTCP:LISTEN` before publishing, and assert the version endpoint's `package` and `version` before trusting a single measurement** — which is what the probe scripts and this spec's own preflight now do.
+
+---
+
+## Step by step *(required)*
+
+The spec runs **3 tests** via Playwright's `request` fixture. No browser, no LLM, no provider key, no API key (`POST /api/v2/workflows` authenticates with the Bearer). Two flows are created in `beforeAll` and deleted in `afterAll`.
+
+**Setup (`beforeAll`)**
+
+1. `getAuthToken(request)` → Bearer for every call.
+2. `createPythonInterpreterFlowViaApi(request, { Authorization: bearer }, { authorCode })` — the existing helper builds `Python Interpreter -> Chat Output` from the **live** catalog (`GET /api/v1/all`). `authorCode` is the causal probe:
+
+   ```python
+   try:
+       print("WIDENED:" + os.name)
+   except NameError:
+       print("AUTHOR-<unique>")
+   ```
+
+   Inline `import` is rejected by `validate_code_safety()`, so `os` is in scope only if `global_imports` was widened.
+3. The stored `global_imports` is read back and asserted **not** to contain `os` — the whole probe is vacuous otherwise, and a template default change upstream must fail here rather than silently.
+4. `createRunnableChatFlowViaApi(request, { Authorization: bearer })` — the benign control, whose `ChatInput-b6UCc.input_value` tweak is visible in the produced text on all three v2 modes.
+
+**Teardown (`afterAll`)** — both flows deleted id-scoped with the `afterAll`'s own `request`, in nested `try/finally` so a failure in one cannot skip the other. No orphan survives the file.
+
+---
+
+**Test 1 — `mode=stream` refuses a protected tweak, and says so** *(`@api @regression`)*
+
+1. `POST /api/v2/workflows` with `mode: "stream"` and `tweaks: { <pythonNodeId>: { global_imports: ["os"] } }`; assert `200` (the stream is committed before the build runs).
+2. Parse the body with `parseStreamEvents()` and assert an `event: "error"` frame exists whose serialized text names both `TweakRefusedError` and the refused key `global_imports` — the refusal is attributable, not a bare failure.
+3. Assert `WIDENED:` appears nowhere in the stream: the sandbox was not widened, in the one place a silent acceptance would show.
+4. Repeat 1–3 for `python_code`, asserting the caller's sentinel never appears.
+5. **Control, same surface:** the benign `input_value` tweak on the chat flow produces that value in the `add_message` text and emits **no** error frame; the same call with no tweaks produces the flow's stored value. Without this, steps 2–4 pass equally well against a dead mechanism.
+
+**Test 2 — `mode=background` refuses it too, and says so** *(`@api @regression`)*
+
+Same five steps, with the events read from `GET /api/v2/workflows/{job_id}/events` after the submit returns a `job_id`. Kept as its own test because `#14538` names both modes and they can regress independently.
+
+**Test 3 — `mode=sync` refuses a protected tweak without ever answering `2xx`** *(`@api @regression`)*
+
+1. `POST /api/v2/workflows` with `mode: "sync"` and the `global_imports` tweak; assert the status is `>= 400`. A `2xx` here means the tweak either took effect or was dropped without telling the caller, and both are the failures this file exists for. The body's shape is deliberately not pinned — see above.
+2. Repeat for `python_code`.
+3. **The refusal left nothing behind:** a subsequent run with no tweaks produces the author's sentinel and never `WIDENED:`, so a refused request did not half-apply into the cached graph.
+4. **Control:** the benign tweak on the same surface answers `200` and takes effect.
+
+---
+
+## Validation criterion *(required)*
+
+The spec passes only when, on each covered surface, **no protected tweak takes effect**, **the refusal names itself and the key**, and **a benign tweak on that same surface still applies**. A run where the benign control did not apply fails, because it measured nothing; a stream carrying `WIDENED:` fails; an error frame that does not name the refused key fails.
+
+The file fails for the right reason in both directions: relaxing an assertion cannot make it pass while the control must still apply, and the day `mode=sync` returns its `422`, Test 3 goes green by deleting one `.fixme`.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **`POST /api/v1/run/{flow_id}`** — owned by `security/tweaks-injection.spec.ts` and by #1566, which is adapting that file to the `422` contract this build returns. Covering it here would duplicate assertions across two files that must then change together. It is measured in the table above only as the reference the other surfaces are compared against.
+- **`LANGFLOW_TWEAKS_POLICY` and the `api_editable` allowlist.** Measured working (above), so this is a lane decision and not a product question: the setting is instance-global, cannot be set from a test, and no lane starts a container with it — so a gated spec would `skip` on every lane the suite runs, which is the failure mode #1010 exists to prevent. It is a *coverable* surface awaiting a lane, and the exact refusal reasons are recorded here so that spec does not have to re-measure them.
+- **The exact refusal shape on `mode=sync`** — `422` + `TWEAKS_REFUSED` + `fields`, as `POST /api/v1/run` returns. Measured to be a generic `500` (above) and deliberately not asserted: the difference is an API-contract cost, not a security one, and a spec pinning either number would be wrong in one of the two worlds. A one-arm addition to that router's `except` ladder would fix it, at which point Test 3 keeps passing unchanged and this entry can be tightened.
+- **The traceback in the stream's error frame.** The frame carries an absolute-path traceback (`/app/.venv/.../langflow/api/build.py`, line 564). Whether that should reach a client is governed by `expose_error_details` and is the same for every component error, so it is a separate question from the tweaks contract and is not asserted either way.
+- **Non-owner callers.** `_enforce_owner_only_tweaks` restricts tweaks to the flow's owner, so the boundary covered here is a run-time bypass of the *build-time* code policies, not a cross-tenant one. Asserting the ownership gate is a separate property and a separate spec.
+- **Whether the refusal is logged server-side.** Same reason as the sibling: an API caller cannot observe it, and asserting on container logs would couple the spec to the deployment shape.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL`, on a build that ships `POST /api/v2/workflows` with `mode` (`sync` / `stream` / `background`) — present on 1.12.x.
+- **The URL must actually be that instance.** See the measurement trap above: verify with `lsof -iTCP:<port> -sTCP:LISTEN` and by reading `GET /api/v1/version`.
+- Superuser credentials (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) for `getAuthToken`.
+- `PythonREPLComponent` present in `GET /api/v1/all` (category `utilities` — a **core** family, so it survives the `lfx-bundles` M4 shim deletion; `docs/component-distribution-policy.md`). The helper fails loudly naming the component when it is absent rather than skipping silently.
+- `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`. With it `false`, `run_python_repl()` refuses to execute at all (`ensure_code_execution_enabled`, GHSA-8qpj-27x8-pwpq) and the control's author baseline would never appear — the tests fail on the baseline assertion rather than passing vacuously. Every CI lane and both start scripts set it (#668/#746).
+- The instance must **not** be started with `LANGFLOW_TWEAKS_POLICY` set to a strict value: under `off` the benign control is refused too, and the tests would fail for the deployment's reason rather than the contract's. Nothing in the suite sets it, and an invalid value stops the instance from serving at all.
+
+---
+
+## External dependencies *(required)*
+
+- `tests/helpers/auth/get-auth-token.ts` — Bearer via `/api/v1/auto_login`; a contract change breaks `beforeAll`.
+- `tests/helpers/flows/create-python-interpreter-flow-via-api.ts` — the flow under test, built from the live catalog. Its `pythonNodeId` is the tweak key; its `authorCode` option carries the causal probe.
+- `tests/helpers/flows/create-runnable-chat-flow-via-api.ts` and `tests/assets/flows/chat-io-ok-trace-fixture.json` — the benign control. Changing the Chat Input's node id or its stored `input_value` breaks the tweak key and the baseline.
+- `tests/fixtures/flow-error-policy.ts` — `parseStreamEvents()`, reused to read the SSE bodies. Named here because it is imported for its parser, not for the gate it belongs to.
+- `src/lfx/src/lfx/processing/process.py` — `process_tweaks`, `process_tweaks_on_graph`, `apply_tweaks_on_vertex`, `_resolve_tweak_policy`, `_refusal_reason`: the enforcement `#14538` added.
+- `src/lfx/src/lfx/utils/flow_validation.py` — `is_protected_tweak_field()`, `is_tweak_refused_by_policy()`, `flow_declares_api_editable()`, `CODE_EXECUTION_COMPONENT_TYPES`, `CODE_EXECUTION_FIELD_NAMES`. The registry the spec pins; `PythonREPLComponent` or `global_imports` leaving it is exactly the regression to catch.
+- `src/lfx/src/lfx/components/utilities/python_repl_core.py` — `get_globals()` (the sandbox namespace built from `global_imports`), `validate_code_safety()` (why inline `import` cannot substitute for the allow-list), `ensure_code_execution_enabled()`.
+- `src/backend/base/langflow/main.py` — the app-level `TweakRefusedError` handler that produces the structured `422`, i.e. the shape `mode=sync` never reaches. The exception class itself lives in `lfx/exceptions/tweaks.py`, a module `#14538` **added on the `release-1.12.0` line and absent from upstream `main`** — measured: `404` on `main`, blob `e21fcaf833e7` on `release-1.12.0`, and `compare/main...4f3b9f3772` reports `diverged`. It is named in prose rather than cited as a dependency path because the guard resolves paths against `main` (#1298), and a path that is real on the line the nightly is cut from would otherwise fail a check whose purpose is to catch paths that are real nowhere. Its `refused` and `reason` fields are the text the stream-frame assertions match.
+- `src/backend/base/langflow/api/v2/workflow_execution.py` — `POST /api/v2/workflows`: the `WorkflowRunRequest` schema (`mode`, `tweaks`), the sync response shape, the `except TweakRefusedError` re-raise at the graph-build seam, and where the streaming mode hands tweaks to the v1 build path.
+- `src/backend/base/langflow/api/build.py` — `generate_flow_events` / `build_graph_and_get_order`: the graph-path call site, and the comment recording that a refusal there surfaces as a stream error event on an already-committed `200`.
+- Upstream references: `langflow-ai/langflow#14538` (the change under test) and `#9319` (the original defect the floor exists for).

--- a/tests/tests-automations/regression/security/tweaks-graph-path-floor.spec.ts
+++ b/tests/tests-automations/regression/security/tweaks-graph-path-floor.spec.ts
@@ -1,0 +1,395 @@
+import type { APIRequestContext, APIResponse } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { parseStreamEvents } from "../../../fixtures/flow-error-policy";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createPythonInterpreterFlowViaApi } from "../../../helpers/flows/create-python-interpreter-flow-via-api";
+import { createRunnableChatFlowViaApi } from "../../../helpers/flows/create-runnable-chat-flow-via-api";
+
+// The protected-field floor is a property of the tweaks contract, not of one
+// endpoint. `security/tweaks-injection.spec.ts` covers it on POST /api/v1/run,
+// where tweaks are applied to the graph PAYLOAD before construction. Langflow
+// has a second, structurally different path: the streaming and background run
+// modes build the Graph first and then push overrides onto built vertices
+// (process_tweaks_on_graph / apply_tweaks_on_vertex). Upstream
+// langflow-ai/langflow#14538 records that this path "filtered only the literal
+// key `code` in api/build.py, so it accepted tweaks the sync mode refused: a
+// `global_imports` override widening the exec sandbox was applied", and adds the
+// enforcement plus `except TweakRefusedError` re-raises at three call sites
+// "because both call sites previously swallowed the refusal into a 500".
+//
+// MEASURED on 1.12.0.dev37: the floor holds on all four run surfaces — no
+// protected tweak is applied anywhere. What differs is how the refusal REACHES
+// THE CALLER, and that is what this file pins:
+//   POST /api/v1/run        -> 422, code TWEAKS_REFUSED, fields naming the key
+//   /api/v2/workflows sync  -> 500 INTERNAL_SERVER_ERROR (the defect; Test 3)
+//   /api/v2/workflows stream/background
+//                           -> 200 plus an event:"error" frame naming
+//                              TweakRefusedError and the refused key. NOT a
+//                              defect: api/build.py records that these callers
+//                              run the build in their own task, so a refusal is
+//                              reported on an already-committed 200.
+//
+// Both failure directions are asserted on every surface, because they are
+// opposite and a spec catching one can miss the other: ACCEPTANCE is caught
+// causally (the author's code branches on whether the widened module is in
+// scope, so the run itself names which value was in effect), and an
+// UNATTRIBUTABLE refusal is caught by requiring the refusal to name itself and
+// the key. Each is paired with a benign tweak on the same surface, because "the
+// sentinel is absent" also passes when the tweaks mechanism is dead altogether.
+//
+// See docs/security/tweaks-graph-path-floor.md for the measured table, the
+// LANGFLOW_TWEAKS_POLICY findings, and the port-shadowing trap this spec was
+// written through.
+
+/**
+ * Node id of the chat fixture's Chat Input. Hardcoded for the same reason as in
+ * `tweaks-injection.spec.ts`: it is stored in the committed fixture
+ * (`tests/assets/flows/chat-io-ok-trace-fixture.json`) and the helper does not
+ * export it. Addressing by node id is deliberate — it is the mode measured to
+ * work on all three v2 run modes.
+ */
+const CHAT_INPUT_NODE_ID = "ChatInput-b6UCc";
+
+/** Printed by the author's code only when the sandbox was widened. */
+const WIDENED_PREFIX = "WIDENED:";
+
+/** A module the author's `global_imports` does not list. */
+const SANDBOX_WIDENING_TWEAK = { global_imports: ["os"] };
+
+/** The exception the refusal must be attributed to, in every surface's report. */
+const REFUSAL_MARKER = "TweakRefusedError";
+
+type StreamingMode = "stream" | "background";
+type Tweaks = Record<string, Record<string, unknown>>;
+
+/**
+ * The author's `python_code`: a causal probe rather than a fixed string.
+ *
+ * `validate_code_safety()` rejects an inline `import`, so `os` is in scope only
+ * when the protected `global_imports` was widened. The run's own output
+ * therefore names which value was in effect, which no status code does.
+ */
+function sandboxProbe(authorMark: string): string {
+  return [
+    "try:",
+    `    print("${WIDENED_PREFIX}" + os.name)`,
+    "except NameError:",
+    `    print("${authorMark}")`,
+    "",
+  ].join("\n");
+}
+
+function unique(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+/**
+ * Posts a run to the v2 endpoint.
+ *
+ * No top-level `input_value` is ever sent: it overrides the Chat Input and would
+ * mask the benign control, which is the half that proves a refusal was measured
+ * rather than a dead mechanism.
+ */
+async function postWorkflow(
+  request: APIRequestContext,
+  bearerToken: string,
+  flowId: string,
+  mode: "sync" | StreamingMode,
+  tweaks?: Tweaks,
+): Promise<APIResponse> {
+  return request.post("/api/v2/workflows", {
+    headers: { Authorization: bearerToken },
+    data: { flow_id: flowId, mode, ...(tweaks ? { tweaks } : {}) },
+  });
+}
+
+interface StreamFacts {
+  /** Every event, so an assertion can look for what must NOT be there too. */
+  events: unknown[];
+  /** The text the flow produced, from the last `add_message` event. */
+  messageText: string | null;
+  /** The serialized `event: "error"` frames, where a refusal is reported. */
+  errorFrames: string[];
+  /** The whole body, for asserting a sentinel appears NOWHERE. */
+  raw: string;
+}
+
+/**
+ * Reads a run stream.
+ *
+ * `parseStreamEvents` is reused from the flow-error policy for its parser only —
+ * it already tolerates SSE, NDJSON and a truncated tail. The message text is
+ * read from the `add_message` event rather than from the raw body because the
+ * response echoes the request's own tweaks, so a substring search could be
+ * satisfied by the request instead of by the run. The reverse holds for
+ * `WIDENED:`, which the request never contains: there the raw body is the
+ * stricter target, since it also covers the component's own log line.
+ */
+function readStream(raw: string): StreamFacts {
+  const events = parseStreamEvents(raw) as Array<{
+    event?: unknown;
+    data?: { data?: { text?: unknown } };
+  }>;
+  const messages = events.filter((event) => event?.event === "add_message");
+  const text = messages.at(-1)?.data?.data?.text;
+  return {
+    events,
+    messageText: typeof text === "string" ? text : null,
+    errorFrames: events
+      .filter((event) => event?.event === "error")
+      .map((event) => JSON.stringify(event)),
+    raw,
+  };
+}
+
+test.describe("Tweaks — the protected-field floor on the graph run path", () => {
+  let bearerToken: string;
+
+  // Flow B — Python Interpreter -> Chat Output, built from the live catalog.
+  let pythonFlowId: string;
+  let pythonNodeId: string;
+  let authorMark: string;
+  let deletePythonFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  // Flow A — Chat Input -> Chat Output passthrough, the benign control.
+  let chatFlowId: string;
+  let deleteChatFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  test.beforeAll(async ({ request }) => {
+    bearerToken = await getAuthToken(request);
+
+    authorMark = unique("AUTHOR");
+    const pythonFlow = await createPythonInterpreterFlowViaApi(
+      request,
+      { Authorization: bearerToken },
+      { authorCode: sandboxProbe(authorMark) },
+    );
+    pythonFlowId = pythonFlow.flowId;
+    pythonNodeId = pythonFlow.pythonNodeId;
+    deletePythonFlow = pythonFlow.deleteFlow;
+
+    // The whole causal probe depends on `os` NOT being on the author's list, so
+    // the stored value is asserted rather than assumed: a template default
+    // change upstream must fail here, not silently make the probe vacuous.
+    const stored = await request.get(`/api/v1/flows/${pythonFlowId}`, {
+      headers: { Authorization: bearerToken },
+    });
+    expect(stored.status()).toBe(200);
+    const storedFlow = await stored.json();
+    const interpreter = storedFlow?.data?.nodes?.find(
+      (node: { id?: string }) => node?.id === pythonNodeId,
+    );
+    expect(
+      String(interpreter?.data?.node?.template?.global_imports?.value ?? ""),
+      "the author's global_imports must not already grant `os`, or the widening tweak would be unobservable",
+    ).not.toContain("os");
+
+    const chatFlow = await createRunnableChatFlowViaApi(request, {
+      Authorization: bearerToken,
+    });
+    chatFlowId = chatFlow.flowId;
+    deleteChatFlow = chatFlow.deleteFlow;
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Both flows are deleted id-scoped, and a failure in one must not skip the
+    // other. `afterAll` uses its OWN request — the beforeAll one cannot be
+    // reused (Playwright fixture-scope rule).
+    try {
+      if (deletePythonFlow) await deletePythonFlow(request);
+    } finally {
+      if (deleteChatFlow) await deleteChatFlow(request);
+    }
+  });
+
+  /** Runs a streaming-family mode and returns its stream, however it is delivered. */
+  async function runStreaming(
+    request: APIRequestContext,
+    mode: StreamingMode,
+    flowId: string,
+    tweaks?: Tweaks,
+  ): Promise<StreamFacts> {
+    const res = await postWorkflow(request, bearerToken, flowId, mode, tweaks);
+    expect(
+      res.status(),
+      `POST /api/v2/workflows (mode=${mode}) commits its response before the build runs`,
+    ).toBe(200);
+
+    if (mode === "stream") return readStream(await res.text());
+
+    const submitted = await res.json();
+    expect(typeof submitted?.job_id, "the background submit must return a job_id").toBe(
+      "string",
+    );
+    const jobId = submitted.job_id as string;
+
+    // The poller returns null instead of throwing on an unreadable answer: a
+    // throw inside expect.poll propagates and aborts the poll rather than retrying.
+    let facts: StreamFacts | null = null;
+    await expect
+      .poll(
+        async () => {
+          try {
+            const events = await request.get(`/api/v2/workflows/${jobId}/events`, {
+              headers: { Authorization: bearerToken },
+            });
+            if (!events.ok()) return null;
+            const read = readStream(await events.text());
+            // A terminal frame either way — the run produced a message, or it
+            // was refused. Anything else means the job is still queued.
+            if (!read.messageText && read.errorFrames.length === 0) return null;
+            facts = read;
+            return read;
+          } catch {
+            return null;
+          }
+        },
+        {
+          message: `background job ${jobId} never reached a terminal event — nothing was measured`,
+          timeout: 60_000,
+          intervals: [500, 1_000, 2_000, 4_000],
+        },
+      )
+      .not.toBeNull();
+    return facts as unknown as StreamFacts;
+  }
+
+  /**
+   * The whole contract for one streaming-family mode. Shared so the two surfaces
+   * cannot drift apart: an assertion added for one is added for both.
+   */
+  async function assertStreamingSurface(
+    request: APIRequestContext,
+    mode: StreamingMode,
+  ): Promise<void> {
+    await test.step(`a global_imports tweak is refused and named (mode=${mode})`, async () => {
+      const facts = await runStreaming(request, mode, pythonFlowId, {
+        [pythonNodeId]: SANDBOX_WIDENING_TWEAK,
+      });
+      expect(
+        facts.raw,
+        "the flow author's sandbox must still be in effect — the run reached the widened branch",
+      ).not.toContain(WIDENED_PREFIX);
+      expect(
+        facts.errorFrames.join("\n"),
+        "the refusal must be attributable on this surface, not a bare failure",
+      ).toContain(REFUSAL_MARKER);
+      expect(
+        facts.errorFrames.join("\n"),
+        "and it must name the key it refused",
+      ).toContain("global_imports");
+    });
+
+    await test.step(`a python_code tweak is refused and named (mode=${mode})`, async () => {
+      const pwned = unique("PWNED");
+      const facts = await runStreaming(request, mode, pythonFlowId, {
+        [pythonNodeId]: { python_code: `print("${pwned}")` },
+      });
+      expect(facts.raw, "the caller's code must never be what executes").not.toContain(
+        pwned,
+      );
+      expect(
+        facts.errorFrames.join("\n"),
+        "the refusal must be attributable on this surface, not a bare failure",
+      ).toContain(REFUSAL_MARKER);
+      expect(
+        facts.errorFrames.join("\n"),
+        "and it must name the key it refused",
+      ).toContain("python_code");
+    });
+
+    await test.step(`a benign tweak on the same surface still applies (mode=${mode})`, async () => {
+      const benign = unique("BENIGN");
+      const applied = await runStreaming(request, mode, chatFlowId, {
+        [CHAT_INPUT_NODE_ID]: { input_value: benign },
+      });
+      expect(
+        applied.messageText ?? "",
+        "tweaks must be alive on this surface, or the refusals above measured nothing",
+      ).toContain(benign);
+      expect(
+        applied.errorFrames,
+        "and a tweak the contract allows must not be reported as a refusal",
+      ).toHaveLength(0);
+    });
+  }
+
+  test(
+    "mode=stream refuses a protected tweak and names the refusal",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      await assertStreamingSurface(request, "stream");
+    },
+  );
+
+  test(
+    "mode=background refuses a protected tweak and names the refusal",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      await assertStreamingSurface(request, "background");
+    },
+  );
+
+  // `mode=sync` is asserted SHAPE-AGNOSTICALLY, on purpose.
+  //
+  // Measured on 1.12.0.dev37 it answers 500 INTERNAL_SERVER_ERROR / "An
+  // unexpected error occurred." for every refusal, where POST /api/v1/run
+  // answers 422 with code TWEAKS_REFUSED and `fields` naming the key — the shape
+  // #14538 introduced, and the shape api/v2/workflow_execution.py's own comment
+  // says this path should produce ("let the app-level handler answer with 422").
+  // TweakRefusedError is deliberately not an HTTPException, so it lands in the
+  // catch-all `except Exception -> 500` arm of api/v2/workflow.py's inline sync
+  // handler and never reaches the app-level handler in main.py.
+  //
+  // Pinning 422 here would ship a test that is red for months on a reporting
+  // difference; pinning 500 would bless it. Neither is what this file is for.
+  // What it asserts instead holds under both shapes and is the failure that
+  // actually matters: a refusal must never answer 2xx — not by applying the
+  // tweak, and not by dropping it silently and running anyway. The shape is
+  // recorded in docs/security/tweaks-graph-path-floor.md instead.
+  test(
+    "mode=sync refuses a protected tweak without ever answering 2xx",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      for (const [field, tweak] of [
+        ["global_imports", SANDBOX_WIDENING_TWEAK],
+        ["python_code", { python_code: 'print("refused")' }],
+      ] as const) {
+        await test.step(`a ${field} tweak is refused`, async () => {
+          const res = await postWorkflow(request, bearerToken, pythonFlowId, "sync", {
+            [pythonNodeId]: tweak,
+          });
+          expect(
+            res.status(),
+            `a refused ${field} tweak must not answer 2xx — a success status means the tweak either took effect or was dropped without telling the caller`,
+          ).toBeGreaterThanOrEqual(400);
+        });
+      }
+
+      await test.step("the refused requests left the flow running the author's code", async () => {
+        const res = await postWorkflow(request, bearerToken, pythonFlowId, "sync");
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        const text = String(body?.output?.text ?? "");
+        expect(
+          text,
+          "a refusal must leave nothing behind — the author's sandbox is still what runs",
+        ).not.toContain(WIDENED_PREFIX);
+        expect(text, "and the author's own code is still what runs").toContain(authorMark);
+      });
+
+      await test.step("a benign tweak on the same surface still applies", async () => {
+        const benign = unique("BENIGN");
+        const res = await postWorkflow(request, bearerToken, chatFlowId, "sync", {
+          [CHAT_INPUT_NODE_ID]: { input_value: benign },
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(
+          String(body?.output?.text ?? ""),
+          "tweaks must be alive on this surface, or the refusals above measured nothing",
+        ).toContain(benign);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1567.

Closes the `[ ]` gap in `QA-CHECKLIST.md` § 17.4 — **the graph run path**, a distinct journey from `security/tweaks-injection.spec.ts` despite guarding the same protection. That spec covers `POST /api/v1/run/{id}`, where tweaks are applied to the graph *payload* before construction. The streaming and background modes of `POST /api/v2/workflows` build the `Graph` first and then push overrides onto built vertices (`process_tweaks_on_graph` / `apply_tweaks_on_vertex`), and upstream `langflow-ai/langflow#14538` records that this second path *"filtered only the literal key `code` in `api/build.py`, so it accepted tweaks the sync mode refused: a `global_imports` override widening the exec sandbox was applied"*. Nothing in the suite exercised it.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `mode=stream refuses a protected tweak and names the refusal` | A `global_imports: ["os"]` and a `python_code` tweak on a `PythonREPLComponent` are refused on the streaming surface, in **both** failure directions: `WIDENED:` appears nowhere in the SSE body (nothing was applied), **and** an `event: "error"` frame carries `TweakRefusedError` plus the refused key (the refusal is attributable, not a bare failure). Paired with a benign `input_value` tweak on the same surface that **does** apply and emits no error frame |
| 2 | `mode=background refuses a protected tweak and names the refusal` | The same contract with the events read from `GET /api/v2/workflows/{job_id}/events`. Its own test because `#14538` names both modes and they can regress independently |
| 3 | `mode=sync refuses a protected tweak without ever answering 2xx` | A refusal never answers `2xx` — a success status there means the tweak either took effect or was dropped without telling the caller, which are the two failures this file exists for. Plus: the refused request left nothing behind (a following no-tweak run still prints the author's sentinel, never `WIDENED:`) |

## 2. How the test was built

- **Setup via API, two flows** (mirroring the sibling spec): `createPythonInterpreterFlowViaApi` for the subject and `createRunnableChatFlowViaApi` for the benign control. No browser, so no selectors are involved — this is a pure REST spec.
- **The assertion is causal, not a status code.** The floor is enforced by dropping the value, so every surface answers `200` on the happy path and a status assertion would prove nothing. The author's `python_code` is a probe instead — `try: print("WIDENED:" + os.name) / except NameError: print("AUTHOR-<uniq>")`. `validate_code_safety()` rejects an inline `import`, so `os` is in scope only if the protected `global_imports` was widened, and the run's own output names which value was in effect.
- **The probe is guarded against becoming vacuous:** `beforeAll` reads the stored flow back and asserts the author's `global_imports` does not already grant `os`, so an upstream template-default change fails loudly instead of silently disarming every assertion.
- **Every refusal is paired with a benign tweak on the same surface and request shape.** Without that control, "the sentinel is absent" passes just as well when the tweaks mechanism is dead altogether.
- **Response shapes were measured, not guessed.** `mode=sync` reads `body.output.text`; the streaming surfaces parse the SSE with `parseStreamEvents()` (reused from `tests/fixtures/flow-error-policy.ts` for its parser — it already tolerates SSE, NDJSON and a truncated tail) and read the last `add_message` event's `data.data.text`. `sender_name` is **not** in the sync output — it is only echoed back under `.inputs` — which is why the control needs a second flow rather than a second field.
- **No top-level `input_value` is ever sent:** it overrides the Chat Input and would mask the control.
- Background polls through `expect.poll` whose poller returns `null` rather than throwing, because a throw inside `expect.poll` propagates and aborts the poll instead of retrying.
- Both flows are deleted id-scoped in `afterAll`, in nested `try/finally` with its own `request`, so a failure in one cannot skip the other.

## 3. Dependencies

None beyond a running Langflow: no LLM, no provider key, no API key (the v2 endpoint takes the Bearer), no browser. Parallel-safe — the file creates only its own flows and sets no instance-wide state — and validated at `--workers=1 --retries=0`. Requires `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` (every lane and both start scripts set it) and an instance **not** started with a strict `LANGFLOW_TWEAKS_POLICY`, which nothing in the suite sets.

## Validation (nightly `1.12.0.dev37`, `--retries=0 --workers=1`)

- Resolved image: `langflowai/langflow-nightly@sha256:b672ab7e91981c6f1719b2932bfa7e2255324d4cfac18b7fedf0dbf5722761de`, the digest both `:latest` and `:1.12.0.dev37` resolve to; upstream revision `50340f2a4322eca624b7ef5684237d87f863fc1b`.
- `3 passed (4.0s)` — re-run on this branch's base after `origin/main` moved 92 files, with the imported helpers confirmed untouched by that move.
- Determinism burst: **3/3 clean**, `expected=3 unexpected=0 flaky=0`, zero `🚨 Backend Error`.
- Force-fail, one mutation per test, each reverted and each verified to fail first: inverted the sandbox-widening check (`.not.toContain` → `.toContain WIDENED_PREFIX`) for `mode=stream`; changed `REFUSAL_MARKER` to a string the error frame cannot carry for `mode=background`; flipped `toBeGreaterThanOrEqual(400)` → `toBeLessThan(400)` for `mode=sync`. Final green run after all reverts, with the gate confirming no `FF-MUTATION` marker survives.
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · QA-CHECKLIST generated-block guard ✅ · `npm run check:checklist-coverage` ✅
- Instance left clean: 26 flows (the starter templates only), no spec or probe residue.

## Scope decisions, and what was measured but deliberately not asserted

**The floor holds on all four run surfaces.** No protected tweak is applied anywhere, in any policy state — `#14538`'s enforcement is real on the graph path, and this spec is what stops a regression from returning it silently.

**`mode=sync` refuses, but reports it as a generic `500`.** `{"code":"INTERNAL_SERVER_ERROR","message":"An unexpected error occurred."}` where `POST /api/v1/run` returns `422` with `code: TWEAKS_REFUSED` and `fields` naming the key. Mechanism: `TweakRefusedError` is deliberately not an `HTTPException` (`lfx/exceptions/tweaks.py` says so), so it lands in the catch-all `except Exception -> 500` arm of `api/v2/workflow.py`'s inline sync handler and never reaches the app-level handler in `main.py`. The re-raise `#14538` added at `workflow_execution.py:704` is present and correct — it hands the exception to a router that swallows it.

Test 3 therefore asserts the surface **shape-agnostically**. The property it pins holds under the current `500` and under the `422` the code intends, so the surface is covered with no quarantine and no red test, while still catching the failure that matters. Pinning `422` would ship a test red for months on a reporting difference; pinning `500` would bless it. The difference is an API-contract cost, not a security one, and it is recorded in the spec doc under *What this test does not cover*, with the mechanism, so tightening it later is a one-line change.

**`LANGFLOW_TWEAKS_POLICY` and the `api_editable` allowlist are scoped out on a lane argument, not a product one.** Both were measured working: with `off` every tweak is refused including the benign one (`"This deployment does not accept tweaks."`), and with `declared` a field the author marked `api_editable` is applied while a **protected** field marked the same way is still refused — the floor outranks the author's allowlist, which is the security-relevant half `#1567` asked to pin. An invalid value fails closed (`literal_error`, container exits `1`), refuting the issue's premise that a typo silently widens the policy. They stay out because the setting is instance-global, cannot be set from a test, and no lane starts a container with it — a gated spec would `skip` everywhere, which is the failure mode #1010 exists to prevent. The exact refusal reasons are recorded in the spec doc so that spec does not have to re-measure them.

**A measurement trap is recorded in the spec doc, because it cost this work a full pass.** The first round was measured against `http://localhost:7866`, which on the author's machine is not the container `docker run -p 7866:7860` published: an SSH tunnel from a parallel session holds `*:7860`, `*:7865`, `*:7866` and `*:7891`. Every conclusion from that pass was wrong in the same direction. Three signals said so and were each explained away individually — the version endpoint answering `1.12.0`/`package: Langflow` where the nightly must answer `.devNN`/`Langflow Nightly`, a container that had exited `1` still answering on its port, and flows nobody in the session had created. The doc now carries the rule: check `lsof -iTCP:<port> -sTCP:LISTEN` and assert the version endpoint's `package` before trusting a measurement.

**No `@stable` in this delivery** — new spec awaiting a validation cycle, so the bullets are `[-]`. The lane profile fits well (pure API, ~4 s, cannot fail for a provider-outage reason) and promotion is a one-line follow-up.

**`#1566` has not landed.** `security/tweaks-injection.spec.ts` still asserts the pre-`#14538` silent-refusal contract on `POST /api/v1/run`; the only change on `main` is the daily's automatic `@stable` removal from its two failing tests (`12bfd899`). That endpoint stays out of this PR so the two files do not have to change together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
