### PR TITLE
fix: resolve echo base URL with || so an empty env var falls back

### DIFF
--- a/tests/helpers/other/private-echo-endpoint.ts
+++ b/tests/helpers/other/private-echo-endpoint.ts
@@ -66,7 +66,7 @@ export type PrivateEchoEndpoint = { url: string } | { skipReason: string };
  * The returned URL has no trailing slash, so a caller can append a path.
  */
 export function privateEchoEndpoint(env: Record<string, string | undefined>): PrivateEchoEndpoint {
-  const base = (env.ECHO_BASE_URL ?? env.HTTPBIN_BASE_URL ?? "").replace(/\/$/, "");
+  const base = (env.ECHO_BASE_URL || env.HTTPBIN_BASE_URL || "").replace(/\/$/, "");
 
   if (!base) {
     return {

--- a/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
@@ -28,8 +28,8 @@ import {
 // well as the daily. Retiring this legacy spec into the consolidated one is still
 // tracked separately.
 const ECHO_BASE = (
-  process.env.ECHO_BASE_URL ??
-  process.env.HTTPBIN_BASE_URL ??
+  process.env.ECHO_BASE_URL ||
+  process.env.HTTPBIN_BASE_URL ||
   "https://postman-echo.com"
 ).replace(/\/$/, "");
 

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -64,8 +64,8 @@ test.afterEach(async ({ request }) => {
 // ECHO_HOST is derived from the same base URL so the echoed-host assertions
 // match whatever endpoint is configured.
 const ECHO_BASE = (
-  process.env.ECHO_BASE_URL ??
-  process.env.HTTPBIN_BASE_URL ??
+  process.env.ECHO_BASE_URL ||
+  process.env.HTTPBIN_BASE_URL ||
   "https://postman-echo.com"
 ).replace(/\/$/, "");
 const ECHO_HOST = new URL(ECHO_BASE).host;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
@@ -66,8 +66,8 @@ if (!process.env.CI) {
 // CI resolves ECHO_BASE_URL to the lane's in-network go-httpbin (#1128); locally
 // it falls back to the public host, same contract as agent-multi-tool-selection.
 const ECHO_BASE = (
-  process.env.ECHO_BASE_URL ??
-  process.env.HTTPBIN_BASE_URL ??
+  process.env.ECHO_BASE_URL ||
+  process.env.HTTPBIN_BASE_URL ||
   "https://httpbin.org"
 ).replace(/\/$/, "");
 const TARGET_URL = `${ECHO_BASE}/uuid`;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -59,8 +59,8 @@ if (!process.env.CI) {
 // below holds against either backend. The env-var names match the ones the daily
 // already exports, so no workflow change is needed to pick this up.
 const HTTPBIN_BASE = (
-  process.env.ECHO_BASE_URL ??
-  process.env.HTTPBIN_BASE_URL ??
+  process.env.ECHO_BASE_URL ||
+  process.env.HTTPBIN_BASE_URL ||
   "https://httpbin.org"
 ).replace(/\/$/, "");
 const FETCH_URL = `${HTTPBIN_BASE}/json`;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
@@ -48,8 +48,8 @@ if (!process.env.CI) {
 }
 
 const HTTPBIN_BASE = (
-  process.env.ECHO_BASE_URL ??
-  process.env.HTTPBIN_BASE_URL ??
+  process.env.ECHO_BASE_URL ||
+  process.env.HTTPBIN_BASE_URL ||
   "https://httpbin.org"
 ).replace(/\/$/, "");
 const FETCH_URL = `${HTTPBIN_BASE}/json`;


### PR DESCRIPTION
Restores the fix that came from PR #2 on the internal mirror (`github.ibm.com:Langflow/e2e-qa`), cherry-picked onto the current `main`. Original authorship preserved: Eric Hare.

## Context

PR #2 was merged directly into the destination repository. The destination is a read-only mirror (see `NOTES.md`): the sync force-pushes `+refs/heads/*` with `--prune`, so the 2026-08-25 sync overwrote that merge (`6a732121` → `c9aa6f00`) and the fix was lost there.

The content was recovered from `refs/pull/2/head` (`3cabd19b`), which the push does not touch. This PR reintroduces the change through the origin repository, which is the correct entry point — the sync propagates it to the mirror from here.

## The change

The six specs that resolve the echo endpoint used `??`, which only falls through on `null`/`undefined`. `.env.example` ships `HTTPBIN_BASE_URL=` and the setup instructions say to copy it, so dotenv sets it to `""` — a value `??` accepts. Every fresh clone therefore resolved an empty base URL.

The consequence is worst in `api-request-component-regression.spec.ts`, where `new URL(ECHO_BASE)` runs at module load: it throws `TypeError: Invalid URL` during collection, which aborts the whole run (`npx playwright test --list` reports 0 tests in 0 files). The agent specs fail more quietly, with the target becoming a relative `/json` or `/uuid`.

Swaps `??` for `||` across the 6 files. The diff was verified to be identical to the original commit — only the surrounding context changed from the rebase.