### PR TITLE
fix(mcp): attribute and repair the blank-flow entry stall (#1126)

### DIFF
--- a/docs/mcp/client/mcp-client-regression.md
+++ b/docs/mcp/client/mcp-client-regression.md
@@ -12,15 +12,26 @@ Validates the full MCP client configuration and tool execution path — without 
 
 ## Tags *(required)*
 
-All tests: `@mcp` `@regression`. Tests 2 (unreachable HTTP server), 3 (HTTP form registration), and 4 (numeric `get-sum`) additionally carry `@stable`.
+All four tests: `@mcp` `@regression` `@stable`.
+
+Test 2 was quarantined by the #1121 daily triage (`test.fixme` added, `@stable` removed) after three same-signature flakes — dailies 2026-07-16, 2026-07-20 and 2026-07-30 — all of them in the shared "Open a blank flow" entry point, none of them in an MCP assertion. The quarantine is lifted with the entry-point repair described in **Step by step → Entry point** and **Notes → The blank-flow entry point does not always route (#1126)**.
 
 Test 4 (numeric `get-sum`) had `@stable` temporarily removed in the #461 daily-triage PR because it depends on the `npx server-everything` MCP server registering its tools in time, which hard-failed the daily suite on cold startup (#463). The dominant root cause was an upstream Langflow defect — root-owned npm cache, `langflow-ai/langflow#13992` — now fixed in the published nightly (see #638/#552). `@stable` was **re-added** (#463) and the poll budget kept at 120s (raised from 90s) as modest margin for startup.
 
-Test 1 (JSON config → echo tool) shares the same `npx server-everything` dependency and is intentionally **not** `@stable` — it was not in scope for #463.
+Test 1 (JSON config → echo tool) shares the same `npx server-everything` dependency and was out of scope for #463; it was promoted later by #947 (PR #954, "promote §13.1 MCP Client remainder to `@stable`"), once that cold-start defect was fixed upstream.
 
 ---
 
 ## Step by step *(required)*
+
+**Entry point — "Open a blank flow" (shared by all four tests)**
+
+1. Land on the flows list and open the new-flow templates modal
+2. Click `blank-flow` and read the created flow's id from `POST /api/v1/flows/` → `201` (the id in the canvas URL is a transient client-side handle on this version and must not be used)
+3. Wait up to 10 s for the SPA to route to `/flow/<id>`
+4. If it has not routed, probe `GET /api/v1/version`:
+   - backend not healthy → fail, attributed as a backend outage, never as an entry-point regression;
+   - backend healthy → load `/flow/<id>` directly, wait for `canvas_controls_dropdown`, and report the repair on stdout so the daily's artifact records it (#1126)
 
 **Test 1 — JSON config → echo tool**
 
@@ -71,6 +82,8 @@ Test 1 (JSON config → echo tool) shares the same `npx server-everything` depen
 - `src/frontend/src/modals/addMcpServerModal/index.tsx` — JSON tab, HTTP tab, and save flow; testids `json-tab`, `http-tab`, `http-name-input`, `http-url-input`, `add-mcp-server-button`
 - `src/frontend/src/components/core/parameterRenderComponent/components/mcpComponent/index.tsx` — `dropdown_str_tool` on the canvas node
 - `src/backend/base/langflow/api/v2/mcp.py` — `GET /api/v2/mcp/servers?action_count=true` and `DELETE /api/v2/mcp/servers/{name}` endpoints
+- `src/frontend/src/modals/templatesModal/index.tsx` — the `blank-flow` button every test enters through, and the `addFlow().then(navigate)` chain whose stall #1126 is about
+- `src/frontend/src/hooks/flows/use-add-flow.ts` — resolves the promise that chain navigates from; a `201` whose per-mutate `onSuccess` never resolves leaves the app parked on the flows list
 - npm package `@modelcontextprotocol/server-everything` — external dependency launched via `npx`
 
 ---
@@ -97,3 +110,6 @@ Test 1 (JSON config → echo tool) shares the same `npx server-everything` depen
 - Tool dropdown interactions use `page.evaluate((el) => el.click())` instead of Playwright's `.click()` to avoid viewport and overlay constraints.
 - The `get-sum` tool option testid is `get-sum-6-option` — index 6 reflects its position in `server-everything`'s tool list and may shift if the package reorders tools in a future release.
 - Test 2 uses `page.waitForFunction` to confirm the dropdown is genuinely open before asserting zero options, preventing a false-positive where the evaluate click fails silently.
+- **The blank-flow entry point does not always route (#1126).** Three dailies (2026-07-16, 2026-07-20, 2026-07-30) failed Test 2 on `page.waitForURL(/\/flow\//)` *after* `POST /api/v1/flows/` had already answered `201` and the id had been read. In all three the Playwright call log is exactly `waiting for navigation until "load"` with **no `navigated to "…"` line** — Playwright logs that line for every main-frame navigation it observes *before* testing the URL predicate, so the frame emitted no navigation at all for the full 30 s. The stall is therefore terminal, not slow, and waiting longer cannot fix it: measured on nightly 1.12.0.dev39, 6 parallel lanes × 8 blank-flow creations navigated **48/48**, min 39 ms, p50 269 ms, **p95 337 ms**, max 457 ms — the retired 30 s budget was ~90× the p95. Upstream, `navigate()` runs only from the `.then()` of `addFlow()` in `templatesModal/index.tsx` and that chain has no `.catch`, so a creation whose per-mutate `onSuccess` never reaches `resolve(createdFlow.id)` parks the app on the flows list forever — the exact observed state. The cause of that non-resolution is **not** established: forcing the modal to unmount mid-flight (Escape immediately after the click) still navigated 5/5 on 1.12.0.dev39, so the "unmounted observer drops the mutate callback" branch alone does not explain it. The repair is therefore deterministic rather than a longer wait — the id from the `201` is authoritative, so the entry point loads `/flow/<id>` directly — and it is never silent: the recovery prints a `📌 Blank-flow entry repaired (#1126)` line, which Playwright's JSON reporter stores under `results[].stdout`, so a future daily can be searched for it.
+- The file runs `test.describe.configure({ mode: "serial" })`, so a failure in this entry point does not cost one test: on the 2026-07-30 daily it also skipped Tests 3 and 4 (the run's only two `skipped`).
+- **Cleanup captures every flow the page creates, not just the blank one.** The teardown used to delete a single tracked id — the one `openBlankFlow` returns — which leaves the flow the "New Flow" entry point creates on its own during bootstrap behind (#1002). Measured on 1.12.0.dev39: one clean 4-test run took the instance from **26 to 28** flows, all named `New Flow (N)`. The file therefore uses `trackCreatedFlows` (#1108), armed in `beforeEach` so bootstrap's creation is inside the capture window, with `{ strict: true }` to keep the pre-existing behaviour that a failed delete fails the teardown rather than logging (#547).

--- a/tests/helpers/flows/blank-flow-entry.test.ts
+++ b/tests/helpers/flows/blank-flow-entry.test.ts
@@ -1,0 +1,149 @@
+// Unit tests for the blank-flow entry point's stall handling (issue #1126).
+// Run with: npm run test:units
+//
+// What rides on these functions: whether a `201`-without-navigation costs a
+// month of coverage, and whether a wedged backend can be repaired into a green
+// test.
+//
+// The failure they exist for cost `mcp-client-regression.spec.ts` its `@stable`
+// on three dailies (2026-07-16, 2026-07-20, 2026-07-30) with the same call log —
+// `waiting for navigation until "load"` and no `navigated to` line — and, because
+// the file is `mode: "serial"`, also skipped the two tests after it on 07-30.
+//
+// Two properties are load-bearing and pull in opposite directions, which is why
+// both are pinned here rather than left to the caller:
+//
+//  - the repair must be reachable ONLY when Langflow answered, so an outage can
+//    never be turned into a pass (#1012);
+//  - the abort must stay classifiable as infra, which it is not by virtue of a
+//    prefix but by EMBEDDING the probe's own transport error — that embedded text
+//    is what `scripts/lib/infra-signatures.ts` matches, and it is what keeps a
+//    wedge out of the `@stable` auto-removal path (#1031).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyInfraError } from "../../../scripts/lib/infra-signatures";
+import { entryBarrierMessage, INFRA_PREFIX } from "../other/page-entry-barrier";
+import {
+  BLANK_FLOW_ENTRY_SURFACE,
+  FLOW_ROUTE_BUDGET_MS,
+  MEASURED_ROUTE_P95_MS,
+  REPAIR_MARKER,
+  flowRouteStallVerdict,
+  repairedEntryNotice,
+} from "./blank-flow-entry";
+
+const FLOW_ID = "0c5779ff-f5d8-4f4d-a5fc-a758c575a943";
+const PROBE_URL = "http://localhost:7860/api/v1/version";
+
+const CAUSE =
+  "TimeoutError: page.waitForURL: Timeout 10000ms exceeded.\n" +
+  "=========================== logs ===========================\n" +
+  'waiting for navigation until "load"\n' +
+  "============================================================";
+
+const abortMessage = (probe: Parameters<typeof repairedEntryNotice>[0]["probe"]) =>
+  entryBarrierMessage({
+    selector: `URL /flow/${FLOW_ID}`,
+    timeoutMs: FLOW_ROUTE_BUDGET_MS,
+    probe,
+    surface: BLANK_FLOW_ENTRY_SURFACE,
+    cause: CAUSE,
+  });
+
+test("a backend that answered earns the repair", () => {
+  assert.equal(
+    flowRouteStallVerdict({ state: "healthy", ms: 12, status: 200, url: PROBE_URL }),
+    "repair",
+  );
+});
+
+test("every state that is not a healthy answer aborts instead of repairing", () => {
+  // The asymmetry is the point: repairing against a backend we could not reach
+  // would turn an outage into a green test.
+  assert.equal(
+    flowRouteStallVerdict({
+      state: "unreachable",
+      ms: 5001,
+      url: PROBE_URL,
+      detail: "apiRequestContext.get: Timeout 5000ms exceeded.",
+    }),
+    "abort",
+  );
+  assert.equal(
+    flowRouteStallVerdict({ state: "http_error", ms: 8, status: 503, url: PROBE_URL }),
+    "abort",
+  );
+  // UNKNOWN is the probe that could not run at all. It is not evidence of health.
+  assert.equal(
+    flowRouteStallVerdict({
+      state: "unknown",
+      ms: 1,
+      url: PROBE_URL,
+      detail: "probe could not run: Target page, context or browser has been closed",
+    }),
+    "abort",
+  );
+});
+
+test("a wedged backend aborts with a message triage can classify as infra", () => {
+  const msg = abortMessage({
+    state: "unreachable",
+    ms: 5001,
+    url: PROBE_URL,
+    detail: "apiRequestContext.get: Timeout 5000ms exceeded.",
+  });
+
+  assert.ok(msg.startsWith(INFRA_PREFIX), `expected the infra prefix, got: ${msg}`);
+  // Not the prefix that classifies it — the EMBEDDED transport error does.
+  assert.equal(classifyInfraError(msg)?.id, "api-request-timeout");
+  // The surface must be named, or the reader cannot tell WHICH entry broke.
+  assert.match(msg, /blank-flow-entry barrier/);
+  // The original Playwright log stays readable against the trace.
+  assert.match(msg, /waiting for navigation until "load"/);
+});
+
+test("the abort names the flow it could not reach", () => {
+  const msg = abortMessage({ state: "http_error", ms: 8, status: 503, url: PROBE_URL });
+  assert.ok(msg.startsWith(INFRA_PREFIX));
+  assert.match(msg, new RegExp(`URL /flow/${FLOW_ID}`));
+  assert.match(msg, /HTTP 503/);
+});
+
+test("the repair notice carries everything an occurrence report needs", () => {
+  const notice = repairedEntryNotice({
+    flowId: FLOW_ID,
+    budgetMs: FLOW_ROUTE_BUDGET_MS,
+    probe: { state: "healthy", ms: 12, status: 200, url: PROBE_URL },
+  });
+
+  // The marker is the greppable contract against a daily's results[].stdout.
+  assert.ok(notice.startsWith(REPAIR_MARKER), `notice must start with the marker: ${notice}`);
+  assert.match(notice, new RegExp(`/flow/${FLOW_ID}`));
+  assert.match(notice, new RegExp(`${FLOW_ROUTE_BUDGET_MS}ms`));
+  assert.match(notice, /HTTP 200/);
+  assert.match(notice, /#1126/);
+  // It must say the 201 already happened — that is what separates this stall
+  // from a creation that simply failed.
+  assert.match(notice, /already answered 201/);
+});
+
+test("the repair notice is NOT an infra signature", () => {
+  // It is not a failure at all; if it ever leaked into a failure message it must
+  // not exempt that test from @stable auto-removal.
+  const notice = repairedEntryNotice({
+    flowId: FLOW_ID,
+    budgetMs: FLOW_ROUTE_BUDGET_MS,
+    probe: { state: "healthy", ms: 12, status: 200, url: PROBE_URL },
+  });
+  assert.equal(classifyInfraError(notice), null);
+});
+
+test("the route budget stays far above the measured p95", () => {
+  // The repair must never be reachable merely because the wait was trimmed: at
+  // 48/48 the route's p95 was 337ms, so anything under ~20x that would start
+  // repairing healthy-but-loaded runs and hide the real rate of #1126.
+  assert.ok(
+    FLOW_ROUTE_BUDGET_MS >= 20 * MEASURED_ROUTE_P95_MS,
+    `budget ${FLOW_ROUTE_BUDGET_MS}ms is not >= 20x the measured p95 (${MEASURED_ROUTE_P95_MS}ms)`,
+  );
+});

--- a/tests/helpers/flows/blank-flow-entry.ts
+++ b/tests/helpers/flows/blank-flow-entry.ts
@@ -1,0 +1,200 @@
+import type { Page } from "@playwright/test";
+import {
+  entryBarrierMessage,
+  probeBackend,
+  waitForAttributedSelector,
+  type BackendProbe,
+} from "../other/page-entry-barrier";
+
+/**
+ * The wait that turns a created flow into a usable canvas — with the
+ * `201`-without-navigation stall of #1126 both ATTRIBUTED and REPAIRED.
+ *
+ * WHAT BREAKS (#1126)
+ *
+ * `POST /api/v1/flows/` answers `201`, the caller reads the authoritative id
+ * from it, and the SPA then never routes to `/flow/<id>`. Three dailies lost the
+ * same test to it — 2026-07-16 (run 29489622983), 2026-07-20 (29736388873) and
+ * 2026-07-30 (30534416609) — and in all three the Playwright call log is exactly
+ *
+ *   TimeoutError: page.waitForURL: Timeout 30000ms exceeded.
+ *   waiting for navigation until "load"
+ *
+ * with NO `navigated to "…"` line. That absence is the whole diagnosis, and it is
+ * not a subtlety of reading: `waitForNavigation` logs `navigated to "<url>"` for
+ * every main-frame navigation it observes BEFORE it tests the URL predicate
+ * (`playwright-core/lib/client/frame.js` — the log is the line above the
+ * `urlMatches` call). So the frame emitted no navigation at all for the full 30 s.
+ * The state is TERMINAL, not slow, and a bigger budget cannot reach it.
+ *
+ * WHY THE BUDGET IS NOT THE PROBLEM
+ *
+ * Measured on nightly 1.12.0.dev39, 6 parallel lanes × 8 blank-flow creations:
+ * 48/48 routed, min 39 ms, p50 269 ms, p95 337 ms, max 457 ms. The retired 30 s
+ * wait was ~90× the p95, so the failures were never near the budget.
+ *
+ * WHERE IT COMES FROM, AND WHAT IS STILL UNKNOWN
+ *
+ * Upstream (`release-1.12.0`), `modals/templatesModal/index.tsx` navigates ONLY
+ * from the `.then()` of `addFlow()`, and that chain has no `.catch`:
+ *
+ *   addFlow().then((id) => { dismissWelcomeForNavigation(); navigate(`/flow/${id}`) })
+ *
+ * `addFlow` (`hooks/flows/use-add-flow.ts`) resolves from react-query's
+ * PER-MUTATE `onSuccess`. A creation whose per-mutate `onSuccess` never reaches
+ * `resolve(createdFlow.id)` therefore leaves the promise pending forever and the
+ * app parked on the flows list — exactly the observed state. WHY it fails to
+ * resolve is NOT established, and this comment does not pretend otherwise: the
+ * obvious candidate (the templates modal unmounts mid-flight, so react-query
+ * drops the per-mutate callback) was tested by pressing Escape immediately after
+ * the click on 1.12.0.dev39 and navigated 5 of 5. So the branch is refuted, not
+ * confirmed, and the stall stays reproducible only in CI.
+ *
+ * WHY REPAIR RATHER THAN FAIL
+ *
+ * This is an ENTRY POINT. The specs behind it assert MCP behaviour, and a red
+ * that names neither MCP nor the real cause is what got one of them quarantined
+ * for a month while the two siblings after it in a `mode: "serial"` file were
+ * skipped as collateral. The repair is deterministic and costs nothing that could
+ * hide a product regression: the id from the `201` is authoritative, so loading
+ * `/flow/<id>` directly reaches the SAME flow the caller already tracks for
+ * cleanup — no second flow is created, unlike the re-click doctrine of #1468.
+ * Measured on 1.12.0.dev39, that load reaches `canvas_controls_dropdown` in
+ * 1.0–2.3 s, 5 of 5.
+ *
+ * It is never SILENT, which is the condition that makes repairing acceptable
+ * (#1012): every repair prints `REPAIR_MARKER` on stdout, and Playwright's JSON
+ * reporter stores test stdout under `results[].stdout` — the same artifact triage
+ * already reads — so a future occurrence is greppable in the daily without a
+ * trace, which is what expires first.
+ *
+ * AND IT NEVER SWALLOWS AN OUTAGE
+ *
+ * A wedged or restarting backend produces the identical timeout (#1262). So the
+ * stall is probed before it is repaired, and a backend that is not healthy
+ * FAILS through `entryBarrierMessage`, which embeds the probe's own transport
+ * error — that embedded text is what `scripts/lib/infra-signatures.ts` matches,
+ * so the wedge stays exempt from `@stable` auto-removal while the repaired,
+ * healthy-backend case is not an error at all.
+ */
+
+/** Measured p95 of the SPA route, 1.12.0.dev39, 48/48 (see the header). */
+export const MEASURED_ROUTE_P95_MS = 337;
+
+/**
+ * Budget for the SPA route. ~30× the measured p95 — generous enough that a
+ * loaded CI backend cannot reach the repair path by being slow, small enough
+ * that the terminal stall is not paid for at 30 s three times a month.
+ */
+export const FLOW_ROUTE_BUDGET_MS = 10000;
+
+/** Named in every failure so a reader knows which entry point broke (#1265). */
+export const BLANK_FLOW_ENTRY_SURFACE = "blank-flow-entry";
+
+/** Surface label for the repair's own barrier, kept distinct from the wait's. */
+export const BLANK_FLOW_REPAIR_SURFACE = "blank-flow-entry-repair";
+
+/**
+ * The canvas-mount barrier the repair waits on. The SPA route does not wait for
+ * it — that path is unchanged and already proven — but a full document load
+ * genuinely has a mount to finish, and returning before it would hand the caller
+ * the same unattributed canvas race #1469 describes.
+ */
+export const CANVAS_BARRIER_SELECTOR = '[data-testid="canvas_controls_dropdown"]';
+
+/** Budget for the barrier above. Measured 1.0–2.3 s on 1.12.0.dev39, 5/5. */
+export const CANVAS_BARRIER_TIMEOUT_MS = 30000;
+
+/**
+ * Stable, greppable prefix of the repair notice. It is a CONTRACT: a daily's
+ * `results[].stdout` is searched for this exact string to count occurrences of
+ * #1126, so renaming it silently loses the history.
+ */
+export const REPAIR_MARKER = "📌 Blank-flow entry repaired (#1126)";
+
+export type FlowRouteStallVerdict = "repair" | "abort";
+
+/**
+ * What to do about a route that did not happen. Pure so the decision is pinned
+ * by a unit test rather than by reading the caller.
+ *
+ * Only a HEALTHY probe earns the repair. Everything else — unreachable,
+ * non-2xx, or a probe that could not run at all — aborts, because repairing
+ * against a backend we could not reach would turn an outage into a green test
+ * (#1012: an unevaluated probe is unknown, never clean).
+ */
+export function flowRouteStallVerdict(probe: BackendProbe): FlowRouteStallVerdict {
+  return probe.state === "healthy" ? "repair" : "abort";
+}
+
+/**
+ * The line printed when the entry point is repaired. Carries everything a triage
+ * needs to add the occurrence to #1126 without a trace: which flow, which
+ * budget, and what the backend answered while the SPA sat still.
+ */
+export function repairedEntryNotice(detail: {
+  flowId: string;
+  budgetMs: number;
+  probe: BackendProbe;
+}): string {
+  const { flowId, budgetMs, probe } = detail;
+  return (
+    `${REPAIR_MARKER}: the SPA did not route to /flow/${flowId} within ` +
+    `${budgetMs}ms even though POST /api/v1/flows/ had already answered 201, ` +
+    `while Langflow answered GET /api/v1/version with HTTP ${probe.status} in ` +
+    `${probe.ms}ms (${probe.url}). Recovered by loading /flow/${flowId} ` +
+    `directly — no second flow was created. This is a product-side stall in ` +
+    `Langflow's post-create navigation, not a slow wait: the route's measured ` +
+    `p95 is ${MEASURED_ROUTE_P95_MS}ms. Record this occurrence on issue #1126.`
+  );
+}
+
+/**
+ * Wait until the caller is on the canvas of the flow it just created, repairing
+ * the #1126 stall if it happens. Returns which path was taken so a caller can
+ * assert on it; the specs do not, they just proceed.
+ *
+ * `flowId` MUST be the id from the creation response, never the one in the
+ * canvas URL — that one is a transient client-side handle on this version and
+ * deleting it 404s while silently leaking the real flow.
+ */
+export async function enterCreatedFlow(
+  page: Page,
+  flowId: string,
+  options?: { baseURL?: string; budgetMs?: number },
+): Promise<"routed" | "repaired"> {
+  const budgetMs = options?.budgetMs ?? FLOW_ROUTE_BUDGET_MS;
+
+  try {
+    await page.waitForURL(/\/flow\//, { timeout: budgetMs });
+    return "routed";
+  } catch (error: unknown) {
+    const cause = String((error as Error)?.message ?? error);
+    const probe = await probeBackend(page, { baseURL: options?.baseURL });
+
+    if (flowRouteStallVerdict(probe) === "abort") {
+      throw new Error(
+        entryBarrierMessage({
+          selector: `URL /flow/${flowId}`,
+          timeoutMs: budgetMs,
+          probe,
+          surface: BLANK_FLOW_ENTRY_SURFACE,
+          cause,
+        }),
+      );
+    }
+
+    await page.goto(`/flow/${flowId}`);
+    await waitForAttributedSelector(
+      page,
+      CANVAS_BARRIER_SELECTOR,
+      CANVAS_BARRIER_TIMEOUT_MS,
+      { baseURL: options?.baseURL, surface: BLANK_FLOW_REPAIR_SURFACE },
+    );
+    // Announced only once the repair has actually landed: a notice printed
+    // before the barrier would claim a recovery that then failed, and the
+    // stdout line is the record a future triage counts occurrences from.
+    console.warn(repairedEntryNotice({ flowId, budgetMs, probe }));
+    return "repaired";
+  }
+}

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -1,9 +1,13 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { enterCreatedFlow } from "../../../../helpers/flows/blank-flow-entry";
+import {
+  trackCreatedFlows,
+  type FlowTracker,
+} from "../../../../helpers/flows/track-created-flows";
 
 // Clicks the blank-flow card and returns the id from the flow-creation POST, NOT
 // from the canvas URL: the URL id is a transient client-side handle on this
@@ -14,6 +18,12 @@ import { zoomOut } from "../../../../helpers/ui/zoom-out";
 // created nothing and the app stays on the flows list (an error toast, no
 // navigation), so re-clicking blank-flow is a safe retry. A 4xx is
 // deterministic and surfaces immediately.
+//
+// The 201 path does NOT retry, and must not: the flow exists, so a re-click
+// would create a second one. Its own failure mode — a 201 the SPA never routes
+// on (#1126) — is handled by `enterCreatedFlow`, which probes the backend, fails
+// attributed when Langflow is the one that is gone, and otherwise recovers by
+// loading the created flow directly. See `helpers/flows/blank-flow-entry.ts`.
 async function openBlankFlow(page: Page): Promise<string> {
   const MAX_ATTEMPTS = 3;
   let lastStatus = 0;
@@ -34,7 +44,7 @@ async function openBlankFlow(page: Page): Promise<string> {
       if (!created.id) {
         throw new Error("blank-flow creation returned no flow id");
       }
-      await page.waitForURL(/\/flow\//, { timeout: 30000 });
+      await enterCreatedFlow(page, created.id);
       return created.id;
     }
 
@@ -92,20 +102,28 @@ test.describe.configure({ mode: "serial" });
 const BAD_SERVER_NAME = "bad-server";
 const HTTP_FORM_SERVER_NAME = "http-form-server";
 
-// Id of the flow the running test created; teardown deletes only this one via
-// the API (scoped) — never a global cleanAllFlows, which wipes flows other
-// parallel workers are actively building mid-run (#515).
-let createdFlowId: string | undefined;
+// Every flow the page creates, id-scoped (#1108) — never a global cleanAllFlows,
+// which wipes flows other parallel workers are actively building mid-run (#515).
+//
+// The single tracked id this replaces was not enough: `awaitBootstrapTest` clicks
+// the "New Flow" entry point, which on this version can create a flow of its own
+// before the templates modal opens (#1002), and nothing returned that id. Measured
+// on 1.12.0.dev39, one clean run of this file took the instance from 26 to 28
+// flows — two orphaned `New Flow (N)` per run.
+let flows: FlowTracker;
 
 test.describe("MCP Client – Configure and Execute Tool", () => {
-  test.afterEach(async ({ page }) => {
-    const flowId = createdFlowId;
-    createdFlowId = undefined;
+  // Armed BEFORE the test body so bootstrap's creation is inside the capture
+  // window; that is precisely the leak the per-test id could not see.
+  test.beforeEach(({ page }) => {
+    flows = trackCreatedFlows(page);
+  });
 
+  test.afterEach(async ({ page, request }) => {
     // Navigate off the editor first so the unmounted flow page stops polling the
-    // flow we are about to delete. The auth header is reused for both the MCP
-    // server cleanup and the flow deletion — page.request is unauthenticated
-    // under AUTO_LOGIN and would 401 otherwise.
+    // flows we are about to delete. This header serves the MCP-server cleanup
+    // below — page.request is unauthenticated under AUTO_LOGIN and would 401
+    // otherwise; the flow deletion authenticates itself inside the tracker.
     await page.goto("/");
     const authHeader = await getAuthToken(page.request);
     const opts = authHeader
@@ -121,11 +139,14 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       // best-effort
     }
 
-    // Delete ONLY the flow this test created (scoped teardown, #515). Not
-    // swallowed: a failed cleanup surfaces instead of silently leaking (#547).
-    if (flowId) {
-      await deleteFlow(page.request, flowId, opts);
-    }
+    // `strict: true` keeps the pre-existing contract: this file failed its
+    // teardown on a failed delete rather than logging it (#547), and migrating to
+    // the shared tracker must not silently downgrade that to a warning line.
+    // The tracker authenticates with the Bearer token itself, so it takes the
+    // `request` fixture — `page.request` carries only browser cookies and the
+    // flows API wants the header.
+    await flows.cleanup(request, { strict: true });
+    flows.dispose();
   });
 
   test(
@@ -138,7 +159,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       await test.step("Open blank flow", async () => {
         await awaitBootstrapTest(page);
         await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-        createdFlowId = await openBlankFlow(page);
+        await openBlankFlow(page);
       });
 
       await test.step("Delete existing MCP server and re-add via JSON", async () => {
@@ -235,20 +256,22 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
     },
   );
 
-  // Quarantined for #1126 — recurrent flake (dailies 2026-07-16, 2026-07-20,
-  // 2026-07-30): openBlankFlow's page.waitForURL times out after 30 s even
-  // though POST /api/v1/flows already returned 201. Lifting the quarantine and
-  // restoring @stable is a deliverable of #1126.
-  test.fixme(
+  // Quarantine lifted (#1126). This test was `test.fixme` after three dailies
+  // (2026-07-16, 2026-07-20, 2026-07-30) lost it in `openBlankFlow`, on a
+  // `waitForURL` that timed out although POST /api/v1/flows had already answered
+  // 201. The stall is terminal rather than slow — no navigation event was
+  // emitted at all — so it is now handled at the entry point by
+  // `enterCreatedFlow`, and `@stable` is restored.
+  test(
     "unreachable HTTP server results in empty tool dropdown",
-    { tag: ["@mcp", "@regression"] },
+    { tag: ["@mcp", "@regression", "@stable"] },
     async ({ page }) => {
       const BAD_SERVER = BAD_SERVER_NAME;
 
       await test.step("Open blank flow", async () => {
         await awaitBootstrapTest(page);
         await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-        createdFlowId = await openBlankFlow(page);
+        await openBlankFlow(page);
       });
 
       await test.step("Pre-clean: delete bad-server if it exists", async () => {
@@ -337,7 +360,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       await test.step("Open blank flow", async () => {
         await awaitBootstrapTest(page);
         await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-        createdFlowId = await openBlankFlow(page);
+        await openBlankFlow(page);
       });
 
       await test.step("Pre-clean: delete http-form-server if it exists", async () => {
@@ -407,7 +430,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       await test.step("Open blank flow", async () => {
         await awaitBootstrapTest(page);
         await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-        createdFlowId = await openBlankFlow(page);
+        await openBlankFlow(page);
       });
 
       await test.step("Register everything server via JSON and wait for tools", async () => {


### PR DESCRIPTION
**Closes #1126.**

## Problem

`mcp-client-regression.spec.ts` was quarantined by the #1121 daily triage (`test.fixme` + `@stable` removed) after three same-signature flakes — dailies **2026-07-16** (run 29489622983), **2026-07-20** (29736388873) and **2026-07-30** (30534416609). In each, `openBlankFlow`'s `page.waitForURL(/\/flow\//)` timed out at 30 s **after** `POST /api/v1/flows/` had already answered `201` and the id had been read.

Two measurements settle what it is.

**It is a terminal stall, not a slow route.** All three runs carry the same call log and nothing else:

```
TimeoutError: page.waitForURL: Timeout 30000ms exceeded.
waiting for navigation until "load"
```

There is **no `navigated to "…"` line**, and that absence is the diagnosis: `waitForNavigation` logs that line for *every* main-frame navigation it observes **before** it tests the URL predicate (`playwright-core/lib/client/frame.js` — the log sits directly above the `urlMatches` call). So the frame emitted no navigation at all for the full 30 s.

**The budget was never close.** Measured on nightly `1.12.0.dev39`, 6 parallel lanes × 8 blank-flow creations: **48/48 routed**, min 39 ms, p50 269 ms, **p95 337 ms**, max 457 ms. The retired 30 s wait was ~90× the p95.

Upstream (`release-1.12.0`), `modals/templatesModal/index.tsx` navigates **only** from the `.then()` of `addFlow()`, and that chain has no `.catch`; `addFlow` (`hooks/flows/use-add-flow.ts`) resolves from react-query's **per-mutate** `onSuccess`. A creation whose per-mutate `onSuccess` never reaches `resolve(createdFlow.id)` therefore leaves the promise pending forever and the app parked on the flows list — exactly the observed state.

**What is NOT established, stated rather than implied:** *why* it fails to resolve. The obvious candidate — the templates modal unmounts mid-flight, so react-query drops the per-mutate callback — was tested by pressing Escape immediately after the click on `1.12.0.dev39` and navigated **5 of 5**. The branch is refuted, not confirmed, and the stall did not reproduce locally at 6-lane parallelism.

One more thing the flake costs that the issue did not record: the file is `mode: "serial"`, so on 2026-07-30 this failure also **skipped Tests 3 and 4** — the run's only two `skipped`.

## Fix

New helper `tests/helpers/flows/blank-flow-entry.ts` (+ 7 unit tests):

- waits **10 s** for the route (~30× the measured p95, pinned by a unit test so nobody trims it into repairing healthy-but-loaded runs);
- on a stall, probes `GET /api/v1/version`:
  - **not healthy ⇒ FAILS**, through `entryBarrierMessage`, which embeds the probe's own transport error — that embedded text is what `scripts/lib/infra-signatures.ts` matches, so a wedge stays exempt from `@stable` auto-removal and can never be repaired into a pass;
  - **healthy ⇒ REPAIRS**: the id from the `201` is authoritative, so it loads `/flow/<id>` directly and waits through the `canvas_controls_dropdown` barrier (measured 1.0–2.3 s, 5/5).
- the repair is **never silent**: it prints `📌 Blank-flow entry repaired (#1126)`, which Playwright's JSON reporter stores under `results[].stdout` — the same artifact triage already reads, and the one that outlives the trace.

**Rejected alternatives, explicitly.** A longer wait: the state is terminal, so no budget reaches it. A re-click (#1468's doctrine): the flow already exists, so a second click creates a second flow. Failing loudly and leaving it quarantined: this is an *entry point*; the specs behind it assert MCP behaviour, and a red naming neither MCP nor the real cause is what cost this file a month of coverage plus two sibling tests.

The teardown moves to `trackCreatedFlows` (#1108) in the same change, because the repo rule is that a touched spec ships id-scoped cleanup and this one did not, measurably: its single tracked id cannot see the flow `awaitBootstrapTest` creates on its own (#1002), and one clean run took the instance from **26 to 28** flows. Armed in `beforeEach` so bootstrap's creation is inside the capture window, with `{ strict: true }` to keep the pre-existing contract that a failed delete fails the teardown rather than logging it (#547). After the migration: **27 → 27** across three runs, including a round of deliberately failing ones.

Quarantine lifted: `test.fixme` → `test`, `@stable` restored.

## Scope note

No assertion changed in any of the four tests — the MCP steps, testids, budgets and observables are untouched; only the shared entry point and the teardown moved. The `5xx` retry loop in `openBlankFlow` is unchanged, and the `201` path deliberately still does **not** retry (the flow exists; a re-click would create a second one).

The spec doc gains the entry-point contract, the two upstream dependencies the stall lives in, and one correction: its **Tags** section claimed Test 1 is intentionally not `@stable`, which stopped being true when #947 (PR #954) promoted it. All four tests are `@stable`.

**Out of scope, flagged:** `webhook-`, `agent-` and `loop-component-regression.spec.ts` still carry their own copies of the old local `openBlankFlow` with the same bare 30 s `waitForURL`. None is quarantined today, so adopting the helper there is prevention and is left as a follow-up.

## Validation (nightly `1.12.0.dev39`, `--retries=0`, `--workers=1`)

- `npm run typecheck` ✅ · `npm run lint` 0 errors ✅ · `npm run test:units` 804/804 ✅ · `npm run test:scripts` 858/858 ✅ · QA-CHECKLIST coverage + generated-block guards ✅
- **8 clean runs**, `4 passed` every time (33.4 s – 60 s) ✅
- zero `🚨 Backend Error` in every run ✅
- flow cleanup verified against `GET /api/v1/flows/`: **no orphans** — 27 before and after, including across the failing force-fail round ✅
- `--trace=on` ❌ **not run** — the known local limitation: it hung >4 min on a test that takes ~5 s, and was killed. Recorded rather than claimed.

### Force-fails (all executed and observed failing)

| Mutation | Result |
|---|---|
| T1 `getByText("oi")` → `"FFMUT1126"` | **1 failed** (18.4 s) |
| T2 `toHaveCount(0)` → `toHaveCount(1)` | **1 failed** (15.8 s) |
| T3 `servers.find(name === HTTP_SERVER)` → a name that does not exist | **1 failed** (5.3 s) |
| T4 `"The sum of 3 and 5 is 8."` → `"… is 9."` | **1 failed** (13.9 s) |
| helper — route regex made unreachable | **4 passed** through the repair, `📌` printed 4× (proves the mechanism for every test in the file) |
| helper — same, probe pointed at `127.0.0.1:1` | **1 failed**: `[backend-unreachable] blank-flow-entry barrier … apiRequestContext.get: connect ECONNREFUSED` |
| helper — same, canvas barrier testid made nonexistent | **1 failed**: `blank-flow-entry-repair barrier … the backend was reachable and this IS a product/UI failure` |
| cleanup — the pre-fix code IS the mutation | leaked 26 → 28 per run; post-fix 27 → 27 over 3 runs |

The four per-test mutations were run **twice** — before and after the teardown migration — because a cleanup edit is in scope for every test in the file. Every mutation was reverted (`grep FFMUT1126 tests/` = 0) and the file re-ran green afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
