### PR TITLE
test(security): cover the connector SSRF policy on model-provider base URLs (#1595)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -938,6 +938,20 @@
       effect or was dropped and the run proceeded anyway. The shape difference is recorded in the
       spec doc → security/tweaks-graph-path-floor.spec.ts
 
+#### 17.5 Model-Provider Base URLs — the connector SSRF seam (1.12)
+
+> A provider component's base-URL field is tenant-editable **and** credential-bearing: the SDK performs a server-side request to whatever host it names, carrying the operator's stored provider credential — `lfx/base/models/provider_ssrf.py` calls it "both an SSRF primitive and a credential-exfiltration primitive". Upstream `langflow-ai/langflow#14640` created that module as the **single seam** where those components apply the policy; `#14704` followed two days later to close the call sites the first pass missed. Distinct from § 17.1, which covers an ordinary connector on a laxer policy: provider URLs block literal loopback even though `connector_ssrf_allow_loopback` ships `true`. Spec doc: `docs/security/model-provider-base-url-ssrf.md`.
+
+- [-] A loopback provider base URL is refused, and the message names **every** address the name resolves to (`::1` *and* `127.0.0.1`) plus the `LANGFLOW_SSRF_ALLOWED_HOSTS` escape hatch — both legs, because a message naming only one means the other went unchecked, and `localhost` resolving to `::1` first is the common case → `security/model-provider-base-url-ssrf.spec.ts`
+- [-] The cloud-metadata address `169.254.169.254` is refused, with the address named → `security/model-provider-base-url-ssrf.spec.ts`
+- [-] A non-`http(s)` scheme is refused naming the scheme (`'file'`) — a different validator branch from the two above, which resolve a host, so a regression could close one and leave the other open → `security/model-provider-base-url-ssrf.spec.ts`
+- [-] The **Anthropic** component refuses the same three values through its differently-named field (`base_url` vs OpenAI's `openai_api_base`) — the asymmetry `#14704` existed for, and the reason a one-component spec would have passed the regression it was written for → `security/model-provider-base-url-ssrf.spec.ts`
+- [-] An allow-listed RFC-1918 base URL is **admitted** through the seam: no `SSRF Protection` in the body and a real `404` from the private echo service. The non-vacuity control — without it every refusal above is equally consistent with "the policy blocks every non-default URL". `test.skip`-gated with a stated reason when `ECHO_BASE_URL` is unset or resolves to a host Langflow does not block by default → `security/model-provider-base-url-ssrf.spec.ts`
+- [-] An empty base URL **and** the provider's own canonical endpoint both **skip** the policy on both components, failing instead with the provider's own refusal of a deliberately invalid key (`Incorrect API key provided` / `API key is invalid`) — the `_is_provider_default` branch, and the control that survives an unset `ECHO_BASE_URL`. Asserted on the provider's words rather than a bare `401`, so the absence of the SSRF marker means *skipped* rather than *died earlier* → `security/model-provider-base-url-ssrf.spec.ts`
+- [ ] DNS rebinding through a provider base URL — `provider_httpx_clients` returns DNS-**pinned** clients precisely so the connection cannot drift from the validated IP; proving the pin needs a DNS server that answers differently on the second lookup
+- [ ] A credential forwarded to an attacker-controlled **public** endpoint — the module's own scope note says the policy blocks internal destinations only and "cannot decide whether an arbitrary *public* host is a legitimate OpenAI-compatible provider". Restricting which hosts a stored credential may reach is a separate, additive control upstream
+- [ ] The unified `LanguageModelComponent`'s `ollama_base_url` and `base_url_ibm_watsonx`, and the Ollama/Watsonx components' own `base_url` — **measured as outside this seam** on `1.12.0.dev38` (only three component files import `provider_ssrf`). Consistent with the scoping (Ollama is keyless and its default *is* loopback), recorded because the most-used model component carrying two unguarded base-URL fields deserves a deliberate look
+
 ---
 
 ## i18n/ — Interface Language and Localization

--- a/docs/security/model-provider-base-url-ssrf.md
+++ b/docs/security/model-provider-base-url-ssrf.md
@@ -1,0 +1,210 @@
+# Model-provider base URLs — the connector SSRF policy at its single seam
+
+**File:** `tests/tests-automations/regression/security/model-provider-base-url-ssrf.spec.ts`
+
+**Last validated:** Langflow 1.12.0.dev38 (`langflowai/langflow-nightly:latest`, `package: "Langflow Nightly"`)
+
+---
+
+## What this test validates *(required)*
+
+A model-provider component's base-URL field is **tenant-editable and credential-bearing**: the
+provider SDK performs a server-side request to whatever host it names, carrying the operator's
+stored provider credential. `lfx/base/models/provider_ssrf.py` states the consequence itself —
+the field is "both an SSRF primitive and a credential-exfiltration primitive". Upstream
+[#14640](https://github.com/langflow-ai/langflow/pull/14640) created that module as the **single
+seam** where those components apply the repository's existing connector SSRF policy, "so a new
+provider bundle picks up the guard by importing one helper rather than copy-pasting a call site";
+[#14704](https://github.com/langflow-ai/langflow/pull/14704) followed two days later to close the
+call sites the first pass missed. Both are on `release-1.12.0`, the line the nightly is cut from.
+
+**A seam whose whole value is that every provider goes through it, and which already needed one
+follow-up for a missed call site, is the regression shape a spec exists for.** The failure is
+silent by construction: a component that stops consulting the policy still builds, still runs, and
+still returns a plausible error — it just sends the credential somewhere internal first.
+
+**This is not `security/ssrf-url-validation.spec.ts` with a different component.** That file
+(#1391) covers the allow-list round trip on the **API Request** component — an ordinary connector,
+a different code path, and a deliberately laxer policy. Provider URLs are stricter, in the
+module's own words: "literal loopback is blocked unless the operator explicitly trusts it through
+`LANGFLOW_SSRF_ALLOWED_HOSTS`", while ordinary connectors ship `connector_ssrf_allow_loopback=True`
+(read back from `Settings()` on `dev38`).
+
+### The measured contract
+
+Observable through `POST /api/v1/run/{id}` on a **single-node flow** — the provider model
+components accept `input_value` directly, so no Chat Input or edge is needed — and with a **dummy
+API key**, because the guard fires before the credential is used.
+
+| component · field | `base_url` value | body of the `500` |
+|---|---|---|
+| both | `''` | the provider's own `401` — the call **left the box** |
+| Anthropic · `base_url` | `https://api.anthropic.com` | the provider's own `401` — the canonical endpoint also skips |
+| both | `http://localhost:8080/v1` | `SSRF Protection: Hostname localhost resolves to blocked IP address(es): ::1, 127.0.0.1` |
+| both | `http://169.254.169.254/v1` | `SSRF Protection: Hostname 169.254.169.254 resolves to blocked IP address(es): …` |
+| both | `file:///etc/passwd` | `SSRF Protection: Invalid URL scheme 'file'. Only http and https are allowed.` |
+| both | `http://<rfc1918 echo>:8080/v1` | `404 page not found` — **admitted**, a real answer from a private host |
+
+Four things make this contract worth pinning rather than one.
+
+**The control and the assertion share a credential.** The *same dummy key* produces the provider's
+own `401` on the skip path and an SSRF refusal on a blocked path. So "refused" is provably a verdict
+about the **URL** and not about the key — and the `401` simultaneously proves the component builds
+and genuinely attempts the request, which is what stops the refusal assertions from passing against
+a component that is broken outright. A spec asserting only "the SSRF string appears" would pass on
+an instance where every provider build fails for an unrelated reason.
+
+**Two components, two different field names, one policy.** OpenAI's field is `openai_api_base`;
+Anthropic's is `base_url`. Only three component files in the image import the seam
+(`lfx_openai/components/openai/openai.py`, `…/openai_chat_model.py`,
+`lfx_anthropic/components/anthropic/anthropic.py`), and both distributions are installed. A
+per-component regression — precisely what #14704 fixed — passes a spec that checks one of them.
+
+**`_is_provider_default` is a branch, not a detail.** Empty **and** the provider's own canonical
+endpoint both skip the policy entirely: no clients minted, no DNS round trip. Measured on both
+components (Anthropic with `https://api.anthropic.com` set explicitly). Asserting only refusals
+would not notice that branch collapsing into "validate everything" — a DNS lookup on every build of
+every provider component — or widening into "validate nothing".
+
+**The admitted case is the non-vacuity control, and it must go through the seam.** An RFC-1918
+address that `LANGFLOW_SSRF_ALLOWED_HOSTS` admits answers `404 page not found` from the echo
+service: not an SSRF refusal, and a real HTTP response from a private host, which is only possible
+because a CIDR entry admits it. Without this, every refusal above is equally consistent with "the
+policy blocks every non-default URL", which would be a different — and also broken — product.
+
+---
+
+## Tags *(required)*
+
+`["@api", "@regression"]`
+
+`@api` for the layer — every call goes through the `request` fixture, no browser. `@regression`
+because the file pins two upstream security fixes.
+
+The sibling `security/ssrf-url-validation.spec.ts` carries the same pair, which is the precedent
+this file follows: `security/` specs are area-by-directory, and no functional tag in `CLAUDE.md`'s
+table names the SSRF surface. `@model-provider` was considered and rejected — that tag means
+provider *configuration* (Settings UI, keys, the model modal), and a reviewer filtering on it would
+get a security spec that never touches those screens.
+
+**No `@stable` yet**, per the rule that the tag is added only after team validation. It is a strong
+candidate: keyless, ~10 s, no model, and the only network it needs is one refused `401`.
+
+---
+
+## Preconditions *(required)*
+
+- A running OSS nightly with `lfx-openai` and `lfx-anthropic` installed (both are, on `dev38`).
+  A component the image does not ship must **fail** naming itself rather than skipping — an absent
+  provider bundle is exactly the packaging change `docs/component-distribution-policy.md` exists
+  for, and it would silently delete this coverage.
+- `LANGFLOW_SSRF_ALLOWED_HOSTS` covering the RFC-1918 ranges — the value every lane and both start
+  scripts already set.
+- `ECHO_BASE_URL` (or `HTTPBIN_BASE_URL`) pointing at a **private** address, for the admitted case
+  only. Every CI lane resolves it through `.github/actions/resolve-echo-endpoint`; locally,
+  `docker run -d -p 8099:8080 ghcr.io/mccutchen/go-httpbin:latest` and pass the container's IP.
+- **Outbound HTTPS to the two providers**, for the skip-path test only, and only far enough to be
+  refused. No key, no tokens, no spend: a deliberately invalid key is sent and both providers answer
+  `401` on the first request.
+
+---
+
+## Step by step *(required)*
+
+Every test creates its own single-node flow, records the id **before** the assertions that can
+throw, and deletes it in `afterAll`.
+
+1. **Refusal — loopback, OpenAI.** One flow with `openai_api_base = http://localhost:8080/v1`, a
+   dummy `api_key` (`load_from_db: false`, so no global variable is consulted), and
+   `input_value = "ping"`. `POST /api/v1/run/{id}` answers `500` whose body names
+   `SSRF Protection` **and both resolved addresses** — `::1` and `127.0.0.1`. Both, because the
+   guard resolves the name and reports every address behind it; a message naming only one would mean
+   the IPv6 leg went unchecked.
+2. **Refusal — the cloud-metadata address, OpenAI.** `http://169.254.169.254/v1`. The canonical
+   SSRF target, and the one address no lane allow-lists.
+3. **Refusal — a non-`http(s)` scheme, OpenAI.** `file:///etc/passwd`; the body names
+   `Invalid URL scheme 'file'`. A different branch of the validator from 1 and 2, which resolve a
+   host — this one never gets that far.
+4. **Refusal — the Anthropic component, through its differently-named field.** The same three
+   values through `base_url`, asserted in three steps of one test. Separate from 1–3 so a
+   per-component regression names the component rather than a value.
+5. **Admitted — an allow-listed private base URL, through the seam.** `${ECHO_BASE_URL}/v1` as the
+   OpenAI base URL. The run still fails — the echo service is not an OpenAI-compatible API — and
+   that is the point: the body carries `404 page not found` and **no** `SSRF Protection`. Skipped,
+   with the reason stated, when `ECHO_BASE_URL` is unset or resolves to a host Langflow does not
+   block by default (reaching a public host would prove nothing about the allow-list). Same guard
+   shape as `ssrf-url-validation.spec.ts`, for the same reason.
+6. **The provider's own endpoint skips the policy.** Four runs: empty and the canonical endpoint, on
+   each component. All four must fail with the **provider's own authentication error** and no
+   `SSRF Protection`. This is the branch `_is_provider_default` guards, and the test that makes 1–4
+   non-vacuous even with `ECHO_BASE_URL` unset.
+
+---
+
+## Validation criterion *(required)*
+
+- Every refusal body carries `SSRF Protection` **and** the reason specific to its branch: both
+  resolved addresses for the name, the literal address for the metadata IP, the scheme for `file:`.
+- Every admitted body carries **no** `SSRF Protection` — and a positive observable of its own
+  (`404 page not found` for the echo case, the provider's authentication error for the skip case),
+  so "the string is absent" cannot pass on a run that never happened.
+- Both components are asserted, through their two different field names.
+
+**Force-fail evidence.** The mutation that matters is the inverse of the security property:
+asserting a blocked URL is **admitted** — the reading a regressed seam produces. Its complement,
+asserting the echo case is refused, covers the block-everything regression, which a refusal-only
+spec would call healthy.
+
+---
+
+## What this test does not cover *(and why)*
+
+- **A public attacker-controlled endpoint.** The module's own scope note: the policy blocks
+  *internal* destinations and "cannot decide whether an arbitrary *public* host is a legitimate
+  OpenAI-compatible provider, so pointing a provider component at an attacker-controlled public
+  endpoint still forwards the configured credential". Restricting which hosts a stored credential
+  may reach is a separate, additive control upstream — asserting it here would assert a product
+  decision that has not been made.
+- **DNS rebinding / TOCTOU.** `provider_httpx_clients` returns DNS-**pinned** clients precisely so
+  the connection cannot drift from the validated IP, and `validate_provider_base_url` is documented
+  as being only for paths that do **not** later connect. Proving the pin needs a DNS server that
+  answers differently on the second lookup; out of scope, named so it reads as a decision.
+- **The unified `LanguageModelComponent`.** Its `ollama_base_url` and `base_url_ibm_watsonx` fields,
+  and the Ollama and Watsonx components' own `base_url`, are **measured as outside this seam** — the
+  grep for `provider_ssrf` returns three component files and none of them is these. Consistent with
+  the scoping (Ollama is keyless and its default *is* loopback, so a strict guard would break it out
+  of the box), but recorded rather than assumed: the most-used model component carries two
+  unguarded base-URL fields, and a future change that makes one of them credential-bearing would
+  need this seam.
+- **The status code.** The refusal is a `500`, wrapped as
+  `Error running graph: Error building Component OpenAI: … SSRF Protection: …`, so a caller cannot
+  tell "your URL is blocked by policy" from "the server broke" by status alone. The spec pins the
+  observable that exists and states the shape here, so a future move to a `4xx` reads as an
+  intentional improvement rather than a mystery.
+- **The other two 1.12 security PRs**, each its own issue: #14646 (the caller-aware component policy
+  on stored flow graphs — needs `LANGFLOW_CUSTOM_COMPONENT_ADMIN_ONLY=true`, hence a container
+  variant) and #14216 (secret values across graph edges — partially adjacent to
+  `security/credential-secret-exposure.spec.ts`, which covers one node rather than a chain).
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/src/lfx/base/models/provider_ssrf.py` — the seam itself: `validate_provider_base_url`,
+  `provider_httpx_clients`, and the `_is_provider_default` skip. Added by #14640.
+- `src/lfx/src/lfx/utils/ssrf_httpx.py` — `validate_strict_url_for_ssrf_or_raise` and
+  `ssrf_protected_strict_openai_clients_for_url`, the strict variants the provider seam uses in
+  place of the ordinary connector ones.
+- `src/lfx/src/lfx/services/settings/groups/security.py` — declares
+  `connector_ssrf_validation_enabled`, `connector_ssrf_allow_loopback` and `ssrf_allowed_hosts`.
+  The loopback default being `True` there, while a provider loopback URL is refused, is the
+  asymmetry this file relies on.
+- `src/bundles/openai/src/lfx_openai/components/openai/openai.py` and
+  `src/bundles/anthropic/src/lfx_anthropic/components/anthropic/anthropic.py` — the two call sites
+  under test, and the two field names.
+- **Langflow API** — `GET /api/v1/auto_login`, `GET /api/v1/all` (the component template the flow is
+  built from), `POST /api/v1/api_key/`, `POST /api/v1/flows/`, `POST /api/v1/run/{id}`,
+  `DELETE /api/v1/flows/{id}`.
+- **`ghcr.io/mccutchen/go-httpbin`** via `ECHO_BASE_URL`, for the admitted case only.
+- **No provider key and no model**: a deliberately invalid key is sent, and the only successful
+  network call in the file is to the echo container.

--- a/tests/helpers/flows/create-provider-model-flow-via-api.test.ts
+++ b/tests/helpers/flows/create-provider-model-flow-via-api.test.ts
@@ -1,0 +1,228 @@
+// Unit tests for the provider-model flow builder.
+// Run with: npm run test:units
+//
+// The builder wires a base URL into a model-provider component so an SSRF spec
+// can ask what the policy does with it. Every failure mode here is a spec that
+// asserts the guard's verdict on a URL it never actually set — green, and about
+// nothing. So the tests assert the wiring, and assert that each way of losing it
+// THROWS naming the cause rather than producing a plausible flow.
+//
+// Pure function only: no catalog fetch, no network, no clock. The fixture is a
+// hand-built catalog shaped like `GET /api/v1/all` (`category -> {type: template}`).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ANTHROPIC_MODEL,
+  OPENAI_MODEL,
+  buildProviderModelFlowData,
+} from "./create-provider-model-flow-via-api";
+
+/** A catalog carrying both components under test, shaped like GET /api/v1/all. */
+function catalogFixture(): Record<string, unknown> {
+  return {
+    openai: {
+      [OPENAI_MODEL.componentType]: {
+        display_name: "OpenAI",
+        template: {
+          openai_api_base: { type: "str", value: "" },
+          api_key: { type: "str", value: "OPENAI_API_KEY", load_from_db: true },
+          input_value: { type: "str", value: "" },
+          model_name: { type: "str", value: "gpt-4o-mini" },
+        },
+      },
+    },
+    anthropic: {
+      [ANTHROPIC_MODEL.componentType]: {
+        display_name: "Anthropic",
+        template: {
+          base_url: { type: "str", value: "https://api.anthropic.com" },
+          api_key: { type: "str", value: "ANTHROPIC_API_KEY", load_from_db: true },
+          input_value: { type: "str", value: "" },
+        },
+      },
+    },
+    // A metadata map, not a category — the catalog carries one and its values are
+    // not templates. Walking it as a category is how a lookup finds nothing.
+    component_display_names: { "ext:openai:openaimodelcomponent@official": "OpenAI" },
+  };
+}
+
+function nodeTemplate(data: ReturnType<typeof buildProviderModelFlowData>) {
+  return data.nodes[0].data.node.template;
+}
+
+test("the base URL lands on the field that component actually uses", () => {
+  // The two components name the field differently — openai_api_base vs base_url
+  // — which is the whole reason #14704 existed. Writing to the wrong one leaves
+  // the component running its DEFAULT url.
+  const openai = buildProviderModelFlowData(catalogFixture(), {
+    provider: OPENAI_MODEL,
+    nodeId: "n1",
+    baseUrl: "http://169.254.169.254/v1",
+  });
+  assert.equal(nodeTemplate(openai).openai_api_base.value, "http://169.254.169.254/v1");
+
+  const anthropic = buildProviderModelFlowData(catalogFixture(), {
+    provider: ANTHROPIC_MODEL,
+    nodeId: "n1",
+    baseUrl: "http://169.254.169.254/v1",
+  });
+  assert.equal(nodeTemplate(anthropic).base_url.value, "http://169.254.169.254/v1");
+});
+
+test("an empty base URL is written through, because empty IS the skip path", () => {
+  // Not a no-op: `_is_provider_default` treats empty as "use the provider
+  // default" and skips the policy. A builder that dropped an empty value would
+  // leave whatever the template shipped — for Anthropic, the canonical endpoint,
+  // which happens to skip too, so the bug would hide.
+  const data = buildProviderModelFlowData(catalogFixture(), {
+    provider: ANTHROPIC_MODEL,
+    nodeId: "n1",
+    baseUrl: "",
+  });
+  assert.equal(nodeTemplate(data).base_url.value, "");
+});
+
+test("the api key is a literal, with load_from_db turned OFF", () => {
+  // The template ships the NAME of a global variable and load_from_db true. Left
+  // alone, the run fails resolving a credential that does not exist — an error
+  // that is not the guard's, on a spec whose whole claim is which error appears.
+  const data = buildProviderModelFlowData(catalogFixture(), {
+    provider: OPENAI_MODEL,
+    nodeId: "n1",
+    baseUrl: "http://127.0.0.1/v1",
+  });
+  const key = nodeTemplate(data).api_key;
+  assert.equal(key.value, OPENAI_MODEL.dummyApiKey);
+  assert.equal(key.load_from_db, false);
+});
+
+test("the dummy key is shaped like the provider's own, but is not a credential", () => {
+  // Shape matters: the control assertion is that the provider ITSELF refuses the
+  // key, and a provider rejects a malformed key before authenticating it, which
+  // would produce a different message.
+  assert.match(OPENAI_MODEL.dummyApiKey, /^sk-/);
+  assert.match(ANTHROPIC_MODEL.dummyApiKey, /^sk-ant-/);
+  for (const p of [OPENAI_MODEL, ANTHROPIC_MODEL]) {
+    assert.match(p.dummyApiKey, /dummy|invalid|not-a-real/i, `${p.label} key must read as fake`);
+  }
+});
+
+test("the input value reaches the component, so the run has something to do", () => {
+  const data = buildProviderModelFlowData(catalogFixture(), {
+    provider: OPENAI_MODEL,
+    nodeId: "n1",
+    baseUrl: "",
+    inputValue: "ping",
+  });
+  assert.equal(nodeTemplate(data).input_value.value, "ping");
+});
+
+test("the node is a single root with no edges", () => {
+  // The provider model components accept input_value directly and run as a graph
+  // root. A second node would only add a surface that can fail for reasons
+  // unrelated to the guard.
+  const data = buildProviderModelFlowData(catalogFixture(), {
+    provider: OPENAI_MODEL,
+    nodeId: "provider-node-1",
+    baseUrl: "",
+  });
+  assert.equal(data.nodes.length, 1);
+  assert.deepEqual(data.edges, []);
+  assert.equal(data.nodes[0].id, "provider-node-1");
+  assert.equal(data.nodes[0].data.id, "provider-node-1");
+  assert.equal(data.nodes[0].data.type, OPENAI_MODEL.componentType);
+});
+
+test("two builds from one catalog do not share mutated state", () => {
+  // The spec fetches the catalog once and builds six flows from it. Without a
+  // deep copy the second build inherits the first one's URL, and every test after
+  // the first asserts the wrong address — silently, since the values are all
+  // plausible.
+  const catalog = catalogFixture();
+  const first = buildProviderModelFlowData(catalog, {
+    provider: OPENAI_MODEL,
+    nodeId: "n1",
+    baseUrl: "http://127.0.0.1/v1",
+  });
+  const second = buildProviderModelFlowData(catalog, {
+    provider: OPENAI_MODEL,
+    nodeId: "n2",
+    baseUrl: "",
+  });
+  assert.equal(nodeTemplate(first).openai_api_base.value, "http://127.0.0.1/v1");
+  assert.equal(nodeTemplate(second).openai_api_base.value, "");
+});
+
+test("a component the image does not ship throws, naming it", () => {
+  // A vendor distribution can be absent per image
+  // (docs/component-distribution-policy.md). An undefined template reaching
+  // POST /api/v1/flows/ surfaces as an unattributable 422.
+  assert.throws(
+    () =>
+      buildProviderModelFlowData(
+        { openai: {} },
+        { provider: OPENAI_MODEL, nodeId: "n1", baseUrl: "" },
+      ),
+    (e: Error) =>
+      e.message.includes(OPENAI_MODEL.componentType) &&
+      /component-distribution-policy/.test(e.message),
+  );
+});
+
+test("a renamed base-URL field throws instead of running the component's default", () => {
+  // The failure this guards is the quiet one: without it the node keeps the
+  // template's own base URL, the policy skips it, and every refusal test reports
+  // "admitted" against a URL the spec never set.
+  const catalog = catalogFixture();
+  const openai = (catalog.openai as Record<string, { template: Record<string, unknown> }>)[
+    OPENAI_MODEL.componentType
+  ];
+  delete openai.template.openai_api_base;
+  openai.template.api_base = { type: "str", value: "" };
+
+  assert.throws(
+    () =>
+      buildProviderModelFlowData(catalog, { provider: OPENAI_MODEL, nodeId: "n1", baseUrl: "" }),
+    (e: Error) =>
+      e.message.includes(OPENAI_MODEL.baseUrlField) && e.message.includes("api_base"),
+  );
+});
+
+test("a missing api_key field throws too", () => {
+  // Without it the run fails on a required field rather than on the guard.
+  const catalog = catalogFixture();
+  const openai = (catalog.openai as Record<string, { template: Record<string, unknown> }>)[
+    OPENAI_MODEL.componentType
+  ];
+  delete openai.template.api_key;
+  assert.throws(
+    () =>
+      buildProviderModelFlowData(catalog, { provider: OPENAI_MODEL, nodeId: "n1", baseUrl: "" }),
+    /api_key/,
+  );
+});
+
+test("each provider declares its own refusal wording, and they differ", () => {
+  // The skip-path control asserts the PROVIDER refused the dummy key. Sharing one
+  // fragment across providers would make that assertion pass on whichever
+  // provider happened to answer, so a component that stopped calling out
+  // altogether could still look controlled.
+  assert.notEqual(OPENAI_MODEL.authRefusalFragment, ANTHROPIC_MODEL.authRefusalFragment);
+  for (const p of [OPENAI_MODEL, ANTHROPIC_MODEL]) {
+    assert.ok(p.authRefusalFragment.length > 8, `${p.label} fragment is too short to discriminate`);
+    // Must not be the SSRF marker: the control's whole point is that this string
+    // appears where the SSRF one does not.
+    assert.ok(!p.authRefusalFragment.includes("SSRF"), `${p.label} fragment collides with the marker`);
+  }
+});
+
+test("the two providers declare different canonical endpoints", () => {
+  // The canonical endpoint is the OTHER value `_is_provider_default` skips, and
+  // it is per provider. One shared constant would test the skip path of one
+  // component against the other's endpoint — a validated, admitted public URL,
+  // which passes for the wrong reason.
+  assert.notEqual(OPENAI_MODEL.canonicalBaseUrl, ANTHROPIC_MODEL.canonicalBaseUrl);
+  assert.match(OPENAI_MODEL.canonicalBaseUrl, /openai\.com/);
+  assert.match(ANTHROPIC_MODEL.canonicalBaseUrl, /anthropic\.com/);
+});

--- a/tests/helpers/flows/create-provider-model-flow-via-api.ts
+++ b/tests/helpers/flows/create-provider-model-flow-via-api.ts
@@ -1,0 +1,272 @@
+import type { APIRequestContext } from "@playwright/test";
+import { createFlow } from "./create-flow";
+import { deleteFlow } from "./delete-flow";
+
+/**
+ * Builds a single-node **model-provider** flow from the LIVE component catalog
+ * (`GET /api/v1/all`) and creates it via the REST API.
+ *
+ * Sibling of `create-api-request-flow-via-api.ts` and built from its skeleton, for
+ * the same two reasons. A live catalog rather than a committed fixture, because
+ * the flow exists to prove what the SSRF policy does with a given base URL and
+ * the policy is reached only through the component's base-URL field — the field
+ * name and the catalog key are exactly what upstream may rename, and a frozen
+ * fixture would keep creating a node the running image no longer understands. A
+ * single node with no edge, because the provider model components accept
+ * `input_value` directly and run as a graph root, so a second node would only add
+ * a surface that can fail for reasons unrelated to the guard.
+ *
+ * The deviation from that sibling is the whole point of the helper: **two
+ * components name the base-URL field differently**, and `langflow-ai/langflow`
+ * #14704 exists because a per-component fix missed a call site. So the component
+ * under test is a record rather than a constant.
+ */
+
+/** A model-provider component behind `lfx/base/models/provider_ssrf.py`. */
+export interface ProviderModelUnderTest {
+  /** Short label for test titles and error messages. */
+  label: string;
+  /** Catalog key in `GET /api/v1/all`. */
+  componentType: string;
+  /** The base-URL field name. Differs per component — that asymmetry is under test. */
+  baseUrlField: string;
+  /**
+   * The provider's own canonical endpoint.
+   *
+   * Per provider, never shared: `_is_provider_default` compares the tenant value
+   * against THIS provider's default, so testing one component's skip path with
+   * the other's endpoint would send a validated, admitted public URL and pass for
+   * the wrong reason.
+   */
+  canonicalBaseUrl: string;
+  /**
+   * A deliberately invalid key, shaped like the provider's own.
+   *
+   * Shape matters: the control assertion is that the PROVIDER refuses the key, and
+   * a malformed key is rejected before authentication with a different message.
+   */
+  dummyApiKey: string;
+  /**
+   * A fragment of the provider's OWN refusal of `dummyApiKey`, measured on
+   * 1.12.0.dev38.
+   *
+   * This is what the skip-path control asserts, and it has to be the provider's
+   * words rather than a bare `401`: the claim is that the request left the box and
+   * the PROVIDER decided, which is what makes "no SSRF refusal here" mean the
+   * policy skipped rather than that the run died early for some other reason.
+   */
+  authRefusalFragment: string;
+}
+
+export const OPENAI_MODEL: ProviderModelUnderTest = {
+  label: "OpenAI",
+  componentType: "ext:openai:OpenAIModelComponent@official",
+  baseUrlField: "openai_api_base",
+  canonicalBaseUrl: "https://api.openai.com/v1",
+  dummyApiKey: "sk-dummy-not-a-real-key",
+  authRefusalFragment: "Incorrect API key provided",
+};
+
+export const ANTHROPIC_MODEL: ProviderModelUnderTest = {
+  label: "Anthropic",
+  componentType: "ext:anthropic:AnthropicModelComponent@official",
+  baseUrlField: "base_url",
+  canonicalBaseUrl: "https://api.anthropic.com",
+  dummyApiKey: "sk-ant-dummy-not-a-real-key",
+  authRefusalFragment: "API key is invalid",
+};
+
+interface TemplateField {
+  type?: string;
+  value?: unknown;
+  load_from_db?: boolean;
+  [key: string]: unknown;
+}
+
+interface ComponentTemplate {
+  template: Record<string, TemplateField>;
+  [key: string]: unknown;
+}
+
+export interface FlowNode {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  data: { id: string; type: string; node: ComponentTemplate };
+}
+
+export interface FlowData {
+  nodes: FlowNode[];
+  edges: never[];
+  viewport: { x: number; y: number; zoom: number };
+}
+
+export interface BuildProviderModelFlowOptions {
+  provider: ProviderModelUnderTest;
+  /** Node id given to the provider node — also the `tweaks` key. */
+  nodeId: string;
+  /**
+   * The base URL to wire in. **Written through even when empty**, because empty
+   * is not "leave the default" — it is the skip path `_is_provider_default`
+   * takes, and it must be set explicitly rather than inherited from whatever the
+   * template shipped.
+   */
+  baseUrl: string;
+  /** The prompt the component runs with. */
+  inputValue?: string;
+}
+
+/**
+ * Finds a component template in a `GET /api/v1/all` payload, whose top level is
+ * `category -> { componentType: template }`.
+ *
+ * Throws naming the component when it is absent: a vendor distribution can be
+ * missing per image (`docs/component-distribution-policy.md`), and an undefined
+ * template reaching `POST /api/v1/flows/` surfaces as an unattributable 422.
+ */
+function findComponentTemplate(
+  catalog: Record<string, unknown>,
+  componentType: string,
+): ComponentTemplate {
+  for (const category of Object.values(catalog)) {
+    if (!category || typeof category !== "object") continue;
+    const entry = (category as Record<string, unknown>)[componentType];
+    if (entry && typeof entry === "object" && "template" in entry) {
+      // Deep copy: the caller fetches the catalog once and builds several flows
+      // from it, and every build mutates field values. Sharing would leave every
+      // build after the first asserting the previous one's URL — silently, since
+      // all the values are plausible.
+      return JSON.parse(JSON.stringify(entry)) as ComponentTemplate;
+    }
+  }
+
+  throw new Error(
+    `Component "${componentType}" is not present in GET /api/v1/all on this instance. ` +
+      "Either the image does not ship its distribution, or the response was not a component " +
+      "catalog (an auth failure answers with a `detail` body). " +
+      "See docs/component-distribution-policy.md.",
+  );
+}
+
+/**
+ * Turns a live catalog into the flow payload. Pure — no network, no clock, no
+ * randomness — so the field wiring and every failure mode are unit-testable.
+ *
+ * Both the provider's base-URL field and `api_key` must exist on the template.
+ * The base-URL check guards the quiet failure: without the field the node keeps
+ * the template's own URL, the policy skips it, and every refusal assertion
+ * reports "admitted" against an address the spec never chose.
+ */
+export function buildProviderModelFlowData(
+  catalog: Record<string, unknown>,
+  { provider, nodeId, baseUrl, inputValue = "ping" }: BuildProviderModelFlowOptions,
+): FlowData {
+  const template = findComponentTemplate(catalog, provider.componentType);
+
+  for (const field of [provider.baseUrlField, "api_key"]) {
+    if (!(field in template.template)) {
+      throw new Error(
+        `The ${provider.label} component (${provider.componentType}) on this instance has no ` +
+          `"${field}" field (fields: ${Object.keys(template.template).join(", ")}). The field was ` +
+          "renamed upstream — a flow built without it would run the component's own default " +
+          "base URL, and the SSRF assertions would report a verdict on an address this spec " +
+          "never set.",
+      );
+    }
+  }
+
+  template.template[provider.baseUrlField] = {
+    ...template.template[provider.baseUrlField],
+    value: baseUrl,
+  };
+  // A literal, with load_from_db OFF. The template ships the NAME of a global
+  // variable and `load_from_db: true`; left alone the run fails resolving a
+  // credential that does not exist, which is not the guard's error — on a spec
+  // whose entire claim is WHICH error appears.
+  template.template.api_key = {
+    ...template.template.api_key,
+    value: provider.dummyApiKey,
+    load_from_db: false,
+  };
+  if ("input_value" in template.template) {
+    template.template.input_value = {
+      ...template.template.input_value,
+      value: inputValue,
+    };
+  }
+
+  return {
+    nodes: [
+      {
+        id: nodeId,
+        type: "genericNode",
+        position: { x: 0, y: 0 },
+        data: { id: nodeId, type: provider.componentType, node: template },
+      },
+    ],
+    edges: [],
+    viewport: { x: 0, y: 0, zoom: 1 },
+  };
+}
+
+export interface ProviderModelFlow {
+  /** The created flow's id, for `POST /api/v1/run/{flow_id}` and teardown. */
+  flowId: string;
+  /** Node id of the provider node. */
+  nodeId: string;
+  /** The base URL wired into the node. */
+  baseUrl: string;
+  /** Deletes the created flow. Safe to call with `afterAll`'s own `request`. */
+  deleteFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+}
+
+/** Fetches the live catalog. Separate so a caller can fetch once and build many. */
+export async function fetchComponentCatalog(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+): Promise<Record<string, unknown>> {
+  const res = await request.get("/api/v1/all", { headers });
+  if (!res.ok()) {
+    throw new Error(
+      `GET /api/v1/all answered HTTP ${res.status()}, so no component template could be read. ` +
+        "This is an instance problem, not a verdict on the SSRF policy.",
+    );
+  }
+  return (await res.json()) as Record<string, unknown>;
+}
+
+/**
+ * Creates the flow. `headers` carries the auth the caller already holds; the same
+ * header is reused for teardown so ownership matches.
+ */
+export async function createProviderModelFlowViaApi(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  catalog: Record<string, unknown>,
+  options: BuildProviderModelFlowOptions,
+): Promise<ProviderModelFlow> {
+  const data = buildProviderModelFlowData(catalog, options);
+
+  // Unique per call: Langflow enforces unique names per user and its auto-rename
+  // fallback is not transaction-safe, so two same-named parallel creations race
+  // and the loser gets a 500 (same convention as the sibling helpers).
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const flowId = await createFlow(
+    request,
+    {
+      name: `Provider SSRF ${options.provider.label} ${suffix}`,
+      description: "Single-node model-provider flow for base-URL SSRF assertions",
+      data,
+      is_component: false,
+    },
+    { headers },
+  );
+
+  return {
+    flowId,
+    nodeId: options.nodeId,
+    baseUrl: options.baseUrl,
+    deleteFlow: (reqOverride?: APIRequestContext) =>
+      deleteFlow(reqOverride ?? request, flowId, { headers }),
+  };
+}

--- a/tests/helpers/other/private-echo-endpoint.test.ts
+++ b/tests/helpers/other/private-echo-endpoint.test.ts
@@ -1,0 +1,94 @@
+// Unit tests for the private-echo-endpoint guard.
+// Run with: npm run test:units
+//
+// The guard decides whether an SSRF spec's ADMITTED case can prove anything. Its
+// two failure modes are opposite and both silent: an unset variable makes the
+// test unrunnable, and a variable pointing at a PUBLIC host makes it green while
+// proving nothing about the allow-list — reaching a public address says nothing
+// about `LANGFLOW_SSRF_ALLOWED_HOSTS`. So both answers are asserted, and the
+// skipReason text is asserted to name which one it is.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isBlockedRangeIpv4, privateEchoUrl } from "./private-echo-endpoint";
+
+test("the ranges Langflow blocks by default are recognised", () => {
+  for (const host of [
+    "10.0.0.5", // 10.0.0.0/8
+    "127.0.0.1", // loopback
+    "172.17.0.5", // 172.16.0.0/12 — the docker bridge, where the echo container lands
+    "172.31.255.254", // upper edge of the same /12
+    "192.168.1.10", // 192.168.0.0/16
+    "169.254.169.254", // link-local / cloud metadata
+    "100.64.0.1", // CGNAT
+  ]) {
+    assert.equal(isBlockedRangeIpv4(host), true, `${host} should be blocked by default`);
+  }
+});
+
+test("public addresses and non-addresses are not blocked ranges", () => {
+  for (const host of [
+    "8.8.8.8",
+    "1.1.1.1",
+    "172.15.0.1", // just below the /12
+    "172.32.0.1", // just above the /12
+    "192.169.0.1", // just outside the /16
+    "api.openai.com", // a NAME, not an address: the guard cannot know what it resolves to
+    "",
+    "999.1.1.1", // syntactically an address, numerically not
+  ]) {
+    assert.equal(isBlockedRangeIpv4(host), false, `${host} should not count as a blocked range`);
+  }
+});
+
+test("an unset variable yields a skip reason naming the variable", () => {
+  const r = privateEchoUrl({});
+  assert.ok("skipReason" in r);
+  assert.match(r.skipReason, /ECHO_BASE_URL/);
+});
+
+test("either variable name is accepted, ECHO_BASE_URL first", () => {
+  const both = privateEchoUrl({
+    ECHO_BASE_URL: "http://10.0.0.5:8080",
+    HTTPBIN_BASE_URL: "http://192.168.1.1:8080",
+  });
+  assert.ok("url" in both);
+  assert.match(both.url, /10\.0\.0\.5/);
+
+  const fallback = privateEchoUrl({ HTTPBIN_BASE_URL: "http://192.168.1.1:8080" });
+  assert.ok("url" in fallback);
+  assert.match(fallback.url, /192\.168\.1\.1/);
+});
+
+test("a PUBLIC echo host is skipped rather than accepted", () => {
+  // The load-bearing case. Reaching a public address proves nothing about the
+  // allow-list, so admitting it here would turn the admitted test into a green
+  // assertion about nothing.
+  const r = privateEchoUrl({ ECHO_BASE_URL: "https://httpbin.org" });
+  assert.ok("skipReason" in r);
+  assert.match(r.skipReason, /not an address Langflow blocks/);
+});
+
+test("a hostname rather than an address is skipped, even a private-sounding one", () => {
+  // Langflow's `validators.url()` rejects a single-label host anyway, and the
+  // guard cannot know what a name resolves to — so it must not guess.
+  const r = privateEchoUrl({ ECHO_BASE_URL: "http://go-httpbin:8080" });
+  assert.ok("skipReason" in r);
+});
+
+test("an unparseable value is skipped, naming the value", () => {
+  const r = privateEchoUrl({ ECHO_BASE_URL: "not a url at all" });
+  assert.ok("skipReason" in r);
+  assert.match(r.skipReason, /not a url at all/);
+});
+
+test("a trailing slash is normalised away so callers can append a path", () => {
+  const r = privateEchoUrl({ ECHO_BASE_URL: "http://10.0.0.5:8080/" });
+  assert.ok("url" in r);
+  assert.equal(r.url, "http://10.0.0.5:8080");
+});
+
+test("the verdict never throws, for any value", () => {
+  for (const v of ["", "http://", "://x", "10.0.0.5", "http://[::1]:8080", "file:///etc/passwd"]) {
+    assert.doesNotThrow(() => privateEchoUrl({ ECHO_BASE_URL: v }), `threw on ${v}`);
+  }
+});

--- a/tests/helpers/other/private-echo-endpoint.ts
+++ b/tests/helpers/other/private-echo-endpoint.ts
@@ -1,0 +1,97 @@
+/**
+ * The private echo endpoint an SSRF spec needs for its ADMITTED case.
+ *
+ * An SSRF spec that only asserts refusals is indistinguishable from one running
+ * against an instance that blocks every non-default URL — a different, and also
+ * broken, product. The admitted case is what separates them, and it only works
+ * against an address Langflow blocks **by default** and reaches only because
+ * `LANGFLOW_SSRF_ALLOWED_HOSTS` admits it. Reaching a *public* host proves
+ * nothing.
+ *
+ * Every CI lane resolves such an address through
+ * `.github/actions/resolve-echo-endpoint` (a `ghcr.io/mccutchen/go-httpbin`
+ * service container, addressed by raw container IP because Langflow's
+ * `validators.url()` rejects a single-label host). Locally there may be none, so
+ * the caller `test.skip`s with the reason this module returns.
+ *
+ * **Canonical home, with one migration outstanding.**
+ * `security/ssrf-url-validation.spec.ts` (#1391) carries an inline copy of both
+ * functions — it is the file they were written in. Migrating it here is a
+ * deliberate follow-up rather than part of #1595: that spec's four tests would
+ * otherwise enter #1595's force-fail scope for no behavioural change.
+ */
+
+/**
+ * Whether an IPv4 literal falls in a range `lfx/utils/ssrf_protection.py` blocks
+ * by default — and which a lane may therefore have to allow-list explicitly.
+ *
+ * A hostname answers **false**: this cannot know what a name resolves to, and
+ * guessing is how a public endpoint would slip in as the admitted case.
+ */
+export function isBlockedRangeIpv4(host: string): boolean {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host ?? "");
+  if (!match) return false;
+  const parts = match.slice(1).map(Number);
+  if (parts.some((p) => p > 255)) return false;
+  const [a, b] = parts;
+  return (
+    a === 10 || // 10.0.0.0/8
+    a === 127 || // 127.0.0.0/8 (loopback)
+    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12 — the docker bridge
+    (a === 192 && b === 168) || // 192.168.0.0/16
+    (a === 169 && b === 254) || // 169.254.0.0/16 (link-local / cloud metadata)
+    (a === 100 && b >= 64 && b <= 127) // 100.64.0.0/10 (CGNAT)
+  );
+}
+
+/** Either a usable base URL, or the reason a caller must skip instead. */
+export type PrivateEchoEndpoint = { url: string } | { skipReason: string };
+
+/**
+ * Resolve the echo endpoint's base URL, refusing anything that would make an
+ * admitted-case assertion vacuous.
+ *
+ * `env` is injected rather than read from `process.env` so the two refusals — no
+ * variable, and a public host — are testable without mutating the environment.
+ * The returned URL has no trailing slash, so a caller can append a path.
+ */
+export function privateEchoEndpoint(env: Record<string, string | undefined>): PrivateEchoEndpoint {
+  const base = (env.ECHO_BASE_URL ?? env.HTTPBIN_BASE_URL ?? "").replace(/\/$/, "");
+
+  if (!base) {
+    return {
+      skipReason:
+        "ECHO_BASE_URL/HTTPBIN_BASE_URL is unset, so there is no private endpoint whose " +
+        "reachability could only come from LANGFLOW_SSRF_ALLOWED_HOSTS. Every CI lane sets it " +
+        "via .github/actions/resolve-echo-endpoint; locally, run " +
+        "`docker run -d -p 8099:8080 ghcr.io/mccutchen/go-httpbin:latest` and pass the " +
+        "container's IP (not `localhost` — Langflow blocks loopback and the container " +
+        "cannot reach the host's loopback anyway).",
+    };
+  }
+
+  let host: string;
+  try {
+    host = new URL(base).hostname;
+  } catch {
+    return { skipReason: `ECHO_BASE_URL is not a URL: ${base}` };
+  }
+
+  if (!isBlockedRangeIpv4(host)) {
+    return {
+      skipReason:
+        `the echo endpoint resolved to ${base}, whose host is not an address Langflow blocks ` +
+        "by default (a public host, or a name rather than an IP). Reaching it proves nothing " +
+        "about the allow-list, so the assertion would be vacuous rather than green.",
+    };
+  }
+
+  return { url: base };
+}
+
+/** `privateEchoEndpoint` over the real environment. */
+export function privateEchoUrl(
+  env: Record<string, string | undefined> = process.env,
+): PrivateEchoEndpoint {
+  return privateEchoEndpoint(env);
+}

--- a/tests/tests-automations/regression/security/model-provider-base-url-ssrf.spec.ts
+++ b/tests/tests-automations/regression/security/model-provider-base-url-ssrf.spec.ts
@@ -1,0 +1,256 @@
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import {
+  ANTHROPIC_MODEL,
+  OPENAI_MODEL,
+  type ProviderModelUnderTest,
+  createProviderModelFlowViaApi,
+  fetchComponentCatalog,
+} from "../../../helpers/flows/create-provider-model-flow-via-api";
+import { privateEchoUrl } from "../../../helpers/other/private-echo-endpoint";
+
+/**
+ * The connector SSRF policy on model-provider base URLs — upstream
+ * langflow-ai/langflow#14640 and its follow-up #14704, both on `release-1.12.0`.
+ *
+ * Spec doc: docs/security/model-provider-base-url-ssrf.md
+ *
+ * A provider component's base-URL field is tenant-editable AND credential-bearing:
+ * the SDK performs a server-side request to whatever host it names, carrying the
+ * operator's stored provider credential. `lfx/base/models/provider_ssrf.py` says so
+ * itself — the field is "both an SSRF primitive and a credential-exfiltration
+ * primitive". That module is the SINGLE SEAM where those components apply the
+ * policy, "so a new provider bundle picks up the guard by importing one helper
+ * rather than copy-pasting a call site"; #14704 followed two days later to close the
+ * call sites the first pass missed. A seam whose whole value is that every provider
+ * goes through it, and which already needed one follow-up, is what a spec is for —
+ * and the regression is silent by construction: a component that stops consulting
+ * the policy still builds, still runs, and still returns a plausible error. It just
+ * sends the credential somewhere internal first.
+ *
+ * NOT `security/ssrf-url-validation.spec.ts` with a different component. That file
+ * (#1391) covers the allow-list round trip on the API Request component — an
+ * ordinary connector, a different code path, and a deliberately laxer policy.
+ * Provider URLs are stricter, in the module's own words: "literal loopback is
+ * blocked unless the operator explicitly trusts it through
+ * LANGFLOW_SSRF_ALLOWED_HOSTS", while ordinary connectors ship
+ * `connector_ssrf_allow_loopback=True` (read back from Settings() on dev38).
+ *
+ * No `page` fixture, and therefore no allowHttpErrors()/allowFlowErrors(): every
+ * call here goes through the `request` fixture and the fixture's monitors are
+ * `page.on("response")` listeners, which a request call never reaches. The honest
+ * consequence is that checklist step 4 carries no information for this file — the
+ * refusals are evidence only because they are asserted directly. (The sibling calls
+ * both hatches, in the one test of its own that takes a page.)
+ *
+ * Serial, like the sibling and for the same reason: one catalog fetch and one minted
+ * API key serve the whole file, and nothing here benefits from a second worker.
+ */
+test.describe.configure({ mode: "serial" });
+
+/** The string every refusal carries, whatever its branch. */
+const SSRF_MARKER = "SSRF Protection";
+
+/** A blocked destination reached by NAME, so the guard resolves it. */
+const LOOPBACK_BY_NAME = "http://localhost:8080/v1";
+
+/** The canonical SSRF target, and the address no lane allow-lists. */
+const CLOUD_METADATA = "http://169.254.169.254/v1";
+
+/** A URL the guard rejects before it ever resolves a host. */
+const NON_HTTP_SCHEME = "file:///etc/passwd";
+
+test.describe("Model-provider base URLs go through the connector SSRF policy", () => {
+  let bearer: Record<string, string>;
+  let apiKey: string;
+  let apiKeyId: string;
+  let catalog: Record<string, unknown>;
+
+  /** Ids pushed BEFORE any assertion that can throw, so a red test cannot leak. */
+  const createdFlowIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    const token = await getAuthToken(request);
+    bearer = { Authorization: token };
+
+    // POST /api/v1/run/{id} authenticates with x-api-key, not a bearer token.
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: bearer,
+      data: { name: `provider-ssrf-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const key = await keyRes.json();
+    apiKey = key.api_key;
+    apiKeyId = key.id;
+
+    catalog = await fetchComponentCatalog(request, bearer);
+  });
+
+  test.afterAll(async ({ request }) => {
+    try {
+      for (const id of createdFlowIds) {
+        await deleteFlow(request, id, { headers: bearer }).catch(() => {});
+      }
+    } finally {
+      if (apiKeyId) {
+        await request.delete(`/api/v1/api_key/${apiKeyId}`, { headers: bearer });
+      }
+    }
+  });
+
+  /**
+   * Wire `baseUrl` into `provider`, run the flow, and return the raw response body.
+   *
+   * The body is read as TEXT rather than JSON: the run's error arrives as a JSON
+   * string nested inside `detail`, so every assertion in this file is about which
+   * message came back, and text is the shape that cannot lose it to an escaping
+   * change.
+   */
+  async function runWith(
+    request: APIRequestContext,
+    provider: ProviderModelUnderTest,
+    baseUrl: string,
+  ): Promise<{ status: number; text: string }> {
+    const flow = await createProviderModelFlowViaApi(request, bearer, catalog, {
+      provider,
+      nodeId: `${provider.label}-ssrf-node`,
+      baseUrl,
+    });
+    createdFlowIds.push(flow.flowId);
+
+    const res = await request.post(`/api/v1/run/${flow.flowId}`, {
+      headers: { "x-api-key": apiKey },
+      data: { input_value: "ping", input_type: "text", output_type: "text" },
+    });
+    return { status: res.status(), text: await res.text() };
+  }
+
+  test(
+    "a loopback base URL is refused, naming every address the name resolves to",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      const { text } = await runWith(request, OPENAI_MODEL, LOOPBACK_BY_NAME);
+
+      expect(text, "a provider base URL on loopback must be refused").toContain(SSRF_MARKER);
+      // Both legs, because the guard resolves the name and reports every address
+      // behind it. A message naming only one would mean the other went unchecked —
+      // and `localhost` resolving to `::1` first is the common case.
+      expect(text, "the IPv6 loopback leg must be reported too").toContain("::1");
+      expect(text).toContain("127.0.0.1");
+      // Provider URLs are STRICTER than ordinary connectors, which ship
+      // connector_ssrf_allow_loopback=true. This refusal is that difference.
+      expect(text, "the refusal must name the escape hatch an operator would use").toContain(
+        "LANGFLOW_SSRF_ALLOWED_HOSTS",
+      );
+    },
+  );
+
+  test(
+    "the cloud-metadata address is refused",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      const { text } = await runWith(request, OPENAI_MODEL, CLOUD_METADATA);
+
+      expect(text).toContain(SSRF_MARKER);
+      expect(text, "the refusal must name the address it blocked").toContain("169.254.169.254");
+    },
+  );
+
+  test(
+    "a non-http(s) scheme is refused, naming the scheme",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // A different branch of the validator from the two above: this one never gets
+      // as far as resolving a host, so a regression could plausibly close the
+      // address checks and leave the scheme check open, or the reverse.
+      const { text } = await runWith(request, OPENAI_MODEL, NON_HTTP_SCHEME);
+
+      expect(text).toContain(SSRF_MARKER);
+      expect(text, "the refusal must name the scheme it rejected").toContain("'file'");
+      expect(text).toContain("Only http and https are allowed");
+    },
+  );
+
+  test(
+    "the same policy guards the Anthropic component through its differently-named field",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // OpenAI's field is `openai_api_base`; Anthropic's is `base_url`. #14704
+      // exists because a per-component fix missed a call site, so a spec that
+      // asserted one component would have passed the regression it was written for.
+      for (const [label, url, fragment] of [
+        ["loopback", LOOPBACK_BY_NAME, "127.0.0.1"],
+        ["cloud metadata", CLOUD_METADATA, "169.254.169.254"],
+        ["a non-http(s) scheme", NON_HTTP_SCHEME, "'file'"],
+      ] as const) {
+        await test.step(`${label} is refused through base_url`, async () => {
+          const { text } = await runWith(request, ANTHROPIC_MODEL, url);
+          expect(text).toContain(SSRF_MARKER);
+          expect(text).toContain(fragment);
+        });
+      }
+    },
+  );
+
+  test(
+    "an allow-listed private base URL is admitted through the provider seam",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // The non-vacuity control for every refusal above: without it they are equally
+      // consistent with "the policy blocks every non-default URL", which would be a
+      // different and also broken product.
+      const echo = privateEchoUrl();
+      test.skip("skipReason" in echo, "skipReason" in echo ? echo.skipReason : "");
+      const base = (echo as { url: string }).url;
+
+      const { text } = await runWith(request, OPENAI_MODEL, `${base}/v1`);
+
+      expect(
+        text,
+        `${base} is in a range Langflow blocks by default, so reaching it can only come from ` +
+          "LANGFLOW_SSRF_ALLOWED_HOSTS — the policy was consulted and said yes",
+      ).not.toContain(SSRF_MARKER);
+      // A positive observable, so "the marker is absent" cannot pass on a run that
+      // never happened: the echo service is not an OpenAI-compatible API, so it
+      // answers 404 — which is a real HTTP response from a private host.
+      expect(text, "the request must have reached the private endpoint").toContain("404");
+    },
+  );
+
+  test(
+    "the provider's own endpoint skips the policy on both components",
+    { tag: ["@api", "@regression"] },
+    async ({ request }) => {
+      // `_is_provider_default` treats an empty value AND the provider's canonical
+      // endpoint as nothing to constrain: no client minted, no DNS round trip.
+      // Asserting only refusals would not notice that branch collapsing into
+      // "validate everything" or widening into "validate nothing".
+      //
+      // This is also the control that survives an unset ECHO_BASE_URL, since the
+      // test above skips without one and these refusals must not stand alone.
+      for (const provider of [OPENAI_MODEL, ANTHROPIC_MODEL]) {
+        for (const [label, baseUrl] of [
+          ["an empty base URL", ""],
+          ["the canonical endpoint", provider.canonicalBaseUrl],
+        ] as const) {
+          await test.step(`${provider.label}: ${label} reaches the provider`, async () => {
+            const { text } = await runWith(request, provider, baseUrl);
+
+            expect(text, "the skip path must not consult the SSRF policy").not.toContain(
+              SSRF_MARKER,
+            );
+            // The provider's OWN words, not a bare 401: the claim is that the
+            // request left the box and the provider decided, which is what makes
+            // the absence above mean "skipped" rather than "died earlier".
+            expect(
+              text,
+              `${provider.label} must have refused the deliberately invalid key itself`,
+            ).toContain(provider.authRefusalFragment);
+          });
+        }
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #1595.

Closes the `[ ]` gap for upstream [#14640](https://github.com/langflow-ai/langflow/pull/14640) (`fix(security): apply connector SSRF policy to model-provider base URLs`) and its follow-up [#14704](https://github.com/langflow-ai/langflow/pull/14704) (`fix(security): close model-provider SSRF follow-up gaps`) — `QA-CHECKLIST.md` § 17.5.

**Why this is a distinct journey from § 17.1.** `security/ssrf-url-validation.spec.ts` covers the allow-list round trip on the **API Request** component — an ordinary connector, a different code path, and a deliberately **laxer** policy. Provider URLs are stricter, in the module's own words: "literal loopback is blocked unless the operator explicitly trusts it through `LANGFLOW_SSRF_ALLOWED_HOSTS`", while ordinary connectors ship `connector_ssrf_allow_loopback=True` (read back from `Settings()` on `dev38`).

**Why the surface is worth a spec.** A provider component's base-URL field is tenant-editable **and** credential-bearing: the SDK performs a server-side request to whatever host it names, carrying the operator's stored provider credential. `lfx/base/models/provider_ssrf.py` states the consequence itself — the field is "both an SSRF primitive and a credential-exfiltration primitive". #14640 created that module as the **single seam** where those components apply the policy, "so a new provider bundle picks up the guard by importing one helper rather than copy-pasting a call site"; #14704 followed two days later to close the call sites the first pass missed. A seam whose whole value is that every provider goes through it, and which already needed one follow-up, is exactly what a spec is for — and the regression is silent by construction: a component that stops consulting the policy still builds, still runs, and still returns a plausible error. It just sends the credential somewhere internal first.

## 1. Covered tests

Six tests, measured on `1.12.0.dev38` through `POST /api/v1/run/{id}` on a **single-node flow** (the provider model components accept `input_value` directly and run as a graph root) with a **deliberately invalid key** — the guard fires before the credential is used.

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `a loopback base URL is refused, naming every address the name resolves to` | `SSRF Protection` **plus both** resolved addresses — `::1` **and** `127.0.0.1` — plus `LANGFLOW_SSRF_ALLOWED_HOSTS`. Both legs, because the guard resolves the name and reports every address behind it: a message naming only one means the other went unchecked, and `localhost` resolving to `::1` first is the common case. This refusal *is* the strict/lax difference against § 17.1 |
| 2 | `the cloud-metadata address is refused` | `SSRF Protection` naming `169.254.169.254` — the canonical target, and the one address no lane allow-lists |
| 3 | `a non-http(s) scheme is refused, naming the scheme` | `Invalid URL scheme 'file'` + `Only http and https are allowed`. A **different validator branch** from 1–2, which resolve a host; a regression could plausibly close the address checks and leave the scheme check open, or the reverse |
| 4 | `the same policy guards the Anthropic component through its differently-named field` | The same three values through `base_url` (OpenAI's is `openai_api_base`). The asymmetry #14704 existed for — a per-component fix passes a spec that checks one of them |
| 5 | `an allow-listed private base URL is admitted through the provider seam` | An RFC-1918 `ECHO_BASE_URL` base URL is **admitted**: no `SSRF Protection`, and a real `404` from the echo service. Reaching an address Langflow blocks by default can only come from the allow-list, so this is the round trip. Without it, every refusal above is equally consistent with "the policy blocks every non-default URL" — a different, and also broken, product |
| 6 | `the provider's own endpoint skips the policy on both components` | Empty **and** the provider's canonical endpoint, on both components: no `SSRF Protection`, and the **provider's own** refusal of the dummy key (`Incorrect API key provided` / `API key is invalid`). The `_is_provider_default` branch — and the control that survives an unset `ECHO_BASE_URL`, so 1–4 never stand alone |

**The control and the assertions share a credential, which is the sharp part.** The *same* dummy key produces the provider's own `401` on the skip path and an SSRF refusal on a blocked path — so "refused" is provably a verdict about the **URL** and not about the key, and the `401` simultaneously proves the component builds and genuinely attempts the request. A spec asserting only "the SSRF string appears" would pass against a component broken outright.

**Test 6 asserts the provider's words, not a bare `401`.** The claim is that the request left the box and the *provider* decided; that is what makes the absence of the SSRF marker mean *skipped* rather than *died earlier*. The two fragments are per provider and a unit test asserts they differ — one shared fragment would let the assertion pass on whichever provider happened to answer.

## 2. How the tests were built

**Family-sibling start.** `tests/helpers/flows/create-api-request-flow-via-api.ts` already builds a single-node flow from the **live** catalog (`GET /api/v1/all`) for § 17.1, with the reasoning this issue needs: a frozen fixture would keep creating a node the running image no longer understands, and a renamed field would silently leave the component running its own default URL. `create-provider-model-flow-via-api.ts` copies that skeleton and parameterises the one deviation that matters — **two components name the base-URL field differently** — so the component under test is a record (`OPENAI_MODEL`, `ANTHROPIC_MODEL`) rather than a constant.

**Both helpers were built test-first** (RED confirmed on `Cannot find module`), 21 unit tests between them, all on pure functions with no network or clock:

- The builder's `api_key` handling is its own test: the template ships the *name* of a global variable with `load_from_db: true`, and left alone the run fails resolving a credential that does not exist — not the guard's error, on a spec whose entire claim is *which* error appears.
- An **empty** base URL is written through rather than skipped, because empty is not "leave the default" — it is the skip path. A builder that dropped it would leave Anthropic's template value (the canonical endpoint, which also skips), hiding the bug.
- Two builds from one catalog must not share mutated state: the spec fetches the catalog once and builds nine flows from it, and without the deep copy every build after the first asserts the previous one's URL — silently, since all the values are plausible.
- A renamed field and an absent component each **throw naming the cause**, rather than producing a plausible flow. The renamed-field case guards the quiet failure: without it the node keeps the template's own base URL, the policy skips it, and every refusal test reports "admitted" against an address the spec never chose.

**`private-echo-endpoint.ts`** extracts the `ECHO_BASE_URL` guard that currently lives inline in `ssrf-url-validation.spec.ts`, becoming its canonical home. Its load-bearing case has its own test: a **public** echo host is *skipped*, not accepted — reaching a public address proves nothing about the allow-list, so admitting it would turn test 5 into a green assertion about nothing. Migrating the sibling spec onto it is a deliberate follow-up rather than part of this PR: touching that file would drag its four tests into this issue's force-fail scope for no behavioural change.

**No selectors, no browser, no POM** — every call goes through the `request` fixture. And therefore **no `allowHttpErrors()`/`allowFlowErrors()`**: the fixture's monitors are `page.on("response")` listeners, which a `request` call never reaches. The honest consequence is that checklist step 4 carries no information for this file — the refusals are evidence only because they are asserted directly. (The sibling calls both hatches, in the one test of its own that takes a `page`.)

## 3. Tags

`@api @regression`, matching the sibling. `security/` is area-by-directory and no functional tag in `CLAUDE.md`'s table names the SSRF surface; `@model-provider` was considered and rejected — that tag means provider *configuration* (Settings UI, keys, the model modal), and a reviewer filtering on it would get a security spec that never opens those screens.

**No `@stable` yet**, per the rule that the tag follows team validation. It is a strong candidate: keyless, ~1 minute, no model.

## 4. Dependencies

- **No provider key and no model.** A deliberately invalid key is sent; both providers answer `401` on the first request. No tokens, no spend.
- **`ECHO_BASE_URL`** (or `HTTPBIN_BASE_URL`) pointing at a **private** address, for test 5 only. Every lane resolves it through `.github/actions/resolve-echo-endpoint`; without it test 5 `test.skip`s with the reason stated and the other five run — the same shape § 17.1 uses, and why test 6 exists as the always-available control.
- **Outbound HTTPS to the two providers**, for test 6 only and only far enough to be refused.
- Serial (`mode: "serial"`), like the sibling: one catalog fetch and one minted API key serve the whole file.

## 5. Validation (nightly `1.12.0.dev38`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `npm run test:units` ✅ **779/779** (up from 758 — the two new helpers)
- **3 clean burst runs**, `expected=6 unexpected=0 flaky=0 backendErrors=false`, plus **1 clean final green run** after the force-fail reverts
- **Force-fail: 6/6 executed**, each reverted, zero `FF-MUTATION` markers left. Each mutation inverts the security property — a blocked URL asserted **admitted** (the reading a regressed seam produces) for tests 1–4, and the two opposite regressions a refusal-only spec would call healthy: test 5's allow-listed address asserted **refused** (block-everything) and test 6's skip path asserted **validated** (validate-everything)
- Zero `🚨 Backend Error` ✅ across all four runs
- **Zero orphan flows** on both local instances, verified with `GET /api/v1/flows/?get_all=true` after the whole run. Every test pushes its flow id **before** the assertions that can throw. Four flows and two API keys of *scouting* residue were purged separately — the spec cleaned its own
- `QA-CHECKLIST.md`: § 17.5 added, Part II bullets only; both repo guards green
- Rebased onto `origin/main` at `10b4bebc` after #1596 landed mid-flight; `git diff origin/main..HEAD` carries only this PR's 7 files, and typecheck / lint / units were re-run after the rebase

**`--trace=on` is not obtainable locally for this file, and the first reading of it was wrong.** The line reporter printed `5 passed (5.9m)`; the JSON reporter says `expected=5 unexpected=1` with **test 1 in `timedOut`** at the config's 5-minute cap — the `1 failed` line had been lost to `\r` interleaving, the exact trap `langflow-e2e` warns about. It is the trace writer, not the spec: the same file with `--trace=retain-on-failure` is **6/6 in 56 s**, and without tracing 6/6 in ~1.0 m on four independent runs. Worth noting for the repo's own record — the known limitation was documented for *UI* specs, and this one drives no browser at all. CI's trace-on-first-retry is unaffected.

## 6. One finding out of scope, recorded rather than assumed

Only **three** component files in the image import `provider_ssrf`. The unified `LanguageModelComponent` — the most-used model component — carries `ollama_base_url` and `base_url_ibm_watsonx`, and **neither** goes through the seam; nor does the `base_url` on the Ollama and Watsonx components themselves. Consistent with the scoping (Ollama is keyless and its default *is* loopback, so a strict guard would break it out of the box), but measured rather than assumed and filed as a `[ ]` bullet in § 17.5, alongside the two limitations the module documents for itself: the policy blocks *internal* destinations only, so an attacker-controlled **public** endpoint still receives the credential, and proving the DNS **pin** in `provider_httpx_clients` needs a DNS server that answers differently on the second lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
