### PR TITLE
test(security): promote the graph-path tweak floor to @stable (#1572)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -923,9 +923,8 @@
       → security/tweaks-graph-path-floor.spec.ts
 - [x] `mode=sync` refuses a protected tweak **without ever answering 2xx**, and the refused request
       leaves the flow still running the author's code. Asserted shape-agnostically on purpose: the
-      status body is a generic `500` on `1.12.0.dev37` and still on `dev38`, where
-      `POST /api/v1/run` returns `422 TWEAKS_REFUSED` naming the field; the property pinned here
-      holds under both, while
+      status body is a generic `500` on `1.12.0.dev37` and still on `dev38`, where `POST /api/v1/run`
+      returns `422 TWEAKS_REFUSED` naming the field; the property pinned here holds under both, while
       still catching the failure that matters — a refusal answering `200` because the tweak took
       effect or was dropped and the run proceeded anyway. The shape difference is recorded in the
       spec doc → security/tweaks-graph-path-floor.spec.ts

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -910,7 +910,7 @@
 - [x] Tweak values passed to `POST /api/v1/run/{id}` cannot reach template fields as
       executable input (`langflow-ai/langflow#9319`, `#8672`)
       → security/tweaks-injection.spec.ts
-- [-] The floor holds on the **graph run path** — `POST /api/v2/workflows` `mode=stream` refuses a
+- [x] The floor holds on the **graph run path** — `POST /api/v2/workflows` `mode=stream` refuses a
       `global_imports` and a `python_code` tweak on a code-execution node, and the refusal is
       **named** in the stream (an `event: "error"` frame carrying `TweakRefusedError` and the
       refused key) rather than being a bare failure. Both failure directions are asserted because
@@ -918,13 +918,14 @@
       widened module is in scope) and an unattributable refusal by requiring the frame to name the
       key. This is the path `langflow-ai/langflow#14538` says previously accepted tweaks the sync
       mode refused → security/tweaks-graph-path-floor.spec.ts
-- [-] The same on `mode=background`, read from `GET /api/v2/workflows/{job_id}/events` — kept as
+- [x] The same on `mode=background`, read from `GET /api/v2/workflows/{job_id}/events` — kept as
       its own bullet because `#14538` names both modes and they can regress independently
       → security/tweaks-graph-path-floor.spec.ts
-- [-] `mode=sync` refuses a protected tweak **without ever answering 2xx**, and the refused request
+- [x] `mode=sync` refuses a protected tweak **without ever answering 2xx**, and the refused request
       leaves the flow still running the author's code. Asserted shape-agnostically on purpose: the
-      status body is a generic `500` on `1.12.0.dev37` where `POST /api/v1/run` returns
-      `422 TWEAKS_REFUSED` naming the field, and the property pinned here holds under both, while
+      status body is a generic `500` on `1.12.0.dev37` and still on `dev38`, where
+      `POST /api/v1/run` returns `422 TWEAKS_REFUSED` naming the field; the property pinned here
+      holds under both, while
       still catching the failure that matters — a refusal answering `200` because the tweak took
       effect or was dropped and the run proceeded anyway. The shape difference is recorded in the
       spec doc → security/tweaks-graph-path-floor.spec.ts

--- a/docs/security/tweaks-graph-path-floor.md
+++ b/docs/security/tweaks-graph-path-floor.md
@@ -1,6 +1,6 @@
 # Tweaks — the protected-field floor on the graph run path
 
-**Last validated:** Langflow 1.12.0.dev38 — `langflowai/langflow-nightly@sha256:5813e74988bf09fdfd6c16fd5aad39aae0099469907ec48d5e5625a3f9c66683` (the `linux/arm64` image of the manifest list `:latest` and `:1.12.0.dev38` both resolve to — the two lists are byte-identical); upstream revision `814fbceeb1dd38d3e52f60ce1e638af6fb725ffe`. First validated on 1.12.0.dev37 (`sha256:b672ab7e…`, revision `50340f2a4322…`); the measured table below is unchanged between the two builds, re-measured for `mode=sync` on dev38.
+**Last validated:** Langflow 1.12.0.dev38 — manifest list shared by `:latest` and `:1.12.0.dev38` (verified identical), `linux/amd64` `sha256:5082eb1ecb056f94491c4debe25925be48948dabc15db7186eeeb9fe645021d0` (the image every CI lane pulls) / `linux/arm64` `sha256:5813e74988bf09fdfd6c16fd5aad39aae0099469907ec48d5e5625a3f9c66683` (the one this validation ran on, named because the arch is part of the measurement); upstream revision `814fbceeb1dd38d3e52f60ce1e638af6fb725ffe`. First validated on 1.12.0.dev37 (`sha256:b672ab7e…`, revision `50340f2a4322…`); the measured table below is unchanged between the two builds, re-measured for `mode=sync` on dev38.
 
 ---
 
@@ -30,7 +30,7 @@ Every refusal is paired with a **benign** tweak on the same surface and the same
 
 No **functional** tag applies: the tag table has no security area, and the sibling `security/` specs (`tweaks-injection`, `code-execution-endpoints`, `ssrf-url-validation`) also carry only cross-cutting tags. `@api` marks the layer; `@regression` is what issue #1567 asks for.
 
-**`@stable` was added in the validation cycle #1572 asked for, not in the first delivery.** PR #1571 shipped the file `@api @regression` only, which the repo's own mechanism turns into *no scheduled lane at all*: `daily-stable.yml` selects `--grep @stable` and `nightly.yml` has been dispatch-only since 2026-03, so the three tests ran only when `pr-validation.yml`'s impacted-specs gate happened to select them. The graph-path half of `langflow-ai/langflow#14538` — the half that closed a real bypass — was therefore watched by nothing, while the sync-endpoint sibling (`security/tweaks-injection.spec.ts`) was watched daily. The lane profile is why promotion needed no design change: pure API, no browser, no LLM, no provider key, no `@destructive` state, three tests in ~3 s, and no failure mode that depends on a provider key or quota. Validated on the build in **Last validated** above — five consecutive `--workers=1 --retries=0` runs plus one default-parallel run (3 workers, one `beforeAll` per worker), 18/18 tests green, zero orphan flows left behind, and one executed force-fail per assertion family (acceptance, attribution, liveness, and the sync `2xx` floor).
+**`@stable` was added in the validation cycle #1572 asked for, not in the first delivery.** PR #1571 shipped the file `@api @regression` only, which the repo's own mechanism turns into *no scheduled lane at all*: `daily-stable.yml` selects `--grep @stable` and `nightly.yml` has been dispatch-only since 2026-03, so the three tests ran only when `pr-validation.yml`'s impacted-specs gate happened to select them. The graph-path half of `langflow-ai/langflow#14538` — the half that closed a real bypass — was therefore watched by nothing, while the sync-endpoint sibling (`security/tweaks-injection.spec.ts`) was watched daily. The lane profile is why promotion needed no design change: pure API, no browser, no LLM, no provider key, no `@destructive` state, three tests in ~3 s, and no failure mode that depends on a provider key or quota. Validated on the build in **Last validated** above — five consecutive `--workers=1 --retries=0` runs plus one default-parallel run (3 workers, one `beforeAll` per worker), 18/18 tests green, zero orphan flows left behind, and an executed force-fail for every assertion family — attribution, liveness, the sync `2xx` floor, and acceptance, the last of which takes a two-part mutation on the streaming surfaces for a reason recorded under **Validation criterion**.
 
 Not `@destructive`, and that is a **precondition of the promotion, not a note**: `@stable` combined with `@destructive` would put the tests back in no scheduled lane, since `daily-stable.yml` has no destructive lane (#1010). The file creates and deletes only its own two flows and sets no instance-wide state.
 
@@ -40,7 +40,7 @@ Not `@destructive`, and that is a **precondition of the promotion, not a note**:
 
 ## Measured contract — one table, four surfaces *(required reading)*
 
-Measured on the digest above, against the container's **own** published port with the identity asserted (`GET /api/v1/version` → `1.12.0.dev37` / `Langflow Nightly`) before every run. Flow: `Python Interpreter -> Chat Output`, author `global_imports = "math"`, author `python_code` = the two-sentinel probe.
+Measured on 1.12.0.dev37 and re-verified on the dev38 digest above, against the container's **own** published port with the identity asserted (`GET /api/v1/version` → the expected `.devNN` / `Langflow Nightly`) before every run. The `mode=sync` cell was re-measured directly on dev38 for the #1572 promotion and is unchanged. Flow: `Python Interpreter -> Chat Output`, author `global_imports = "math"`, author `python_code` = the two-sentinel probe.
 
 | tweak on the interpreter node | `POST /api/v1/run/{id}` | `/api/v2/workflows` `sync` | `/api/v2/workflows` `stream` | `/api/v2/workflows` `background` |
 |---|---|---|---|---|
@@ -92,7 +92,7 @@ The spec runs **3 tests** via Playwright's `request` fixture. No browser, no LLM
 
 ---
 
-**Test 1 — `mode=stream` refuses a protected tweak, and says so** *(`@api @regression`)*
+**Test 1 — `mode=stream` refuses a protected tweak, and says so** *(`@stable @api @regression`)*
 
 1. `POST /api/v2/workflows` with `mode: "stream"` and `tweaks: { <pythonNodeId>: { global_imports: ["os"] } }`; assert `200` (the stream is committed before the build runs).
 2. Parse the body with `parseStreamEvents()` and assert an `event: "error"` frame exists whose serialized text names both `TweakRefusedError` and the refused key `global_imports` — the refusal is attributable, not a bare failure.
@@ -100,11 +100,11 @@ The spec runs **3 tests** via Playwright's `request` fixture. No browser, no LLM
 4. Repeat 1–3 for `python_code`, asserting the caller's sentinel never appears.
 5. **Control, same surface:** the benign `input_value` tweak on the chat flow produces that value in the `add_message` text and emits **no** error frame; the same call with no tweaks produces the flow's stored value. Without this, steps 2–4 pass equally well against a dead mechanism.
 
-**Test 2 — `mode=background` refuses it too, and says so** *(`@api @regression`)*
+**Test 2 — `mode=background` refuses it too, and says so** *(`@stable @api @regression`)*
 
 Same five steps, with the events read from `GET /api/v2/workflows/{job_id}/events` after the submit returns a `job_id`. Kept as its own test because `#14538` names both modes and they can regress independently.
 
-**Test 3 — `mode=sync` refuses a protected tweak without ever answering `2xx`** *(`@api @regression`)*
+**Test 3 — `mode=sync` refuses a protected tweak without ever answering `2xx`** *(`@stable @api @regression`)*
 
 1. `POST /api/v2/workflows` with `mode: "sync"` and the `global_imports` tweak; assert the status is `>= 400`. A `2xx` here means the tweak either took effect or was dropped without telling the caller, and both are the failures this file exists for. The body's shape is deliberately not pinned — see above.
 2. Repeat for `python_code`.
@@ -123,10 +123,13 @@ Force-fail evidence for the `@stable` promotion (#1572), each mutation executed 
 
 | mutation | emulates | tests that failed, and on which assertion |
 |---|---|---|
-| the protected `global_imports` tweak replaced by a benign `sender_name` one | the floor stops refusing and the run proceeds | 1, 2 — *"the flow author's sandbox must still be in effect"*; 3 — *"a refused global_imports tweak must not answer 2xx"* |
-| `REFUSAL_MARKER` → a string the frame does not carry | the refusal becomes unattributable | 1, 2 — *"the refusal must be attributable on this surface, not a bare failure"* |
+| the protected `global_imports` tweak replaced by a benign `sender_name` one | the floor stops refusing, so no refusal is reported at all | 1, 2 — *"the refusal must be attributable on this surface, not a bare failure"*; 3 — *"a refused global_imports tweak must not answer 2xx"* |
+| `REFUSAL_MARKER` → a string the frame does not carry | the refusal happens but is unattributable | 1, 2 — *"the refusal must be attributable on this surface, not a bare failure"* |
 | `CHAT_INPUT_NODE_ID` → an id no node has | the tweaks mechanism is dead, so the refusals measured nothing | 1, 2, 3 — *"tweaks must be alive on this surface"* |
-| `WIDENED_PREFIX` → text the author's own run really prints | the widened branch executed | 3 — *"a refusal must leave nothing behind"*. **Not** 1 or 2, and that is the honest reading: on those two surfaces the refused run emits no program output at all, so the `WIDENED:` check there is proven live only by the first mutation above, where the run does execute. |
+| `WIDENED_PREFIX` → text the author's own run really prints | the widened branch executed | 3 — *"a refusal must leave nothing behind"* |
+| **both together**: the benign `sender_name` tweak **and** `WIDENED_PREFIX` set to text the executed run prints | the graph path *accepts* the protected tweak — the run executes and emits the widened sentinel | 1, 2 — *"the flow author's sandbox must still be in effect — the run reached the widened branch"*; 3 — the `2xx` floor |
+
+**Why the acceptance check on the two streaming surfaces needs that last, two-part mutation, and what that says about it.** On `mode=stream` and `mode=background` a protected tweak is refused *before the build runs*, so the refused request emits no program output whatsoever — measured, not inferred: mutating `sandboxProbe` so that **both** of its branches print the sentinel leaves tests 1 and 2 **green** (only test 3 fails, on its own no-residue step). No test-side edit to the probe or the sentinel alone can make the streaming `WIDENED:` assertion fire. It fires only when the run actually executes while the sentinel matches what it prints, which is exactly the causal shape of a real acceptance — and that is the mutation in the last row. Read the row as what it is: the assertion is proven live, by the one mutation that reproduces the bypass `langflow-ai/langflow#14538` closed, and by nothing cheaper.
 
 ---
 

--- a/docs/security/tweaks-graph-path-floor.md
+++ b/docs/security/tweaks-graph-path-floor.md
@@ -1,6 +1,6 @@
 # Tweaks — the protected-field floor on the graph run path
 
-**Last validated:** Langflow 1.12.0.dev37 — `langflowai/langflow-nightly@sha256:b672ab7e91981c6f1719b2932bfa7e2255324d4cfac18b7fedf0dbf5722761de`, the digest both `:latest` and `:1.12.0.dev37` resolve to (`docker manifest inspect`); upstream revision `50340f2a4322eca624b7ef5684237d87f863fc1b`.
+**Last validated:** Langflow 1.12.0.dev38 — `langflowai/langflow-nightly@sha256:5813e74988bf09fdfd6c16fd5aad39aae0099469907ec48d5e5625a3f9c66683` (the `linux/arm64` image of the manifest list `:latest` and `:1.12.0.dev38` both resolve to — the two lists are byte-identical); upstream revision `814fbceeb1dd38d3e52f60ce1e638af6fb725ffe`. First validated on 1.12.0.dev37 (`sha256:b672ab7e…`, revision `50340f2a4322…`); the measured table below is unchanged between the two builds, re-measured for `mode=sync` on dev38.
 
 ---
 
@@ -26,13 +26,15 @@ Every refusal is paired with a **benign** tweak on the same surface and the same
 
 ## Tags *(required)*
 
-`@api` `@regression`
+`@stable` `@api` `@regression`
 
 No **functional** tag applies: the tag table has no security area, and the sibling `security/` specs (`tweaks-injection`, `code-execution-endpoints`, `ssrf-url-validation`) also carry only cross-cutting tags. `@api` marks the layer; `@regression` is what issue #1567 asks for.
 
-**No `@stable` in this delivery**, for the ordinary reason: it is a new spec awaiting a validation cycle, so its checklist bullets are `[-]`. The lane profile is a good fit and promotion is a one-line follow-up — pure API, no browser, no LLM, no provider key, three tests in ~4 s, and it cannot fail for a provider-outage reason. Nothing in the file is quarantined.
+**`@stable` was added in the validation cycle #1572 asked for, not in the first delivery.** PR #1571 shipped the file `@api @regression` only, which the repo's own mechanism turns into *no scheduled lane at all*: `daily-stable.yml` selects `--grep @stable` and `nightly.yml` has been dispatch-only since 2026-03, so the three tests ran only when `pr-validation.yml`'s impacted-specs gate happened to select them. The graph-path half of `langflow-ai/langflow#14538` — the half that closed a real bypass — was therefore watched by nothing, while the sync-endpoint sibling (`security/tweaks-injection.spec.ts`) was watched daily. The lane profile is why promotion needed no design change: pure API, no browser, no LLM, no provider key, no `@destructive` state, three tests in ~3 s, and no failure mode that depends on a provider key or quota. Validated on the build in **Last validated** above — five consecutive `--workers=1 --retries=0` runs plus one default-parallel run (3 workers, one `beforeAll` per worker), 18/18 tests green, zero orphan flows left behind, and one executed force-fail per assertion family (acceptance, attribution, liveness, and the sync `2xx` floor).
 
-Not `@destructive`: the file creates and deletes only its own two flows and sets no instance-wide state. (A spec for `LANGFLOW_TWEAKS_POLICY` *would* be instance-global — that surface is scoped out below.)
+Not `@destructive`, and that is a **precondition of the promotion, not a note**: `@stable` combined with `@destructive` would put the tests back in no scheduled lane, since `daily-stable.yml` has no destructive lane (#1010). The file creates and deletes only its own two flows and sets no instance-wide state.
+
+(A spec for `LANGFLOW_TWEAKS_POLICY` *would* be instance-global — that surface is scoped out below.)
 
 ---
 
@@ -115,7 +117,16 @@ Same five steps, with the events read from `GET /api/v2/workflows/{job_id}/event
 
 The spec passes only when, on each covered surface, **no protected tweak takes effect**, **the refusal names itself and the key**, and **a benign tweak on that same surface still applies**. A run where the benign control did not apply fails, because it measured nothing; a stream carrying `WIDENED:` fails; an error frame that does not name the refused key fails.
 
-The file fails for the right reason in both directions: relaxing an assertion cannot make it pass while the control must still apply, and the day `mode=sync` returns its `422`, Test 3 goes green by deleting one `.fixme`.
+The file fails for the right reason in both directions: relaxing an assertion cannot make it pass while the control must still apply. There is no `.fixme` and no quarantined assertion anywhere in it — the day `mode=sync` returns its `422`, Test 3 stays green **unchanged**, because the property it pins (never `2xx`) is true under both shapes. That is what makes the file safe to run in the daily lane: no assertion in it is waiting on an upstream fix.
+
+Force-fail evidence for the `@stable` promotion (#1572), each mutation executed against 1.12.0.dev38 and reverted:
+
+| mutation | emulates | tests that failed, and on which assertion |
+|---|---|---|
+| the protected `global_imports` tweak replaced by a benign `sender_name` one | the floor stops refusing and the run proceeds | 1, 2 — *"the flow author's sandbox must still be in effect"*; 3 — *"a refused global_imports tweak must not answer 2xx"* |
+| `REFUSAL_MARKER` → a string the frame does not carry | the refusal becomes unattributable | 1, 2 — *"the refusal must be attributable on this surface, not a bare failure"* |
+| `CHAT_INPUT_NODE_ID` → an id no node has | the tweaks mechanism is dead, so the refusals measured nothing | 1, 2, 3 — *"tweaks must be alive on this surface"* |
+| `WIDENED_PREFIX` → text the author's own run really prints | the widened branch executed | 3 — *"a refusal must leave nothing behind"*. **Not** 1 or 2, and that is the honest reading: on those two surfaces the refused run emits no program output at all, so the `WIDENED:` check there is proven live only by the first mutation above, where the run does execute. |
 
 ---
 

--- a/tests/tests-automations/regression/security/tweaks-graph-path-floor.spec.ts
+++ b/tests/tests-automations/regression/security/tweaks-graph-path-floor.spec.ts
@@ -17,9 +17,10 @@ import { createRunnableChatFlowViaApi } from "../../../helpers/flows/create-runn
 // enforcement plus `except TweakRefusedError` re-raises at three call sites
 // "because both call sites previously swallowed the refusal into a 500".
 //
-// MEASURED on 1.12.0.dev37: the floor holds on all four run surfaces — no
-// protected tweak is applied anywhere. What differs is how the refusal REACHES
-// THE CALLER, and that is what this file pins:
+// MEASURED on 1.12.0.dev37, re-measured on 1.12.0.dev38 when the file was
+// promoted to @stable (#1572) and unchanged between the two: the floor holds on
+// all four run surfaces — no protected tweak is applied anywhere. What differs
+// is how the refusal REACHES THE CALLER, and that is what this file pins:
 //   POST /api/v1/run        -> 422, code TWEAKS_REFUSED, fields naming the key
 //   /api/v2/workflows sync  -> 500 INTERNAL_SERVER_ERROR (the defect; Test 3)
 //   /api/v2/workflows stream/background
@@ -316,7 +317,7 @@ test.describe("Tweaks — the protected-field floor on the graph run path", () =
 
   test(
     "mode=stream refuses a protected tweak and names the refusal",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       await assertStreamingSurface(request, "stream");
     },
@@ -324,7 +325,7 @@ test.describe("Tweaks — the protected-field floor on the graph run path", () =
 
   test(
     "mode=background refuses a protected tweak and names the refusal",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       await assertStreamingSurface(request, "background");
     },
@@ -349,7 +350,7 @@ test.describe("Tweaks — the protected-field floor on the graph run path", () =
   // recorded in docs/security/tweaks-graph-path-floor.md instead.
   test(
     "mode=sync refuses a protected tweak without ever answering 2xx",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       for (const [field, tweak] of [
         ["global_imports", SANDBOX_WIDENING_TWEAK],


### PR DESCRIPTION
Closes #1572.

`security/tweaks-graph-path-floor.spec.ts` landed on `main` in PR #1571 with all three of its tests tagged `@api @regression` and no `@stable`, which the repo's own lane selection turns into **no scheduled coverage at all**: `daily-stable.yml` runs `--grep @stable` and `nightly.yml` has been dispatch-only since 2026-03. So the graph run path — the half of `langflow-ai/langflow#14538` that closed a **real bypass** (`api/build.py` filtered only the literal key `code`, so a `global_imports` override widening the exec sandbox was applied) — was watched by nothing, while its sync-endpoint sibling `security/tweaks-injection.spec.ts` was watched every weekday.

The issue allowed either outcome: promote after validation, or record in the spec doc's **Tags** section why not. This PR **promotes**, because the validation held and the lane profile fits without a design change — pure API, no browser, no LLM, no provider key, no instance-wide state, three tests in ~3 s, and no assertion waiting on an upstream fix (Test 3 is shape-agnostic on purpose, so the day `mode=sync` returns its `422` it stays green unchanged).

## 1. Covered tests

No test logic changed. The tags did.

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `mode=stream refuses a protected tweak and names the refusal` | On `POST /api/v2/workflows` `mode=stream`: a `global_imports` and a `python_code` tweak on a code-execution node are refused; `WIDENED:` appears nowhere (the author's sandbox is still in effect); an `event: "error"` frame names both `TweakRefusedError` and the refused key (attributable, not a bare failure); and a benign `input_value` tweak on the same surface still applies with no error frame — without which the refusals would pass equally against a dead tweaks mechanism |
| 2 | `mode=background refuses a protected tweak and names the refusal` | The same contract read from `GET /api/v2/workflows/{job_id}/events`. Its own test because `#14538` names both modes and they can regress independently |
| 3 | `mode=sync refuses a protected tweak without ever answering 2xx` | The refusal never answers `2xx` — a success status would mean the tweak took effect or was dropped without telling the caller; a later untweaked run still prints the author's sentinel and never `WIDENED:` (the refusal left no residue in the cached graph); the benign control still applies |

## 2. How the promotion was validated

Local podman container running `langflowai/langflow-nightly:latest` = **1.12.0.dev38**, on its own published port with the identity asserted (`GET /api/v1/version` → `Langflow Nightly` / `.dev38`) — the port-shadowing trap the spec doc records cost the original author a whole measurement pass.

- **5 consecutive `--workers=1 --retries=0` runs** → 15/15 green, 2.5–3.8 s each.
- **1 default-parallel run** (3 workers, one `beforeAll` per worker) → 3/3 green.
- **Zero orphan flows**: `GET /api/v1/flows/` is 26 before and after every run, including the mutated ones — only Langflow's starter templates.
- **`npx playwright test --grep @stable --list`** now selects all three, which is the actual deliverable of the issue.
- **`mode=sync` re-measured on dev38**: still `500 INTERNAL_SERVER_ERROR` / `"An unexpected error occurred."`, so the doc's measured table is carried forward as verified rather than assumed.

### Force-fail — every assertion family, executed and reverted

| mutation | tests that failed, and on which assertion |
|---|---|
| protected `global_imports` tweak → a benign `sender_name` one | 1, 2 — *"the refusal must be attributable on this surface"*; 3 — *"must not answer 2xx"* |
| `REFUSAL_MARKER` → a string the frame does not carry | 1, 2 — *"the refusal must be attributable on this surface"* |
| `CHAT_INPUT_NODE_ID` → an id no node has | 1, 2, 3 — *"tweaks must be alive on this surface"* |
| `WIDENED_PREFIX` → text the author's own run really prints | 3 — *"a refusal must leave nothing behind"* |
| **both together**: the benign tweak **and** `WIDENED_PREFIX` matching the executed run's output | 1, 2 — *"the flow author's sandbox must still be in effect"*; 3 — the `2xx` floor |

That last row is not padding, and the second commit exists because the first version of this table got it wrong. On the two streaming surfaces a protected tweak is refused **before the build runs**, so the refused request emits no program output at all — measured, not inferred: mutating `sandboxProbe` so that *both* of its branches print the sentinel leaves tests 1 and 2 **green**. No test-side edit to the probe or the sentinel alone can make the streaming `WIDENED:` assertion fire. It fires only when the run actually executes while the sentinel matches what it prints — the causal shape of a real acceptance, i.e. of the bypass `#14538` closed. The assertion is proven live, by that mutation and by nothing cheaper, and the spec doc now says so instead of leaving it looking like a gap.

## 3. Dependencies

- **None beyond the lane's defaults** — no LLM, no provider key, no API key (`POST /api/v2/workflows` authenticates with the Bearer from `/api/v1/auto_login`).
- `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` is load-bearing (without it `run_python_repl()` refuses to execute and the control's baseline never appears). Verified set by the scheduled lane at `.github/workflows/daily-stable.yml:178`.
- `LANGFLOW_TWEAKS_POLICY` must not be set to a strict value — under `off` the benign control is refused too. Verified: nothing anywhere under `.github/` sets it.
- **Parallel-safe.** Both flows are created and deleted id-scoped in nested `try/finally`; node ids are per-flow, so the hardcoded `ChatInput-b6UCc` tweak key cannot address another worker's flow. No `@stable` spec calls `cleanAllFlows` any more, so there is no cross-worker wiper in either direction.
- Not `@destructive` and not `@enterprise` — a precondition of the promotion rather than a note, since either combination would put the tests straight back into no scheduled lane (#1010).

## 4. Also in this PR

The spec doc's *Validation criterion* claimed Test 3 would go green "by deleting one `.fixme`". There is no `.fixme`, `test.skip` or `.only` anywhere in the file — the sentence was wrong, and it mattered here: it described the file as carrying a quarantined assertion, which is exactly what would make it unsafe for the daily lane. Replaced with the accurate statement.

The `Last validated` line now names **both** architecture digests of the dev38 manifest list, with `linux/amd64` called out as the image CI actually pulls — the validation ran on `linux/arm64`, and a promotion record whose whole claim is "this is safe in the daily" should not hide which image it measured.

## Validation (nightly 1.12.0.dev38, `--retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · QA-CHECKLIST guard ✅ (no generated block edited) · `check:checklist-coverage` ✅
- `npm run test:units` ✅ 742/742 · `npm run test:scripts` ✅
- 5 clean `--workers=1 --retries=0` runs + 1 parallel run, no flake ✅
- Force-fail ✅ (table above, all reverted — `grep FF-` is 0 hits)
- Zero `🚨 Backend Error` ✅ — the spec never instantiates the `page` fixture, so the deliberate `500`s do not reach the advisory log and no `allowHttpErrors()` hatch is needed
- `--trace=on` ⛔ not run — the known local hang (#518/#490); coverage came from the `--retries=0` bursts and the force-fails instead

Reviewed independently with clean context before this PR was opened; that review is what produced the second commit.
