### PR TITLE
chore(security): migrate ssrf-url-validation.spec.ts onto the private-echo-endpoint helper (#1599)

### DIFF
--- a/docs/security/ssrf-url-validation.md
+++ b/docs/security/ssrf-url-validation.md
@@ -116,10 +116,13 @@ Test 4 uses the canvas. Every flow is created id-scoped and deleted in `afterEac
 
 **Test 3 — an address inside a blocked range is admitted when a CIDR entry covers it** *(`@api`)*
 
-1. **Precondition, asserted not assumed:** `ECHO_BASE_URL` is set and its host is a literal IPv4 in
-   a blocked-by-default range (RFC-1918, loopback, link-local or CGNAT). If it is not — no echo
-   service, or the lane fell back to the public `postman-echo.com` — `test.skip` with the resolved
-   value in the reason, because a public host proves nothing about the allow-list.
+1. **Precondition, asserted not assumed**, and resolved by the shared
+   `tests/helpers/other/private-echo-endpoint.ts` rather than by logic local to this file:
+   `ECHO_BASE_URL` is set and its host is a literal IPv4 in a blocked-by-default range (RFC-1918,
+   loopback, link-local or CGNAT). If it is not — no echo service, or the lane fell back to a public
+   host — the helper returns a `skipReason` naming the resolved value and the test `test.skip`s on
+   it, because a public host proves nothing about the allow-list. The helper answers with the base
+   URL only; the `/get` path is this spec's own.
 2. Create the flow with `url_input = ${ECHO_BASE_URL}/get` and run it.
 3. Assert **200**, and that the run output carries `status_code: 200` and `source` equal to the URL
    requested — the request really left the backend and came back.
@@ -229,8 +232,14 @@ Test 4 uses the canvas. Every flow is created id-scoped and deleted in `afterEac
 - `tests/helpers/flows/delete-flow.ts` — id-scoped teardown.
 - `tests/helpers/flows/open-flow-by-id.ts` — Test 4's canvas entry (`canvas_controls_dropdown` +
   writability gate), avoiding the sidebar-add race.
+- `tests/helpers/other/private-echo-endpoint.ts` — the canonical `ECHO_BASE_URL` guard
+  (`isBlockedRangeIpv4` + `privateEchoUrl`): decides whether the resolved endpoint is an address
+  Langflow blocks by default, and returns the skip reason when it is not. Shared with
+  `security/model-provider-base-url-ssrf.spec.ts`, which asserts the same non-vacuity control
+  through the provider seam.
 - `ECHO_BASE_URL` — resolved per lane by `.github/actions/resolve-echo-endpoint`
-  (`scripts/resolve-echo-endpoint.mjs`); Test 3 reads it and skips when it is not a private IP.
+  (`scripts/resolve-echo-endpoint.mjs`); Test 3 reads it through the helper above and skips when it
+  is not a private IP.
 - `src/lfx/src/lfx/utils/ssrf_protection.py` — `validate_and_resolve_url`, `is_host_allowed`,
   `get_allowed_hosts`, `is_ip_blocked` and the blocked-range table: the code under test.
 - `src/lfx/src/lfx/components/data_source/api_request.py` — calls `validate_and_resolve_url` and

--- a/tests/helpers/other/private-echo-endpoint.ts
+++ b/tests/helpers/other/private-echo-endpoint.ts
@@ -14,11 +14,16 @@
  * `validators.url()` rejects a single-label host). Locally there may be none, so
  * the caller `test.skip`s with the reason this module returns.
  *
- * **Canonical home, with one migration outstanding.**
- * `security/ssrf-url-validation.spec.ts` (#1391) carries an inline copy of both
- * functions — it is the file they were written in. Migrating it here is a
- * deliberate follow-up rather than part of #1595: that spec's four tests would
- * otherwise enter #1595's force-fail scope for no behavioural change.
+ * **Canonical home, and the only copy** (#1599). The functions were written in
+ * `security/ssrf-url-validation.spec.ts` (#1391) and extracted here by #1595,
+ * which left that spec's inline copy in place rather than dragging its four tests
+ * into its own force-fail scope; #1599 migrated it. Both consumers now import
+ * from here — that spec's admitted case, and
+ * `security/model-provider-base-url-ssrf.spec.ts`'s non-vacuity control on the
+ * provider seam. Keep it that way: the load-bearing branch is that a PUBLIC host
+ * is *skipped* rather than accepted, and a second copy is the shape where a
+ * tightening reaches one caller and not the other (#1108's 51 hand-copied
+ * cleanup blocks are the precedent).
  */
 
 /**
@@ -27,6 +32,11 @@
  *
  * A hostname answers **false**: this cannot know what a name resolves to, and
  * guessing is how a public endpoint would slip in as the admitted case.
+ *
+ * Deliberately wider than `isPrivateIpv4` in `scripts/resolve-echo-endpoint.mjs`,
+ * which answers a different question (may this endpoint need the allow-list?) and
+ * covers RFC-1918 only. Here the question is whether a 200 is attributable to the
+ * allow-list, which is true for every range the guard blocks by default.
  */
 export function isBlockedRangeIpv4(host: string): boolean {
   const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host ?? "");

--- a/tests/tests-automations/regression/security/ssrf-url-validation.spec.ts
+++ b/tests/tests-automations/regression/security/ssrf-url-validation.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { createApiRequestFlowViaApi } from "../../../helpers/flows/create-api-request-flow-via-api";
 import { openFlowById } from "../../../helpers/flows/open-flow-by-id";
+import { privateEchoUrl } from "../../../helpers/other/private-echo-endpoint";
 
 /**
  * SSRF allow-list round trip on a URL-fetching component (issue #1391).
@@ -47,70 +48,6 @@ const LOOPBACK_URL = "http://127.0.0.1:7860/api/v1/version";
 // stays refused on the very instance where Test 3's private address goes
 // through — which is what makes Test 3's 200 attributable to the allow-list.
 const METADATA_URL = "http://169.254.169.254/latest/meta-data/";
-
-// The echo endpoint each CI lane self-hosts; `resolve-echo-endpoint` sets this to
-// the go-httpbin CONTAINER IP (a private RFC-1918 address), which the lane's
-// `LANGFLOW_SSRF_ALLOWED_HOSTS` CIDRs admit. Unset (or public) means the accept
-// arm has nothing to prove — see `privateEchoUrl()`.
-const ECHO_BASE = (
-  process.env.ECHO_BASE_URL ??
-  process.env.HTTPBIN_BASE_URL ??
-  ""
-).replace(/\/$/, "");
-
-/**
- * The ranges `lfx/utils/ssrf_protection.py` blocks by default and that a lane may
- * allow-list. Only these prove anything: a PUBLIC echo host is reachable with or
- * without an allow-list, so asserting a 200 against it would pass on an instance
- * that ignores `LANGFLOW_SSRF_ALLOWED_HOSTS` entirely.
- *
- * Deliberately wider than `isPrivateIpv4` in `scripts/resolve-echo-endpoint.mjs`,
- * which answers a different question (may this endpoint need the allow-list?) and
- * covers RFC-1918 only. Here the question is whether a 200 is attributable to the
- * allow-list, which is true for every range the guard blocks by default.
- */
-function isBlockedRangeIpv4(host: string): boolean {
-  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host ?? "");
-  if (!match) return false;
-  const parts = match.slice(1).map(Number);
-  if (parts.some((p) => p > 255)) return false;
-  const [a, b] = parts;
-  return (
-    a === 10 || // 10.0.0.0/8
-    a === 127 || // 127.0.0.0/8 (loopback)
-    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
-    (a === 192 && b === 168) || // 192.168.0.0/16
-    (a === 169 && b === 254) || // 169.254.0.0/16 (link-local / metadata)
-    (a === 100 && b >= 64 && b <= 127) // 100.64.0.0/10 (CGNAT)
-  );
-}
-
-/** `${ECHO_BASE}/get` when the echo host is an address the guard blocks by default. */
-function privateEchoUrl(): { url: string } | { skipReason: string } {
-  if (!ECHO_BASE) {
-    return {
-      skipReason:
-        "ECHO_BASE_URL/HTTPBIN_BASE_URL is unset, so there is no private endpoint whose " +
-        "reachability could only come from LANGFLOW_SSRF_ALLOWED_HOSTS. Every CI lane sets it " +
-        "via .github/actions/resolve-echo-endpoint; locally see docs/security/ssrf-url-validation.md.",
-    };
-  }
-  let host: string;
-  try {
-    host = new URL(ECHO_BASE).hostname;
-  } catch {
-    return { skipReason: `ECHO_BASE_URL is not a URL: ${ECHO_BASE}` };
-  }
-  if (!isBlockedRangeIpv4(host)) {
-    return {
-      skipReason:
-        `the echo endpoint resolved to ${ECHO_BASE}, whose host is not an address Langflow blocks ` +
-        "by default (a public host, or a name rather than an IP). Reaching it proves nothing about " +
-        "the allow-list, so this test would be vacuous rather than green.",
-    };
-  }
-  return { url: `${ECHO_BASE}/get` };
-}
 
 /** The component's own result object inside a `POST /api/v1/run/{id}` response. */
 interface ApiRequestResult {
@@ -270,7 +207,9 @@ test.describe("SSRF URL validation — allow-list round trip", () => {
         "skipReason" in echo,
         "skipReason" in echo ? echo.skipReason : "",
       );
-      const url = (echo as { url: string }).url;
+      // The helper answers with the base URL only — the path is this spec's own, and
+      // `/get` is the go-httpbin route that echoes the request back.
+      const url = `${(echo as { url: string }).url}/get`;
 
       let flowId = "";
       await test.step(`create a flow targeting the allow-listed private endpoint ${url}`, async () => {


### PR DESCRIPTION
Closes #1599.

## Problem

`tests/helpers/other/private-echo-endpoint.ts` has been the canonical home of the `ECHO_BASE_URL` guard (`isBlockedRangeIpv4` + `privateEchoUrl`, 9 unit tests) since #1595. `security/ssrf-url-validation.spec.ts` — the file the functions were written in — still carried an **inline copy of both**, knowingly: migrating it inside #1595's PR would have dragged that spec's four tests into that issue's force-fail scope for no behavioural change.

Two copies of one guard is the shape that drifts. #1108 is the precedent: the id-scoped flow-cleanup block had been hand-copied into **51** spec files, four axes had already diverged, "and a fix to one reached none of the other 50". Here the load-bearing branch is that a **public** echo host must be *skipped* rather than accepted — reaching a public address proves nothing about `LANGFLOW_SSRF_ALLOWED_HOSTS`, so a tightening applied to one copy would silently leave the other admitting a vacuous green.

## Fix

The spec imports `privateEchoUrl` from the helper; the inline `ECHO_BASE` const, `isBlockedRangeIpv4` and `privateEchoUrl` are deleted (−62 net lines in the spec). The helper returns the **base URL only**, so Test 3 appends its own `/get` — the same idiom `model-provider-base-url-ssrf.spec.ts:204-208` already uses for `/v1`.

**The divergence this issue guarded against had not happened yet.** The two `isBlockedRangeIpv4` bodies are **byte-identical** with comments stripped (checked programmatically, not by eye). The only difference is textual, in two `skipReason` strings:

| | spec inline | helper |
|---|---|---|
| `ECHO_BASE_URL` unset | points at `docs/security/ssrf-url-validation.md` | carries the `docker run … go-httpbin` recipe and the "not `localhost`" warning |
| host not in a blocked range | "…this **test** would be vacuous" | "…the **assertion** would be vacuous" |

The helper's wording wins, as the single source. What is lost is the pointer to the spec doc; what is gained is a runnable command. Recorded here rather than smoothed over, per the issue's own instruction.

Two documentation moves accompany it, both additive, neither touching what the guard decides:

- the JSDoc paragraph explaining why this predicate is **deliberately wider** than `isPrivateIpv4` in `scripts/resolve-echo-endpoint.mjs` (a different question — *is a 200 attributable to the allow-list?* versus *may this endpoint need one?*) moves into the helper, so the deletion does not take it;
- the helper's header block titled *"Canonical home, with one migration outstanding"* is rewritten — this PR **is** that migration, and leaving it would make the file describe a state that no longer exists.

The spec doc gains the helper under **External dependencies** and says, in Test 3's step 1, that the precondition is resolved by the shared helper and that the `/get` path is the spec's own.

## Scope note

No assertion, tag, `describe` structure, serial mode, fixture import or `afterEach` cleanup changed. Nothing about what the guard decides changed. `git diff origin/main..HEAD` is 3 files, +33/−75.

## Validation (nightly `1.12.0.dev37`, `--workers=1 --retries=0`)

`ECHO_BASE_URL=http://172.17.0.5:8080` — a `go-httpbin` container on the docker bridge, measured reachable **from inside** the Langflow container (`langflow->echo:200`), on an instance already carrying `LANGFLOW_SSRF_ALLOWED_HOSTS=172.16.0.0/12,10.0.0.0/8,192.168.0.0/16`.

```
run 1/3 ssrf-url-validation.spec.ts: clean expected=4 unexpected=0 flaky=0 backendErrors=false skipped=0
run 2/3 ssrf-url-validation.spec.ts: clean expected=4 unexpected=0 flaky=0 backendErrors=false skipped=0
run 3/3 ssrf-url-validation.spec.ts: clean expected=4 unexpected=0 flaky=0 backendErrors=false skipped=0
typecheck=0 lint=0
```

`skipped=0` is the figure that matters: Test 3 **executed** rather than passing by skip, which is the precondition for force-failing it at all.

- **Import-graph sibling also validated.** `scripts/impacted-specs-by-import.mjs` reaches `security/model-provider-base-url-ssrf.spec.ts` through the touched helper: **3/3 clean, `expected=6`, `skipped=0`**.
- **typecheck** ✅ `tsc --noEmit` clean.
- **eslint** ✅ 0 errors — and the **same 9 warnings, rule for rule**, that `HEAD` already emits on this file (compared against `git show HEAD:…`), so none was introduced.
- **Helper unit tests** ✅ 9/9.
- **Backend errors** ✅ zero `🚨 Backend Error` across every run.
- **Cleanup** ✅ `GET /api/v1/flows/` after 9 runs lists only the 20 starter templates — neither file leaked a flow.

### Force-fail — all 4 tests of the touched file

Mutations were made at the **input**, never at the assertion: each test was pointed at a URL whose SSRF verdict is the opposite of the one it asserts, so the assertions stayed byte-identical and the *product observable* moved.

| # | Test | Mutation | Result |
|---|---|---|---|
| 1 | a loopback address is refused, and the refusal names the allow-list | flow points at the allow-listed private echo instead of loopback → guard admits, run answers 200 | red ✅ |
| 2 | a blocked address the allow-list does not cover is refused the same way | same, instead of `169.254.169.254` | red ✅ |
| 3 | an address inside a blocked range is admitted when a CIDR entry covers it | flow points at the cloud-metadata address → refused 500 | red ✅ |
| 4 | the refusal surfaces in the editor as an error, not a silent empty result | flow points at the allow-listed private echo → the canvas run succeeds, no banner ever renders | red ✅ |

Test 3 is the mutation that proves the **migrated seam** is load-bearing: it still resolves its precondition through the imported `privateEchoUrl`, does **not** skip, and then fails on the observable.

`FF coverage: complete` · `no FF-MUTATION markers in diff ✓` · `final green run after reverts ✓ (1 file)`.

### One caveat, stated rather than hidden

The pipeline reported a nightly mismatch — the container is `1.12.0.dev37` while the locally pulled `nightly:latest` is newer. **Not acted on, deliberately:** `scripts/start-langflow-docker.sh` sets no `LANGFLOW_SSRF_ALLOWED_HOSTS`, so restarting would drop the allow-list this container already carries and make Test 3 **skip** — strictly weaker evidence for a change whose entire point is that Test 3 must execute. This PR asserts no product behaviour, so the older nightly costs nothing here.

## QA-CHECKLIST

No bullet change. §17.1 already carries the four bullets at `[x]` pointing at `ssrf-url-validation.spec.ts`, and this PR changes no coverage. `npm run check:checklist-coverage` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
