### PR TITLE
chore(coverage): exclude enterprise/ from the TOTAL, and give the generator its first unit test (#1607)

### DIFF
--- a/scripts/coverage-summary.test.ts
+++ b/scripts/coverage-summary.test.ts
@@ -1,0 +1,127 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as path from "path";
+import { execFileSync } from "child_process";
+import { renderCoverageTable, type Counts, type ModuleConfig } from "./coverage-summary";
+
+// The generator's first unit test (#1607). It had none: the script exported
+// nothing, so the table the roadmap and leadership read — regenerated on every
+// push to `main` by update-coverage-summary.yml — was covered by neither unit
+// lane. Assertions are on the RENDERED OUTPUT, never on the shape of the code
+// (#1226: a guard that pins a spelling pins no behaviour).
+
+const c = (validated: number, needsValidation: number, partial: number, notAutomated: number): Counts =>
+  ({ validated, needsValidation, partial, notAutomated });
+
+const mod = (label: string, excludeFromTotal = false): ModuleConfig =>
+  ({ label, sectionStart: `## ${label}`, ...(excludeFromTotal ? { excludeFromTotal } : {}) });
+
+test("an excluded module keeps its own row, with its real counts", () => {
+  // The work must stay visible: 19 files and 62 tests do not vanish because the
+  // lane was declined. Only the denominator changes.
+  const rows = renderCoverageTable(
+    [mod("oss"), mod("ent", true)],
+    [c(10, 2, 0, 1), c(0, 56, 9, 6)],
+  );
+  const entRow = rows.find(r => r.includes("| ent"))!;
+  assert.ok(entRow, "the excluded module must still have a row");
+  assert.match(entRow, /\| 71 \| 0 \| 56 \| 9 \| 6 \|/);
+});
+
+test("an excluded module is absent from the TOTAL", () => {
+  const rows = renderCoverageTable(
+    [mod("oss"), mod("ent", true)],
+    [c(10, 2, 0, 1), c(0, 56, 9, 6)],
+  );
+  const total = rows.find(r => r.includes("TOTAL"))!;
+  // 13, not 84: the excluded module's 71 bullets are out of the denominator.
+  assert.match(total, /\*\*13\*\*/);
+  assert.match(total, /10 \(77%\)/);
+});
+
+test("the total row NAMES what it excludes — the exclusion is never silent", () => {
+  // The half that matters. A silent exclusion is how the number starts lying
+  // again the day the decision reverses (the mode=count lesson, #1252).
+  const total = renderCoverageTable(
+    [mod("oss"), mod("ent", true)],
+    [c(10, 2, 0, 1), c(0, 56, 9, 6)],
+  ).find(r => r.includes("TOTAL"))!;
+  assert.match(total, /excludes/i);
+  assert.match(total, /ent/);
+});
+
+test("with nothing excluded the total counts every module, and says nothing extra", () => {
+  // The no-op guarantee: this change must be invisible until a module opts in.
+  const rows = renderCoverageTable([mod("a"), mod("b")], [c(1, 1, 0, 0), c(2, 0, 0, 0)]);
+  const total = rows.find(r => r.includes("TOTAL"))!;
+  assert.match(total, /\*\*4\*\*/);
+  assert.equal(/excludes/i.test(total), false, "no exclusion note when nothing is excluded");
+  assert.match(total, /\| \*\*TOTAL\*\* \|/);
+});
+
+test("excluding every module reports zero rather than dividing by zero", () => {
+  const total = renderCoverageTable([mod("a", true)], [c(3, 1, 0, 0)]).find(r => r.includes("TOTAL"))!;
+  assert.match(total, /\*\*0\*\*/);
+  assert.doesNotMatch(total, /NaN/);
+});
+
+test("module rows and counts stay aligned by index", () => {
+  // A zip bug here would silently attribute one module's numbers to another —
+  // invisible in a table that always renders.
+  const rows = renderCoverageTable(
+    [mod("first"), mod("second")],
+    [c(1, 0, 0, 0), c(0, 0, 0, 9)],
+  );
+  assert.match(rows.find(r => r.includes("| first"))!, /\| 1 \| 1 \| 0 \| 0 \| 0 \|/);
+  assert.match(rows.find(r => r.includes("| second"))!, /\| 9 \| 0 \| 0 \| 0 \| 9 \|/);
+});
+
+test("the exclusion note uses the module KEY, not its whole em-dashed label", () => {
+  // The fixture this file first used was `label: "ent"` — a shape the real
+  // MODULES array never contains. Every real label is "`dir/` — Description",
+  // and splicing the whole thing into a sentence that already has an em-dash
+  // renders "TOTAL (OSS — excludes `enterprise/` — Enterprise-only Surfaces)".
+  const total = renderCoverageTable(
+    [mod("`oss/` — Open Source"), mod("`enterprise/` — Enterprise-only Surfaces", true)],
+    [c(10, 2, 0, 1), c(0, 56, 9, 6)],
+  ).find(r => r.includes("TOTAL"))!;
+  assert.match(total, /excludes `enterprise\/`\)/);
+  assert.doesNotMatch(total, /Enterprise-only Surfaces\)/);
+});
+
+test("two excluded modules are both named, comma-separated", () => {
+  const total = renderCoverageTable(
+    [mod("`a/` — A", true), mod("`b/` — B", true), mod("`c/` — C")],
+    [c(1, 0, 0, 0), c(1, 0, 0, 0), c(5, 0, 0, 0)],
+  ).find(r => r.includes("TOTAL"))!;
+  assert.match(total, /excludes `a\/`, `b\/`\)/);
+  assert.match(total, /\*\*5\*\*/);
+});
+
+test("importing the module does NOT run the generator", () => {
+  // The defect this pins was live for one commit: making the script importable
+  // left `main()` bare at module scope, so merely LOADING it rewrote a tracked
+  // file — on every `npm run test:units`, CI included. A unit lane that mutates
+  // the repo as a side effect of importing is worse than no lane.
+  //
+  // Asserted on the child's STDOUT, not on the checklist's bytes. The first
+  // version of this test compared the file before and after and could not fail:
+  // with the guard removed, the import at the top of THIS file has already run
+  // the generator by the time the test reads its baseline, so the baseline is
+  // the rewritten content and the child then finds nothing to do. Reading the
+  // output also means the test writes nothing at all.
+  //
+  // Behavioural on purpose rather than grepping the source for `require.main` —
+  // a guard that pins a spelling pins no behaviour (#1226).
+  const repoRoot = path.resolve(__dirname, "..");
+  const out = execFileSync(
+    process.execPath,
+    ["--require", "ts-node/register", "-e", "require('./scripts/coverage-summary.ts')"],
+    { cwd: repoRoot, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  assert.equal(
+    out.trim(),
+    "",
+    `importing coverage-summary.ts ran the generator (it printed: ${out.trim()}) — the entry point is unguarded`,
+  );
+});

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -13,11 +13,29 @@
 import * as fs from "fs";
 import * as path from "path";
 
-interface ModuleConfig {
+export interface ModuleConfig {
   /** Label as it appears in the first column of the table. */
   label: string;
   /** Prefix of the markdown header line where the section starts. */
   sectionStart: string;
+  /**
+   * Keep the module's own row, but leave its bullets out of the `**TOTAL**`
+   * (#1607).
+   *
+   * The total answers "what fraction of what we INTEND to run is validated".
+   * A module whose lane the team has declined can never reach `[x]` — not
+   * because its specs are unfinished, but because nothing will ever schedule
+   * them — so counting it guarantees the metric never closes and drifts
+   * further with every OSS bullet validated.
+   *
+   * This is deliberately a property of the MODULE, not a sixth bullet symbol:
+   * every one of those bullets is accurately `[-]` (automated, not validated).
+   * What changed is whether we intend to validate it. Reversing the decision is
+   * deleting this field.
+   *
+   * The exclusion is rendered, never silent — see `renderCoverageTable`.
+   */
+  excludeFromTotal?: boolean;
 }
 
 /**
@@ -49,7 +67,12 @@ const MODULES: ModuleConfig[] = [
   { label: "`i18n/` — Language and Localization",            sectionStart: "## i18n/" },
   { label: "`memory/` — Memory Base Registration",           sectionStart: "## memory/" },
   { label: "`governance/` — Catalog and Provider Policy",    sectionStart: "## governance/" },
-  { label: "`enterprise/` — Enterprise-only Surfaces",       sectionStart: "## enterprise/" },
+  // Enterprise is out of CI scope by team decision (2026-08-26): only OSS is
+  // tested on a schedule. `governance/` and `serving/` stay counted — both are
+  // OSS (the nightly ships and enforces the governance routes; serving is the
+  // same image under different env vars) and both are slated for lanes.
+  { label: "`enterprise/` — Enterprise-only Surfaces",       sectionStart: "## enterprise/",
+    excludeFromTotal: true },
   { label: "`serving/` — Serving-Plane End-User Identity",   sectionStart: "## serving/" },
 ];
 
@@ -78,7 +101,7 @@ const LAST_UPDATED_PREFIX = "> **Last updated:**";
 
 const BULLET_RE = /^- \[([x\- ~!])\] /;
 
-interface Counts {
+export interface Counts {
   validated: number;       // [x]
   needsValidation: number; // [-]
   partial: number;         // [~] + [!]
@@ -174,6 +197,58 @@ function computeCounts(lines: string[]): Counts[] {
   return counts;
 }
 
+/**
+ * The Coverage Summary table, header row through `**TOTAL**`.
+ *
+ * Pure and exported so the table the roadmap and leadership read is asserted on
+ * its OUTPUT — it had no unit test at all before #1607, despite regenerating on
+ * every push to `main`.
+ *
+ * A module with `excludeFromTotal` keeps its row and its real counts; only the
+ * denominator drops it. Both the row and the total say so out loud: a silent
+ * exclusion is how the number starts lying again the day the decision reverses.
+ */
+export function renderCoverageTable(modules: ModuleConfig[], counts: Counts[]): string[] {
+  const tot = emptyCounts();
+  const excluded: string[] = [];
+  modules.forEach((m, i) => {
+    const c = counts[i];
+    if (m.excludeFromTotal) {
+      // The module KEY, not its whole label: real labels carry an em-dash
+      // description ("`enterprise/` — Enterprise-only Surfaces"), and splicing
+      // that whole string into a sentence that already has an em-dash renders
+      // "TOTAL (OSS — excludes `enterprise/` — Enterprise-only Surfaces)".
+      excluded.push(m.label.split(" — ")[0]);
+      return;
+    }
+    tot.validated += c.validated;
+    tot.needsValidation += c.needsValidation;
+    tot.partial += c.partial;
+    tot.notAutomated += c.notAutomated;
+  });
+  const totSum = totalOf(tot);
+
+  const dataRows = modules.map((m, i) => {
+    const c = counts[i];
+    // Decorate the RENDERED cell only — `m.label` itself is the key the Phase
+    // tables are matched by (`labelToIndex`), so changing it would break them.
+    const label = m.excludeFromTotal ? `${m.label} (not scheduled — decision)` : m.label;
+    return `| ${label} | ${totalOf(c)} | ${c.validated} | ${c.needsValidation} | ${c.partial} | ${c.notAutomated} |`;
+  });
+
+  const totalLabel = excluded.length
+    ? `**TOTAL (OSS — excludes ${excluded.join(", ")})**`
+    : "**TOTAL**";
+  const totalRow =
+    `| ${totalLabel} | **${totSum}** | ` +
+    `**${tot.validated} (${fmtPercent(tot.validated, totSum)})** | ` +
+    `**${tot.needsValidation} (${fmtPercent(tot.needsValidation, totSum)})** | ` +
+    `**${tot.partial} (${fmtPercent(tot.partial, totSum)})** | ` +
+    `**${tot.notAutomated} (${fmtPercent(tot.notAutomated, totSum)})** |`;
+
+  return [TABLE_HEADER, TABLE_SEPARATOR, ...dataRows, totalRow];
+}
+
 function regenerateCoverageTable(
   lines: string[],
   counts: Counts[]
@@ -192,27 +267,7 @@ function regenerateCoverageTable(
     throw new Error(`Coverage Summary header not found: "${COVERAGE_SUMMARY_HEADER_PREFIX}"`);
   }
 
-  const tot = emptyCounts();
-  for (const c of counts) {
-    tot.validated += c.validated;
-    tot.needsValidation += c.needsValidation;
-    tot.partial += c.partial;
-    tot.notAutomated += c.notAutomated;
-  }
-  const totSum = totalOf(tot);
-
-  const dataRows = MODULES.map((m, i) => {
-    const c = counts[i];
-    return `| ${m.label} | ${totalOf(c)} | ${c.validated} | ${c.needsValidation} | ${c.partial} | ${c.notAutomated} |`;
-  });
-  const totalRow =
-    `| **TOTAL** | **${totSum}** | ` +
-    `**${tot.validated} (${fmtPercent(tot.validated, totSum)})** | ` +
-    `**${tot.needsValidation} (${fmtPercent(tot.needsValidation, totSum)})** | ` +
-    `**${tot.partial} (${fmtPercent(tot.partial, totSum)})** | ` +
-    `**${tot.notAutomated} (${fmtPercent(tot.notAutomated, totSum)})** |`;
-
-  const newTable = [TABLE_HEADER, TABLE_SEPARATOR, ...dataRows, totalRow];
+  const newTable = renderCoverageTable(MODULES, counts);
 
   const tableHeaderIdx = findLineIndex(
     lines,
@@ -346,4 +401,10 @@ function main(): void {
   console.log("QA-CHECKLIST.md updated (Coverage Summary, Phase tables, and/or Last updated).");
 }
 
-main();
+// Only run when invoked as a script — keeps the module importable from tests.
+// Without this the import in coverage-summary.test.ts REGENERATES
+// QA-CHECKLIST.md on every `npm run test:units`, in CI included: the unit lane
+// would silently rewrite a tracked file as a side effect of loading it (#1607).
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Type

- [ ] `feat` — new test or new helper/page object
- [ ] `fix` — fix for a broken or flaky test
- [x] `chore` — CI, checklist, dependencies, internal refactoring
- [ ] `docs` — documentation update

---

## Roadmap linkage (required — do not delete)

- [ ] **Current wave** — a `roadmap`-labeled issue in the current wave's milestone: #___
- [x] **Exception** — off-wave work backed by an issue: a follow-up, a `daily-failure` triage issue, or a `community`-labeled regression. Issue **#1607** (`qa-infra`, `follow-up`)

---

## What this PR does

**Enterprise surfaces are out of CI scope by team decision (2026-08-26): only OSS is tested on a schedule.**

That makes the Coverage Summary's `**TOTAL**` answer a question nobody asked. The total reads as *"what fraction of what we intend to run is validated"*, and 71 `enterprise/` bullets can no longer reach `[x]` — not because the specs are unfinished (19 files, 62 tests, merged and green) but because the lane they would need has been declined. Counting them in the denominator guaranteed the metric never closes, and it drifts further every time an OSS bullet is validated.

**68 % → 77 %** (451/660 → 451/589), with the work still visible on its own row.

### Why not a sixth bullet symbol

The obvious fix — `[o]` for *automated, deliberately unscheduled* — is the wrong shape and far more expensive: `BULLET_RE` is a fixed character class, `classify()` branches on it, the table would grow a **sixth** column, the legend is duplicated across `CLAUDE.md`, `CONTRIBUTING.md` and the `langflow-e2e` skill, and `check-checklist-guard.mjs` matches generated line shapes. Five places to express something that is not about the bullet at all: every one of those 56 `[-]` is accurately *automated, not validated*. What changed is whether we **intend** to validate it — a property of the module. Hence `excludeFromTotal` on `ModuleConfig`.

Reversing the decision is deleting one field.

### The exclusion is rendered, never silent

This is the load-bearing half. A silent exclusion is how the number starts lying again the day the decision reverses — the same failure mode as the `mode=count` warning nobody read (#1252) and the `@stable` justification that survived in two spec docs (#1604).

```
| `enterprise/` — Enterprise-only Surfaces (not scheduled — decision) | 71 | 0 | 56 | 9 | 6 |
| **TOTAL (OSS — excludes `enterprise/`)** | **589** | **451 (77%)** | **59 (10%)** | **16 (3%)** | **63 (11%)** |
```

`governance/` (14) and `serving/` (13) stay **counted**: both are OSS — the nightly ships and *enforces* 25 of EE's governance routes, and serving is the same image under different env vars — and both are slated to gain scheduled lanes.

### The generator gets its first unit test

Found while scoping: `scripts/coverage-summary.ts` **exported nothing and had no `*.test.ts`**, despite generating the table the roadmap and leadership read and running on every push to `main` via `update-coverage-summary.yml`. The same gap #1017 created `test:units` for, and #1593 just closed for the issue pipeline. The sum and row rendering moved into an exported pure `renderCoverageTable`, asserted on its **output** rather than on the shape of the code (#1226).

---

## Tests covered

`scripts/coverage-summary.test.ts` — new, 9 tests in `npm run test:units`:

| # | Test | What it validates |
|---|---|---|
| 1 | an excluded module keeps its own row, with its real counts | the work does not vanish — 71/0/56/9/6 still renders |
| 2 | an excluded module is absent from the TOTAL | the denominator actually drops it (13, not 84) |
| 3 | the total row NAMES what it excludes | the exclusion can never be silent |
| 4 | with nothing excluded the total counts every module, and says nothing extra | the no-op guarantee — invisible until a module opts in |
| 5 | excluding every module reports zero rather than dividing by zero | no `NaN` in a table that always renders |
| 6 | module rows and counts stay aligned by index | a zip bug would silently attribute one module's numbers to another |
| 7 | the exclusion note uses the module KEY, not its whole em-dashed label | see the first defect below |
| 8 | two excluded modules are both named, comma-separated | the plural path |
| 9 | importing the module does NOT run the generator | see the second defect below |

---

## How the tests were built

Two defects the implementation itself produced, both caught here and pinned:

**1. The total rendered two em-dashes.** Splicing the whole label produced `TOTAL (OSS — excludes \`enterprise/\` — Enterprise-only Surfaces)`. It survived the first fixture because that fixture used `label: "ent"` — a shape `MODULES` never contains. Exactly the #1216 trap, where a hand-built fixture the real resolver never emits let the bug through. Fixed to the key (`label.split(" — ")[0]`) and pinned with a realistic label.

**2. Making the script importable left `main()` bare at module scope**, so merely **loading** it rewrote `QA-CHECKLIST.md` — on every `npm run test:units`, CI included. A unit lane that mutates a tracked file as a side effect of importing is worse than no lane. Guarded with the repo's existing `require.main === module` idiom, the same one `remove-stable-from-failures.ts` and `update-component-catalog-baseline.ts` already use.

The test for it asserts the child process's **stdout**, not the checklist's bytes — and that matters. The first version compared the file before and after, and **could not fail**: with the guard removed, the import at the top of the test file has already run the generator by the time the test reads its baseline, so the baseline is the rewritten content and the child then finds nothing to do. Reading the output also means the test writes nothing at all.

Verified in both directions: importing runs nothing, invoking still regenerates, and a second invocation produces no diff.

---

## Dependencies

None. No Langflow instance, no `.spec.ts`, no new package.

---

## What this PR does not cover

- **`QA-CHECKLIST.md` is deliberately not in this diff.** The label and the total live in the generator; `update-coverage-summary.yml` regenerates the block on merge. Committing regenerated counts is what the `pr-validation.yml` guard rejects (#741).
- **`ROADMAP.md`'s hand-copied snapshot** (`76% (402/532)`) is already stale and will disagree further. It says *"refresh from `QA-CHECKLIST.md` when it changes — do not hand-maintain"*, and the checklist only regenerates on merge, so refreshing it here would mean writing numbers that do not exist yet. Post-merge step.
- **The scheduled lanes for `@destructive` and `@serving`** — the OSS half of the same conversation, 22 bullets, tracked separately.

---

## Known limitations

`renderCoverageTable` decorates the **rendered** label only; `m.label` itself is untouched, because it is the key the Phase tables are matched by (`labelToIndex`). Changing the field would break them with *"Phase N row … does not match any module in MODULES"*. Recorded as a comment at the site.

---

## Related issue

Closes #1607

---

## Validation

- [x] **Forced a failure — 7 mutations, 7 red, reverted byte-identical:**
  - `M1 ignore excludeFromTotal in the sum` → **5** failed
  - `M2 drop the excluded module's row` → 1 failed
  - `M3 total no longer names the exclusion` → 3 failed
  - `M4 splice the whole label instead of the key` → 2 failed
  - `M5 always add the note, even with nothing excluded` → 1 failed
  - `M6 misalign counts against modules` → 2 failed
  - `M7 remove the `require.main` guard` → 1 failed
- [x] **Rendered output inspected against the real file** before reverting it — the two rows above are what merge will produce.
- [x] **Idempotent** — a second `npm run coverage:summary` produces no diff.
- [x] **Phase tables still resolve** — no `does not match any module in MODULES` error.
- [x] `npm run typecheck` 0 · `npm run lint` 0 · `test:units` **797/797** · `test:scripts` 857 · `test:pipeline` 119/119 · QA-CHECKLIST guard clean
- [ ] ~`--trace=on` / `--debug` / backend errors~ — not applicable: no Playwright spec, no Langflow instance.
- [ ] ~Updated `QA-CHECKLIST.md`~ — deliberately not; see above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
