### PR TITLE
fix(mcp): make the MCP tool-count wait survive a slow probe (#1266)

### DIFF
--- a/docs/mcp/server/mcp-server.md
+++ b/docs/mcp/server/mcp-server.md
@@ -1,6 +1,7 @@
 # MCP Server — add-server modal: stdio / HTTP registration, field persistence & tool refresh
 
-**Last validated:** Langflow 1.12.x (tests 1–7 on nightly `1.12.0.dev9`; tests 8–9 on `1.12.0.dev20`)
+**Last validated:** Langflow 1.12.x (tests 1–7 on nightly `1.12.0.dev9`; tests 8–9 on
+`1.12.0.dev20`; tests 1 and 6 re-validated on `1.12.0.dev39` under #1266)
 
 ---
 
@@ -61,6 +62,10 @@ read-back/update tests)
 - `@regression` — on the contract test only: it guards an intentional upstream
   security change (see *External dependencies*), so a silent removal of that
   validation must fail the suite.
+- `@stable` on test 1 was **removed as a quarantine** at the 2026-08-04 triage
+  (#1258) and restored in the #1266 fix PR, re-validated per `CONTRIBUTING.md` on
+  nightly `1.12.0.dev39`. The quarantine was `test.fixme` + tag removal, so the
+  test ran in no lane at all while it stood.
 - `@workspace`/`@components` — drives the flow canvas, sidebar and MCPTools
   node; `@mcp` — MCP server area; `@release` — happy-path MCP registration.
 
@@ -99,8 +104,11 @@ read-back/update tests)
 3. Open the Add MCP Server modal → **stdio** tab; register
    `command: npx`, `args[0]: @modelcontextprotocol/server-everything` under a
    per-run random name.
-4. Poll `GET /api/v2/mcp/servers?action_count=true` until the server's
-   `toolsCount` is non-null; open `dropdown_str_tool` and pick `echo-0-option`.
+4. Wait for the server to report a tool count via
+   `waitForMcpToolsCount` — a probe of
+   `GET /api/v2/mcp/servers?action_count=true` that treats its OWN failure as
+   "not ready yet" and only gives up when the whole budget is spent (#1266; see
+   *Notes*). Then open `dropdown_str_tool` and pick `echo-0-option`.
 5. Assert the `echo` tool's `message` input renders on the node.
 6. Settings → MCP Servers → Edit the server: assert the JSON and HTTP tabs are
    disabled, stdio is enabled, and **both** `stdio-command-input` (`npx`) and
@@ -186,8 +194,8 @@ failure unattributed. See the note below.
 Unchanged by #1091 (no stdio surface). Derives the project's own
 `/api/v1/mcp/project/{id}/streamable` URL, registers it via the HTTP tab **with an
 `x-api-key` header** (`http-headers-key-0` / `popover-anchor-http-headers-value-0`),
-polls `toolsCount`, and asserts ≥1 tool option; cleans up the server and the key via
-the API.
+waits for `toolsCount` through the same `waitForMcpToolsCount` probe as test 1
+(#1266), and asserts ≥1 tool option; cleans up the server and the key via the API.
 
 The header is what makes the poll meaningful rather than a wait on a value that can
 never arrive: Langflow connects out to that URL itself, so with no credential stored
@@ -387,7 +395,8 @@ and nothing is fetched from the npm registry.
   `helpers/ui/zoom-out.ts`, `helpers/flows/delete-flow.ts`,
   `helpers/flows/add-component-from-sidebar.ts`
   (`addComponentFromSidebarWithoutSearch`),
-  `helpers/mcp/wait-for-mcp-tool-option.ts` (`waitForMcpToolOption`).
+  `helpers/mcp/wait-for-mcp-tool-option.ts` (`waitForMcpToolOption`),
+  `helpers/mcp/wait-for-mcp-tools-count.ts` (`waitForMcpToolsCount`).
 
 ---
 
@@ -408,6 +417,10 @@ and nothing is fetched from the npm registry.
 - If Langflow starts re-querying a failed MCP tool list on its own: the bounded
   refresh loop would then be redundant, and the spec should say so rather than
   keep paying for it.
+- If `GET /api/v2/mcp/servers?action_count=true` starts caching its per-server
+  connection, capping concurrency, or answering from stored counts: the probe
+  budgets in `waitForMcpToolsCount` are sized for the measured behaviour above
+  and should be re-measured, not assumed (#1266).
 - If `MCPServerConfig` gains or drops a field, or the single read starts
   returning a wrapper (a `name`, a transport label) instead of the bare config —
   test 8's deep equality is the assertion that will say so.
@@ -417,6 +430,61 @@ and nothing is fetched from the npm registry.
 ---
 
 ## Notes *(optional)*
+
+- **#1266 — the readiness poll could not survive the slowness it existed to wait
+  out, and the test paid for load it was itself creating.** Tests 1 and 6 waited
+  for `toolsCount` with a bare `expect.poll` whose poller called
+  `page.request.get("/api/v2/mcp/servers?action_count=true")` with no explicit
+  timeout. Two facts make that shape indefensible. **`expect.poll` propagates a
+  throw from the poller** instead of treating it as "not ready", so the first
+  probe to exceed the suite's 20 s `actionTimeout` aborted the test — the 120 s
+  budget was unreachable. The recorded signature proves the propagation: a
+  swallowed failure would read `expect.poll … timed out after 120000ms`, and
+  what three dailies recorded (2026-07-30, 2026-08-03, 2026-08-04) was
+  `TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.`
+  **And the endpoint really is that slow under concurrency.** Measured on
+  `1.12.0.dev39` (4 CPU, `LANGFLOW_WORKERS=1`), `action_count=true` starts EVERY
+  registered server on EVERY call — `langflow/api/v2/mcp.py` builds a fresh
+  `MCPStdioClient` per server inside `check_server` and disconnects it in
+  `finally`, so a stdio server costs one `npx` subprocess per request, with no
+  cache and no concurrency cap:
+
+  | Registered servers | c=1 | c=2 | c=3 | c=4 | c=6 |
+  |---|---|---|---|---|---|
+  | 2 (1 stdio) | 1.25 s | 1.33–1.44 s | 1.73–1.92 s | 1.60–1.97 s | — |
+  | 4 (3 stdio) | 1.25 s | 1.74–1.78 s | 3.03–4.09 s | 4.16–6.52 s | **137.9 s, all six** |
+
+  Cold first call: 2.98 s at one server, 5.30 s at two. Sequentially by server
+  count the same instance degrades past the budget on its own at nine servers
+  (9.3 / 14.0 / 20.6 s). This is **not a regression** — `1.12.0.dev37` measures
+  the same, and on that 47-hour-old instance the cliff arrived earlier still
+  (18.1 s and 75.1 s at four servers / three callers).
+
+  The load hypothesis `CONTRIBUTING.md` → *Infra-signature exemption* predicts is
+  therefore **confirmed**, and the spec was a contributor on three counts: it
+  polled the expensive variant itself every 3 s; the page it had open polls the
+  same endpoint independently (`useGetMCPServers` issues both
+  `?action_count=false` and `?action_count=true` — read from the
+  `1.12.0.dev39` bundle), so two concurrent callers were structural; and the
+  daily runs `workers: 2` per shard over ten `@stable` MCP files sharing one
+  Langflow, four of which drive `action_count`.
+
+  The fix is the one the family sibling already shipped —
+  `mcp-client-agent-gemini-tool-regression.spec.ts` carries this exact remedy,
+  and is the *other* spec that showed a transport-level signature on 2026-07-30.
+  It was never replicated here. `waitForMcpToolsCount` now owns it for the area:
+  an explicit per-request timeout so the probe cannot inherit `actionTimeout`, a
+  failed probe recorded and returned as "not ready yet", and the last probe
+  failure printed when the budget does run out (#1012) — the difference between
+  "the server never started" and "every probe timed out" is the whole diagnosis.
+  **The assertion is unchanged**: a server that never reports a tool count still
+  fails the test, now naming why.
+
+  What this does NOT claim to fix is the endpoint. A page that keeps a slow
+  `action_count=true` in flight is Langflow's own behaviour, and at six
+  concurrent callers the run above left `lf-starter_project` answering
+  `Error loading server: Connection closed` and never recovering. That belongs
+  upstream, not in a wait strategy.
 
 - **#1422 — the 120 s tool-list budget was hanging on a control that is ready in
   140 ms, and the failure blamed the UI for a dead subprocess.** Test 5 waited

--- a/tests/helpers/mcp/wait-for-mcp-tools-count.test.ts
+++ b/tests/helpers/mcp/wait-for-mcp-tools-count.test.ts
@@ -1,0 +1,174 @@
+// Unit tests for the MCP tool-count readiness wait (issue #1266).
+// Run with: npm run test:units
+//
+// What rides on this helper: whether a slow probe ends the wait or is retried.
+// The shape it replaces was `expect.poll` over a bare
+// `page.request.get("/api/v2/mcp/servers?action_count=true")` with no explicit
+// timeout, so the request inherited `playwright.config.ts` `actionTimeout: 20000`
+// AND `expect.poll` propagated the throw instead of polling again — a poll
+// declaring 120 000 ms that died on its first probe. Measured on the three
+// dailies where the test was `@stable` (2026-07-30 / 08-03 / 08-04): attempt 0
+// failed at 33-35 s, three times out of three, with
+// `TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.`
+//
+// Both halves of that defect are pinned below — the retry (a failed probe is
+// "not ready yet") and the explicit per-request budget (it can never inherit
+// `actionTimeout` again). The message branches are pinned too, because the
+// difference between "every probe timed out" and "the server never reported a
+// count" is the whole diagnosis (#1012: a wait that gives up must say why).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Page } from "@playwright/test";
+import {
+  MCP_TOOLS_COUNT_PROBE_TIMEOUT_MS,
+  missingMcpToolsCountMessage,
+  toolsCountOf,
+  waitForMcpToolsCount,
+} from "./wait-for-mcp-tools-count";
+
+/** Records every probe so a test can assert what the helper actually asked for. */
+function fakePage(
+  responses: Array<
+    | { throws: string }
+    | { status: number; body?: unknown; text?: string }
+  >,
+) {
+  const probes: Array<{ url: string; options?: { timeout?: number } }> = [];
+  const sleeps: number[] = [];
+  let i = 0;
+  const page = {
+    request: {
+      get: async (url: string, options?: { timeout?: number }) => {
+        probes.push({ url, options });
+        const spec = responses[Math.min(i, responses.length - 1)];
+        i += 1;
+        if ("throws" in spec) throw new Error(spec.throws);
+        return {
+          ok: () => spec.status >= 200 && spec.status < 300,
+          status: () => spec.status,
+          text: async () => spec.text ?? "",
+          json: async () => spec.body,
+        };
+      },
+    },
+    waitForTimeout: async (ms: number) => {
+      sleeps.push(ms);
+    },
+  } as unknown as Page;
+  return { page, probes, sleeps };
+}
+
+const ready = (name: string, toolsCount: number | null) => ({
+  status: 200,
+  body: [{ name: "lf-starter_project", mode: null, toolsCount: null }, { name, mode: "stdio", toolsCount }],
+});
+
+test("a probe that throws is not ready yet, not the end of the wait", async () => {
+  // THE defect. A transport timeout on the first probe used to abort a poll that
+  // declared 120 s; it must now cost one interval and nothing else.
+  const { page, probes } = fakePage([
+    { throws: "apiRequestContext.get: Timeout 20000ms exceeded." },
+    ready("test_server_12345", 13),
+  ]);
+
+  const count = await waitForMcpToolsCount(page, "test_server_12345", {
+    timeout: 30_000,
+    intervalMs: 10,
+  });
+
+  assert.equal(count, 13);
+  assert.equal(probes.length, 2, "the failed probe must be retried, not propagated");
+});
+
+test("every probe carries an EXPLICIT timeout, so it can never inherit actionTimeout", async () => {
+  // The regression guard for the other half: dropping the option would compile,
+  // pass every behavioural test above, and silently restore the 20 s budget that
+  // produced the recorded signature.
+  const { page, probes } = fakePage([ready("srv", 3)]);
+
+  await waitForMcpToolsCount(page, "srv", { timeout: 30_000, intervalMs: 10 });
+
+  assert.equal(probes.length, 1);
+  assert.match(probes[0].url, /\/api\/v2\/mcp\/servers\?action_count=true/);
+  assert.equal(probes[0].options?.timeout, MCP_TOOLS_COUNT_PROBE_TIMEOUT_MS);
+});
+
+test("a non-2xx answer is not ready yet either", async () => {
+  const { page, probes } = fakePage([
+    { status: 500, text: "Internal Server Error" },
+    ready("srv", 1),
+  ]);
+
+  assert.equal(await waitForMcpToolsCount(page, "srv", { timeout: 30_000, intervalMs: 10 }), 1);
+  assert.equal(probes.length, 2);
+});
+
+test("a listed server whose toolsCount is still null keeps the wait going", async () => {
+  // The real "still spinning up" shape: Langflow lists the server immediately and
+  // fills `toolsCount` only once it has connected to it.
+  const { page, probes } = fakePage([ready("srv", null), ready("srv", 13)]);
+
+  assert.equal(await waitForMcpToolsCount(page, "srv", { timeout: 30_000, intervalMs: 10 }), 13);
+  assert.equal(probes.length, 2);
+});
+
+test("the wait still goes red when the count never arrives", async () => {
+  // A tolerant probe must not become a wait that cannot fail. This is the
+  // assertion the fix is NOT allowed to weaken.
+  const { page } = fakePage([ready("srv", null)]);
+
+  await assert.rejects(
+    () => waitForMcpToolsCount(page, "srv", { timeout: 30, intervalMs: 10 }),
+    /never reported a tool count/i,
+  );
+});
+
+test("toolsCountOf reads only the named server, and only a real count", () => {
+  const body = [
+    { name: "lf-starter_project", toolsCount: 7 },
+    { name: "srv", toolsCount: null },
+  ];
+  assert.equal(toolsCountOf(body, "srv"), null, "null is not a count");
+  assert.equal(toolsCountOf(body, "lf-starter_project"), 7);
+  assert.equal(toolsCountOf(body, "absent"), null, "an unlisted server is not ready");
+  // An error body is not an array. Read unchecked it throws `body.find is not a
+  // function` inside the wait, hiding the status that explains the run.
+  assert.equal(toolsCountOf({ detail: "Not authenticated" }, "srv"), null);
+  assert.equal(toolsCountOf(null, "srv"), null);
+  assert.equal(toolsCountOf([{ name: "srv", toolsCount: 0 }], "srv"), 0, "zero tools is an answer");
+});
+
+test("the failure message separates a dead transport from a server that never served tools", () => {
+  const allFailed = missingMcpToolsCountMessage({
+    serverName: "srv",
+    waitedMs: 120_000,
+    probes: 6,
+    failedProbes: 6,
+    lastProbeError: "apiRequestContext.get: Timeout 45000ms exceeded.",
+  });
+  assert.match(allFailed, /6 of 6/);
+  assert.match(allFailed, /apiRequestContext\.get: Timeout 45000ms exceeded\./);
+  assert.match(allFailed, /never answered/i);
+
+  const neverReported = missingMcpToolsCountMessage({
+    serverName: "srv",
+    waitedMs: 120_000,
+    probes: 6,
+    failedProbes: 0,
+    lastProbeError: null,
+  });
+  assert.match(neverReported, /never reported a tool count/i);
+  assert.match(neverReported, /answered every probe/i);
+  assert.doesNotMatch(neverReported, /apiRequestContext/);
+
+  const mixed = missingMcpToolsCountMessage({
+    serverName: "srv",
+    waitedMs: 120_000,
+    probes: 6,
+    failedProbes: 2,
+    lastProbeError: "HTTP 503 — upstream unavailable",
+  });
+  assert.match(mixed, /2 of 6/);
+  assert.match(mixed, /HTTP 503 — upstream unavailable/);
+  assert.match(mixed, /never reported a tool count/i);
+});

--- a/tests/helpers/mcp/wait-for-mcp-tools-count.ts
+++ b/tests/helpers/mcp/wait-for-mcp-tools-count.ts
@@ -1,0 +1,189 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Waits until a registered MCP server reports a tool count — issue #1266.
+ *
+ * `GET /api/v2/mcp/servers?action_count=true` is the only readiness signal
+ * Langflow offers for "this server is up and its tools are known", and it is an
+ * expensive one: `langflow/api/v2/mcp.py` builds a fresh MCP client for EVERY
+ * registered server on EVERY call and disconnects it in `finally`, with no cache
+ * and no concurrency cap, so a stdio server costs one `npx` subprocess per
+ * request. Measured on nightly `1.12.0.dev39` (4 CPU, `LANGFLOW_WORKERS=1`) with
+ * four registered servers: 1.25 s at one caller, 1.74-1.78 s at two, 3.03-4.09 s
+ * at three, 4.16-6.52 s at four and 137.9 s at six — after which the instance's
+ * own `lf-starter_project` stays "Error loading server: Connection closed" and
+ * does not recover. A cold first call is 2.98 s at one server and 5.30 s at two.
+ *
+ * A caller is never alone on that curve: the page it has open queries the same
+ * endpoint itself (`useGetMCPServers` issues both `?action_count=false` and
+ * `?action_count=true`), and the daily runs `workers: 2` per shard over ten
+ * `@stable` MCP files sharing one Langflow.
+ *
+ * So the probe must be allowed to be slow, and the wait must survive it. The
+ * shape this replaces could do neither: an `expect.poll` over a bare
+ * `page.request.get(...)` with no explicit timeout inherits the suite's
+ * `actionTimeout: 20000` (`playwright.config.ts`), and `expect.poll` PROPAGATES a
+ * throw from its poller instead of polling again — so the first probe to exceed
+ * 20 s aborted a poll that declared 120 s. Measured: on the three dailies where
+ * `mcp-server.spec.ts`'s tool-mode test ran `@stable`, attempt 0 failed at
+ * 33 s / 35 s / 34 s — one probe, then out — 3 out of 3, always as
+ * `TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.`
+ *
+ * What is NOT loosened: a server that never reports a count still fails the
+ * test, now naming whether the probes failed or the server simply never served
+ * a list.
+ *
+ * The remedy is the one `mcp-client-agent-gemini-tool-regression.spec.ts`
+ * already carried inline; it lives here so the area has one copy.
+ */
+
+/** The readiness endpoint, with the query that makes Langflow actually connect. */
+export const MCP_SERVERS_ACTION_COUNT_URL =
+  "/api/v2/mcp/servers?action_count=true";
+
+/**
+ * Budget for ONE probe.
+ *
+ * Its only job is to be larger than `actionTimeout` — a probe that inherits the
+ * 20 s action budget is the defect — while still bounding a request that has
+ * stopped coming back, so the wait can retry it. 45 s sits above every latency
+ * measured at a realistic caller count (6.5 s worst case at four concurrent
+ * callers over four servers) and well below the 137.9 s pathological case, which
+ * no probe should ever sit through.
+ */
+export const MCP_TOOLS_COUNT_PROBE_TIMEOUT_MS = 45_000;
+
+/** Default budget for the whole wait, matching the family sibling's. */
+export const MCP_TOOLS_COUNT_TIMEOUT_MS = 150_000;
+
+/** Spacing between probes — the interval the polls this replaces already used. */
+export const MCP_TOOLS_COUNT_INTERVAL_MS = 3_000;
+
+/**
+ * The tool count `serverName` currently reports, or `null` when it reports none.
+ *
+ * Everything that is not a number for THIS server is "not ready yet": the server
+ * absent from the list, `toolsCount: null` (Langflow lists a server the moment it
+ * is registered and fills the count only once it has connected), and a body that
+ * is not an array at all. That last case is checked rather than assumed — an
+ * error body such as `{"detail": "Not authenticated"}` read unchecked throws
+ * `body.find is not a function` from inside the wait, hiding the status that
+ * would have explained the run.
+ */
+export function toolsCountOf(body: unknown, serverName: string): number | null {
+  if (!Array.isArray(body)) return null;
+  const entry = (body as Array<{ name?: string; toolsCount?: number | null }>).find(
+    (s) => s?.name === serverName,
+  );
+  return typeof entry?.toolsCount === "number" ? entry.toolsCount : null;
+}
+
+/**
+ * Names why the wait gave up.
+ *
+ * The split that matters is whether the probes themselves failed. "Every probe
+ * timed out" points at the endpoint under load; "the server answered every probe
+ * and never reported a count" points at the server that was registered. A single
+ * message covering both would send the next reader at the wrong layer — the
+ * mis-attribution #1422 already paid for on this file's other wait.
+ */
+export function missingMcpToolsCountMessage(d: {
+  serverName: string;
+  waitedMs: number;
+  probes: number;
+  failedProbes: number;
+  lastProbeError: string | null;
+}): string {
+  const head =
+    `[waitForMcpToolsCount] MCP server "${d.serverName}" was not ready within ` +
+    `${d.waitedMs}ms, across ${d.probes} probe(s) of ` +
+    `${MCP_SERVERS_ACTION_COUNT_URL}.`;
+
+  if (d.failedProbes === d.probes && d.probes > 0) {
+    return (
+      `${head} The endpoint never answered: ${d.failedProbes} of ${d.probes} ` +
+      `probes failed, the last with "${d.lastProbeError}". This is a transport ` +
+      `or backend-load problem, not a statement about the server that was ` +
+      `registered — read it against the endpoint's cost, which grows with how ` +
+      `many servers are registered and how many callers are in flight.`
+    );
+  }
+
+  if (d.failedProbes > 0) {
+    return (
+      `${head} The server answered but never reported a tool count, and ` +
+      `${d.failedProbes} of ${d.probes} probes also failed outright, the last ` +
+      `with "${d.lastProbeError}". Both layers were unhealthy — decide which ` +
+      `before changing either.`
+    );
+  }
+
+  return (
+    `${head} The endpoint answered every probe and the server never reported a ` +
+    `tool count, so no probe budget can help: it was registered but never ` +
+    `served a tool list — the stdio subprocess died, or the configured URL is ` +
+    `unreachable or refused the stored credential. Langflow does not retry this ` +
+    `by itself.`
+  );
+}
+
+/**
+ * Polls the readiness endpoint until `serverName` reports a tool count.
+ *
+ * A probe that throws or answers non-2xx is recorded and treated as "not ready
+ * yet" — it costs one interval, never the wait. Resolves with the count.
+ */
+export async function waitForMcpToolsCount(
+  page: Page,
+  serverName: string,
+  options: {
+    timeout?: number;
+    probeTimeoutMs?: number;
+    intervalMs?: number;
+  } = {},
+): Promise<number> {
+  const timeout = options.timeout ?? MCP_TOOLS_COUNT_TIMEOUT_MS;
+  const probeTimeoutMs = options.probeTimeoutMs ?? MCP_TOOLS_COUNT_PROBE_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? MCP_TOOLS_COUNT_INTERVAL_MS;
+  const deadline = Date.now() + timeout;
+
+  let probes = 0;
+  let failedProbes = 0;
+  // Sticky on purpose: the last probe is routinely a healthy one that simply
+  // reported no count, and overwriting with `null` there is how a wait that
+  // spent its whole budget on timeouts ends up reporting "the server never
+  // served a tool list".
+  let lastProbeError: string | null = null;
+
+  for (;;) {
+    probes += 1;
+    try {
+      const resp = await page.request.get(MCP_SERVERS_ACTION_COUNT_URL, {
+        timeout: probeTimeoutMs,
+      });
+      if (!resp.ok()) {
+        failedProbes += 1;
+        lastProbeError = `HTTP ${resp.status()} — ${await resp.text()}`;
+      } else {
+        const count = toolsCountOf(await resp.json(), serverName);
+        if (count !== null) return count;
+      }
+    } catch (e) {
+      failedProbes += 1;
+      lastProbeError = String(e).split("\n")[0];
+    }
+
+    if (Date.now() >= deadline) break;
+    await page.waitForTimeout(intervalMs);
+  }
+
+  throw new Error(
+    missingMcpToolsCountMessage({
+      serverName,
+      waitedMs: timeout,
+      probes,
+      failedProbes,
+      lastProbeError,
+    }),
+  );
+}

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -17,6 +17,7 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { openFlowById } from "../../../../helpers/flows/open-flow-by-id";
 import { waitForMcpToolOption } from "../../../../helpers/mcp/wait-for-mcp-tool-option";
+import { waitForMcpToolsCount } from "../../../../helpers/mcp/wait-for-mcp-tools-count";
 
 /**
  * Add-MCP-Server modal: stdio / HTTP registration, field persistence and tool
@@ -187,16 +188,8 @@ test.afterEach(async ({ request }) => {
   }
 });
 
-// Quarantined for #1266 — recurrent flake on a TRANSPORT-level signature:
-// `apiRequestContext.get: Timeout 20000ms exceeded.` on GET
-// /api/v2/mcp/servers?action_count=true, same signature on the 2026-07-30,
-// 2026-08-03 and 2026-08-04 dailies. Filed as load/reachability about this
-// spec, not about changing tool mode (CONTRIBUTING.md -> Infra-signature
-// exemption: a spec that keeps appearing as collateral while others do not).
-// Lifting the quarantine (remove test.fixme + restore @stable) is a
-// deliverable of #1266.
-test.fixme("user must be able to change mode of MCP tools without any issues",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+test("user must be able to change mode of MCP tools without any issues",
+  { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     (page as any).allowFlowErrors();
     await page.waitForTimeout(5000);
@@ -251,20 +244,12 @@ test.fixme("user must be able to change mode of MCP tools without any issues",
 
     await page.getByTestId("add-mcp-server-button").click();
 
-    // Poll API until server tools are loaded before interacting with dropdown
-    await expect
-      .poll(
-        async () => {
-          const resp = await page.request.get(
-            "/api/v2/mcp/servers?action_count=true",
-          );
-          const servers: Array<{ name: string; toolsCount: number | null }> =
-            await resp.json();
-          return servers.find((s) => s.name === testName)?.toolsCount ?? null;
-        },
-        { timeout: TOOL_LIST_TIMEOUT, intervals: [3000] },
-      )
-      .not.toBeNull();
+    // Wait for the server's tools to be loaded before touching the dropdown.
+    // The budget is the one this site always carried; what changed is that a
+    // slow probe no longer ENDS the wait (#1266) — see the helper's docstring
+    // for the endpoint's measured cost and for why the poll this replaced could
+    // not spend its own 120 s.
+    await waitForMcpToolsCount(page, testName, { timeout: TOOL_LIST_TIMEOUT });
 
     await expect(page.getByTestId("dropdown_str_tool")).toBeVisible({
       timeout: 30000,
@@ -1287,20 +1272,9 @@ test("Streamable HTTP MCP server with server-everything should load tools correc
     await zoomOut(page, 3);
 
     // The Langflow MCP endpoint exposes project flows as tools
-    // Poll API until toolsCount is available
-    await expect
-      .poll(
-        async () => {
-          const resp = await page.request.get(
-            "/api/v2/mcp/servers?action_count=true",
-          );
-          const servers: Array<{ name: string; toolsCount: number | null }> =
-            await resp.json();
-          return servers.find((s) => s.name === testName)?.toolsCount ?? null;
-        },
-        { timeout: 60000, intervals: [3000] },
-      )
-      .not.toBeNull();
+    // Same wait, same budget as this site always used — tolerant of a slow
+    // probe rather than ended by one (#1266).
+    await waitForMcpToolsCount(page, testName, { timeout: 60_000 });
 
     await page.evaluate(() => {
       (


### PR DESCRIPTION
**Closes #1266.**

## Problem

`mcp-server.spec.ts`'s tool-mode test flaked on a **transport-level** signature —
`TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.` on
`GET /api/v2/mcp/servers?action_count=true` — and was quarantined at the
2026-08-04 triage (`test.fixme` + `@stable` removed).

**The pre-fix rate is 3 out of 3, not a low-percentage flake.** The test became
`@stable` when #1091 merged on 2026-07-29 16:37 BRT (after that day's 05:00 BRT
daily) and was quarantined on 2026-08-04 10:32 BRT (after that day's daily), so
its `@stable` exposure window is exactly three dailies — and
`reports/daily-history.jsonl` records it flaky in **all three**, with the
identical `error_signature`:

| Daily | Run | attempt 0 | attempt 1 |
|---|---|---|---|
| 2026-07-30 | [30534416609](https://github.com/oriontech-me/langflow-e2e/actions/runs/30534416609) | failed, 33 s | passed, 43 s |
| 2026-08-03 | [30809091241](https://github.com/oriontech-me/langflow-e2e/actions/runs/30809091241) | failed, 35 s | passed, 43 s |
| 2026-08-04 | [30901311395](https://github.com/oriontech-me/langflow-e2e/actions/runs/30901311395) | failed, 34 s | passed, 44 s |

**Root cause — a poll that could not spend its own budget.** The readiness wait
was an `expect.poll` declaring 120 000 ms over a bare
`page.request.get("/api/v2/mcp/servers?action_count=true")` with **no explicit
timeout**, so the request inherited the suite's `actionTimeout: 20000`
(`playwright.config.ts`), and **`expect.poll` propagates a throw from its poller**
instead of polling again. The first probe to exceed 20 s therefore ended the test.
The per-attempt durations above are the proof: a 120 s poll that dies at 33–35 s
made exactly **one** probe and quit — had the throw been swallowed, the attempt
would have run past 120 s and failed with the poll's own message.

**The endpoint really is that slow, and this spec was a load contributor —
#1266's load hypothesis is confirmed.** `langflow/api/v2/mcp.py` builds a fresh
`MCPStdioClient` for **every** registered server on **every** call and disconnects
it in `finally` — no cache, no concurrency cap — so a stdio server costs one `npx`
subprocess per server per request. Measured on nightly `1.12.0.dev39` (4 CPU,
`LANGFLOW_WORKERS=1`):

| Registered servers | c=1 | c=2 | c=3 | c=4 | c=6 |
|---|---|---|---|---|---|
| 2 (1 stdio) | 1.25 s | 1.33–1.44 s | 1.73–1.92 s | 1.60–1.97 s | — |
| 4 (3 stdio) | 1.25 s | 1.74–1.78 s | 3.03–4.09 s | 4.16–6.52 s | **137.9 s, all six** |

Cold first call: 2.98 s at one server, 5.30 s at two. The spec sat at the worst
point of that curve — it began polling the instant the add-server modal closed,
while `npx` was cold-fetching the package **and** the open page was querying the
same endpoint itself (`useGetMCPServers` issues both `?action_count=false` and
`?action_count=true`, read from the dev39 bundle), so two concurrent callers were
structural; the daily adds `workers: 2` per shard over ten `@stable` MCP files
sharing one Langflow, four of which drive `action_count`.

**This is not a Langflow regression** — `1.12.0.dev37` measures the same. It is a
standing scalability characteristic, reported separately; no wait strategy can fix
it, and this PR does not pretend to.

## Fix

New helper `tests/helpers/mcp/wait-for-mcp-tools-count.ts` —
`waitForMcpToolsCount(page, serverName, { timeout })`:

- an **explicit per-probe timeout** (45 s) so the request can never inherit
  `actionTimeout` again;
- a probe that throws or answers non-2xx is **recorded and returned as "not ready
  yet"**, costing one interval rather than the wait;
- when the budget really runs out, the failure **names which layer broke** — "the
  endpoint never answered, N of M probes failed, the last with …" vs "the endpoint
  answered every probe and the server never reported a tool count" (#1012: the
  difference between those two is the whole diagnosis).

This is not new invention: `mcp-client-agent-gemini-tool-regression.spec.ts` has
carried exactly this remedy inline since #1404 — and is the *other* spec that
showed a transport-level signature on 2026-07-30. It was never replicated here.
The helper gives the area one copy.

**Rejected alternatives.** *Raising the poll budget*: the budget was never spent,
so raising it changes nothing. *Retrying the whole test*: the daily already does,
which is why this surfaced as `flaky` rather than red for three days. *Replacing
the API poll with the UI observable (`waitForMcpToolOption`)*: viable and it would
also drop one caller from the endpoint, but it rewrites more of the test body than
the defect warrants, and the family sibling had already settled on the API poll.

## Scope note

- **Both call sites keep the budget they already had** — 120 s in the tool-mode
  test, 60 s in the Streamable-HTTP test. Nothing is loosened; the only change is
  that a slow probe no longer ends the wait.
- **No assertion changed.** The `echo-0-option` selection, the
  `popover-anchor-input-message` check, the Settings round-trip, the tool-option
  count — all untouched. A server that never reports a tool count still fails.
- **Quarantine lifted** (a #1266 deliverable): `test.fixme` → `test`, `@stable`
  restored on *user must be able to change mode of MCP tools without any issues*.
- `QA-CHECKLIST.md` is deliberately untouched: the behaviour bullet already reads
  `[x]` and the `Phase 0` block is generated on merge.
- **Out of scope, follow-up to file:** the identical raw-poll shape survives at
  three further sites — `mcp-client-regression.spec.ts` (×2, `@stable`) and
  `mcp-client-agent.spec.ts` (×1). Each is now a one-line swap.

## Validation (nightly `1.12.0.dev39`, `--retries=0 --workers=1`)

- typecheck ✅ · eslint ✅ (0 errors) · zero `🚨 Backend Error` ✅
- **3/3 clean runs of the whole file**, `expected=9 unexpected=0 flaky=0
  skipped=0` on each ✅
- **force-fail 9/9** — every `test()` in the touched file got a mutation carrying
  `// FF-MUTATION`, a verified red run, and a revert; `grep -c FF-MUTATION` = 0
  afterwards, plus a final green run of the file ✅
- **unit lane**: 7 new tests for the helper, `npm run test:units` 811 pass / 0
  fail ✅. Both guards were mutation-checked: dropping `{ timeout: probeTimeoutMs }`
  fails the explicit-budget test, dropping the `try/catch` fails the retry test.
- **before/after under identical induced load** (2 extra registered stdio servers
  + a loop holding 2 concurrent `action_count=true` callers):

  | | Result |
  |---|---|
  | unloaded, pre-fix | 0/5 clean (~21 s per run) — confirms it is load-dependent |
  | loaded, pre-fix | **2 of 6 red**, with the issue's exact signature |
  | loaded, post-fix | **5/5 green** (25.2–39.1 s) |

- instance left clean: 26 flows (all Langflow starters) and one MCP server
  (`lf-starter_project`) after ~20 runs — no orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
