### PR TITLE
test(serving): cover serving-plane end-user identity across four configurations (#1583)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -134,6 +134,15 @@
 - [!] A completed `mode=sync` run answers its own status query with the session and outputs it just returned — **declared failing (`test.fail()`) against a live defect, 15/15 on `1.12.0.dev37`**; it flips to an *unexpected pass* the day upstream fixes it, which is the alarm to remove the annotation: the read-back reports `status: "completed"` alongside `session_id == flow_id` and `outputs: {}`, self-healing in 250–463 ms (median 434, 12/12 cold jobs). #14512's fix is present (its `sync_result_storage_enabled` setting reads `False`, the default) but the flag-off path races the `vertex_build` commit it reconstructs from. Detection depends on issuing the two calls back to back — with assertions interleaved between them the defect went unseen in 1 of 13 runs → `api/flows/workflows-v2-job-lifecycle.spec.ts`
 - [-] Attribution control: the same sync read-back **is** correct once the job's rows settle (≤10 s). Paired with the row above on purpose — that red plus this green is the race; *both* red would be a strictly worse regression, reconstruction unavailable at any time, and without the pair the two would report as one finding → `api/flows/workflows-v2-job-lifecycle.spec.ts`
 
+#### 1.9 Serving End-User Identity — inert by default (1.12)
+
+> Langflow 1.12's serving-plane end-user identity (`langflow-ai/langflow` #14443, #14550) scopes per-user chat memory behind a **trusted gateway** header, `X-End-User-Id`. It is **off by default** and turned on only by instance-global environment variables, so this subsection asserts the *off* half — the configuration every deployment is in today. The *on* half needs a different container and lives under § 23. Spec doc: `docs/api/flows/serving-end-user-identity-default.md`.
+
+- [-] Premise guard: the instance under test genuinely has no identity header configured, probed by running the flow because `GET /api/v1/config` exposes no serving setting at all (35 keys, none matching `serving`/`end_user`/`trust`) — it **fails** rather than skipping, since a skip here would read green on all four configurations → `api/flows/serving-end-user-identity-default.spec.ts`
+- [-] `POST /api/v2/workflows` twice on one `session_id` as `alice` then `bob`: both report the session **verbatim** and all 4 messages land in it, with `alice::<S>` and `bob::<S>` holding 0 — the scoped counts are the load-bearing half, since an instance could report the plain session while persisting to the scoped one → `api/flows/serving-end-user-identity-default.spec.ts`
+- [-] `POST /api/v1/run/{id}` behaves identically (4 / 0 / 0) — asserted because #14550's phase 1 extends the v2-only scoping to *all* serving APIs, making v1 the surface a partial rollout would honour first, and the one deployed integrations actually call → `api/flows/serving-end-user-identity-default.spec.ts`
+- [-] Non-vacuity control: one identity-less run on a **different** `session_id` persists its 2 messages there. Without it, "the header did nothing" and "chat memory is broken outright" give identical readings — both leave the scoped sessions empty → `api/flows/serving-end-user-identity-default.spec.ts`
+
 ---
 
 ## core-components/ — Component Configuration + Core Components
@@ -1209,6 +1218,53 @@
 - [-] **Assigning at project scope through the dialog creates a project-scoped assignment** — `domain_type: "project"` with `domain_id` equal to the id of a project the test created, asserted at the API rather than from the row's text. Scope is the axis the deny matrix turns on, and a picker submitting `global` regardless would hand instance-wide access to an operator who asked for one project. The test owns its project because two stock projects are both named `Starter Project`, told apart in the picker only by a ` — <owner>` suffix → `enterprise/authz/access-control-ui.spec.ts`
 - [-] **Revoking on the screen removes the assignment at the API** — the confirm dialog names the role and the user losing it, and the state is read from the admin listing afterwards rather than from the row disappearing. Both buttons are named exactly `Revoke`, so the row's and the dialog's are addressed separately → `enterprise/authz/access-control-ui.spec.ts`
 - [ ] Cross-replica convergence — needs Redis and a second replica: without one `invalidation.listener_connected` is `false` while the policy still resolves `active`, so a single-container assertion would measure nothing. **Recipe measured out; blocked only on machine memory** (a second Langflow replica costs ~1.1 GiB against an 8 GiB local Docker VM already holding six): the variable is `LANGFLOW_AUTHZ_REDIS_URL` (`src/authz/policy_invalidation.py`), so it takes a `redis:7-alpine` on `langflow-ee-net`, the RBAC container recreated with `LANGFLOW_AUTHZ_REDIS_URL=redis://redis-ee:6379/0`, and a second replica on another port sharing the same `LANGFLOW_DATABASE_URL`. The assertions are then `listener_connected: true` on both, and a grant written through replica A flipping replica B's enforcement with no restart, `seen_revision` / `observed_revision` converging
+
+---
+
+## serving/ — Serving-Plane End-User Identity (1.12)
+
+> **New area (2026-08-25).** The *on* half of § 1.9. Langflow 1.12 lets a trusted
+> gateway scope per-user chat memory with a request header, so two end users
+> sharing one `session_id` do not read each other's history
+> (`langflow-ai/langflow` #14443, #14550). The feature is configured entirely by
+> instance-global environment variables, which is why it is its own area rather
+> than more bullets under `api/flows/`: it needs a **different container**, reached
+> through the `@serving` lane selector and
+> `./scripts/start-langflow-serving-identity.sh` (#1582).
+
+> **Three files because there are three container states**, one per row of the
+> contract — a spec cannot restart its own instance, and a single file that
+> detected the state would have to branch inside its tests, hiding which row was
+> actually asserted. Every file opens with a **fail-closed configuration guard**:
+> the configuration is exposed by no API, so it is probed by running the flow, and
+> a mismatch **fails** naming both readings and the exact invocation that produces
+> the state the spec needs.
+
+> **None of these can be `@stable`** — nothing runs `@serving` on a cron, so the
+> tag would mark a test that never runs (#1010). The four-configuration contract
+> is in `docs/serving/end-user-identity-lane.md`.
+
+#### 23.1 Isolation, when the header is trusted
+
+- [-] Configuration guard: the instance names the header **and** trusts it, told apart from its three siblings by two probe runs — an *identified* request is `200` and scoped under `trusted` **and** under `required`, so only the identity-less run separates them → `serving/end-user-identity-isolation.spec.ts`
+- [-] `POST /api/v2/workflows` as `alice` then `bob` on one `session_id` resolves to `alice::<S>` and `bob::<S>`, 2 messages each, **and the bare `<S>` holds 0** — that last clause is the boundary: a merge that scoped the read but also wrote to the unscoped session leaves both per-user counts correct while a third client on plain `<S>` reads everybody's history → `serving/end-user-identity-isolation.spec.ts`
+- [-] `POST /api/v1/run/{id}` isolates identically, through a minted `x-api-key` → `serving/end-user-identity-isolation.spec.ts`
+- [-] An identity-less run reports `anon::<uuid>` and persists **nothing**, asserted over the whole flow (`?flow_id=`) rather than the session it reported — checking the reported session confirms it did not write *there* while saying nothing about whether it wrote somewhere else, which is exactly what a scoping bug does → `serving/end-user-identity-isolation.spec.ts`
+
+#### 23.2 Named but untrusted — fail-closed *and* fail-silent
+
+- [-] Configuration guard: the header is named and **not** trusted (both probe runs anonymised) → `serving/end-user-identity-untrusted.spec.ts`
+- [-] An identified run answers `200 completed` while being anonymised to `anon::<uuid>` and persisting zero rows anywhere in the flow — the `200` is asserted on purpose: this configuration is fail-closed for security and fail-**silent** for operations, so an operator who names the header and forgets the trust flag has a working-looking instance that remembers nothing, instance-wide → `serving/end-user-identity-untrusted.spec.ts`
+- [-] A whitespace-only header value is treated as **absent**, never as a scope named `"   "::<S>` that every client would collide on, and two consecutive blank runs on one session get **different** uuids — the anonymous scope is minted per *request*, which is what makes "remembers nothing" exact rather than approximate → `serving/end-user-identity-untrusted.spec.ts`
+
+#### 23.3 Required — refused, on every surface
+
+- [-] Configuration guard: an identity-less request is refused while an identified one is scoped → `serving/end-user-identity-required.spec.ts`
+- [-] `POST /api/v2/workflows`: an identified run is `200`, scoped and persisted; an identity-less one is `401` with `detail.code: "END_USER_IDENTITY_REQUIRED"`; a whitespace-only value is refused the same way. Asserted on the **code**, not the sentence — the code is what a gateway branches on — plus one property of the message: that it **names the configured header**, since an operator running a non-default name needs the error to say which one is missing → `serving/end-user-identity-required.spec.ts`
+- [-] `POST /api/v1/run/{id}` refuses with the same code and accepts an identified run — the accepted half is asserted because a guard that refuses everything is as broken as one that refuses nothing, and would pass a spec that only checked the `401`s → `serving/end-user-identity-required.spec.ts`
+- [ ] Job-lifecycle gating by end user (#14550 phase 3) — `GET /api/v2/workflows`, `/stop` and `/resume` refusing another end user's job. The natural follow-up now that the lane exists; kept out so the memory boundary landed first
+- [ ] `serving_internal_mcp_hosts` (#14550 phase 4) — the fail-closed outbound allowlist that forwards the identity only to operator-allowlisted internal hosts. Needs an internal MCP host to point at
+- [ ] `serving_trace_end_user` and the end-user span link (#14616) — needs an OTLP collector, which this repo has none of (`otlp|opentelemetry` returns zero matches across `tests/`, `docs/`, `scripts/` and `.github/`)
 
 ---
 

--- a/docs/api/flows/serving-end-user-identity-default.md
+++ b/docs/api/flows/serving-end-user-identity-default.md
@@ -1,0 +1,147 @@
+# Serving-plane end-user identity — inert on a default instance
+
+**File:** `tests/tests-automations/regression/api/flows/serving-end-user-identity-default.spec.ts`
+
+**Last validated:** Langflow 1.12.0.dev38 (`langflowai/langflow-nightly:latest`, `package: "Langflow Nightly"`)
+
+---
+
+## What this test validates *(required)*
+
+On a **default** instance, a client-supplied `X-End-User-Id` header must do **nothing**.
+
+Langflow 1.12 added serving-plane end-user identity (`langflow-ai/langflow`
+[#14443](https://github.com/langflow-ai/langflow/pull/14443),
+[#14550](https://github.com/langflow-ai/langflow/pull/14550)): a *trusted gateway* header
+scopes per-user chat memory, so two end users sharing one `session_id` do not read each
+other's history. The feature is off by default and turned on only by instance-global
+environment variables — `LANGFLOW_SERVING_END_USER_HEADER` plus
+`LANGFLOW_SERVING_TRUST_PROXY_HEADERS`.
+
+**This spec asserts the "off" half of that contract**, which is the configuration every
+deployment is in today. If a future change ever honours the header without the trust flag,
+an attacker who can set a request header picks which user's memory a run reads and writes —
+a cross-user memory-read vector reachable from any client. Nothing in the suite would notice:
+the run answers `200`, the output is correct, and the only difference is *which* session row
+the message landed in.
+
+**Measured on `dev38`, both serving surfaces, header ignored on each:**
+
+| surface | `alice` on `S` | `bob` on `S` | in `S` | in `alice::S` | in `bob::S` |
+|---|---|---|---|---|---|
+| `POST /api/v2/workflows` | reports `S` | reports `S` | **4** | 0 | 0 |
+| `POST /api/v1/run/{id}` | reports `S` | reports `S` | **4** | 0 | 0 |
+
+**Both surfaces are asserted, not just v2.** #14550's phase 1 describes extending the
+v2-only session-scoping behaviour "to all serving APIs", so v1 is the surface where a
+partial rollout would first honour the header — and it is also the surface with the wider
+blast radius, since `POST /api/v1/run/{id}` is what a deployed integration calls with a
+minted `x-api-key`.
+
+**The control is not optional.** "The header did nothing" and "chat memory does not work at
+all" produce identical readings for the assertions above — both leave `alice::S` and `bob::S`
+empty. So the spec also runs one identity-less request on a **different** `session_id` and
+requires that session to hold exactly its own 2 messages. Without it the test passes on an
+instance where persistence is broken outright, which is the vacuous-assert failure mode this
+suite has paid for before (#570/#1012: a green run that measured nothing).
+
+The header value itself is chosen adversarially rather than cosmetically: the identities are
+`alice`/`bob`-shaped, and the assertion looks for the *scoped* session keys
+(`alice::<session>`) that a trusting instance produces. A spec that only checked
+"the reported `session_id` equals what I sent" would miss an instance that reports the plain
+session while persisting to the scoped one.
+
+---
+
+## Tags *(required)*
+
+`["@api", "@regression"]`
+
+`@api` for the layer — the whole spec is `request`-fixture calls, no browser. `@regression`
+because it pins an upstream security property rather than exploring a feature.
+
+**Deliberately not `@serving`.** That tag is a *lane selector*: `tests/fixtures/lane.ts`
+`grepInvert`s it out of every normal run, so adding it here would move this spec into the
+opt-in lane and it would then never run on the default instance — which is the only instance
+it has anything to say about. The inert half belongs on the stock lane by construction.
+
+**No `@stable` yet**, per the repo rule that the tag is added only after team validation.
+It is a genuine candidate — keyless, no model, no external network, ~4 s — and promoting it
+is a one-line follow-up once the team has run it.
+
+---
+
+## Precondition *(required)*
+
+- A default OSS instance: no `LANGFLOW_SERVING_*` variable set. `./scripts/start-langflow-docker.sh`
+  produces one; so does any instance this suite normally targets.
+- `auto_login` (the stock nightly), for the bearer token and the minted API key.
+- No provider key, no model, no external network.
+
+**A serving-configured instance must not silently pass this spec**, so step 1 is a
+fail-closed guard: the spec probes the instance and **fails** if the header is honoured,
+naming what it found. Skipping instead would make the spec green on the one instance where
+its premise is false (#1010's green all-skip).
+
+---
+
+## Step by step *(required)*
+
+1. **Guard the premise.** Mint a bearer token (`GET /api/v1/auto_login`), create the
+   keyless `Chat Input → Chat Output` flow (`createRunnableChatFlowViaApi`), and run it once
+   through `POST /api/v2/workflows` carrying `X-End-User-Id: <probe>`. The reported
+   `session_id` must equal the session sent, verbatim. A `<probe>::<session>` or `anon::<uuid>`
+   reading means the instance is serving-configured — the spec fails naming which, and points
+   at the stock start script.
+2. **v2, two identities, one session.** Run `POST /api/v2/workflows` twice on the same
+   `session_id` with `X-End-User-Id: alice` then `bob`. Both responses report the session
+   verbatim. `GET /api/v1/monitor/messages?session_id=<S>` holds **4**;
+   `?session_id=alice::<S>` and `?session_id=bob::<S>` hold **0** each.
+3. **v1 run, same shape.** Mint an `x-api-key` (`POST /api/v1/api_key/`), run
+   `POST /api/v1/run/{flow_id}` twice on a fresh `session_id` with the same two identities.
+   Same three counts: 4 / 0 / 0.
+4. **Control.** One `POST /api/v2/workflows` with **no** identity header on a third
+   `session_id`; that session holds exactly **2**. This is what makes steps 2–3 non-vacuous.
+5. **Cleanup.** `afterAll` deletes the flow by id and revokes the minted API key. Ids are
+   recorded *before* the asserts that could throw, so a failing assertion cannot leak the
+   flow — the ordering bug caught during #1575's force-fail.
+
+---
+
+## Validation criterion *(required)*
+
+Every count above is exact, on both surfaces, with the control session non-empty — and the
+premise guard passes, so all of it was measured on an instance whose header is genuinely
+unconfigured.
+
+**Force-fail evidence** (what a real regression would look like): inverting any single count
+must redden exactly one test. The behavioural mutation that matters is the one that mimics
+the vector — asserting `alice::S` holds 2 instead of 0 — because that is the reading a
+trusting instance produces.
+
+---
+
+## What this does not cover *(and why)*
+
+- **The trusted configuration.** `serving/end-user-identity-isolation.spec.ts` — a different
+  instance, hence a different lane. The pair is the point: the same header, inert here and
+  decisive there. Either alone is weak.
+- **Other clients of the header** — the playground UI, MCP, A2A. This is the API contract;
+  a UI that sets the header is a separate surface.
+- **Whether the plain session is itself isolated per user account.** Out of scope: this is
+  about the *end-user* dimension the header adds, not about account ownership.
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/src/lfx/services/settings/groups/security.py` — declares
+  `serving_end_user_header` and `serving_trust_proxy_headers`, both off by default. The
+  defaults are what this spec asserts the behaviour of.
+- `src/lfx/src/lfx/workflow/end_user_identity.py` — the resolver that would scope the
+  session if the flags were on.
+- **Langflow API** — `GET /api/v1/auto_login`, `POST /api/v1/flows/`, `POST /api/v1/api_key/`,
+  `POST /api/v2/workflows`, `POST /api/v1/run/{id}`, `GET /api/v1/monitor/messages`,
+  `DELETE /api/v1/flows/{id}`.
+- **`langflowai/langflow-nightly:latest`** at its stock configuration.
+- **No provider key, no model, no external network.**

--- a/docs/serving/end-user-identity-isolation.md
+++ b/docs/serving/end-user-identity-isolation.md
@@ -1,0 +1,154 @@
+# Serving-plane end-user identity — the isolation boundary, when trusted
+
+**File:** `tests/tests-automations/regression/serving/end-user-identity-isolation.spec.ts`
+
+**Last validated:** Langflow 1.12.0.dev38 (`langflowai/langflow-nightly:latest`, `package: "Langflow Nightly"`)
+
+---
+
+## What this test validates *(required)*
+
+With the serving-plane identity header **configured and trusted**, two end users sharing one
+`session_id` get separate chat memory, on every serving surface — and nothing leaks into the
+shared session they nominally sent.
+
+The lane, the container script and the four-configuration contract are specified in
+[`docs/serving/end-user-identity-lane.md`](end-user-identity-lane.md) (#1582); read the
+contract there rather than here. This document specifies the **trusted** row of it, which is
+the row the feature exists for.
+
+**Measured on `dev38`, `HEADER=X-End-User-Id` + `TRUST=true`:**
+
+| surface | `alice` on `S` | `bob` on `S` | in `alice::S` | in `bob::S` | in bare `S` |
+|---|---|---|---|---|---|
+| `POST /api/v2/workflows` | `alice::S` | `bob::S` | 2 | 2 | **0** |
+| `POST /api/v1/run/{id}` | `alice::S` | `bob::S` | 2 | 2 | **0** |
+
+**The bare-`S`-is-empty clause is the boundary, not a tidiness check.** A merge that scoped
+the read but also wrote to the unscoped session would leave both per-user reads looking
+perfectly correct — `alice::S` has alice's two, `bob::S` has bob's two — while a third client
+running on plain `S` reads everybody's history. That third reading is the only one that
+catches it, so it is asserted explicitly rather than implied.
+
+**Anonymous persists nothing, asserted over the whole flow.** A run with no identity header
+reports `anon::<uuid>` — a **fresh uuid per request**, not per session — and writes zero rows.
+The assertion is `GET /api/v1/monitor/messages?flow_id=<id>` (measured **0**), not
+`?session_id=<the reported anon session>`: asserting only the reported session would pass on
+a run that persisted somewhere else entirely, which is exactly the failure a scoping bug
+produces. Checking the flow means "nowhere", not "not there".
+
+**Both surfaces, because a partial rollout is the likely regression.** #14550's phase 1 is
+described as extending the v2-only scoping to all serving APIs; v1 (`POST /api/v1/run/{id}`,
+through a minted `x-api-key`) is where that extension would come undone first, and it is the
+surface deployed integrations actually call.
+
+---
+
+## Tags *(required)*
+
+`["@api", "@regression", "@serving"]`
+
+`@api` for the layer, `@regression` for the upstream property being pinned, and `@serving` —
+the **lane selector** added in #1582 — because this spec is unrunnable anywhere else:
+`tests/fixtures/lane.ts` `grepInvert`s `@serving` out of every invocation without
+`PW_SERVING_IDENTITY=1`, and the configuration it needs cannot be reached from the stock
+image's defaults.
+
+**No `@stable`, and it cannot have it**: nothing runs `@serving` on a cron, so a `@stable`
+`@serving` test would silently never run — the exact hole #1010 documented for
+`@destructive` and `@enterprise`.
+
+---
+
+## Precondition *(required)*
+
+```bash
+./scripts/start-langflow-serving-identity.sh
+```
+
+The default invocation: `serving_end_user_header='X-End-User-Id'`,
+`serving_trust_proxy_headers=True`, `serving_end_user_required=False`. Container
+`langflow-serving-identity` on port `7893`; the script reads the three settings back out of
+the running process and prints them, and fails when another process shadows its port.
+
+`auto_login` is on (the same image, only the configuration differs), so the bearer token and
+the API key are minted the usual way.
+
+**The configuration is not observable through any API.** `GET /api/v1/config` exposes 35
+keys and **none** of them mention `serving`, `end_user` or `trust` (measured on `dev38`), and
+there is no settings endpoint that does. So the spec cannot read its precondition — it has
+to *probe* it, which is why step 1 below is a behavioural guard and why it fails rather than
+skips.
+
+---
+
+## Step by step *(required)*
+
+1. **Guard the configuration, fail-closed.** Create the keyless `Chat Input → Chat Output`
+   flow and run it once with `X-End-User-Id: <probe>`. The reported `session_id` must be
+   `<probe>::<session>`. Two other readings are named distinctly, because they are two
+   different mistakes with the same symptom: the session **verbatim** means the header is
+   unset (a stock instance — this is `api/flows/serving-end-user-identity-default.spec.ts`'s
+   instance, not this one), and `anon::<uuid>` means the header is named but untrusted
+   (`end-user-identity-untrusted.spec.ts`'s instance). Each message names the exact script
+   invocation that produces the state this spec needs. Same shape as
+   `requireRbacInstance()` in the Enterprise lane, for the same reason: a foundation test
+   that proves the variant is what it claims, so every later assertion measures the product
+   and not a misconfigured container.
+2. **v2 isolation.** `POST /api/v2/workflows` twice on one `session_id`, as `alice` then
+   `bob`. Responses report `alice::S` and `bob::S`. Counts: `alice::S` = 2, `bob::S` = 2,
+   bare `S` = **0**.
+3. **v1 isolation.** Mint an `x-api-key`, then `POST /api/v1/run/{flow_id}` twice on a fresh
+   `session_id` with the same two identities. Same three readings.
+4. **Anonymous writes nothing.** On a **fresh flow** — so the count is unambiguous — one
+   `POST /api/v2/workflows` with no identity header. The response reports
+   `anon::<uuid>`; `?flow_id=<that flow>` holds **0**.
+5. **Cleanup.** `afterAll` deletes every flow by recorded id and revokes the minted key.
+   Ids are pushed **before** the asserts that can throw.
+
+---
+
+## Validation criterion *(required)*
+
+- Every count above exact, on both surfaces, with bare `S` empty and the anonymous flow
+  holding zero rows — after the guard confirmed the instance is in the trusted state.
+- The guard itself is verified in the other direction: pointed at the stock instance it
+  **fails** naming "header unset", and pointed at the untrusted container it **fails** naming
+  `anon::`. A guard that only ever sees its happy state is not a guard.
+
+**Force-fail evidence:** the mutation that matters is asserting bare `S` holds 2 instead of
+0 — the leak reading. Inverting a per-user count reddens the same test more loudly but
+proves less, since a broken instance would fail it either way.
+
+---
+
+## What this does not cover *(and why)*
+
+- **`TRUST=false` and `REQUIRED=true`** — `end-user-identity-untrusted.spec.ts` and
+  `end-user-identity-required.spec.ts`. One file per container state, because a spec cannot
+  restart its own instance and a state-detecting file would have to branch inside its tests,
+  hiding which row was actually asserted. The three files also give the pipeline three
+  separately-burstable targets.
+- **`serving_internal_mcp_hosts`** (#14550 phase 4) — needs an internal MCP host to point at.
+- **`serving_trace_end_user`** and the span link (#14616) — need an OTLP collector this repo
+  does not have.
+- **Job-lifecycle gating by end user** (#14550 phase 3 — `GET /workflows`, `/stop`,
+  `/resume` refusing another end user's run). Real, and the natural follow-up now that the
+  lane exists; kept out so this issue lands the memory boundary first.
+- **A scheduled lane.** None exists for `@serving`; adding one is a separate CI-spend
+  decision.
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/src/lfx/services/settings/groups/security.py` — declares
+  `serving_end_user_header`, `serving_trust_proxy_headers` and `serving_end_user_required`.
+- `src/lfx/src/lfx/workflow/end_user_identity.py` — the resolver producing `alice::S` and
+  `anon::<uuid>`.
+- **Langflow API** — `GET /api/v1/auto_login`, `POST /api/v1/flows/`, `POST /api/v1/api_key/`,
+  `POST /api/v2/workflows`, `POST /api/v1/run/{id}`, `GET /api/v1/monitor/messages`,
+  `DELETE /api/v1/flows/{id}`.
+- **`scripts/start-langflow-serving-identity.sh`** and the `PW_SERVING_IDENTITY` lane, both
+  from #1582.
+- **No provider key, no model, no external network.**

--- a/docs/serving/end-user-identity-required.md
+++ b/docs/serving/end-user-identity-required.md
@@ -1,0 +1,145 @@
+# Serving-plane end-user identity — required means refused, on every surface
+
+**File:** `tests/tests-automations/regression/serving/end-user-identity-required.spec.ts`
+
+**Last validated:** Langflow 1.12.0.dev38 (`langflowai/langflow-nightly:latest`, `package: "Langflow Nightly"`)
+
+---
+
+## What this test validates *(required)*
+
+With `LANGFLOW_SERVING_END_USER_REQUIRED=true` (on top of a configured, trusted header), an
+identity-less request is **refused** rather than anonymised — `401`, with a machine-readable
+code and a message naming the configured header — while an identified request still runs.
+
+This is the row an operator relies on to guarantee that *no* traffic reaches a flow
+unattributed. A regression here does not corrupt data; it silently re-opens the instance to
+anonymous traffic, which is why the refusal is asserted as a status **and** a code **and** on
+both serving surfaces.
+
+**Measured on `dev38`, `HEADER=X-End-User-Id` + `TRUST=true` + `REQUIRED=true`:**
+
+| request | `POST /api/v2/workflows` | `POST /api/v1/run/{id}` |
+|---|---|---|
+| `X-End-User-Id: alice` | `200`, session `alice::S` | `200`, session `alice::S` |
+| no header | **`401`** | **`401`** |
+| `X-End-User-Id: "   "` | **`401`** | — |
+
+The refusal body, byte-for-byte on both surfaces:
+
+```json
+{"detail":{"error":"End-user identity required",
+           "code":"END_USER_IDENTITY_REQUIRED",
+           "message":"End-user identity is required but the 'X-End-User-Id' header is missing."}}
+```
+
+**`code` is what the spec asserts on, not the sentence.** A refusal message is copy tuned
+over time; the code is the contract a gateway branches on. The message is still asserted for
+one specific property — that it **names the configured header** — because an operator who set
+a non-default header name needs the error to tell them which one is missing, and a hardcoded
+`'X-End-User-Id'` in the message would be a real (if small) defect that only this assertion
+would catch.
+
+**The whitespace-only case is refused with the identical body** — including the word
+"missing", even though the header was present. That is worth recording rather than
+paraphrasing: blank is not an identity, and the product does not distinguish blank from
+absent in its message. A spec that asserted a *different* message for the blank case would
+fail against correct behaviour.
+
+**Both surfaces, and asserting the `200` half too.** A guard that refuses everything is as
+broken as one that refuses nothing, and would pass a spec that only checked the `401`s.
+
+---
+
+## Tags *(required)*
+
+`["@api", "@regression", "@serving"]`
+
+`@serving` is the lane selector; the configuration is unreachable without it. **No
+`@stable`** — no scheduled `@serving` lane, so the tag would mark a test that never runs
+(#1010).
+
+---
+
+## Precondition *(required)*
+
+```bash
+LANGFLOW_SERVING_REQUIRED=1 ./scripts/start-langflow-serving-identity.sh
+```
+
+Reads back `serving_end_user_header='X-End-User-Id'`, `serving_trust_proxy_headers=True`,
+`serving_end_user_required=True`.
+
+**This spec provokes `401`s on purpose and still needs no `page.allowHttpErrors()`.** The
+fixture's HTTP monitor is a `page.on("response")` listener, and the whole spec is
+`request`-fixture calls, which never reach it — so there is nothing to quieten and nothing to
+declare. The instinct to declare it anyway made it into a first draft of
+`api/flows/workflows-v2-job-lifecycle.spec.ts` (#1575) before being measured away. The honest
+consequence is worth stating rather than leaving implicit: checklist step 4 ("no
+`🚨 Backend Error:` logged") carries no information for this spec, so the refusals are
+evidence only because they are asserted directly.
+
+The configuration is not readable through any API, so step 1 probes it behaviourally.
+
+---
+
+## Step by step *(required)*
+
+1. **Guard the configuration, fail-closed.** Create the keyless `Chat Input → Chat Output`
+   flow, then `POST /api/v2/workflows` with **no** identity header. It must answer `401` with
+   `detail.code === "END_USER_IDENTITY_REQUIRED"`. A `200` means the instance is not in the
+   required state — the message names which sibling container it looks like (session verbatim
+   ⇒ stock; `anon::` ⇒ untrusted; `<probe>::<session>` ⇒ trusted-but-not-required) and the
+   invocation that produces this one.
+2. **v2 — identified runs, identity-less and blank refused.** On the flow from step 1:
+   `X-End-User-Id: alice` answers `200` reporting `alice::S` and its 2 rows land in
+   `alice::S`; no header answers `401`; `X-End-User-Id: "   "` answers `401`. Both refusals
+   carry the same `code`, and both messages contain the configured header name
+   `X-End-User-Id`.
+3. **v1 — the same refusal on the other surface.** Mint an `x-api-key`; `POST /api/v1/run/{id}`
+   with no header answers `401` with the same `code`; with `X-End-User-Id: alice` it answers
+   `200` reporting `alice::<session>`.
+4. **Cleanup.** `afterAll` deletes every recorded flow id and revokes the minted key.
+
+---
+
+## Validation criterion *(required)*
+
+- Both surfaces refuse an identity-less request with `401` and
+  `code: "END_USER_IDENTITY_REQUIRED"`, and both accept an identified one with `200` and a
+  scoped session — so the guard is shown to discriminate, not merely to refuse.
+- Every refusal message contains the configured header name.
+- A whitespace-only value is refused exactly like an absent one.
+- The configuration guard fails, naming the state found, when pointed at any sibling
+  container.
+
+**Force-fail evidence:** the mutation that matters is asserting `200` where the contract says
+`401` — the reading a re-opened instance produces. Flipping the accepted request to expect a
+refusal is the complementary half and covers the refuse-everything regression.
+
+---
+
+## What this does not cover *(and why)*
+
+- **Non-default header names.** The spec asserts the message *names* the configured header
+  but runs only with the script's `X-End-User-Id`; proving the message tracks a renamed
+  header would need a fourth container state for one assertion. Recorded here as the known
+  limit of that assertion rather than left implicit.
+- **Rate limiting or auth interaction with the refusal.** `401` here is the serving-identity
+  guard, not authentication; the request carries valid credentials throughout.
+- The trusted and untrusted rows — the two sibling files.
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/src/lfx/services/settings/groups/security.py` — `serving_end_user_required`
+  alongside the header and trust settings.
+- `src/lfx/src/lfx/workflow/end_user_identity.py` — raises the
+  `END_USER_IDENTITY_REQUIRED` refusal.
+- **Langflow API** — `GET /api/v1/auto_login`, `POST /api/v1/flows/`, `POST /api/v1/api_key/`,
+  `POST /api/v2/workflows`, `POST /api/v1/run/{id}`, `GET /api/v1/monitor/messages`,
+  `DELETE /api/v1/flows/{id}`.
+- **`scripts/start-langflow-serving-identity.sh`** with `LANGFLOW_SERVING_REQUIRED=1`, and the
+  `PW_SERVING_IDENTITY` lane — both from #1582.
+- **No provider key, no model, no external network.**

--- a/docs/serving/end-user-identity-untrusted.md
+++ b/docs/serving/end-user-identity-untrusted.md
@@ -1,0 +1,126 @@
+# Serving-plane end-user identity — named but untrusted is fail-closed *and* fail-silent
+
+**File:** `tests/tests-automations/regression/serving/end-user-identity-untrusted.spec.ts`
+
+**Last validated:** Langflow 1.12.0.dev38 (`langflowai/langflow-nightly:latest`, `package: "Langflow Nightly"`)
+
+---
+
+## What this test validates *(required)*
+
+With `LANGFLOW_SERVING_END_USER_HEADER` set but `LANGFLOW_SERVING_TRUST_PROXY_HEADERS`
+**false**, the header is not honoured — and the request does **not** fall back to the plain
+session either. Every request becomes `anon::<uuid>` and persists nothing, while still
+answering `200 completed`.
+
+That second half is the reason this spec exists as its own file rather than a footnote to the
+trusted one. The configuration is **fail-closed for security** — no client can pick a
+victim's scope by setting a header — and **fail-silent for operations**: an operator who sets
+the header name and forgets the trust flag has an instance that runs every flow successfully
+and remembers nothing, instance-wide, with no error, no warning and no observable difference
+in any response status.
+
+**Measured on `dev38`, `HEADER=X-End-User-Id` + `TRUST=false`, three requests on one session:**
+
+| request | reported `session_id` | rows in `S` | rows in `alice::S` | rows in the whole flow |
+|---|---|---|---|---|
+| `X-End-User-Id: alice` | `anon::5cc7904c…` | 0 | 0 | **0** |
+| no header | `anon::9207374a…` | 0 | 0 | **0** |
+| `X-End-User-Id: "   "` | `anon::1ff2bf07…` | 0 | 0 | **0** |
+
+All three `status: "completed"`, HTTP `200`. **Three distinct uuids** — the anonymous scope is
+minted per request, not per session, which is what makes "remembers nothing" exact rather
+than approximate: even two consecutive requests from the same client share no memory.
+
+**The flow-wide count is the load-bearing assertion.** Reading only the session the response
+reported (`anon::<uuid>`) would confirm the run did not write *there* while saying nothing
+about whether it wrote somewhere else — and "wrote somewhere else" is precisely what a
+scoping bug does. `?flow_id=` is the query that means *nowhere*.
+
+**The whitespace-only value is asserted here too**, not only under `REQUIRED=true`. Blank is
+not an identity, and the interesting question in this configuration is that a blank value is
+treated exactly like an absent one rather than becoming a scope named `"   "::S` — a scope
+every client could trivially collide on.
+
+---
+
+## Tags *(required)*
+
+`["@api", "@regression", "@serving"]`
+
+Same reasoning as the isolation spec: `@serving` is the lane selector, and the configuration
+is unreachable outside it. **No `@stable`** — no scheduled `@serving` lane exists, so the tag
+would mean a test that never runs (#1010).
+
+---
+
+## Precondition *(required)*
+
+```bash
+LANGFLOW_SERVING_TRUST=0 ./scripts/start-langflow-serving-identity.sh
+```
+
+Reads back `serving_end_user_header='X-End-User-Id'`, `serving_trust_proxy_headers=False`,
+`serving_end_user_required=False`.
+
+The configuration is not readable through any API (`GET /api/v1/config` carries no
+`serving`/`end_user`/`trust` key on `dev38`), so step 1 probes it behaviourally and **fails**
+on any other state.
+
+---
+
+## Step by step *(required)*
+
+1. **Guard the configuration, fail-closed.** Create the keyless `Chat Input → Chat Output`
+   flow, run it once with `X-End-User-Id: <probe>`. The reported `session_id` must start with
+   `anon::`. The two other readings are named separately: the session **verbatim** means the
+   header is unset (stock instance), and `<probe>::<session>` means it is trusted — that is
+   `end-user-identity-isolation.spec.ts`'s container. Each names the invocation that produces
+   this spec's state.
+2. **An identified request is anonymised and persists nothing.** On a fresh flow, one
+   `POST /api/v2/workflows` with `X-End-User-Id: alice` on session `S`. Assert: HTTP `200`,
+   `status: "completed"` (the fail-*silent* half — the run succeeds), reported session matches
+   `anon::<uuid>`, and **all three** of `?session_id=S`, `?session_id=alice::S` and
+   `?flow_id=<flow>` hold 0.
+3. **A whitespace-only value is treated as absent, not as a scope.** Same flow, one run with
+   `X-End-User-Id: "   "`. Reported session matches `anon::<uuid>`, and the flow still holds 0
+   rows. The reported uuid must **differ** from step 2's — same request, same session, no
+   shared scope.
+4. **Cleanup.** `afterAll` deletes every recorded flow id.
+
+---
+
+## Validation criterion *(required)*
+
+- Every identified request reports `anon::<uuid>` and the flow holds **zero** rows after all
+  of them — with the run reporting `200 completed` throughout, so the silence is asserted
+  rather than assumed.
+- The two `anon::` uuids differ.
+- The guard fails, naming the state found, when pointed at either sibling container.
+
+**Force-fail evidence:** the mutation that matters is asserting the flow holds rows — the
+reading a leaking instance produces. Asserting `alice::S` non-empty is the same class and
+narrower.
+
+---
+
+## What this does not cover *(and why)*
+
+- **A warning or log line for the misconfiguration.** There is none to assert: the
+  configuration is silent by design and the point of this spec is to record that. Whether
+  Langflow *should* refuse to start in this state is an upstream product question, not a test.
+- The trusted and required rows — the two sibling files.
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/src/lfx/services/settings/groups/security.py` — `serving_end_user_header`,
+  `serving_trust_proxy_headers`.
+- `src/lfx/src/lfx/workflow/end_user_identity.py` — the resolver that produces
+  `anon::<uuid>` when the header is not trusted.
+- **Langflow API** — `GET /api/v1/auto_login`, `POST /api/v1/flows/`,
+  `POST /api/v2/workflows`, `GET /api/v1/monitor/messages`, `DELETE /api/v1/flows/{id}`.
+- **`scripts/start-langflow-serving-identity.sh`** with `LANGFLOW_SERVING_TRUST=0`, and the
+  `PW_SERVING_IDENTITY` lane — both from #1582.
+- **No provider key, no model, no external network.**

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -50,6 +50,7 @@ const MODULES: ModuleConfig[] = [
   { label: "`memory/` — Memory Base Registration",           sectionStart: "## memory/" },
   { label: "`governance/` — Catalog and Provider Policy",    sectionStart: "## governance/" },
   { label: "`enterprise/` — Enterprise-only Surfaces",       sectionStart: "## enterprise/" },
+  { label: "`serving/` — Serving-Plane End-User Identity",   sectionStart: "## serving/" },
 ];
 
 const PART_II_HEADER = "# PART II — TEST AUTOMATION COVERAGE";

--- a/tests/helpers/serving/serving-identity.test.ts
+++ b/tests/helpers/serving/serving-identity.test.ts
@@ -1,0 +1,161 @@
+// Unit tests for the serving-identity configuration classifier.
+// Run with: npm run test:units
+//
+// The classifier decides which of Langflow's four serving-identity
+// configurations an instance is in, from two probe runs. It is the only thing
+// standing between a spec and asserting a contract against the wrong container:
+// the configuration is NOT readable through any API (`GET /api/v1/config`
+// carries no `serving`/`end_user`/`trust` key — measured on 1.12.0.dev38), so
+// behaviour is the only signal there is.
+//
+// Every case below is asserted on the STATE, never on the reason text, with one
+// exception noted at the bottom: the reason has to carry both readings, because
+// a guard that says "wrong container" without saying what it saw sends the
+// reader back to re-run the probe by hand.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyServingConfiguration,
+  type ServingProbeReadings,
+} from "./serving-identity";
+
+const SESSION = "probe-session-1";
+const IDENTITY = "probe-identity";
+
+function readings(
+  identified: ServingProbeReadings["identified"],
+  anonymous: ServingProbeReadings["anonymous"],
+): ServingProbeReadings {
+  return { sentSessionId: SESSION, probeIdentity: IDENTITY, identified, anonymous };
+}
+
+const ok = (sessionId: string) => ({ status: 200, sessionId });
+const refused = { status: 401, detailCode: "END_USER_IDENTITY_REQUIRED" };
+const scoped = ok(`${IDENTITY}::${SESSION}`);
+const verbatim = ok(SESSION);
+const anon = ok("anon::5cc7904c-ba7a-4ee3-873e-df7cf68bbc72");
+
+test("a header that changes nothing is the default configuration", () => {
+  const { state } = classifyServingConfiguration(readings(verbatim, verbatim));
+  assert.equal(state, "default");
+});
+
+test("a scoped identity plus an anonymised identity-less run is the trusted configuration", () => {
+  const { state } = classifyServingConfiguration(readings(scoped, anon));
+  assert.equal(state, "trusted");
+});
+
+test("an anonymised identified run is the untrusted configuration", () => {
+  // Named but not trusted: the header is not honoured AND the request does not
+  // fall back to the plain session either.
+  const { state } = classifyServingConfiguration(readings(anon, anon));
+  assert.equal(state, "untrusted");
+});
+
+test("a scoped identity plus a refused identity-less run is the required configuration", () => {
+  const { state } = classifyServingConfiguration(readings(scoped, refused));
+  assert.equal(state, "required");
+});
+
+test("the identified and identity-less readings are BOTH needed to separate trusted from required", () => {
+  // The whole reason the probe costs two runs. An identified request is 200 and
+  // scoped under trusted AND under required; only the identity-less run differs.
+  // A classifier that read the identified run alone would answer the same for
+  // both, and a `required` spec would then assert its 401s against a container
+  // that never refuses anything.
+  const trusted = classifyServingConfiguration(readings(scoped, anon)).state;
+  const required = classifyServingConfiguration(readings(scoped, refused)).state;
+  assert.notEqual(trusted, required);
+});
+
+test("an identity whose value is a prefix of the session is not read as scoped", () => {
+  // `alice` sent against session `alice-1` reports `alice-1` verbatim on a
+  // default instance. A substring or startsWith test would read that as scoped
+  // and classify a stock instance as trusted — the exact inversion that makes a
+  // guard worse than none.
+  const r: ServingProbeReadings = {
+    sentSessionId: "alice-1",
+    probeIdentity: "alice",
+    identified: ok("alice-1"),
+    anonymous: ok("alice-1"),
+  };
+  assert.equal(classifyServingConfiguration(r).state, "default");
+});
+
+test("a scope belonging to a DIFFERENT identity is not a recognised configuration", () => {
+  // Reading back someone else's scope is not a configuration, it is a leak.
+  // Answering `trusted` here would let a spec proceed against it.
+  const { state } = classifyServingConfiguration(readings(ok(`someone-else::${SESSION}`), anon));
+  assert.equal(state, "unknown");
+});
+
+test("a refused identified run is not a recognised configuration", () => {
+  // No specified configuration refuses an identified request. Under `required`
+  // it is exactly the request that succeeds.
+  const { state } = classifyServingConfiguration(readings(refused, refused));
+  assert.equal(state, "unknown");
+});
+
+test("a scoped identity with an unscoped identity-less run is not a recognised configuration", () => {
+  // Half-configured: the header is honoured but the identity-less path still
+  // persists to the plain session. Not a row of the contract, so not a pass.
+  const { state } = classifyServingConfiguration(readings(scoped, verbatim));
+  assert.equal(state, "unknown");
+});
+
+test("an unscoped identity with a refused identity-less run is not a recognised configuration", () => {
+  const { state } = classifyServingConfiguration(readings(verbatim, refused));
+  assert.equal(state, "unknown");
+});
+
+test("a refusal without the contracted code is not the required configuration", () => {
+  // A 401 from authentication is not a 401 from the identity guard, and treating
+  // any 401 as `required` would classify an instance whose credentials expired.
+  const { state } = classifyServingConfiguration(
+    readings(scoped, { status: 401, detailCode: "AUTH_EXPIRED" }),
+  );
+  assert.equal(state, "unknown");
+});
+
+test("a reading with no session id at all is unknown rather than a crash", () => {
+  // A non-JSON body, a 500, a shape change upstream: the classifier is the
+  // guard's only decision point and must reach a verdict, never throw.
+  const cases: ServingProbeReadings[] = [
+    readings({ status: 200 }, { status: 200 }),
+    readings({ status: 500 }, { status: 500 }),
+    readings({ status: 200, sessionId: "" }, anon),
+  ];
+  for (const r of cases) {
+    const { state } = classifyServingConfiguration(r);
+    assert.equal(state, "unknown", `expected unknown for ${JSON.stringify(r)}`);
+  }
+});
+
+test("the verdict never throws, for any pair of readings", () => {
+  // Property, not an example: the classifier is called from a guard whose job is
+  // to produce a NAMED failure. A throw there reports as an unattributed error
+  // and costs the reader the diagnosis the guard exists to give (#1012).
+  const values = [
+    { status: 200, sessionId: SESSION },
+    { status: 200, sessionId: `${IDENTITY}::${SESSION}` },
+    { status: 200, sessionId: "anon::x" },
+    { status: 200, sessionId: undefined },
+    { status: 401, detailCode: "END_USER_IDENTITY_REQUIRED" },
+    { status: 401 },
+    { status: 500, sessionId: "" },
+  ];
+  for (const identified of values) {
+    for (const anonymous of values) {
+      assert.doesNotThrow(() => classifyServingConfiguration(readings(identified, anonymous)));
+    }
+  }
+});
+
+test("the reason names both readings, so a wrong container is diagnosable from the message", () => {
+  // The one assertion on the text. Without both readings in it, the guard's
+  // failure says "not the container this spec needs" and the reader has to
+  // re-run the probe by hand to learn which one it is.
+  const { reason } = classifyServingConfiguration(readings(anon, refused));
+  assert.match(reason, /anon::/);
+  assert.match(reason, /401/);
+});

--- a/tests/helpers/serving/serving-identity.ts
+++ b/tests/helpers/serving/serving-identity.ts
@@ -1,0 +1,308 @@
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * Serving-plane end-user identity: the header, the probe, and the fail-closed
+ * guard every `@serving` spec opens with.
+ *
+ * Langflow 1.12 added a trusted-gateway header that scopes per-user chat memory
+ * (`langflow-ai/langflow` #14443, #14550). The feature has FOUR configurations,
+ * selected entirely by instance-global environment variables — see
+ * `docs/serving/end-user-identity-lane.md` for the measured contract — and each
+ * of this area's specs asserts exactly one of them.
+ *
+ * **The configuration is not readable through any API.** `GET /api/v1/config`
+ * returns 35 keys and none of them mentions `serving`, `end_user` or `trust`
+ * (measured on `1.12.0.dev38`), and no settings endpoint exposes them either. So
+ * a spec cannot read its own precondition; it has to observe it. That is why the
+ * guard below runs the flow rather than reading a flag, and why it FAILS instead
+ * of skipping: a spec that skipped here would be green on every instance,
+ * including the three where its assertions are false (#1010's green all-skip).
+ *
+ * Same shape and same reason as `requireA2aEnabled` and the Enterprise lane's
+ * `requireRbacInstance`: prove the variant is what it claims before measuring
+ * the product through it.
+ */
+
+/** The header name `scripts/start-langflow-serving-identity.sh` configures. */
+export const SERVING_IDENTITY_HEADER = "X-End-User-Id";
+
+/** The refusal code `serving_end_user_required` answers an identity-less request with. */
+export const IDENTITY_REQUIRED_CODE = "END_USER_IDENTITY_REQUIRED";
+
+/** The prefix the resolver mints for a request it will not attribute. */
+export const ANONYMOUS_SCOPE_PREFIX = "anon::";
+
+/**
+ * The four configurations of the contract, plus the verdict for anything else.
+ *
+ * `unknown` is not a fifth configuration — it is the refusal to guess, and it
+ * fails the guard. An unrecognised instance is unknown, not clean (#1012).
+ */
+export type ServingConfiguration =
+  | "default"
+  | "trusted"
+  | "untrusted"
+  | "required"
+  | "unknown";
+
+/** One probe run, reduced to what the classification turns on. */
+export interface ServingProbeReading {
+  status: number;
+  /** `session_id` from the response body, when it carried one. */
+  sessionId?: string;
+  /** `detail.code` from a refusal body, when it carried one. */
+  detailCode?: string;
+}
+
+/**
+ * The pair of readings the verdict needs.
+ *
+ * Two runs, not one, and that is the crux: an *identified* request is `200` with
+ * a scoped session under BOTH `trusted` and `required`. Only the identity-less
+ * run separates them — anonymised under `trusted`, refused under `required`. A
+ * one-run probe would answer the same for both and let a `required` spec assert
+ * its refusals against a container that never refuses.
+ */
+export interface ServingProbeReadings {
+  /** The `session_id` sent on both probe runs. */
+  sentSessionId: string;
+  /** The identity sent on the identified probe run. */
+  probeIdentity: string;
+  identified: ServingProbeReading;
+  anonymous: ServingProbeReading;
+}
+
+export interface ServingVerdict {
+  state: ServingConfiguration;
+  /** Both readings, in words — the guard's failure message quotes this. */
+  reason: string;
+}
+
+/**
+ * How each reading looked, for the reason string.
+ *
+ * NOT named `describe`: the `eslint-plugin-playwright` rule
+ * `valid-describe-callback` matches any call to a function of that name and
+ * reported this helper's two call sites as malformed test suites.
+ */
+function renderReading(label: string, r: ServingProbeReading): string {
+  if (r.status !== 200) {
+    return `${label}: HTTP ${r.status}${r.detailCode ? ` code=${r.detailCode}` : ""}`;
+  }
+  return `${label}: HTTP 200 session_id=${r.sessionId === undefined ? "<absent>" : `"${r.sessionId}"`}`;
+}
+
+type Shape = "verbatim" | "scoped" | "anonymous" | "refused" | "other";
+
+/**
+ * Classify one reading. Comparison against the scoped form is EXACT — an
+ * identity that happens to be a prefix of the session (`alice` sent against
+ * session `alice-1`) reports the session verbatim on a default instance, and a
+ * `startsWith` test would read that as scoped and call a stock instance trusted.
+ */
+function shapeOf(r: ServingProbeReading, sentSessionId: string, identity: string): Shape {
+  if (r.status === 401 && r.detailCode === IDENTITY_REQUIRED_CODE) return "refused";
+  if (r.status !== 200 || typeof r.sessionId !== "string" || r.sessionId === "") return "other";
+  if (r.sessionId === sentSessionId) return "verbatim";
+  if (r.sessionId === `${identity}::${sentSessionId}`) return "scoped";
+  if (r.sessionId.startsWith(ANONYMOUS_SCOPE_PREFIX)) return "anonymous";
+  // A scope that is neither ours nor anonymous — someone else's, or a shape this
+  // helper has not been taught. Deliberately not `scoped`.
+  return "other";
+}
+
+/**
+ * PURE, and it cannot throw.
+ *
+ * The layering is the same one `component-catalog-drift.ts` records: the verdict
+ * is a pure function and the I/O lives in its caller, because that is what makes
+ * "the guard always reaches a named verdict" a testable property instead of a
+ * claim. A throw in here would surface as an unattributed error from a helper
+ * whose entire job is to attribute.
+ */
+export function classifyServingConfiguration(r: ServingProbeReadings): ServingVerdict {
+  const identified = shapeOf(r.identified, r.sentSessionId, r.probeIdentity);
+  const anonymous = shapeOf(r.anonymous, r.sentSessionId, r.probeIdentity);
+  const reason = `${renderReading("identified", r.identified)}; ${renderReading("identity-less", r.anonymous)}`;
+
+  // The header changed nothing, on both paths: no header is configured.
+  if (identified === "verbatim" && anonymous === "verbatim") {
+    return { state: "default", reason };
+  }
+  // Named but not trusted: the identity is discarded AND the plain session is
+  // not used as a fallback — every request becomes its own anonymous scope.
+  if (identified === "anonymous" && anonymous === "anonymous") {
+    return { state: "untrusted", reason };
+  }
+  if (identified === "scoped") {
+    if (anonymous === "anonymous") return { state: "trusted", reason };
+    if (anonymous === "refused") return { state: "required", reason };
+  }
+  return { state: "unknown", reason };
+}
+
+/** The invocation that produces each configuration, quoted in the guard's failure. */
+const HOW_TO_GET_THERE: Record<Exclude<ServingConfiguration, "unknown">, string> = {
+  default: "./scripts/start-langflow-docker.sh (any instance with no LANGFLOW_SERVING_* variable set)",
+  trusted: "./scripts/start-langflow-serving-identity.sh",
+  untrusted: "LANGFLOW_SERVING_TRUST=0 ./scripts/start-langflow-serving-identity.sh",
+  required: "LANGFLOW_SERVING_REQUIRED=1 ./scripts/start-langflow-serving-identity.sh",
+};
+
+export interface RunWorkflowOptions {
+  flowId: string;
+  sessionId: string;
+  /** Omit to send no identity header at all — not the same as sending a blank one. */
+  identity?: string;
+  inputValue?: string;
+}
+
+export interface WorkflowRunReading extends ServingProbeReading {
+  /** The parsed body, for callers that assert on more than the session. */
+  body: Record<string, unknown>;
+}
+
+/**
+ * `POST /api/v2/workflows` in `mode=sync`, reduced to the readings these specs
+ * assert on. `mode=sync` because the session scope is decided at submit time and
+ * a synchronous reply removes any need to poll — the job-lifecycle race
+ * `api/flows/workflows-v2-job-lifecycle.spec.ts` pins is a different surface and
+ * does not touch `session_id` on the submit reply.
+ */
+export async function runWorkflowV2(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  { flowId, sessionId, identity, inputValue = "ping" }: RunWorkflowOptions,
+): Promise<WorkflowRunReading> {
+  const res = await request.post("/api/v2/workflows", {
+    headers: {
+      ...headers,
+      ...(identity === undefined ? {} : { [SERVING_IDENTITY_HEADER]: identity }),
+    },
+    data: { flow_id: flowId, input_value: inputValue, session_id: sessionId, mode: "sync" },
+  });
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  const detail = body.detail as { code?: unknown } | undefined;
+  return {
+    status: res.status(),
+    sessionId: typeof body.session_id === "string" ? body.session_id : undefined,
+    detailCode: typeof detail?.code === "string" ? detail.code : undefined,
+    body,
+  };
+}
+
+/**
+ * `POST /api/v1/run/{id}` — the other serving surface. #14550's phase 1 extends
+ * the v2-only scoping to all serving APIs, so v1 is where a partial rollout
+ * would come undone, and it is the surface deployed integrations actually call.
+ *
+ * It authenticates with `x-api-key`, not a bearer token, which is why the specs
+ * mint one.
+ */
+export async function runFlowV1(
+  request: APIRequestContext,
+  apiKey: string,
+  { flowId, sessionId, identity, inputValue = "ping" }: RunWorkflowOptions,
+): Promise<WorkflowRunReading> {
+  const res = await request.post(`/api/v1/run/${flowId}`, {
+    headers: {
+      "x-api-key": apiKey,
+      ...(identity === undefined ? {} : { [SERVING_IDENTITY_HEADER]: identity }),
+    },
+    data: {
+      input_value: inputValue,
+      session_id: sessionId,
+      output_type: "chat",
+      input_type: "chat",
+    },
+  });
+  const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  const detail = body.detail as { code?: unknown } | undefined;
+  return {
+    status: res.status(),
+    sessionId: typeof body.session_id === "string" ? body.session_id : undefined,
+    detailCode: typeof detail?.code === "string" ? detail.code : undefined,
+    body,
+  };
+}
+
+/**
+ * How many messages `GET /api/v1/monitor/messages` holds for a query.
+ *
+ * `query` is the raw query string (`session_id=…` or `flow_id=…`). The
+ * `flow_id=` form is the one that means **nowhere**: asserting only the session
+ * a run reported confirms it did not write *there* while saying nothing about
+ * whether it wrote somewhere else, which is exactly what a scoping bug does.
+ *
+ * A non-list body is `-1`, never `0` — an unreadable count must not read as an
+ * empty one.
+ */
+export async function countMessages(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  query: string,
+): Promise<number> {
+  const res = await request.get(`/api/v1/monitor/messages?${query}`, { headers });
+  if (!res.ok()) return -1;
+  const body = await res.json().catch(() => null);
+  return Array.isArray(body) ? body.length : -1;
+}
+
+/**
+ * Probe the instance with two runs and classify. `flowId` should be a flow the
+ * caller owns and will delete — under `trusted` the identified probe run
+ * persists two rows into `<identity>::<probe session>`, so a spec that asserts
+ * flow-wide counts must not share this flow with them.
+ */
+export async function probeServingConfiguration(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  flowId: string,
+): Promise<ServingVerdict> {
+  const sentSessionId = `serving-probe-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const probeIdentity = "serving-probe-identity";
+  const identified = await runWorkflowV2(request, headers, {
+    flowId,
+    sessionId: sentSessionId,
+    identity: probeIdentity,
+  });
+  const anonymous = await runWorkflowV2(request, headers, { flowId, sessionId: sentSessionId });
+  return classifyServingConfiguration({
+    sentSessionId,
+    probeIdentity,
+    identified,
+    anonymous,
+  });
+}
+
+/**
+ * Fail-closed precondition: throw unless the instance is in `expected`.
+ *
+ * The message names the state observed, both readings behind it, and the exact
+ * invocation that produces the state the caller needs — because the four
+ * configurations are four different mistakes with one symptom (a spec asserting
+ * the wrong row), and "wrong container" without the reading sends the reader
+ * back to re-run the probe by hand.
+ */
+export async function requireServingConfiguration(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  flowId: string,
+  expected: Exclude<ServingConfiguration, "unknown">,
+): Promise<void> {
+  const { state, reason } = await probeServingConfiguration(request, headers, flowId);
+  if (state === expected) return;
+
+  const found =
+    state === "unknown"
+      ? "an unrecognised state — no row of the contract matches these readings"
+      : `the "${state}" configuration (produced by: ${HOW_TO_GET_THERE[state]})`;
+
+  throw new Error(
+    `This spec asserts the "${expected}" serving-identity configuration, but the instance ` +
+      `under test is in ${found}. Observed — ${reason}. ` +
+      `Start the instance this spec needs with: ${HOW_TO_GET_THERE[expected]} ` +
+      "(the configuration is not exposed by any API, so it is probed by running the flow; " +
+      "see docs/serving/end-user-identity-lane.md for the four-configuration contract).",
+  );
+}

--- a/tests/tests-automations/regression/api/flows/serving-end-user-identity-default.spec.ts
+++ b/tests/tests-automations/regression/api/flows/serving-end-user-identity-default.spec.ts
@@ -1,0 +1,203 @@
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
+import {
+  countMessages,
+  requireServingConfiguration,
+  runFlowV1,
+  runWorkflowV2,
+} from "../../../../helpers/serving/serving-identity";
+
+// Spec doc: docs/api/flows/serving-end-user-identity-default.md
+//
+// On a DEFAULT instance, a client-supplied `X-End-User-Id` must do nothing.
+//
+// Langflow 1.12's serving-plane end-user identity (langflow-ai/langflow #14443,
+// #14550) scopes per-user chat memory behind a TRUSTED gateway header. It is off
+// by default, and this file asserts the off half — the configuration every
+// deployment is in today. If a future change ever honours the header without the
+// trust flag, whoever can set a request header picks which user's memory a run
+// reads and writes, and nothing else in the suite would notice: the run answers
+// 200, the output is correct, and the only difference is WHICH session row the
+// message landed in.
+//
+// The trusted half is `serving/end-user-identity-isolation.spec.ts`, on its own
+// lane and its own container. The pair is the point — the same header proven
+// inert here and decisive there. Either alone is weak: this file passes on an
+// instance where the feature is broken outright, and that one says nothing about
+// the deployments that never turn it on.
+//
+// Deliberately NOT tagged `@serving`: that tag is a lane selector, and
+// `tests/fixtures/lane.ts` grepInverts it out of every normal run — carrying it
+// would move this spec to the opt-in lane and it would then never run on the one
+// instance it has anything to say about.
+
+/** Two identities that must both be ignored, and must not scope anything. */
+const ALICE = "alice";
+const BOB = "bob";
+
+/** Chat Input -> Chat Output writes one user row and one machine row per run. */
+const ROWS_PER_RUN = 2;
+
+function uniqueSession(label: string): string {
+  return `default-identity-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+test.describe("Serving end-user identity is inert on a default instance", () => {
+  let bearer: Record<string, string>;
+  let apiKey: string;
+  let apiKeyId: string;
+  let flowId: string;
+  let deleteFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  test.beforeAll(async ({ request }) => {
+    const token = await getAuthToken(request);
+    bearer = { Authorization: token };
+
+    // `POST /api/v1/run/{id}` authenticates with x-api-key, not a bearer token,
+    // so one is minted here and revoked in afterAll. The flow is created through
+    // the key so its owner matches on both surfaces.
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: bearer,
+      data: { name: `serving-default-identity-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const key = await keyRes.json();
+    apiKey = key.api_key;
+    apiKeyId = key.id;
+
+    const flow = await createRunnableChatFlowViaApi(request, { "x-api-key": apiKey });
+    flowId = flow.flowId;
+    deleteFlow = flow.deleteFlow;
+  });
+
+  test.afterAll(async ({ request }) => {
+    try {
+      // afterAll needs its OWN request fixture — the beforeAll one is out of
+      // scope here (Playwright fixture-scope rule).
+      if (deleteFlow) await deleteFlow(request);
+    } finally {
+      if (apiKeyId) {
+        await request.delete(`/api/v1/api_key/${apiKeyId}`, { headers: bearer });
+      }
+    }
+  });
+
+  test(
+    "the instance under test has no serving identity header configured",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // The premise, asserted rather than assumed. A serving-configured instance
+      // must not pass this file silently: every assertion below would then be
+      // measuring the wrong row of the contract. The guard FAILS rather than
+      // skipping, because a skip here would be green on all four configurations
+      // (#1010's green all-skip), and it has to probe rather than read a flag —
+      // GET /api/v1/config exposes no serving setting at all.
+      await requireServingConfiguration(request, bearer, flowId, "default");
+    },
+  );
+
+  test(
+    "two identities on one session share it on POST /api/v2/workflows",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      const session = uniqueSession("v2");
+
+      const asAlice = await runWorkflowV2(request, bearer, {
+        flowId,
+        sessionId: session,
+        identity: ALICE,
+      });
+      const asBob = await runWorkflowV2(request, bearer, {
+        flowId,
+        sessionId: session,
+        identity: BOB,
+      });
+
+      await test.step("both runs report the session verbatim", async () => {
+        expect(asAlice.status, "an ignored header must not change the run's outcome").toBe(200);
+        expect(asBob.status).toBe(200);
+        expect(
+          asAlice.sessionId,
+          "a default instance must echo the session sent, not a scoped derivative",
+        ).toBe(session);
+        expect(asBob.sessionId).toBe(session);
+      });
+
+      await test.step("all four messages land in that one session", async () => {
+        // The reported session is not enough on its own: an instance could report
+        // the plain session while persisting to the scoped one, which is the
+        // silent half of the vector. So the scoped keys are counted too.
+        expect(await countMessages(request, bearer, `session_id=${session}`)).toBe(
+          2 * ROWS_PER_RUN,
+        );
+        expect(
+          await countMessages(request, bearer, `session_id=${ALICE}::${session}`),
+          "a scoped session must not exist on an instance that never scopes",
+        ).toBe(0);
+        expect(await countMessages(request, bearer, `session_id=${BOB}::${session}`)).toBe(0);
+      });
+    },
+  );
+
+  test(
+    "two identities on one session share it on POST /api/v1/run/{id}",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // Both surfaces, because #14550's phase 1 extends the v2-only scoping to
+      // all serving APIs — v1 is where a partial rollout would first honour the
+      // header, and it is the surface a deployed integration actually calls.
+      const session = uniqueSession("v1");
+
+      const asAlice = await runFlowV1(request, apiKey, {
+        flowId,
+        sessionId: session,
+        identity: ALICE,
+      });
+      const asBob = await runFlowV1(request, apiKey, {
+        flowId,
+        sessionId: session,
+        identity: BOB,
+      });
+
+      await test.step("both runs report the session verbatim", async () => {
+        expect(asAlice.status).toBe(200);
+        expect(asBob.status).toBe(200);
+        expect(asAlice.sessionId).toBe(session);
+        expect(asBob.sessionId).toBe(session);
+      });
+
+      await test.step("all four messages land in that one session", async () => {
+        expect(await countMessages(request, bearer, `session_id=${session}`)).toBe(
+          2 * ROWS_PER_RUN,
+        );
+        expect(await countMessages(request, bearer, `session_id=${ALICE}::${session}`)).toBe(0);
+        expect(await countMessages(request, bearer, `session_id=${BOB}::${session}`)).toBe(0);
+      });
+    },
+  );
+
+  test(
+    "a different session persists separately, so the counts above are not vacuous",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // Without this, "the header did nothing" and "chat memory does not work at
+      // all" produce identical readings — both leave the scoped sessions empty.
+      // This is the assertion that makes the two tests above mean something.
+      const session = uniqueSession("control");
+
+      const run = await runWorkflowV2(request, bearer, { flowId, sessionId: session });
+
+      expect(run.status).toBe(200);
+      expect(
+        run.sessionId,
+        "an identity-less run on a default instance keeps its own session",
+      ).toBe(session);
+      expect(
+        await countMessages(request, bearer, `session_id=${session}`),
+        "persistence must be working, otherwise the empty scoped sessions above prove nothing",
+      ).toBe(ROWS_PER_RUN);
+    },
+  );
+});

--- a/tests/tests-automations/regression/serving/end-user-identity-isolation.spec.ts
+++ b/tests/tests-automations/regression/serving/end-user-identity-isolation.spec.ts
@@ -1,0 +1,210 @@
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createRunnableChatFlowViaApi } from "../../../helpers/flows/create-runnable-chat-flow-via-api";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import {
+  ANONYMOUS_SCOPE_PREFIX,
+  countMessages,
+  requireServingConfiguration,
+  runFlowV1,
+  runWorkflowV2,
+} from "../../../helpers/serving/serving-identity";
+
+// Spec doc: docs/serving/end-user-identity-isolation.md
+// Lane: PW_SERVING_IDENTITY=1, against ./scripts/start-langflow-serving-identity.sh
+//
+// The trusted row of the serving-identity contract: with the header configured
+// AND trusted, two end users sharing one `session_id` get separate chat memory,
+// on every serving surface, and nothing leaks into the shared session they
+// nominally sent.
+//
+// The four-configuration contract, the container script and the lane selector
+// are specified in docs/serving/end-user-identity-lane.md (#1582). The inert
+// half — the same header doing nothing on a default instance — is
+// `api/flows/serving-end-user-identity-default.spec.ts`, on the stock lane.
+//
+// No @stable, and it cannot have one: nothing runs @serving on a cron, so the
+// tag would mark a test that never runs (#1010).
+
+const ALICE = "alice";
+const BOB = "bob";
+
+/** Chat Input -> Chat Output writes one user row and one machine row per run. */
+const ROWS_PER_RUN = 2;
+
+function uniqueSession(label: string): string {
+  return `serving-iso-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+test.describe("Serving end-user identity isolates users on a trusted instance", () => {
+  let bearer: Record<string, string>;
+  let apiKey: string;
+  let apiKeyId: string;
+  let flowId: string;
+  let deleteWorkFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  // Flows created inside a test, deleted id-scoped in afterAll. Ids are pushed
+  // BEFORE the assertions that can throw, so a red test cannot leak a flow —
+  // the ordering bug #1575's force-fail caught.
+  const createdFlowIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    const token = await getAuthToken(request);
+    bearer = { Authorization: token };
+
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: bearer,
+      data: { name: `serving-isolation-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const key = await keyRes.json();
+    apiKey = key.api_key;
+    apiKeyId = key.id;
+
+    const flow = await createRunnableChatFlowViaApi(request, { "x-api-key": apiKey });
+    flowId = flow.flowId;
+    deleteWorkFlow = flow.deleteFlow;
+  });
+
+  test.afterAll(async ({ request }) => {
+    try {
+      for (const id of createdFlowIds) {
+        await deleteFlow(request, id, { headers: bearer }).catch(() => {});
+      }
+    } finally {
+      try {
+        if (deleteWorkFlow) await deleteWorkFlow(request);
+      } finally {
+        if (apiKeyId) {
+          await request.delete(`/api/v1/api_key/${apiKeyId}`, { headers: bearer });
+        }
+      }
+    }
+  });
+
+  test(
+    "the instance under test has the identity header configured and trusted",
+    { tag: ["@api", "@regression", "@serving"] },
+    async ({ request }) => {
+      // Fail-closed, and it has to probe rather than read: the configuration is
+      // exposed by no API at all — GET /api/v1/config returns 35 keys and none of
+      // them mentions serving, end_user or trust (measured on 1.12.0.dev38). The
+      // guard names the state it found and the invocation that produces this one,
+      // because the four configurations are four different mistakes with one
+      // symptom: a spec asserting the wrong row.
+      await requireServingConfiguration(request, bearer, flowId, "trusted");
+    },
+  );
+
+  test(
+    "two identities on one session are isolated on POST /api/v2/workflows",
+    { tag: ["@api", "@regression", "@serving"] },
+    async ({ request }) => {
+      const session = uniqueSession("v2");
+
+      const asAlice = await runWorkflowV2(request, bearer, {
+        flowId,
+        sessionId: session,
+        identity: ALICE,
+      });
+      const asBob = await runWorkflowV2(request, bearer, {
+        flowId,
+        sessionId: session,
+        identity: BOB,
+      });
+
+      await test.step("each run reports its own scoped session", async () => {
+        expect(asAlice.status).toBe(200);
+        expect(asBob.status).toBe(200);
+        expect(asAlice.sessionId).toBe(`${ALICE}::${session}`);
+        expect(asBob.sessionId).toBe(`${BOB}::${session}`);
+      });
+
+      await test.step("each scope holds only its own messages", async () => {
+        expect(await countMessages(request, bearer, `session_id=${ALICE}::${session}`)).toBe(
+          ROWS_PER_RUN,
+        );
+        expect(await countMessages(request, bearer, `session_id=${BOB}::${session}`)).toBe(
+          ROWS_PER_RUN,
+        );
+      });
+
+      await test.step("the bare session both clients sent stays empty", async () => {
+        // THE boundary. A merge that scoped the read but also wrote to the
+        // unscoped session would leave both per-user counts above perfectly
+        // correct, while a third client running on plain `session` reads
+        // everybody's history. This is the only reading that catches it.
+        expect(
+          await countMessages(request, bearer, `session_id=${session}`),
+          "a row in the unscoped session is readable by every other end user",
+        ).toBe(0);
+      });
+    },
+  );
+
+  test(
+    "two identities on one session are isolated on POST /api/v1/run/{id}",
+    { tag: ["@api", "@regression", "@serving"] },
+    async ({ request }) => {
+      // #14550's phase 1 extends the v2-only scoping to all serving APIs, so v1
+      // is where that extension would come undone first — and it is the surface
+      // deployed integrations call, with a minted x-api-key.
+      const session = uniqueSession("v1");
+
+      const asAlice = await runFlowV1(request, apiKey, {
+        flowId,
+        sessionId: session,
+        identity: ALICE,
+      });
+      const asBob = await runFlowV1(request, apiKey, {
+        flowId,
+        sessionId: session,
+        identity: BOB,
+      });
+
+      await test.step("each run reports its own scoped session", async () => {
+        expect(asAlice.status).toBe(200);
+        expect(asBob.status).toBe(200);
+        expect(asAlice.sessionId).toBe(`${ALICE}::${session}`);
+        expect(asBob.sessionId).toBe(`${BOB}::${session}`);
+      });
+
+      await test.step("each scope holds only its own messages, and the bare session none", async () => {
+        expect(await countMessages(request, bearer, `session_id=${ALICE}::${session}`)).toBe(
+          ROWS_PER_RUN,
+        );
+        expect(await countMessages(request, bearer, `session_id=${BOB}::${session}`)).toBe(
+          ROWS_PER_RUN,
+        );
+        expect(await countMessages(request, bearer, `session_id=${session}`)).toBe(0);
+      });
+    },
+  );
+
+  test(
+    "an identity-less run is anonymised and persists nothing anywhere in the flow",
+    { tag: ["@api", "@regression", "@serving"] },
+    async ({ request }) => {
+      // On a FRESH flow, so "nothing" is unambiguous: the shared work flow above
+      // already carries the guard's and the isolation tests' rows.
+      const flow = await createRunnableChatFlowViaApi(request, { Authorization: bearer.Authorization });
+      createdFlowIds.push(flow.flowId);
+
+      const session = uniqueSession("anon");
+      const run = await runWorkflowV2(request, bearer, { flowId: flow.flowId, sessionId: session });
+
+      expect(run.status, "an unattributed run still succeeds — it just does not persist").toBe(200);
+      expect(run.sessionId ?? "").toContain(ANONYMOUS_SCOPE_PREFIX);
+
+      // Asserted over the WHOLE flow, not over the anon session the run reported:
+      // checking the reported session confirms it did not write THERE while
+      // saying nothing about whether it wrote somewhere else — and "somewhere
+      // else" is exactly what a scoping bug does. `flow_id=` means nowhere.
+      expect(
+        await countMessages(request, bearer, `flow_id=${flow.flowId}`),
+        "an anonymous run must leave no row anywhere in the flow",
+      ).toBe(0);
+    },
+  );
+});

--- a/tests/tests-automations/regression/serving/end-user-identity-required.spec.ts
+++ b/tests/tests-automations/regression/serving/end-user-identity-required.spec.ts
@@ -1,0 +1,182 @@
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createRunnableChatFlowViaApi } from "../../../helpers/flows/create-runnable-chat-flow-via-api";
+import {
+  IDENTITY_REQUIRED_CODE,
+  SERVING_IDENTITY_HEADER,
+  countMessages,
+  requireServingConfiguration,
+  runFlowV1,
+  runWorkflowV2,
+  type WorkflowRunReading,
+} from "../../../helpers/serving/serving-identity";
+
+// Spec doc: docs/serving/end-user-identity-required.md
+// Lane: PW_SERVING_IDENTITY=1, against
+//   LANGFLOW_SERVING_REQUIRED=1 ./scripts/start-langflow-serving-identity.sh
+//
+// With the identity REQUIRED, an identity-less request is refused rather than
+// anonymised — 401, with a machine-readable code and a message naming the
+// configured header — while an identified request still runs.
+//
+// This is the row an operator relies on to guarantee that no traffic reaches a
+// flow unattributed. A regression here does not corrupt data; it silently
+// re-opens the instance to anonymous traffic. So the refusal is asserted as a
+// status AND a code AND on both serving surfaces — and the accepted request is
+// asserted too, because a guard that refuses everything is as broken as one that
+// refuses nothing and would pass a spec that only checked the 401s.
+//
+// This spec provokes 401s on purpose and needs no page.allowHttpErrors(): the
+// fixture's HTTP monitor is a page.on("response") listener and every call here
+// goes through the `request` fixture, which never reaches it. The honest
+// consequence is that checklist step 4 ("no 🚨 Backend Error: logged") carries no
+// information for this file — the refusals are evidence only because they are
+// asserted directly.
+//
+// No @stable — no scheduled @serving lane exists (#1010).
+
+const ALICE = "alice";
+
+/** A header present but empty of content. Blank is not an identity. */
+const BLANK_IDENTITY = "   ";
+
+/** Chat Input -> Chat Output writes one user row and one machine row per run. */
+const ROWS_PER_RUN = 2;
+
+function uniqueSession(label: string): string {
+  return `serving-required-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+/**
+ * The refusal contract, asserted the same way wherever it is reached.
+ *
+ * `code` is what a gateway branches on, so it is the assertion; the sentence is
+ * copy and may be retuned. The message is still checked for ONE property — that
+ * it names the CONFIGURED header — because an operator running a non-default
+ * header name needs the error to say which one is missing, and a hardcoded name
+ * there would be a real defect only this assertion would catch.
+ */
+function expectIdentityRefusal(reading: WorkflowRunReading, surface: string): void {
+  expect(reading.status, `${surface} must refuse an unattributed request`).toBe(401);
+  expect(reading.detailCode, `${surface} must refuse with the contracted code`).toBe(
+    IDENTITY_REQUIRED_CODE,
+  );
+  const detail = reading.body.detail as { message?: unknown } | undefined;
+  expect(
+    typeof detail?.message === "string" ? detail.message : "",
+    `${surface}'s refusal must name the configured header`,
+  ).toContain(SERVING_IDENTITY_HEADER);
+}
+
+test.describe("Serving end-user identity, when required, refuses unattributed runs", () => {
+  let bearer: Record<string, string>;
+  let apiKey: string;
+  let apiKeyId: string;
+  let flowId: string;
+  let deleteWorkFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  test.beforeAll(async ({ request }) => {
+    const token = await getAuthToken(request);
+    bearer = { Authorization: token };
+
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: bearer,
+      data: { name: `serving-required-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const key = await keyRes.json();
+    apiKey = key.api_key;
+    apiKeyId = key.id;
+
+    const flow = await createRunnableChatFlowViaApi(request, { "x-api-key": apiKey });
+    flowId = flow.flowId;
+    deleteWorkFlow = flow.deleteFlow;
+  });
+
+  test.afterAll(async ({ request }) => {
+    try {
+      if (deleteWorkFlow) await deleteWorkFlow(request);
+    } finally {
+      if (apiKeyId) {
+        await request.delete(`/api/v1/api_key/${apiKeyId}`, { headers: bearer });
+      }
+    }
+  });
+
+  test(
+    "the instance under test requires an end-user identity",
+    { tag: ["@api", "@regression", "@serving"] },
+    async ({ request }) => {
+      // Fail-closed, probed rather than read — no API exposes the setting. The
+      // guard's message separates this container from its three siblings, which
+      // is the diagnosis a reader needs: all four produce the same symptom, a
+      // spec asserting the wrong row of the contract.
+      await requireServingConfiguration(request, bearer, flowId, "required");
+    },
+  );
+
+  test(
+    "POST /api/v2/workflows accepts an identity and refuses its absence",
+    { tag: ["@api", "@regression", "@serving"] },
+    async ({ request }) => {
+      const session = uniqueSession("v2");
+
+      await test.step("an identified run is accepted, scoped and persisted", async () => {
+        const accepted = await runWorkflowV2(request, bearer, {
+          flowId,
+          sessionId: session,
+          identity: ALICE,
+        });
+        expect(accepted.status, "a guard that refuses everything is also broken").toBe(200);
+        expect(accepted.sessionId).toBe(`${ALICE}::${session}`);
+        expect(await countMessages(request, bearer, `session_id=${ALICE}::${session}`)).toBe(
+          ROWS_PER_RUN,
+        );
+      });
+
+      await test.step("an identity-less run is refused", async () => {
+        const refused = await runWorkflowV2(request, bearer, { flowId, sessionId: session });
+        expectIdentityRefusal(refused, "POST /api/v2/workflows");
+      });
+
+      await test.step("a whitespace-only identity is refused the same way", async () => {
+        // Blank is not an identity. The product answers with the identical body,
+        // including the word "missing", even though the header was present —
+        // recorded here rather than paraphrased, because a spec that demanded a
+        // DIFFERENT message for the blank case would fail correct behaviour.
+        const blank = await runWorkflowV2(request, bearer, {
+          flowId,
+          sessionId: session,
+          identity: BLANK_IDENTITY,
+        });
+        expectIdentityRefusal(blank, "POST /api/v2/workflows with a blank identity");
+      });
+    },
+  );
+
+  test(
+    "POST /api/v1/run/{id} accepts an identity and refuses its absence",
+    { tag: ["@api", "@regression", "@serving"] },
+    async ({ request }) => {
+      // Both surfaces: the guard is only worth its configuration if no serving
+      // API can be reached around it.
+      const session = uniqueSession("v1");
+
+      await test.step("an identified run is accepted and scoped", async () => {
+        const accepted = await runFlowV1(request, apiKey, {
+          flowId,
+          sessionId: session,
+          identity: ALICE,
+        });
+        expect(accepted.status).toBe(200);
+        expect(accepted.sessionId).toBe(`${ALICE}::${session}`);
+      });
+
+      await test.step("an identity-less run is refused with the same code", async () => {
+        const refused = await runFlowV1(request, apiKey, { flowId, sessionId: session });
+        expectIdentityRefusal(refused, "POST /api/v1/run/{id}");
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/serving/end-user-identity-untrusted.spec.ts
+++ b/tests/tests-automations/regression/serving/end-user-identity-untrusted.spec.ts
@@ -1,0 +1,163 @@
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createRunnableChatFlowViaApi } from "../../../helpers/flows/create-runnable-chat-flow-via-api";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import {
+  ANONYMOUS_SCOPE_PREFIX,
+  countMessages,
+  requireServingConfiguration,
+  runWorkflowV2,
+} from "../../../helpers/serving/serving-identity";
+
+// Spec doc: docs/serving/end-user-identity-untrusted.md
+// Lane: PW_SERVING_IDENTITY=1, against
+//   LANGFLOW_SERVING_TRUST=0 ./scripts/start-langflow-serving-identity.sh
+//
+// Header NAMED but not TRUSTED. The header is not honoured — and the request does
+// not fall back to the plain session either: every request becomes its own
+// `anon::<uuid>` and persists nothing, while still answering 200 completed.
+//
+// That second half is why this is its own file rather than a footnote. The
+// configuration is fail-closed for SECURITY — no client can pick a victim's
+// scope by setting a header — and fail-SILENT for operations: an operator who
+// sets the header name and forgets the trust flag has an instance that runs
+// every flow successfully and remembers nothing, instance-wide, with no error,
+// no warning, and no observable difference in any response status.
+//
+// The four-configuration contract is in docs/serving/end-user-identity-lane.md.
+// No @stable — no scheduled @serving lane exists (#1010).
+
+const ALICE = "alice";
+
+/** A header present but empty of content. Blank is not an identity. */
+const BLANK_IDENTITY = "   ";
+
+function uniqueSession(label: string): string {
+  return `serving-untrusted-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+test.describe("Serving end-user identity is inert and silent when untrusted", () => {
+  let bearer: Record<string, string>;
+  let probeFlowId: string;
+  let deleteProbeFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  // Ids pushed BEFORE the assertions that can throw, so a red test cannot leak.
+  const createdFlowIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    const token = await getAuthToken(request);
+    bearer = { Authorization: token };
+    const flow = await createRunnableChatFlowViaApi(request, { Authorization: token });
+    probeFlowId = flow.flowId;
+    deleteProbeFlow = flow.deleteFlow;
+  });
+
+  test.afterAll(async ({ request }) => {
+    try {
+      for (const id of createdFlowIds) {
+        await deleteFlow(request, id, { headers: bearer }).catch(() => {});
+      }
+    } finally {
+      if (deleteProbeFlow) await deleteProbeFlow(request);
+    }
+  });
+
+  test(
+    "the instance under test names the identity header but does not trust it",
+    { tag: ["@api", "@regression", "@serving"] },
+    async ({ request }) => {
+      // Fail-closed. The probe runs on its OWN flow so the flow-wide counts below
+      // start from a flow nothing else has touched — which is what makes "zero
+      // rows anywhere" a statement about the run rather than about bookkeeping.
+      await requireServingConfiguration(request, bearer, probeFlowId, "untrusted");
+    },
+  );
+
+  test(
+    "an identified run succeeds, is anonymised, and persists nothing anywhere",
+    { tag: ["@api", "@regression", "@serving"] },
+    async ({ request }) => {
+      const flow = await createRunnableChatFlowViaApi(request, {
+        Authorization: bearer.Authorization,
+      });
+      createdFlowIds.push(flow.flowId);
+
+      const session = uniqueSession("identified");
+      const run = await runWorkflowV2(request, bearer, {
+        flowId: flow.flowId,
+        sessionId: session,
+        identity: ALICE,
+      });
+
+      await test.step("the run reports success — this is the fail-SILENT half", async () => {
+        // Asserted, not assumed: the whole hazard of this configuration is that
+        // nothing in the response tells an operator memory is off.
+        expect(run.status).toBe(200);
+        expect(run.body.status).toBe("completed");
+      });
+
+      await test.step("the identity is discarded for an anonymous scope", async () => {
+        expect(run.sessionId ?? "").toContain(ANONYMOUS_SCOPE_PREFIX);
+      });
+
+      await test.step("nothing is persisted — not the scope, not the session, not the flow", async () => {
+        // Three readings because two of them can pass on a leak. Only the
+        // flow-wide count means NOWHERE; the other two mean "not there".
+        expect(await countMessages(request, bearer, `session_id=${ALICE}::${session}`)).toBe(0);
+        expect(await countMessages(request, bearer, `session_id=${session}`)).toBe(0);
+        expect(
+          await countMessages(request, bearer, `flow_id=${flow.flowId}`),
+          "an untrusted instance must leave no row anywhere in the flow",
+        ).toBe(0);
+      });
+    },
+  );
+
+  test(
+    "a whitespace-only identity is treated as absent, not as a scope of its own",
+    { tag: ["@api", "@regression", "@serving"] },
+    async ({ request }) => {
+      // The interesting failure here is not a refusal — it is a scope literally
+      // named "   ::<session>", which every client would trivially collide on.
+      const flow = await createRunnableChatFlowViaApi(request, {
+        Authorization: bearer.Authorization,
+      });
+      createdFlowIds.push(flow.flowId);
+
+      const session = uniqueSession("blank");
+      const first = await runWorkflowV2(request, bearer, {
+        flowId: flow.flowId,
+        sessionId: session,
+        identity: BLANK_IDENTITY,
+      });
+      const second = await runWorkflowV2(request, bearer, {
+        flowId: flow.flowId,
+        sessionId: session,
+        identity: BLANK_IDENTITY,
+      });
+
+      await test.step("both runs are anonymised, and never scoped by the blank value", async () => {
+        expect(first.status).toBe(200);
+        expect(second.status).toBe(200);
+        expect(first.sessionId ?? "").toContain(ANONYMOUS_SCOPE_PREFIX);
+        expect(second.sessionId ?? "").toContain(ANONYMOUS_SCOPE_PREFIX);
+        expect(
+          await countMessages(request, bearer, `session_id=${BLANK_IDENTITY}::${session}`),
+          "a blank identity must not mint a scope",
+        ).toBe(0);
+      });
+
+      await test.step("the anonymous scope is minted per REQUEST, not per session", async () => {
+        // Two consecutive requests from the same client on the same session share
+        // no scope — which is what makes "remembers nothing" exact rather than
+        // approximate.
+        expect(first.sessionId).not.toBe(second.sessionId);
+      });
+
+      await test.step("neither run persisted anywhere in the flow", async () => {
+        expect(await countMessages(request, bearer, `flow_id=${flow.flowId}`)).toBe(0);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1583.

Closes the `[ ]` gap for Langflow 1.12's **serving-plane end-user identity** (upstream [#14443](https://github.com/langflow-ai/langflow/pull/14443), [#14550](https://github.com/langflow-ai/langflow/pull/14550)) — `QA-CHECKLIST.md` § 1.9 (the *off* half) and the new § 23 (`## serving/`, the *on* half). Consumes the `@serving` lane and container script from #1582/#1591.

**The pairing is the deliverable.** The same `X-End-User-Id` header is proven **inert** on a default instance and **decisive** on a configured one. Either alone is weak: the inert half passes on an instance where the feature is broken outright, and the decisive half says nothing about the deployments that never turn it on — which is all of them today. What the pair protects against is a change that honours the header *without* the trust flag: whoever can set a request header then picks which user's memory a run reads and writes, and nothing else in the suite would notice. The run answers `200`, the output is correct, and the only difference is **which session row** the message landed in.

## 1. Covered tests

Four specs, one per configuration, 14 tests, both serving surfaces (`POST /api/v2/workflows` and `POST /api/v1/run/{id}`).

### `api/flows/serving-end-user-identity-default.spec.ts` — stock lane, `@api @regression`

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `the instance under test has no serving identity header configured` | The premise. Two probe runs must both report the session **verbatim** ⇒ `default`. **Fails**, never skips — a skip here reads green on all four configurations |
| 2 | `two identities on one session share it on POST /api/v2/workflows` | `S` = **4**, `alice::S` = **0**, `bob::S` = **0**. The scoped counts are the load-bearing half: an instance could report the plain session while persisting to the scoped one |
| 3 | `two identities on one session share it on POST /api/v1/run/{id}` | Same 4 / 0 / 0. Asserted because #14550's phase 1 extends the v2-only scoping to *all* serving APIs, making v1 where a partial rollout honours the header first — and the surface deployed integrations actually call |
| 4 | `a different session persists separately, so the counts above are not vacuous` | One identity-less run on a third session holds exactly **2**. Without it, "the header did nothing" and "chat memory is broken outright" give identical readings |

### `serving/end-user-identity-isolation.spec.ts` — `PW_SERVING_IDENTITY=1`, trusted container

| # | Test | What it validates |
|---|------|-------------------|
| 5 | `the instance under test has the identity header configured and trusted` | Identified → `probe::S`, identity-less → `anon::` ⇒ `trusted`. Also verified in the negative: pointed at the untrusted container it fails naming both readings |
| 6 | `two identities on one session are isolated on POST /api/v2/workflows` | `alice::S` = 2, `bob::S` = 2, **bare `S` = 0**. That last clause is **the boundary** — a merge that scoped the read but also wrote to the unscoped session leaves both per-user counts correct while a third client on plain `S` reads everybody's history |
| 7 | `two identities on one session are isolated on POST /api/v1/run/{id}` | Same three readings through a minted `x-api-key` |
| 8 | `an identity-less run is anonymised and persists nothing anywhere in the flow` | `anon::<uuid>` and `?flow_id=` = **0**, on a fresh flow. Asserted over the flow, not the reported session: checking the session confirms it did not write *there* while saying nothing about whether it wrote somewhere else — exactly what a scoping bug does |

### `serving/end-user-identity-untrusted.spec.ts` — `LANGFLOW_SERVING_TRUST=0`

| # | Test | What it validates |
|---|------|-------------------|
| 9 | `the instance under test names the identity header but does not trust it` | Both probe readings `anon::` ⇒ `untrusted` |
| 10 | `an identified run succeeds, is anonymised, and persists nothing anywhere` | `200` + `status: "completed"` **and** `alice::S` = 0, `S` = 0, `?flow_id=` = 0. The `200` is asserted on purpose: this configuration is fail-closed for security and fail-**silent** for operations — an operator who names the header and forgets the trust flag has a working-looking instance that remembers nothing, instance-wide |
| 11 | `a whitespace-only identity is treated as absent, not as a scope of its own` | No scope named `"   "::S` (which every client would collide on), flow holds 0, and the two `anon::<uuid>` values **differ** — the anonymous scope is minted per *request*, which is what makes "remembers nothing" exact rather than approximate |

### `serving/end-user-identity-required.spec.ts` — `LANGFLOW_SERVING_REQUIRED=1`

| # | Test | What it validates |
|---|------|-------------------|
| 12 | `the instance under test requires an end-user identity` | Identity-less → `401 END_USER_IDENTITY_REQUIRED` ⇒ `required` |
| 13 | `POST /api/v2/workflows accepts an identity and refuses its absence` | Identified `200` + `alice::S` + 2 rows; identity-less `401`; blank `401`. Asserted on `detail.code` — what a gateway branches on — plus one property of the message: that it **names the configured header**, since an operator on a non-default name needs the error to say which one is missing |
| 14 | `POST /api/v1/run/{id} accepts an identity and refuses its absence` | Same code on the other surface, **and** the identified run accepted — a guard that refuses everything is as broken as one that refuses nothing, and would pass a spec checking only the `401`s |

## 2. How the tests were built

**The configuration is exposed by no API.** `GET /api/v1/config` returns 35 keys and **none** mentions `serving`, `end_user` or `trust` (measured on `1.12.0.dev38`); no settings endpoint does either. So a spec cannot read its own precondition — it has to observe it. `tests/helpers/serving/serving-identity.ts` therefore probes by running the flow, and **fails** rather than skipping, the same shape and the same reason as `requireA2aEnabled` and the Enterprise lane's `requireRbacInstance`.

**The probe takes two runs, and that is the crux.** An identified request is `200` with a scoped session under **both** `trusted` and `required`; only the identity-less run separates them (anonymised vs refused). A one-run probe answers the same for both and would let the `required` spec assert its refusals against a container that never refuses. Pinned by a unit test that asserts the two verdicts differ.

**`classifyServingConfiguration` is pure and cannot throw**, with the I/O in its caller — the layering `component-catalog-drift.ts` records, because it makes "the guard always reaches a named verdict" a tested property instead of a claim. A throw inside a helper whose whole job is attribution would surface as an unattributed error. Built test-first: the RED run failed on `Cannot find module './serving-identity'`, 14 unit tests now cover it, including that the scoped comparison is **exact** — `alice` sent against session `alice-1` reports `alice-1` verbatim on a default instance, and a `startsWith` test would read that as scoped and call a stock instance trusted.

**Three files for the three container states.** A spec cannot restart its own instance, and a single state-detecting file would have to branch inside its tests, hiding which row was actually asserted. Each file's guard names the state it found *and* the exact invocation that produces the one it needs, because the four configurations are four different mistakes with one symptom: a spec asserting the wrong row.

**No selectors involved** — every call goes through the `request` fixture, no browser, no POM, no testid. Reuses `getAuthToken`, `createRunnableChatFlowViaApi`, `createApiKey`/`deleteApiKey` and `deleteFlow`.

**Two details worth flagging for review.** The `required` spec provokes `401`s deliberately and still needs **no** `page.allowHttpErrors()`: the fixture's HTTP monitor is a `page.on("response")` listener and a `request` call never reaches it. The honest consequence is that checklist step 4 carries no information for these files — the refusals are evidence only because they are asserted directly. And the helper's reading formatter is named `renderReading`, not `describe`, because `eslint-plugin-playwright`'s `valid-describe-callback` matches any call to a function of that name.

## 3. Tags

`@api @regression` on the stock spec; `@api @regression @serving` on the three lane specs. `@serving` is a **lane selector** — `tests/fixtures/lane.ts` `grepInvert`s it out of every normal run — so the stock spec deliberately does **not** carry it, or it would move to the opt-in lane and never run on the only instance it has anything to say about.

**No `@stable` anywhere.** The three `@serving` specs cannot have it: nothing runs `@serving` on a cron, so the tag would mark a test that never runs (#1010). The stock spec is a genuine candidate — keyless, no model, no external network, ~2.6 s — and promoting it is a one-line follow-up after team validation.

## 4. Dependencies

None external: no provider key, no model, no network. Keyless `Chat Input → Chat Output` flow throughout.

Instances — one per configuration:

```bash
# stock (the lane every other spec uses)
npx playwright test tests/tests-automations/regression/api/flows/serving-end-user-identity-default.spec.ts --workers=1 --retries=0

# trusted
./scripts/start-langflow-serving-identity.sh
PW_SERVING_IDENTITY=1 npx playwright test tests/tests-automations/regression/serving/end-user-identity-isolation.spec.ts --workers=1 --retries=0

# untrusted
LANGFLOW_SERVING_TRUST=0 ./scripts/start-langflow-serving-identity.sh
PW_SERVING_IDENTITY=1 npx playwright test tests/tests-automations/regression/serving/end-user-identity-untrusted.spec.ts --workers=1 --retries=0

# required
LANGFLOW_SERVING_REQUIRED=1 ./scripts/start-langflow-serving-identity.sh
PW_SERVING_IDENTITY=1 npx playwright test tests/tests-automations/regression/serving/end-user-identity-required.spec.ts --workers=1 --retries=0
```

Parallel-safe (the lane is the only one of the three that is not serialised — isolation is keyed per `session_id`, so every test owns its own bucket), but run with `--workers=1` above because each command targets one file.

## 5. Validation (nightly `1.12.0.dev38`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `npm run test:units` ✅ **758/758**
- **12 clean burst runs** — 3 per spec file, each on its own container
- Post-revert green, one container at a time: required **3 passed**, untrusted **3 passed**, isolation **4 passed**, stock **4 passed**
- **Force-fail: 14/14 executed**, each reverted, zero `FF-MUTATION` markers left. The mutations that matter are the ones mimicking the vector — bare `S` required to hold rows (the leak reading), `alice::S` required to hold rows on a stock instance (the reading a trusting instance produces), the refusal required to be `200` (a re-opened instance). Each guard was also mutated to demand a sibling configuration
- The configuration guard verified in the **negative** live: the isolation spec pointed at the `TRUST=0` container fails with `Observed — identified: HTTP 200 session_id="anon::9df938c3…"; identity-less: HTTP 200 session_id="anon::e38192f6…"` plus the command that fixes it. A guard that only ever sees its happy state is not a guard
- `--trace=on` ✅ — **4 passed (2.6 s)**, traces produced. The Simple-Agent-template hang does not apply: these specs drive no canvas
- Zero `🚨 Backend Error` ✅ (`backendErrors=false` on all 12 burst runs)
- **Zero orphan flows** on both instances, checked with `GET /api/v1/flows/?get_all=true` after the full run. Every spec records ids **before** the assertions that can throw, so a red test cannot leak — the ordering bug #1575's force-fail caught
- `QA-CHECKLIST.md`: Part II bullets only (§ 1.9 and the new § 23.1–23.3); generated blocks untouched, both repo guards green. `scripts/coverage-summary.ts` gains the matching `MODULES` entry — verified locally to produce `| serving/ — Serving-Plane End-User Identity | 13 | 0 | 10 | 0 | 3 |`, then reverted, since the counts regenerate on merge (#741)

## 6. Process note

This issue was worked through the deterministic pipeline up to `FORCE_FAIL` and finished through the prose orchestrator. `FORCE_FAIL`'s final-green step loops over every touched spec against the single instance `PLAYWRIGHT_BASE_URL` points at, and this issue needs four — a limitation inherent to any multi-configuration contract, not to the file split (even a two-file design fails identically). Filed as #1593, including the trap that running it with the lane selector unset makes the gate pass having executed **zero** tests. All the phase's evidence was produced and is listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)