### PR TITLE
chore(model-provider): stop counting two never-run Azure credential tests as validated (#1480)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/model-provider/azure-ai-foundry-provider-setup.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/azure-ai-foundry-provider-setup.spec.ts
@@ -496,7 +496,7 @@ test.describe("Azure AI Foundry — unified provider setup", () => {
   // then timed out on. The poll was never the problem, and it is kept.
   test(
     "real credentials configure the provider and enable a portal deployment through the UI",
-    { tag: ["@stable", "@model-provider", "@settings"] },
+    { tag: ["@model-provider", "@settings"] },
     async ({ page, request }) => {
       const probe = await probeFoundry(request);
       test.skip(!probe.usable, `Azure AI Foundry not usable: ${probe.reason}`);
@@ -715,7 +715,7 @@ test.describe("Azure AI Foundry — unified provider setup", () => {
 
   test(
     "the configured deployment answers a real inference through the Language Model component",
-    { tag: ["@stable", "@model-provider", "@components", "@playground"] },
+    { tag: ["@model-provider", "@components", "@playground"] },
     async ({ page, request }) => {
       const probe = await probeFoundry(request);
       test.skip(!probe.usable, `Azure AI Foundry not usable: ${probe.reason}`);


### PR DESCRIPTION
Removes `@stable` from the two Azure AI Foundry credential tests that have skipped on every daily since 2026-08-04.

Traces to **#1480** (`daily-failure`, open) — an approved exception issue per `ROADMAP.md` → *Intake*. Deliberately **not** `Closes`: the restore is #1480's deliverable, so it stays open and owns it.

## Why

`probeFoundry()` gets a `401` from `https://langflow-test-123.openai.azure.com/openai/v1/models`, so `test.skip(!probe.usable, …)` fires before either test asserts anything. The cause is the secret's value, not the spec — #1270's wiring landed and closed in 10 minutes without the per-secret value-correctness check, which is why #1480 exists. No code change makes these two run.

Removing the tag does two things a `test.fixme` would not:

- they leave `daily-stable.yml`'s selection, so they stop showing up as two skips in every triage panorama (~16 dailies so far — a floor, the `results.json` artifacts expire);
- they leave the `Phase 0 — Validated` block `scripts/stable-tests.ts` generates, where they have been counted as validated coverage without running once. A skip reports SUCCESS and is indistinguishable from real coverage (#1456).

## Not the usual quarantine pair, on purpose

`CONTRIBUTING.md` couples `@stable` removal with `test.fixme` because tag removal alone leaves the test **red** on the `pr-validation.yml` impacted-specs gate, which selects by file diff rather than by tag (#871).

That rationale is absent here: these two do not go red on that gate — the PR lane carries the same 401 secret, so they skip and it stays green. Adding `test.fixme` would only hide them from the one gate where you want them to run again the moment the secret is fixed.

## Scope

Two `test()` calls, tag array only:

| Spec:line | Before | After |
|---|---|---|
| `azure-ai-foundry-provider-setup.spec.ts:499` | `["@stable", "@model-provider", "@settings"]` | `["@model-provider", "@settings"]` |
| `azure-ai-foundry-provider-setup.spec.ts:718` | `["@stable", "@model-provider", "@components", "@playground"]` | `["@model-provider", "@components", "@playground"]` |

The file's other four tests cover the unconfigured-provider surface, pass on every daily and keep `@stable` — the file stays **4/6** in the daily.

## Checklist

- No spec-doc change: `CONTRIBUTING.md` allows a temporary removal tracked by an open issue (#1480), rather than a spec doc's *Tags* section.
- No `QA-CHECKLIST.md` change: the file still carries `@stable` on four tests, so its Part II bullet stays required and unchanged. `check:checklist-coverage` ✓ and `check-checklist-guard` ✓ locally; generated blocks left to `update-coverage-summary.yml` on merge (#741).
- `npm run typecheck` ✓.

From the triage of #1588 (run [32827671203](https://github.com/oriontech-me/langflow-e2e/actions/runs/32827671203)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
