### PR TITLE
test(api): cover the v2 workflows job lifecycle (#1575)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -124,6 +124,16 @@
 - [x] Expired API key is rejected on `POST /api/v1/run/{id}` with 403; valid key accepted with 200 → `api/flows/api-key-expiry-enforcement.spec.ts`
 - [x] Expiry boundary is evaluated in UTC, not shifted by viewer offset (±30 min UTC keys resolve correctly) → `api/flows/api-key-expiry-enforcement.spec.ts`
 
+#### 1.8 Workflows v2 — Job Lifecycle (1.12)
+
+> `POST /api/v2/workflows` is the run path the product itself uses, and this suite already **observes** it — `tests/fixtures/flow-error-policy.ts` classifies its stream and eight specs trigger it incidentally — but until now nothing **drove it as an API contract**. The submit half was exercised constantly; the read-back half by nothing. Spec doc: `docs/api/flows/workflows-v2-job-lifecycle.md`.
+
+- [-] A batch create with a duplicate name is refused `409 "Name must be unique"` rather than stalling on the SQLite write lock, the body renders no SQL or bound parameters, and the **next write still succeeds** — the last clause is the one that matters: a `409` that left the lock held satisfies every other assertion and is still the defect `langflow-ai/langflow#14634` fixed, because the caller sees a clean conflict and the *next* writer dies with "database is locked" → `api/flows/workflows-v2-job-lifecycle.spec.ts`
+- [-] A batch create with a duplicate `endpoint_name` is refused with its **own** message (`"Endpoint name must be unique"`), asserted as not equal to the name guard's — two guards, one status, so the message is the only thing separating them → `api/flows/workflows-v2-job-lifecycle.spec.ts`
+- [-] A completed `mode=background` run reports the `session_id` it was submitted with, and its outputs, on the **first** status read that says `completed` — asserted as "not the flow id" too, since the flow id is the specific degradation `langflow-ai/langflow#14512` names → `api/flows/workflows-v2-job-lifecycle.spec.ts`
+- [!] A completed `mode=sync` run answers its own status query with the session and outputs it just returned — **declared failing (`test.fail()`) against a live defect, 15/15 on `1.12.0.dev37`**; it flips to an *unexpected pass* the day upstream fixes it, which is the alarm to remove the annotation: the read-back reports `status: "completed"` alongside `session_id == flow_id` and `outputs: {}`, self-healing in 250–463 ms (median 434, 12/12 cold jobs). #14512's fix is present (its `sync_result_storage_enabled` setting reads `False`, the default) but the flag-off path races the `vertex_build` commit it reconstructs from. Detection depends on issuing the two calls back to back — with assertions interleaved between them the defect went unseen in 1 of 13 runs → `api/flows/workflows-v2-job-lifecycle.spec.ts`
+- [-] Attribution control: the same sync read-back **is** correct once the job's rows settle (≤10 s). Paired with the row above on purpose — that red plus this green is the race; *both* red would be a strictly worse regression, reconstruction unavailable at any time, and without the pair the two would report as one finding → `api/flows/workflows-v2-job-lifecycle.spec.ts`
+
 ---
 
 ## core-components/ — Component Configuration + Core Components

--- a/docs/api/flows/workflows-v2-job-lifecycle.md
+++ b/docs/api/flows/workflows-v2-job-lifecycle.md
@@ -1,0 +1,179 @@
+# Workflows v2 — the job lifecycle
+
+**Last validated:** Langflow 1.12.0.dev37 — `langflowai/langflow-nightly@sha256:b672ab7e91981c6f1719b2932bfa7e2255324d4cfac18b7fedf0dbf5722761de`, the digest `:latest` resolves to (`docker inspect --format '{{index .RepoDigests 0}}'`); upstream revision `50340f2a4322eca624b7ef5684237d87f863fc1b`.
+
+---
+
+## What this test validates *(required)*
+
+Validates the **job lifecycle** of `POST /api/v2/workflows` — submit, then read the job back through `GET /api/v2/workflows?job_id=…` — and the **conflict contract** of `POST /api/v1/flows/batch/`.
+
+`POST /api/v2/workflows` is the run path the product itself uses: the flow editor, the playground and every agent run go through it. This suite already **observes** that path — `tests/fixtures/flow-error-policy.ts` classifies its stream and eight specs trigger it incidentally — but nothing **drives it as an API contract**. The only spec addressing the endpoint directly is `security/tweaks-graph-path-floor.spec.ts` (#1567), and it covers the tweaks floor, not the lifecycle. So the submit half is exercised constantly and the read-back half is exercised by nothing.
+
+That read-back half is where three upstream PRs on `release-1.12.0` changed behaviour:
+
+| Upstream | What it changed |
+|---|---|
+| [#14353](https://github.com/langflow-ai/langflow/pull/14353) | `GET`-status reads the durable `Job.result` blob first; `vertex_build` reconstruction becomes the recovery path. The completed response preserves the submitted `session_id`, falling back to the flow id. |
+| [#14512](https://github.com/langflow-ai/langflow/pull/14512) | Fixes completed `mode=sync` runs reporting `session_id == flow_id` on `GET` — *"a regression from #14353"*. Adds `sync_result_storage_enabled` (**default off**); with it off, the session is meant to resolve through `vertex_build` reconstruction. |
+| [#14634](https://github.com/langflow-ai/langflow/pull/14634) | `POST /api/v1/flows/batch/` builds `Flow` rows directly instead of going through `_new_flow`, which pre-deduplicates names — so a duplicate reached `session.flush()` as an unhandled `UNIQUE` violation. On SQLite the failed `INSERT` was never rolled back and **held the write lock for the full 30 s `busy_timeout`**, so a duplicate surfaced as *"database is locked"* on the *next* writer; the unhandled exception also **leaked the SQL statement and its bound parameters** to the caller. |
+
+**The `session_id` is not cosmetic.** It is the key message memory and chat history scope to, so a status read that reports the wrong one hands the caller a thread that is not the one that ran.
+
+Three of the four axes below are green on the measured build. The fourth is **red on purpose** — see *The sync defect* — and the file is designed so that a red there is attributable rather than ambiguous.
+
+---
+
+## Tags *(required)*
+
+`@api` `@regression`
+
+No **functional** tag applies, following the `api/flows/` family: `api-run-with-tweaks`, `api-run-flow`, `api-flows-crud` and `api-key-expiry-enforcement` all carry cross-cutting tags only, because the tag table's functional axis names product areas (playground, agents, MCP…) and this is the transport layer under all of them. `@api` marks the layer; `@regression` is what #1575 asks for — every axis here pins a specific upstream fix.
+
+**No `@stable`.** Two independent reasons, and the first is the disqualifying one:
+
+- **Test 4 is declared failing** (`test.fail()`) against a live product defect. Even declared, it does not belong in a scheduled lane: the day upstream lands the fix it starts reporting *"expected to fail but passed"*, and that alarm should reach a reviewer on a PR, not open a `daily-failure` issue at 05:00.
+- The rest is a new spec awaiting a validation cycle, so its bullets are `[-]`.
+
+**Why Test 4 is `test.fail()` rather than a plain red.** The assertions are identical either way — `test.fail()` inverts the *verdict*, never the assertion, so nothing is weakened. What it buys is the half a plain red does not have: **the fix becomes detectable**. A permanent red is a signal that decays — it fails every run, reviewers learn its name, and the day it starts passing nobody notices. Declared failing, the fix arrives as a *new* red (`expected to fail but passed`) asking for the annotation back.
+
+This suite rejects `test.fail()` elsewhere, and the reason is sound: `mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts` records that it *"converts ANY failure (a broken bootstrap, a down instance, an unregistered MCP server) into a green 'expected failure'"*. That objection is answered here **by construction, not by argument**: Test 5 issues the same submit and the same read-back, against the same flow, through the same helpers, and is not declared failing. A broken bootstrap or a dead instance reddens it — and Tests 1–3 — instead of disappearing into Test 4's declaration.
+
+Not `@destructive`: the file creates and deletes only its own flows and sets no instance-wide state. (`sync_result_storage_enabled=true` **would** be instance-global — scoped out below.)
+
+---
+
+## Measured contract *(required reading)*
+
+Every figure below was measured against `1.12.0.dev37` with the instance identity asserted first (`GET /api/v1/version` → `package: "Langflow Nightly"`), because a shadowed port silently answers as a different instance — the trap that invalidated a whole measurement pass on #1567.
+
+### `POST /api/v1/flows/batch/` — all green
+
+| Request | Observed |
+|---|---|
+| `{flows: [A, B]}`, unique names | `201`, both rows created |
+| `{flows: [D, D]}`, duplicate name in one payload | `409` `{"detail":"Name must be unique"}` **in 18 ms** |
+| `{flows: [E]}` where `E`'s name already exists | `409`, same message, 12 ms |
+| `{flows: [x1, x2]}` sharing an `endpoint_name` | `409` `{"detail":"Endpoint name must be unique"}` |
+| a plain `POST /api/v1/flows/` right after a `409` | `201` in 14 ms |
+
+The last row is the load-bearing one. A `409` that left the write lock held would satisfy every other assertion in this file and still be the exact defect #14634 fixed — the caller sees a clean conflict and the *next* writer dies 30 s later with an unrelated-looking error. Asserting that the following write simply succeeds is enough, and is preferable to a duration threshold: if the lock were held, that request would stall out rather than return `201`.
+
+The **absence of SQL** in the `409` body is asserted for the same reason it was fixed: an unhandled `IntegrityError` renders the statement and its bound parameters, so the failure mode is a leak, not just an ugly message. Nothing else in this suite would notice.
+
+### `POST /api/v2/workflows` `mode=background` — green
+
+The first `GET` that reports `status: "completed"` already carries the submitted `session_id` and the populated `outputs`. This path persists `job_metadata["request"]` at submit time, so the session is read back from storage rather than reconstructed.
+
+### `POST /api/v2/workflows` `mode=sync` — **red**
+
+`sync_result_storage_enabled` reads `False` (its default) and `vertex_builds_storage_enabled` reads `True`, so the reconstruction path #14512 documents is the live one. Yet:
+
+```
+POST /api/v2/workflows  {mode: "sync", session_id: "ses-38b014ff"}
+  → 200  status="completed"  session_id="ses-38b014ff"  outputs=[ChatOutput-…]
+
+GET  /api/v2/workflows?job_id=<that job>        ← the obvious next call
+  → 200  status="completed"  session_id="<flow_id>"  outputs=[]
+                                                     output={reason:"none", text:null}
+```
+
+Reproduced 15/15 through the spec. It **self-heals in 250–463 ms** — median 434 ms, 12 of 12 cold jobs, each on its own freshly created flow — so a caller that polls converges and a caller that reads once loses the session *and* every output. The window is narrow, which is what makes the ordering of the two calls a design constraint rather than a detail (see *Validation criterion*).
+
+Mechanism, read from `langflow/api/v2/workflow.py` inside the image (the `COMPLETED` branch): with the flag off `job_metadata` is `null`, so `effective_session_id = flow_id_str`; `job.result` is `null`, so the primary path is skipped; `reconstruct_workflow_response_from_job_id` then raises `ValueError("No vertex builds found for job_id …")` because the `vertex_build` rows have not committed yet, and the `except` arm returns an empty response carrying the flow id. The reconstruction itself is **correct** — a later `GET` on the same job returns the submitted session and the outputs, and the stored blob carries `session_id` at `results.message.data.session_id`, exactly where `_recover_session_id` looks.
+
+What rules out *"eventual consistency, working as intended"*: **the same response body asserts `status: "completed"` while reporting no outputs**, and `mode=background` answers correctly on its first completed `GET`. A caller cannot distinguish this from a run that genuinely produced nothing.
+
+No upstream issue exists for it; a ticket is drafted alongside this spec and not filed, by the reporter's decision.
+
+---
+
+## Step by step *(required)*
+
+Five tests via Playwright's `request` fixture, sharing one flow created in `beforeAll`. No browser, no LLM, no provider key.
+
+**Setup (`beforeAll`)**
+1. `getAuthToken(request)` → bearer token, used as `Authorization` on every call (the v2 workflow routes accept it; unlike `POST /api/v1/run/{id}` no `x-api-key` is minted).
+2. `createRunnableChatFlowViaApi(request, { Authorization: bearer })` → a `Chat Input → Chat Output` passthrough flow. It echoes its input, so a run's output text is deterministic with no provider configured.
+
+**Teardown (`afterAll`)**
+Delete the shared flow plus every flow the batch tests created, each by id, in nested `try/finally` so one failure cannot strand the rest. Batch-created ids are collected as the tests run.
+
+---
+
+**Test 1 — a duplicate name is refused `409`, leaks no SQL, and leaves the next write working**
+
+1. `POST /api/v1/flows/batch/` with `{flows: [A, B]}` carrying two unique names. Assert `201` and that two ids came back; record them for teardown. *This control comes first: without it, every assertion below is equally consistent with the batch endpoint being broken outright.*
+2. `POST` again with `{flows: [D, D]}` — the same name twice in one payload. Assert `409` and `detail === "Name must be unique"`, asserted exactly so this guard cannot later collapse onto the endpoint-name one.
+3. Assert the raw response body contains none of `INSERT`, `SELECT`, `UNIQUE constraint`, `sqlalchemy`, `[SQL:` or `parameters:` — the leak #14634 closed.
+4. `POST /api/v1/flows/batch/` with `{flows: [E]}` where `E` reuses the name of a flow created in step 1. Assert `409` with the same message — a name already committed is a different code path from two names inside one flush.
+5. `POST /api/v1/flows/` (the singular endpoint) with a fresh unique name. Assert `201` — the rollback released the write lock. Record the id for teardown.
+
+**Test 2 — a duplicate `endpoint_name` is refused with its own message**
+
+1. `POST /api/v1/flows/batch/` with two flows carrying distinct names and the **same** `endpoint_name`. Assert `409` and `detail === "Endpoint name must be unique"`.
+2. Assert that message is **not** `"Name must be unique"` — two guards, two strings; a regression collapsing them would still return `409` and would still pass Test 1.
+3. Assert no SQL in the body, as in Test 1.
+
+**Test 3 — a completed background run reports the session it was given**
+
+1. `POST /api/v2/workflows` with `{flow_id, input_value: "ping", session_id: <unique>, mode: "background"}`. Assert `200`, a `job_id`, and `status: "queued"`.
+2. Poll `GET /api/v2/workflows?job_id=<job_id>` until `status === "completed"` (bounded; the measured run completes on the first or second poll).
+3. On that **first completed** response assert: `session_id` equals the submitted session; `session_id` is **not** the flow id — the specific degradation #14512 names, so the assertion is not vacuous; `outputs` carries the Chat Output node key, and its content is the echoed `"ping"`.
+
+**Test 4 — a completed sync run answers its own status query with what it just returned** *(expected red)*
+
+1. `POST /api/v2/workflows` with `{flow_id, input_value: "ping", session_id: <unique>, mode: "sync"}`. Assert `200`, `status === "completed"`, `session_id` equals the submitted session, and `outputs` carries the Chat Output content. *These are the premise: the run finished and the API said so.*
+2. `GET /api/v2/workflows?job_id=<job_id>` **once**, immediately — the call a client makes next.
+3. Assert `status === "completed"` — it is, which is what makes the rest a contradiction rather than a timing question.
+4. Assert `session_id` equals the submitted session and is **not** the flow id. **Fails today.**
+5. Assert `outputs` is non-empty. **Fails today.**
+
+**Test 5 — attribution control: the same read is correct once the job's rows settle**
+
+1. Submit a second `mode=sync` run exactly as in Test 4.
+2. Poll `GET /api/v2/workflows?job_id=…` for up to 10 s until the response carries the submitted `session_id` **and** non-empty `outputs`.
+3. Assert it converged, and assert the converged `session_id` is the submitted one.
+
+This test exists to make Test 4's red **attributable**, and it is the pairing that decides the diagnosis: *Test 4 red + Test 5 green* is the race described above; *both red* is a strictly worse regression — reconstruction dead, the session unrecoverable at any time — and would otherwise be reported as the same finding.
+
+---
+
+## Validation criterion *(required)*
+
+- Tests 1, 2, 3 and 5 pass. **Test 4 fails and is declared to** (`test.fail()`), so the run reports `5 passed` with Test 4 counted as an expected failure; its failure is at the read-back step, with the reported `session_id` equal to the flow id. Should it ever *pass*, Playwright reports *"expected to fail but passed"* — that is the fix landing, and the annotation plus this criterion come off together.
+- **Detection is 15/15, and that took a design decision worth keeping.** The settle window is 250–463 ms (median 434), measured over 12 cold jobs. The defect is a race, so the submit and the read-back are issued back to back with no assertion between them — the sequence a real client runs. An earlier draft parsed the submit body and asserted its four premises first, and that work was enough to let the race go the other way: the defect went undetected in 1 of 13 measured runs. Any future edit that reintroduces work between those two calls silently weakens the test to ~92 %.
+- Test 1's control (step 1) passes, so the `409`s are refusals and not a broken endpoint.
+- Test 3's first completed response carries the submitted session — proving the endpoint *can* do this, which is what makes Test 4 a defect rather than an unsupported feature.
+- Test 5 converges within 10 s, so Test 4's red is the race and not a dead reconstruction path.
+- No orphan flows: `GET /api/v1/flows/?remove_example_flows=true` returns the same count before and after the file runs.
+- No `🚨 Backend Error:` in the log — and, for this file, that is a weaker statement than it looks: see *Preconditions*.
+
+---
+
+## What this test does not cover *(and why)*
+
+- **`sync_result_storage_enabled=true`** — the flag-on half of #14512, where the submit request is persisted to `job_metadata` before `Job.result` and the cached blob must carry the session while carrying **no** `tweaks` or `globals`. The setting is instance-global, so it needs a dedicated container; a spec gated on it would skip on every lane and could never be `@stable` (#1010). The keyless default-off path is the one every lane actually runs.
+- **`mode=stream`** — its read-back is the event stream, not the status endpoint; `tweaks-graph-path-floor.spec.ts` already drives that surface.
+- **`/api/v2/workflows/stop`, `/resume`, `/pending`** — separate surfaces with their own lifecycles (HITL suspend/resume is #14353's third axis).
+- **The 30 s SQLite lock timing itself.** #14634's pre-fix symptom was a stall, but asserting a duration bound would make the test a performance assertion on shared CI hardware. Step 5's plain `201` proves the lock released without one.
+
+---
+
+## Preconditions *(required)*
+
+- A running Langflow instance reachable at `PLAYWRIGHT_BASE_URL`, on the nightly image.
+- Auto-login superuser (the suite's default), for `getAuthToken`.
+- **No provider key, no model, no browser.** Every test is `request`-only against a Chat Input → Chat Output flow.
+- **No `allowHttpErrors()` is needed, and the reason is worth stating rather than assuming.** The batch tests drive `/api/v1/flows/batch/` into a deliberate `409`, and the HTTP-error policy reports every 4xx/5xx on an `/api/` route — but it is wired to `page.on("response")`, so it only ever sees browser-driven traffic. Every request in this file goes through Playwright's `request` fixture, which never passes through a `page`, so none of it reaches the monitor at all. The same is true of every sibling in `api/flows/` — none calls `allowHttpErrors()`, including `api-invalid-key.spec.ts`, which exists to provoke a `401`/`403`.
+
+  The honest consequence: for a `request`-only spec, checklist step 4 ("confirm no backend error was logged") carries no information — the log would be empty whether the endpoint answered `409` or `500`. What replaces it here is that every call asserts its own status explicitly, so an unexpected `500` fails the test rather than passing quietly into a log nobody reads.
+
+---
+
+## External dependencies *(required)*
+
+- **Langflow API** — `POST /api/v1/flows/`, `POST /api/v1/flows/batch/`, `DELETE /api/v1/flows/{id}`, `POST /api/v2/workflows`, `GET /api/v2/workflows?job_id=`, `GET /api/v1/version`.
+- **Upstream source** — `src/backend/base/langflow/api/v2/workflow.py` (the `COMPLETED` branch of `get_workflow_status`, which resolves `effective_session_id` and falls back to reconstruction) and `src/backend/base/langflow/api/v1/flows.py` (`POST /flows/batch/`, `_handle_unique_constraint_error`). The reconstruction module `workflow_reconstruction.py` and the `sync_result_storage_enabled` setting were both read **inside the running container** rather than from a ref: they arrived with #14353/#14512 on `release-1.12.0`, which is the line the nightly is cut from and which upstream `main` lags — the spec-doc dependency guard resolves paths against `main` and would reject them (#1574).
+- **Fixture** — `tests/assets/flows/chat-io-ok-trace-fixture.json`, via `createRunnableChatFlowViaApi`.
+- **No external network, no provider account.**

--- a/tests/tests-automations/regression/api/flows/workflows-v2-job-lifecycle.spec.ts
+++ b/tests/tests-automations/regression/api/flows/workflows-v2-job-lifecycle.spec.ts
@@ -1,0 +1,418 @@
+import type { APIRequestContext, APIResponse } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
+
+// The Chat Output node id inside `tests/assets/flows/chat-io-ok-trace-fixture.json`.
+// The fixture echoes its input, so a run's output is deterministic with no
+// provider configured, and the outputs map is keyed by this id.
+const CHAT_OUTPUT_NODE_ID = "ChatOutput-yK0AU";
+
+// What the flow echoes back, and therefore what a completed run's output must say.
+const RUN_INPUT = "ping";
+
+// The two uniqueness guards on `POST /api/v1/flows/batch/`. Asserted as exact
+// strings so a regression collapsing both onto one message cannot pass: the
+// status is `409` either way, so the message is the only thing that separates them.
+const DUPLICATE_NAME_DETAIL = "Name must be unique";
+const DUPLICATE_ENDPOINT_DETAIL = "Endpoint name must be unique";
+
+// Fragments an unhandled `IntegrityError` renders into the response: SQLAlchemy
+// appends the statement and its bound parameters to the exception message. This
+// is the leak upstream #14634 closed, and nothing else in this suite would
+// notice it — a leaking `409` still looks like a clean conflict to a status check.
+const SQL_LEAK_MARKERS = [
+  "INSERT",
+  "SELECT",
+  "UNIQUE constraint",
+  "sqlalchemy",
+  "sqlite3",
+  "[SQL:",
+  "parameters:",
+];
+
+/** How long the attribution control waits for the sync read-back to settle. */
+const SETTLE_BUDGET_MS = 10_000;
+const SETTLE_POLL_MS = 100;
+
+interface JobStatusFacts {
+  status: unknown;
+  sessionId: unknown;
+  outputKeys: string[];
+  outputText: unknown;
+}
+
+function unique(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+/** Reads the fields of a workflow submit/status body this spec asserts on. */
+async function readJobFacts(res: APIResponse): Promise<JobStatusFacts> {
+  const body = await res.json();
+  const outputs = (body?.outputs ?? {}) as Record<string, { content?: unknown }>;
+  return {
+    status: body?.status,
+    sessionId: body?.session_id,
+    outputKeys: Object.keys(outputs),
+    outputText: outputs[CHAT_OUTPUT_NODE_ID]?.content,
+  };
+}
+
+test.describe("Workflows v2 — the job lifecycle", () => {
+  let bearerToken: string;
+
+  // The shared Chat Input -> Chat Output flow every run test submits.
+  let flowId: string;
+  let deleteChatFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  // Ids the batch tests create, deleted id-scoped in `afterAll`. Collected into
+  // a local array rather than through `track-created-flows.ts`: that helper is
+  // the suite's cleanup standard for 51 specs, but it listens on
+  // `page.on("response")` and this file drives no page.
+  const createdFlowIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    bearerToken = await getAuthToken(request);
+    const chatFlow = await createRunnableChatFlowViaApi(request, {
+      Authorization: bearerToken,
+    });
+    flowId = chatFlow.flowId;
+    deleteChatFlow = chatFlow.deleteFlow;
+  });
+
+  test.afterAll(async ({ request }) => {
+    // A failure deleting one flow must not strand the rest. `afterAll` uses its
+    // OWN request — the beforeAll one cannot be reused (Playwright scope rule).
+    try {
+      for (const id of createdFlowIds) {
+        await deleteFlow(request, id, {
+          headers: { Authorization: bearerToken },
+        }).catch(() => {});
+      }
+    } finally {
+      if (deleteChatFlow) await deleteChatFlow(request);
+    }
+  });
+
+  /** `POST /api/v1/flows/batch/`. `FlowCreate` requires only `name`. */
+  function postBatch(
+    request: APIRequestContext,
+    flows: Array<{ name: string; endpoint_name?: string }>,
+  ): Promise<APIResponse> {
+    return request.post("/api/v1/flows/batch/", {
+      headers: { Authorization: bearerToken },
+      data: { flows },
+    });
+  }
+
+  /** `POST /api/v2/workflows`. */
+  function postWorkflow(
+    request: APIRequestContext,
+    mode: "sync" | "background",
+    sessionId: string,
+  ): Promise<APIResponse> {
+    return request.post("/api/v2/workflows", {
+      headers: { Authorization: bearerToken },
+      data: {
+        flow_id: flowId,
+        input_value: RUN_INPUT,
+        session_id: sessionId,
+        mode,
+      },
+    });
+  }
+
+  /** `GET /api/v2/workflows?job_id=…` — the read-back half of the lifecycle. */
+  function getJob(
+    request: APIRequestContext,
+    jobId: string,
+  ): Promise<APIResponse> {
+    return request.get(`/api/v2/workflows?job_id=${jobId}`, {
+      headers: { Authorization: bearerToken },
+    });
+  }
+
+  async function assertNoSqlLeak(res: APIResponse, label: string) {
+    const raw = await res.text();
+    for (const marker of SQL_LEAK_MARKERS) {
+      expect(
+        raw.toLowerCase(),
+        `${label} must not render the failed statement: an unhandled IntegrityError appends the SQL and its bound parameters, and a leaking 409 is indistinguishable from a clean one to any caller that only reads the status`,
+      ).not.toContain(marker.toLowerCase());
+    }
+  }
+
+  test(
+    "batch create refuses a duplicate name with 409, leaks no SQL, and leaves the next write working",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      const base = unique("batch-unique");
+      let seededName = "";
+
+      await test.step("a batch of unique names is accepted — the control", async () => {
+        // First on purpose: without it every 409 below is equally consistent
+        // with the batch endpoint being broken outright.
+        const res = await postBatch(request, [
+          { name: `${base}-a` },
+          { name: `${base}-b` },
+        ]);
+
+        // Ids are recorded BEFORE anything is asserted. Cleanup must not depend
+        // on the assertions passing: a row this call created is on the instance
+        // whether or not the status is what we expected, and pushing the id
+        // after a failing expect() is how a red test orphans a flow (measured —
+        // the force-fail pass on the post-conflict write left exactly one).
+        const created = (await res.json().catch(() => [])) as Array<{
+          id?: string;
+        }>;
+        if (Array.isArray(created)) {
+          for (const flow of created) {
+            if (flow?.id) createdFlowIds.push(String(flow.id));
+          }
+        }
+
+        expect(res.status()).toBe(201);
+        expect(Array.isArray(created)).toBe(true);
+        expect(created).toHaveLength(2);
+        for (const flow of created) {
+          expect(flow?.id, "every accepted row comes back with an id").toBeTruthy();
+        }
+        seededName = `${base}-a`;
+      });
+
+      await test.step("the same name twice in one payload is refused 409", async () => {
+        const duplicated = unique("batch-dup-name");
+        const res = await postBatch(request, [
+          { name: duplicated },
+          { name: duplicated },
+        ]);
+        expect(
+          res.status(),
+          "a duplicate must be a conflict, not the 30s SQLite lock timeout upstream #14634 replaced",
+        ).toBe(409);
+        expect((await res.json())?.detail).toBe(DUPLICATE_NAME_DETAIL);
+        await assertNoSqlLeak(res, "the duplicate-name 409");
+      });
+
+      await test.step("a name that is already committed is refused the same way", async () => {
+        // A different code path from two names inside one flush: this row exists
+        // and is visible to the transaction rather than colliding within it.
+        const res = await postBatch(request, [{ name: seededName }]);
+        expect(res.status()).toBe(409);
+        expect((await res.json())?.detail).toBe(DUPLICATE_NAME_DETAIL);
+        await assertNoSqlLeak(res, "the already-committed-name 409");
+      });
+
+      await test.step("the next write succeeds — the rollback released the lock", async () => {
+        // The load-bearing assertion. A 409 that left the write lock held
+        // satisfies every assertion above and is still the exact defect #14634
+        // fixed: the caller sees a clean conflict and the NEXT writer dies with
+        // "database is locked". No duration threshold is needed — if the lock
+        // were held this request would stall out instead of returning 201.
+        const res = await request.post("/api/v1/flows/", {
+          headers: { Authorization: bearerToken },
+          data: { name: unique("after-conflict") },
+        });
+
+        // Recorded before the assert, for the reason given in step 1.
+        const createdId = (await res.json().catch(() => ({})))?.id;
+        if (createdId) createdFlowIds.push(String(createdId));
+
+        expect(
+          res.status(),
+          "a write immediately after a refused batch must succeed; a held lock would make this stall rather than answer",
+        ).toBe(201);
+      });
+    },
+  );
+
+  test(
+    "batch create refuses a duplicate endpoint_name with its own message",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      const sharedEndpoint = `ep${Date.now().toString(36)}${Math.random()
+        .toString(36)
+        .slice(2, 6)}`;
+
+      const res = await postBatch(request, [
+        { name: unique("batch-ep-1"), endpoint_name: sharedEndpoint },
+        { name: unique("batch-ep-2"), endpoint_name: sharedEndpoint },
+      ]);
+
+      expect(res.status()).toBe(409);
+      const detail = (await res.json())?.detail;
+      expect(detail).toBe(DUPLICATE_ENDPOINT_DETAIL);
+      expect(
+        detail,
+        "two guards, two messages: a regression collapsing them would still answer 409 and would still satisfy the duplicate-name test",
+      ).not.toBe(DUPLICATE_NAME_DETAIL);
+
+      await assertNoSqlLeak(res, "the duplicate-endpoint_name 409");
+    },
+  );
+
+  test(
+    "a completed background run reports the session it was given",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      const sessionId = unique("bg-session");
+      let jobId = "";
+
+      await test.step("the run is queued and answers with a job id", async () => {
+        const res = await postWorkflow(request, "background", sessionId);
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body?.status).toBe("queued");
+        expect(body?.job_id).toBeTruthy();
+        jobId = String(body.job_id);
+      });
+
+      await test.step("the first completed status carries the session and the outputs", async () => {
+        // Read the FIRST response that reports completion, not a settled one:
+        // this test's whole contrast with the sync test is that background gets
+        // it right immediately, so polling past the first `completed` would
+        // measure convergence instead of the property.
+        let facts: JobStatusFacts | null = null;
+        const deadline = Date.now() + SETTLE_BUDGET_MS;
+        while (Date.now() < deadline) {
+          const res = await getJob(request, jobId);
+          expect(res.status()).toBe(200);
+          const seen = await readJobFacts(res);
+          if (seen.status === "completed") {
+            facts = seen;
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, SETTLE_POLL_MS));
+        }
+
+        expect(
+          facts,
+          `the background job never reported completed within ${SETTLE_BUDGET_MS}ms`,
+        ).not.toBeNull();
+        expect(facts!.sessionId).toBe(sessionId);
+        expect(
+          facts!.sessionId,
+          "the flow id is the documented degradation upstream #14512 names, so asserting only equality would pass on a flow whose id happened to match",
+        ).not.toBe(flowId);
+        expect(facts!.outputKeys).toContain(CHAT_OUTPUT_NODE_ID);
+        expect(facts!.outputText).toBe(RUN_INPUT);
+      });
+    },
+  );
+
+  test(
+    "a completed sync run answers its own status query with the session and outputs it returned",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // DECLARED FAILING, and the declaration is the alarm in both directions.
+      //
+      // The assertions below are the intended contract, unweakened: 15/15 they
+      // fail on 1.12.0.dev37 because the sync read-back races the vertex_build
+      // commit it reconstructs from (spec doc → *The sync defect*). Declaring
+      // that keeps a known-broken product path out of a permanent red, and —
+      // the half a plain red does not give — makes the FIX detectable: the day
+      // upstream lands it this body passes, Playwright reports "expected to
+      // fail but passed", and the suite goes red asking for this line back.
+      //
+      // `test.fail()` is rejected elsewhere in this suite for a real reason —
+      // mcp-client-agent-gemini-tool-regression.spec.ts: it "converts ANY
+      // failure (a broken bootstrap, a down instance …) into a green expected
+      // failure". That objection is answered here by construction rather than
+      // by argument: the attribution-control test below runs the SAME submit
+      // and read-back, on the same flow, through the same helpers, and is NOT
+      // declared failing — so a broken bootstrap or a dead instance reddens it
+      // (and the three tests above it) rather than hiding here.
+      test.fail();
+
+      const sessionId = unique("sync-session");
+
+      // The two calls are issued back to back with NOTHING between them, and
+      // every assertion is deferred until both have answered. This is the
+      // sequence a real client runs — submit, then read the job it was given —
+      // and the ordering is load-bearing: the degradation below is a race
+      // against the vertex_build commit, so parsing bodies or asserting the
+      // submit response first spends the very window the test is measuring.
+      // With the assertions interleaved the defect went undetected in 1 of 13
+      // measured runs; issued back to back it is 10 of 10.
+      const submit = await postWorkflow(request, "sync", sessionId);
+      const jobId = String((await submit.json())?.job_id ?? "");
+      const readBack = await getJob(request, jobId);
+
+      await test.step("the run completed and said so, carrying its session and outputs", async () => {
+        // The premise. Everything below contradicts it, rather than asking a
+        // timing question — which is why it is asserted rather than assumed.
+        expect(submit.status()).toBe(200);
+        expect(jobId, "the submit response names the job to read back").toBeTruthy();
+
+        const facts = await readJobFacts(submit);
+        expect(facts.status).toBe("completed");
+        expect(facts.sessionId).toBe(sessionId);
+        expect(facts.outputKeys).toContain(CHAT_OUTPUT_NODE_ID);
+        expect(facts.outputText).toBe(RUN_INPUT);
+      });
+
+      await test.step("reading that job back reports the same session and outputs", async () => {
+        expect(readBack.status()).toBe(200);
+        const facts = await readJobFacts(readBack);
+
+        // Asserted first: it is what makes the rest a contradiction. The API
+        // says the job is done, so "the outputs are not ready yet" is not an
+        // available reading of the two assertions below.
+        expect(
+          facts.status,
+          "the status endpoint agrees the job is complete",
+        ).toBe("completed");
+
+        expect(
+          facts.sessionId,
+          "a completed job must report the session it was submitted with — message memory and chat history scope to this key, so a status read that substitutes the flow id hands the caller a thread that is not the one that ran",
+        ).toBe(sessionId);
+        expect(facts.sessionId).not.toBe(flowId);
+        expect(
+          facts.outputKeys,
+          "a job the API reports as completed must not report zero outputs: a caller cannot tell this from a run that genuinely produced nothing",
+        ).toContain(CHAT_OUTPUT_NODE_ID);
+        expect(facts.outputText).toBe(RUN_INPUT);
+      });
+    },
+  );
+
+  test(
+    "attribution control: the sync read-back is correct once the job's rows settle",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // This test exists to make the previous one's failure attributable, and
+      // the pair is the diagnosis: previous red + this green is a race between
+      // the reply and the vertex_build commit. BOTH red is a strictly worse
+      // regression — reconstruction dead, the session unrecoverable at any
+      // time — and without this test the two would report as one finding.
+      const sessionId = unique("settle-session");
+
+      const submit = await postWorkflow(request, "sync", sessionId);
+      expect(submit.status()).toBe(200);
+      const jobId = String((await submit.json())?.job_id ?? "");
+      expect(jobId).toBeTruthy();
+
+      let settled: JobStatusFacts | null = null;
+      const deadline = Date.now() + SETTLE_BUDGET_MS;
+      while (Date.now() < deadline) {
+        const res = await getJob(request, jobId);
+        expect(res.status()).toBe(200);
+        const facts = await readJobFacts(res);
+        if (facts.sessionId === sessionId && facts.outputKeys.length > 0) {
+          settled = facts;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, SETTLE_POLL_MS));
+      }
+
+      expect(
+        settled,
+        `the sync read-back never reported the submitted session with outputs within ${SETTLE_BUDGET_MS}ms — reconstruction is not merely late, it is unavailable`,
+      ).not.toBeNull();
+      expect(settled!.sessionId).toBe(sessionId);
+      expect(settled!.outputKeys).toContain(CHAT_OUTPUT_NODE_ID);
+    },
+  );
+});


### PR DESCRIPTION
Closes #1575.

Fills the new `QA-CHECKLIST.md` § 1.8 (*Workflows v2 — Job Lifecycle*), five bullets.

`POST /api/v2/workflows` is the run path the product itself uses — the flow editor, the playground and every agent run go through it. This suite already **observes** it: `tests/fixtures/flow-error-policy.ts` classifies its stream and eight specs trigger it incidentally. Nothing **drove it as an API contract**. The only spec addressing the endpoint directly is `security/tweaks-graph-path-floor.spec.ts` (#1567), and it covers the tweaks floor, not the lifecycle. So the submit half was exercised constantly and the read-back half by nothing.

No overlap with `api/flows/api-flows-batch.spec.ts`, which probes a batch **DELETE** against `/api/v1/flows/batch` (no trailing slash, `{flow_ids}`) and GET pagination. Nothing there drives `POST /api/v1/flows/batch/` as a batch **create** with `{flows}`. That file's first test is a pre-existing deliberate red on a premise that has gone stale, flagged separately rather than folded in here.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `batch create refuses a duplicate name with 409, leaks no SQL, and leaves the next write working` | A unique-name batch answers `201` with both ids (the control — without it every `409` below is equally consistent with a broken endpoint). A duplicate inside one payload, and a name already committed, each answer `409 {"detail":"Name must be unique"}`. The body renders none of `INSERT` / `SELECT` / `UNIQUE constraint` / `sqlalchemy` / `[SQL:` / `parameters:`. **The next write answers `201`** — the rollback released the SQLite write lock. Catches `langflow-ai/langflow#14634` regressing: before it, the failed INSERT held the lock for the full 30 s `busy_timeout`, so a duplicate surfaced as "database is locked" on the *next* writer, and the unhandled exception leaked the statement and its bound parameters |
| 2 | `batch create refuses a duplicate endpoint_name with its own message` | `409 {"detail":"Endpoint name must be unique"}`, asserted as **not equal** to the name guard's message. Two guards, one status — the message is the only thing separating them, so a regression collapsing them would still answer `409` and would still satisfy test 1 |
| 3 | `a completed background run reports the session it was given` | On the **first** status read that says `completed`: `session_id` equals the submitted session, is **not** the flow id, and `outputs` carries the Chat Output node with the echoed text. The flow id is the specific degradation `langflow-ai/langflow#14512` names, so asserting only equality would be weaker than it looks |
| 4 | `a completed sync run answers its own status query with the session and outputs it returned` | **Declared failing** (`test.fail()`) against a live defect — see § 4 |
| 5 | `attribution control: the sync read-back is correct once the job's rows settle` | The same read converges within 10 s with the submitted session and non-empty outputs. Exists to make test 4's failure **attributable**: *4 failing + 5 passing* is the race; *both* failing would be a strictly worse regression — reconstruction unavailable at any time — and without the pair the two would report as one finding |

## 2. How the test was built

- **Setup:** `getAuthToken(request)` → Bearer, used on every call. Measured that the v2 workflow routes accept it, so no `x-api-key` is minted (unlike `POST /api/v1/run/{id}`). `createRunnableChatFlowViaApi` builds the shared `Chat Input → Chat Output` fixture flow, which echoes its input — so a run's output is deterministic with no provider configured.
- **No selectors to confirm:** request-only, no browser, no POM. Nothing was invented because nothing was needed.
- **Payload shape measured, not assumed:** `FlowCreate` requires only `name` and accepts an optional `endpoint_name`. A name-only two-flow batch answers `201` and both duplicate axes still answer `409`, so the batch payloads are minimal rather than full fixture graphs.
- **Cleanup is id-scoped and ordered so a red test cannot orphan a flow.** Every created id is recorded **before** anything is asserted about the response. This is not theoretical: the force-fail pass on test 1's lock-release assertion left exactly one orphan, because the `push` sat after the `expect`. Fixed in both creation sites and verified by re-running the same mutation — `1 failed`, **zero** orphans.
- **`allowHttpErrors()` is deliberately absent.** The HTTP-error monitor is wired to `page.on("response")` and never sees `request`-fixture traffic, so the deliberate `409`s cannot reach the advisory log. Every call therefore asserts its own status explicitly — which is what makes an unexpected `500` fail the test rather than pass into a log nobody reads. Same as every sibling in `api/flows/`, including `api-invalid-key.spec.ts`.

## 3. Dependencies

- **None** — no LLM, no provider key, no `collect-models`, no browser. Only a running instance.
- **Parallel-safe.** Every name carries a unique suffix and no instance-wide state is touched; not `@destructive`.
- Whole file runs in **~2.8 s**.

## 4. The declared failure, and why `test.fail()`

Measured on `1.12.0.dev37` (`langflowai/langflow-nightly@sha256:b672ab7e…`, upstream revision `50340f2a…`):

```
POST /api/v2/workflows  {mode: "sync", session_id: "ses-38b014ff"}
  → 200  status="completed"  session_id="ses-38b014ff"  outputs=[ChatOutput-…]

GET  /api/v2/workflows?job_id=<that job>        ← the obvious next call
  → 200  status="completed"  session_id="<the flow id>"  outputs={}
```

15/15. It self-heals in **250–463 ms** (median 434, 12 of 12 cold jobs). #14512's fix **is** present — the `sync_result_storage_enabled` setting it added exists and reads its `False` default — but the flag-off path it documents (*"GET resolves session via vertex-build reconstruction"*) races the `vertex_build` commit and loses. The reconstruction itself is correct: a later read of the same job returns the submitted session and the outputs, and the stored blob carries `session_id` at `results.message.data.session_id`, exactly where `_recover_session_id` walks.

What rules out "eventual consistency, working as intended": **the same body asserts `status: "completed"` while reporting no outputs**, and `mode=background` — which persists `job_metadata["request"]` — answers correctly on its first completed read. A caller cannot distinguish this from a run that genuinely produced nothing.

No upstream issue exists; a ticket is drafted and, by the reporter's decision, not filed. The measurement and the mechanism live in the spec doc.

**Why declared rather than plain red.** The assertions are identical either way — `test.fail()` inverts the verdict, never the assertion. What it buys is that the **fix becomes detectable**: a permanent red decays into noise, while a declared failure turns the fix into a *new* red (`Expected to fail, but passed`) asking for the annotation back. This suite rejects `test.fail()` elsewhere for a sound reason — `mcp-client-agent-gemini-tool-regression.spec.ts` records that it "converts ANY failure (a broken bootstrap, a down instance …) into a green expected failure". That objection is answered here **by construction**: test 5 runs the same submit and read-back, on the same flow, through the same helpers, and is not declared failing, so a broken bootstrap or dead instance reddens it and tests 1–3 instead of hiding.

## Validation

- **Instance:** `1.12.0.dev37` / `Langflow Nightly`, digest `sha256:b672ab7e91981c6f1719b2932bfa7e2255324d4cfac18b7fedf0dbf5722761de`, upstream revision `50340f2a4322eca624b7ef5684237d87f863fc1b`.
- **Burst** at `--retries=0 --workers=1`: `expected=5 unexpected=0 flaky=0 backendErrors=false`, ~2.8 s. `typecheck=0`, `lint` 0 errors.
- **Force-fail 5/5**, each verified red then reverted (no `FF-MUTATION` marker survives; final green run recorded):
  - test 1 — lock-release assertion inverted (`201` → `500`)
  - test 2 — endpoint guard expected to answer the duplicate-**name** message, collapsing the two guards
  - test 3 — session assertions inverted (expects the flow id)
  - test 4 — the four read-back assertions inverted to the buggy values, so the declared-failing body passes and Playwright reports `Expected to fail, but passed`
  - test 5 — settle budget cut `10 s` → `1 ms`, so the poll can never converge
- **Detection of the test-4 defect is 15/15, and the ordering is load-bearing.** The submit and the read-back are issued back to back with no assertion between them. An earlier draft asserted the submit's four premises first, and that work was enough to let the race go the other way — the defect went undetected in 1 of 13 runs. Any future edit that reintroduces work between those two calls silently weakens the test to ~92 %.
- **Orphans:** `GET /api/v1/flows/?remove_example_flows=true` reports **0** non-example flows after the run.
- Spec-doc guards pass: `npm run validate:specs` and `watch-upstream-areas --mode=check-docs` report no unresolved dependency path in the changed docs.

No `@stable`: test 4 is declared failing, and that alarm should reach a reviewer on a PR rather than open a `daily-failure` issue at 05:00. The other four are a new spec awaiting a validation cycle, so their bullets are `[-]`; test 4's is `[!]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
