### PR TITLE
fix(memory): select the embedding option by identity, not by its sr-only text (#1460)

### DIFF
--- a/docs/core-functionality/memory/memory-base-registration.md
+++ b/docs/core-functionality/memory/memory-base-registration.md
@@ -39,11 +39,17 @@ Test 2: `@api` `@workspace` (cross-cutting) + `@files` (functional).
 `@files` on test 2 is the repo's functional tag for the knowledge/vector
 ingestion family, which is the resource boundary that test asserts.
 
-**`@stable` decision:** proposed for both. Test 2 is provider-free and fully
-deterministic. Test 1 skips loudly rather than failing when the daily's provider
-key is drained (a state this account has been in three times — #772, #1029,
-#1169), so it cannot redden the daily for a credential reason. Confirm with the
-team before the PR; a `@stable` test must not be `@destructive`, and neither is.
+**`@stable` decision:** both. Test 2 is provider-free and fully deterministic.
+Test 1 skips loudly rather than failing when the daily's provider key is drained
+(a state this account has been in three times — #772, #1029, #1169), so it cannot
+redden the daily for a credential reason. Neither is `@destructive`.
+
+Test 1's `@stable` was **auto-removed** by the daily triage (`f6f4c398`, daily
+`31786538844`) when the `sr-only` counter broke its option matcher, and is
+**restored here** — that is the quarantine #1460 asks to lift. The removal was
+correct as triage: with no scheduled lane running it afterwards, the defect
+stayed invisible to the daily and surfaced only on PRs, because the
+impacted-specs lane selects by import graph rather than by tag (#871/#1054).
 
 ---
 
@@ -99,6 +105,36 @@ team before the PR; a `@stable` test must not be `@destructive`, and neither is.
   list: enabling a model while the modal is open leaves the picker reading
   `No Models Enabled` until `refresh-model-list` is clicked (measured). The
   spec avoids the refresh path entirely by doing the API write first.
+- **The embedding option is selected by its IDENTITY, never by its rendered
+  text — issue #1460.** Since **1.12.0.dev26** every option of the unified model
+  picker renders its own position inside itself as
+  `<span class="sr-only">N of M</span>`: invisible to a user, but part of both
+  `textContent` and the accessible name. Measured on **1.12.0.dev37** in this
+  very picker, with one enabled embeddings model, the single option reads
+
+  ```
+  data-testid  Google Generative AI-gemini-embedding-2-option
+  data-value   Google Generative AI::gemini-embedding-2
+  textContent  "gemini-embedding-21 of 1"        <- .sr-only = ["1 of 1"]
+  ```
+
+  so `getByRole("option", { name: "gemini-embedding-2", exact: true }).count()`
+  is **0** (the loose matcher: 1) and the click the spec used to make times out
+  at 20 s. The selection therefore goes through `selectPinnedModelOption`
+  (`tests/helpers/provider-setup/model-option.ts`, built for the sibling
+  issue #1459): it resolves the option by `data-value` / `data-testid`, clicks by
+  identity, and raises a loud `MODEL_PICKER_DEFECT` when the picker contradicts
+  the API probe rather than degrading into a skip (#1461). The announcement can
+  change wording, position or total without touching this test.
+- **The counter is intended product behaviour, and the trigger is the clean
+  half.** Both readings #1460 asked to separate were measured on 1.12.0.dev37.
+  Re-read after a 4 s settle the option is byte-identical (`1 of 1` persists), so
+  it is not a mid-update render artefact. And after selecting, the trigger
+  `#memory-embedding-model` carries `textContent === "gemini-embedding-2"` with
+  **zero** `.sr-only` descendants — so the existing
+  `toHaveText(embedding.modelId)` assertion on the trigger asserts a real product
+  contract and is kept unweakened. Only the *matcher* that reached the option was
+  wrong; nothing about what the test proves is relaxed.
 - **A skip is never a silent pass.** Test 1 skips with the concrete reason; test
   2 runs regardless, so the file always executes at least one falsifiable
   assertion about registration.
@@ -184,6 +220,16 @@ is shared with parallel workers.
   still there. The submit button and the panel's list item carry **no**
   `data-testid` (the item is a plain `div`), so they resolve by role+name and by
   exact text inside the panel's `aside`.
+- **The option markup measured for #1460, on 1.12.0.dev37**, with
+  `Google Generative AI / gemini-embedding-2` enabled (the model
+  `findEmbeddingModel` picks on the suite's own instance — Anthropic is
+  configured but exposes no embeddings model, so it is skipped):
+  `role=option` count 1, accessible name `"gemini-embedding-21 of 1"`,
+  `exact: true` count **0** / loose count 1, unchanged after a 4 s settle;
+  trigger after selection `"gemini-embedding-2"` with no `.sr-only` node, and
+  `Provider: ` rendered. The `data-testid` embeds the provider display name
+  **spaces included** (`Google Generative AI-…-option`), which is why the
+  identity is read from `data-value` first and the testid only as a fallback.
 - **Batch Size is `threshold` on the wire** — the modal's `#memory-batch-size`
   maps to the `threshold` field (default `50` in the model, `1` in the modal).
   Worth knowing before reading a payload and concluding a field is missing.

--- a/tests/tests-automations/regression/core-functionality/memory/memory-base-registration.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/memory/memory-base-registration.spec.ts
@@ -5,6 +5,7 @@ import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { openFlowById } from "../../../../helpers/flows/open-flow-by-id";
 import { unmountEditorForCleanup } from "../../../../helpers/flows/unmount-editor-for-cleanup";
+import { selectPinnedModelOption } from "../../../../helpers/provider-setup/model-option";
 
 // Memory Base — registering a memory base end-to-end (QA-CHECKLIST §20.3).
 // Spec doc: docs/core-functionality/memory/memory-base-registration.md
@@ -229,8 +230,13 @@ test.describe("core-functionality/memory — registering a memory base", () => {
     await deleteFlow(request, flowId, { headers: { Authorization: token } });
   });
 
+  // `@stable` was auto-removed by the daily triage (f6f4c398, daily 31786538844)
+  // when the `sr-only` counter broke the option matcher below, and is restored
+  // here — the quarantine lift #1460 asks for. The removal was correct as triage,
+  // but it left no scheduled lane running this test, so the defect was invisible
+  // to the daily and surfaced only on PRs whose diff the import graph reached.
   test("registering a memory base from the Create Memory modal persists it",
-    { tag: ["@release", "@workspace", "@ui-ux", "@model-provider"] },
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux", "@model-provider"] },
     async ({ page, request }) => {
       const choice = await findEmbeddingModel(request, token);
       test.skip(
@@ -257,11 +263,37 @@ test.describe("core-functionality/memory — registering a memory base", () => {
       await test.step("the form is completed with a name and an embedding model", async () => {
         await page.locator("#memory-name").fill(memoryName);
         await page.locator("#memory-embedding-model").click();
-        await page
-          .getByRole("option", { name: embedding.modelId, exact: true })
-          .click();
+
+        // Selected by IDENTITY, never by the option's rendered text, and that is
+        // #1460: since 1.12.0.dev26 every option of the unified model picker
+        // renders its own position inside itself —
+        //
+        //     <div data-testid="Google Generative AI-gemini-embedding-2-option"
+        //          data-value="Google Generative AI::gemini-embedding-2"
+        //          role="option">
+        //       <div class="truncate text-[13px]">gemini-embedding-2</div>
+        //       <span class="sr-only">1 of 1</span>
+        //     </div>
+        //
+        // The span is invisible to a user but part of both `textContent` and the
+        // accessible name, so `getByRole("option", { name, exact: true })` counts
+        // ZERO (measured on 1.12.0.dev37; the loose matcher counts 1) and the
+        // click this used to make died on a 20 s timeout. The counter is intended
+        // product behaviour — unchanged after a 4 s settle, so not a mid-update
+        // artefact — and `data-value` carries `{Provider}::{model}` exactly, so
+        // the helper resolves the option there and clicks it by identity. It
+        // raises a loud MODEL_PICKER_DEFECT when the picker contradicts the API
+        // probe above rather than degrading into a skip (#1461).
+        await selectPinnedModelOption(page, {
+          requested: embedding.modelId,
+          providerLabel: embedding.provider,
+        });
+
         // Both halves of "a model is chosen": the trigger carries the id, and
-        // the `Provider:` line renders only once one is.
+        // the `Provider:` line renders only once one is. Asserted unweakened —
+        // the trigger is the half that was CORRECT all along (measured: it reads
+        // exactly the model id, with no `sr-only` descendant of its own), so this
+        // still fails if the trigger shows a model other than the one selected.
         await expect(page.locator("#memory-embedding-model")).toHaveText(
           embedding.modelId,
           { timeout: 15000 },


### PR DESCRIPTION
**Fixes #1460.** Closes #1460.

## Problem

Two `@stable` tests hard-failed 3/3 attempts in daily #1458 (run
[31786538844](https://github.com/oriontech-me/langflow-e2e/actions/runs/31786538844),
2026-08-14) reading a model option's own **text**. Since **1.12.0.dev26** every
option of the unified model picker renders its own position inside itself:

```
<div data-testid="Google Generative AI-gemini-embedding-2-option"
     data-value="Google Generative AI::gemini-embedding-2" role="option">
  <div class="truncate text-[13px]">gemini-embedding-2</div>
  <span class="sr-only">1 of 1</span>
</div>
```

The span is invisible to a user but part of both `textContent` and the
accessible name, which defeats a full-string comparison and an exact
accessible-name match alike.

Only **one** of the issue's two rows was still broken. `modelInputComponent.spec.ts:140`
had already been repaired on `main` by e7601f9b (PR #1538) — it reads through
`enumerateModelOptions` → `visibleLabel` and its `@stable` is back. Re-verified
here, untouched: `expected=1 unexpected=0`, 8.6 s. This PR closes the remaining
row, `memory-base-registration.spec.ts:232`, whose
`getByRole("option", { name: embedding.modelId, exact: true })` timed out at 20 s.

**Verdict: test-defect.** The counter is intended product behaviour and the
product side of every assertion was already correct. Measured on **1.12.0.dev37**,
answering the issue's four investigation directives:

| Directive | Measured |
|---|---|
| (a) is the `sr-only` span in the **embedding** picker? | Yes — `.sr-only = ["1 of 1"]`, `textContent = "gemini-embedding-21 of 1"` |
| (b) what should the test key on? | `data-value` = `{Provider}::{model}`, exact. The `data-testid` embeds the provider display name **spaces included**, so `data-value` is read first |
| (c) render artefact, picker mid-update? | No — byte-identical after a 4 s settle |
| (d) does the **trigger** carry the counter too? | No — after selection `#memory-embedding-model` reads exactly `gemini-embedding-2` with **zero** `.sr-only` descendants |

Reproduced deterministically two independent ways: a DOM scout where
`getByRole("option", { name: "gemini-embedding-2", exact: true }).count()` is
**0** while the loose matcher counts 1, and a pre-fix baseline of **2/2 failed
(100 %, 0 voided)** carrying the issue's own signature,
`TimeoutError: locator.click: Timeout 20000ms exceeded.`

## Fix

Route the one call site through **`selectPinnedModelOption`**
(`tests/helpers/provider-setup/model-option.ts`) — the helper built for the
sibling issue #1459, so nothing new is introduced. It enumerates the open
picker, resolves the option by `data-value` with `data-testid` as fallback,
clicks by identity, and raises a loud `MODEL_PICKER_DEFECT` /
`MODEL_NOT_AVAILABLE` when the picker contradicts the API probe rather than
degrading into a silent skip (#1461). The announcement can change its wording,
position or total without touching this test.

**Rejected alternative:** an inline `[data-value="…"]` locator in the spec. Smaller
diff, but it duplicates logic that already exists centralised and loses the loud
verdicts — an empty or unresolvable picker would go back to being a mute timeout,
which is exactly what #1461 was filed about.

Also **restores the `@stable`** the daily triage auto-removed in `f6f4c398` — the
quarantine lift the issue asks for. There was no `test.fixme`, so that is the
whole lift. Worth recording why it mattered: with no scheduled lane running the
test, the defect was invisible to the daily and surfaced only on PRs, because the
impacted-specs lane selects by import graph rather than by tag (#871/#1054) —
PR #1538 had to justify this red in writing to merge.

## Scope note

Nothing the test proves is relaxed. Kept verbatim: the API-probe precondition
(`/api/v1/models` + `/api/v1/models/enabled_models`), the additive enablement
write before page load with restore in `afterEach`, the trigger assertion
`toHaveText(embedding.modelId)` — a real product contract, and the half that was
correct all along — the `Provider: ` line, the `201` on `POST /api/v1/memories`,
the `kb_name` shape, the panel re-read after a full `page.reload()`, and the
id-scoped cleanup. No wait, retry, catch, or loosened selector was added.

The other three `getByRole("option", { exact: true })` sites in the repo
(`if-else-component-regression`, `data-operations-component`,
`data-operations-legacy-link`) are non-model pickers and are outside this
mechanism, as the issue already noted.

## Validation (nightly 1.12.0.dev37, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ (0) · `npm run lint` ✅ (0 errors) · `npm run check:checklist-coverage` ✅
- **3/3 clean burst**, `expected=2 unexpected=0 flaky=0 skipped=0` on every run — both tests
  executed, no skip, so the run is evidence rather than a vacuous green (#1593)
- Zero `🚨 Backend Error` (`backendErrors=false` on all three runs)
- **Force-fail, both tests in the file, reverted with 0 `FF-MUTATION` markers left and a final green run:**
  - test 1 — `requested` → `${embedding.modelId}-ff-nonexistent` (the *Selection* class of the
    force-fail menu) → `unexpected=1`. Proves the identity-keyed selection depends on **this**
    model and that an unmatchable target is a loud failure, never a skip.
  - test 2 — the resource-boundary assertion inverted, `.not.toContain(kbName)` →
    `.toContain(kbName)` → `unexpected=1`. Proves the absence assert has bite and is not
    vacuously true on an empty list.
- Orphan sweep after the final run: `GET /api/v1/flows/?remove_example_flows=true&header_flows=true`
  → **0 flows**

Cross-links, per the issue's last deliverable: #1459 (the shared `provider-setup`
matchers — same triage, same mechanism, where `selectPinnedModelOption` comes
from) and #1461 (the `MODEL_NOT_AVAILABLE` guard that turned the same mechanism
into ~30 silent skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
