### PR TITLE
fix(ui-ux): gate filterSidebar on the welcome overlay and the shared add primitive (#1623)

### DIFF
--- a/docs/ui-ux/filterSidebar.md
+++ b/docs/ui-ux/filterSidebar.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/ui-ux/filterSidebar.spec.ts`
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev8`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev40`)
 
 ---
 
@@ -33,8 +33,11 @@ The test drives an **API Request** node and exercises two of its inputs:
 
 ## Step by step
 
-1. Bootstrap; open a blank flow; drag an **API Request** node onto the canvas.
-   The created flow is captured from `POST /api/v1/flows → 201` and deleted
+1. Bootstrap; open a blank flow from the templates modal; wait out the
+   `flow-builder-welcome` onboarding overlay and confirm the editor has mounted
+   (`canvas_controls_dropdown`) **before touching the sidebar**; then drag an
+   **API Request** node onto the canvas through the shared add primitive. The
+   created flow is captured from `POST /api/v1/flows → 201` and deleted
    id-scoped in `afterEach`.
 2. Click the `url` input handle → assert the filter chip (`icon-ListFilter`)
    shows and the expected category disclosures are visible.
@@ -58,6 +61,8 @@ The test drives an **API Request** node and exercises two of its inputs:
 
 | Step | Criterion |
 |---|---|
+| blank flow entered | the templates modal is gone, `flow-builder-welcome-panel` is hidden and `canvas_controls_dropdown` is visible before any sidebar interaction |
+| API Request added | a node id that was **not** on the canvas before the drag is present |
 | `url` handle clicked | `icon-ListFilter` visible; category disclosures visible |
 | legacy on / beta off | legacy components visible; `Prompt Hub` hidden with beta off |
 | `headers` handle clicked | `data_sourceAPI Request`, `datastaxAstra DB`, `flow_controlsSub Flow` visible |
@@ -71,6 +76,13 @@ The test drives an **API Request** node and exercises two of its inputs:
 - API Request component (its `url` and advanced `headers` inputs).
 - `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions` /
   `closeAdvancedOptions` (dev46 inspector; `inspector-add-headers`).
+- `tests/helpers/flows/open-blank-flow-from-modal.ts` — `openBlankFlowFromModal`
+  (re-issues the `blank-flow` click when the creation is refused, #1468).
+- `tests/helpers/flows/add-component-from-sidebar.ts` —
+  `dragComponentFromSidebar` (repairs the swallowed sidebar add, #1304/#1320/#1335;
+  it also owns the search fill and its reset repair, #1518).
+- The `flow-builder-welcome` onboarding overlay (`flow-builder-welcome-panel`)
+  and the canvas readiness barrier (`canvas_controls_dropdown`).
 - Sidebar legacy/beta toggles (`sidebar-options-trigger`, `sidebar-legacy-switch`,
   `sidebar-beta-switch`) and the filter chip (`icon-ListFilter`, `icon-X`,
   `sidebar-filter-reset`).
@@ -109,6 +121,26 @@ The test drives an **API Request** node and exercises two of its inputs:
   subject (clicking a handle reveals the compatible connections) is this
   spec's subject, exercised here on a non-legacy component and with
   substantially stronger assertions.
+- **#1623 — readiness, not behavior.** On the 2026-08-27 daily (run
+  `33105369510`) this test hard-failed all three attempts, at **two** different
+  locators: attempt 0 on `sidebar-search-input` and attempts 1-2 on
+  `handle-apirequest-shownode-url-left`. Both are the same root cause class —
+  every gate in this spec was budgeted at 3000 ms and the spec drove the entry,
+  the search fill and the drag by hand.
+  Measured on nightly `1.12.0.dev40`, 3 of 3 blank-flow entries: the
+  `flow-builder-welcome-panel` overlay is **visible at the moment of the
+  `blank-flow` click**, and `sidebar-search-input` is in the DOM but **not
+  visible** — the exact reported shape. On an idle host the overlay clears in
+  ~107 ms and the input becomes visible at ~211-231 ms; #1301 measured the
+  sibling observable at up to ~10.6 s under load, which is why 3000 ms is the
+  whole margin. The overlay is intentional onboarding, present since ~dev17 —
+  this is a test-side readiness gap, **not** a Langflow regression, and nothing
+  was filed upstream. The second locator is the swallowed sidebar add
+  (#1304/#1320): the bare `dragTo` is accepted, no node is created and no flow
+  write follows, so the handle never renders — a longer wait provably cannot fix
+  it. Fixed by routing the entry through `openBlankFlowFromModal`, gating on the
+  overlay and the canvas controls explicitly (attribution: a stuck overlay must
+  fail as the overlay), and adding the node through `dragComponentFromSidebar`.
 - Validated on `1.11.0.dev46` (2026-07-20): 3/3 green (~52s), `--workers=1
   --retries=0`, 0 orphan flows. Force-fail: asserting a component that is not in
   the compatible set (`processingSplit Text`) fails.

--- a/tests/tests-automations/regression/ui-ux/filterSidebar.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/filterSidebar.spec.ts
@@ -8,6 +8,8 @@ import {
 } from "../../../helpers/ui/open-advanced-options";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { dragComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { openBlankFlowFromModal } from "../../../helpers/flows/open-blank-flow-from-modal";
 
 // Capture every flow THIS page creates from its POST /api/v1/flows → 201
 // responses and delete them id-scoped in afterEach (repo convention, #490/#681).
@@ -42,38 +44,70 @@ test.afterEach(async ({ request }) => {
 
 test(
   "user must see on handle click the possibility connections",
-  { tag: ["@release", "@components", "@api", "@ui-ux"] },
+  { tag: ["@stable", "@release", "@components", "@api", "@ui-ux"] },
 
   async ({ page }) => {
     trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
-    await page.waitForSelector('[data-testid="blank-flow"]', {
-      timeout: 3000,
+    await expect(page.getByTestId("blank-flow")).toBeVisible({
+      timeout: 30000,
     });
 
-    await page.getByTestId("blank-flow").click();
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 3000,
+    // Entry through the shared primitive, not a bare click: the blank-flow click
+    // IS a flow creation and the backend can refuse it with 400 "flow must be
+    // unique" while the modal stays open over the editor (#1468). The helper
+    // re-issues the click and only returns once the modal is gone.
+    await openBlankFlowFromModal(page);
+
+    // Readiness barrier before ANY sidebar interaction — this is what #1623 was.
+    // On a blank-flow entry the `flow-builder-welcome` onboarding overlay covers
+    // the canvas and leaves `sidebar-search-input` in the DOM but NOT visible,
+    // which is the exact shape the 2026-08-27 daily reported ("10 x locator
+    // resolved to hidden"). Measured on nightly 1.12.0.dev40: the overlay was
+    // visible at the moment of the click in 6 of 6 entries, the input hidden in
+    // 6 of 6, and the input turned visible within ~100 ms of the overlay
+    // clearing every time. Idle it clears in 140-790 ms, so the old 3000 ms wait
+    // was the entire margin; holding the editor's mount GETs for 4 s reproduced
+    // the daily's error byte-for-byte, 2 of 2. The overlay is waited out FIRST
+    // and explicitly so a stuck overlay fails AS the overlay rather than as a
+    // sidebar that never appeared (#1301's attribution lesson), and 30 s is the
+    // budget `setupBlankFlow` already uses for the canvas barrier.
+    const welcomeOverlay = page.locator(
+      '[data-testid="flow-builder-welcome-panel"]',
+    );
+    if (await welcomeOverlay.isVisible().catch(() => false)) {
+      await expect(welcomeOverlay).toBeHidden({ timeout: 30000 });
+    }
+    await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+      timeout: 30000,
     });
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("api request");
+    // Drag through the shared primitive, not a bare fill + dragTo: Langflow drops
+    // the sidebar add outright a measurable fraction of the time — the gesture is
+    // accepted, no node is created and no flow write follows (#1304/#1320/#1335)
+    // — and the bare version here surfaced that as
+    // `handle-apirequest-shownode-url-left` never appearing, which is how
+    // attempts 1 and 2 of the same daily died and what the 2026-08-25 run
+    // recorded as flaky. The helper owns the search fill and its #1518 reset
+    // repair, requires a node id that was NOT on the canvas before, and re-issues
+    // the drag once when none appeared. A longer wait cannot fix a gesture the
+    // app never registered.
+    await dragComponentFromSidebar(
+      page,
+      "api request",
+      "data_sourceAPI Request",
+    );
 
-    await page.waitForSelector('[data-testid="data_sourceAPI Request"]', {
-      timeout: 3000,
-    });
-    await page
-      .getByTestId("data_sourceAPI Request")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'));
-    await page.mouse.up();
-    await page.mouse.down();
     await adjustScreenView(page);
 
+    // Post-condition rather than the place a failure lands: the helper above
+    // already guarantees a new node, so this budget is only ever paid by a real
+    // regression in the node's handles.
     await page.waitForSelector(
       '[data-testid="handle-apirequest-shownode-url-left"]',
       {
-        timeout: 3000,
+        timeout: 30000,
       },
     );
     await page.getByTestId("handle-apirequest-shownode-url-left").click();


### PR DESCRIPTION
**Fixes #1623.** Closes #1623.

## Problem

`filterSidebar.spec.ts` hard-failed on the 2026-08-27 daily (run
[33105369510](https://github.com/oriontech-me/langflow-e2e/actions/runs/33105369510)),
final status after retries. `@stable` was auto-removed in `2ec9e39e`.

The issue body quotes attempt 0. **All three attempts failed, at two different
locators** — read back from the run's own artifact:

```
attempt 0: failed (15s) → sidebar-search-input                (:56)
attempt 1: failed (23s) → handle-apirequest-shownode-url-left (:74)
attempt 2: failed (19s) → handle-apirequest-shownode-url-left (:74)
```

Every gate in the file was budgeted at 3000 ms and the spec drove the entry, the
search fill and the drag by hand. Two independent readiness gaps follow.

**(1) `sidebar-search-input` — the `flow-builder-welcome` overlay.** On a
blank-flow entry the onboarding overlay covers the canvas and leaves the input in
the DOM but not visible, which is exactly what the daily reported (`10 × locator
resolved to hidden`).

`repro-run` on the unmodified spec: **0/10, 0 voided** — expected, because on an
idle host the overlay clears in 140–790 ms against a 3000 ms budget. The defect
is load-sensitive, so it was proven by fault injection on nightly `1.12.0.dev40`:

* *Observation*, 6 entries (3 control + 3 at CDP CPU rate 8): `flow-builder-welcome-panel`
  visible at the instant of the `blank-flow` click in **6/6**; `sidebar-search-input`
  count 1 and `visible=false` in **6/6**. Overlay hidden at 140/192/790/365/788/827 ms,
  input visible at 243/194/790/377/800/841 ms — the input turns visible within
  ~100 ms of the overlay clearing in every run. CPU throttling alone does **not**
  lengthen the overlay (it is gated on the editor's mount GETs, not on CPU), so it
  is not the injection.
* *Decisive injection*: `page.route('**/api/v1/**')` holding every GET for 4000 ms
  after the click, then replaying the spec's exact statement. **2 of 2 failed with
  the byte-identical daily error**, down to the same
  `class="nopan nodelete nodrag noflow primary-input !placeholder-transparent pl-9 w-full rounded-lg bg-background text-sm"`.
  Under injection the overlay lived 3011/3015 ms and the input became visible at
  4165/4314 ms. Remove the injection and the wait passes 3/3 (139/191/789 ms).

**Not a Langflow regression.** The overlay is intentional onboarding, shipped
since ~`1.12.0.dev17`; this spec was last validated on `1.11.0.dev46`
(2026-07-20), so it predates the overlay and never grew a gate for it. Nothing
filed upstream.

**(2) `handle-apirequest-shownode-url-left` — the swallowed sidebar add.** The
bare `dragTo` + `mouse.up/down` is the #1304/#1320/#1335 class: the gesture is
accepted, no node is created, no flow write follows, so the handle never renders
and a longer wait provably cannot help. That is what killed attempts 1 and 2, and
it is the same failure the 2026-08-25 daily recorded as `flaky` at `:73`.

**The issue's "is 2026-08-25 a distinct problem?" is answered: no.** It is this
file's second exposure, and it recurred twice inside the 2026-08-27 run itself.

## Fix

Reuse only — no new helper, no new POM, no new testid.

| before | after |
|---|---|
| `waitForSelector('blank-flow', 3000)` + `.click()` | `openBlankFlowFromModal(page)` — re-issues the click when the creation is refused and only returns once the modal is gone (#1468) |
| `waitForSelector('sidebar-search-input', 3000)` | attributed barrier: `flow-builder-welcome-panel` → `toBeHidden(30s)`, then `canvas_controls_dropdown` → `toBeVisible(30s)` |
| `fill` + `waitForSelector('data_sourceAPI Request', 3000)` + `dragTo` + `mouse.up/down` | `dragComponentFromSidebar(page, "api request", "data_sourceAPI Request")` — owns the #1518 search-reset repair and the #1304/#1320 swallowed-add repair |
| handle wait `3000` | `30000` — paid only on a real failure now that the node is proven present |
| tags without `@stable` | `@stable` restored (auto-removed in `2ec9e39e`) |

The overlay is waited out **first and explicitly** rather than left to the
`fill()` action timeout: a stuck overlay must fail *as the overlay*, not as a
sidebar that never appeared (#1301's attribution lesson). 30 s is the budget
`setupBlankFlow` already uses for the canvas barrier.

**Rejected alternatives.** Raising the budgets alone — it cannot fix a gesture the
app never registered, and #1301 measured 9 of 10 first clicks producing no node
within 40 s. Swapping the drag for a click — dragging a component out of the
sidebar is an interaction Langflow ships, and a spec that stops exercising it
stops covering it. Moving to `setupBlankFlow` (API-created flow) — it would skip
the `blank-flow` UI entry this spec's journey starts from.

## Scope note

The connection-filtering behavior and every assertion are unchanged: the same
disclosures, the same legacy/beta toggle expectations, the same compatible-set
components, the same `sidebar-filter-reset` and `icon-X` teardown checks. Only
the entry, the readiness barrier, the add gesture's primitive and the wait
budgets changed. The id-scoped `afterEach` cleanup is untouched.

`QA-CHECKLIST.md` is deliberately not edited: the manual bullet already exists as
`[x]` and references this spec; the generated blocks regenerate on merge.

The spec doc [`docs/ui-ux/filterSidebar.md`](docs/ui-ux/filterSidebar.md) was
updated first (spec-first gate): readiness precondition in Step 1, two new
Validation-criterion rows, the helpers in External dependencies, the #1623 note,
and `Last validated → 1.12.0.dev40`.

## Follow-up filed

#1626 (`qa-infra`, `follow-up`) — the triage dataset reported this spec as
`recurrence.count: 2, same_signature: true` across two dailies with **different**
causes, because `error_signature` carries neither the locator nor the line, so a
spec issuing several `waitForSelector` calls at the same budget collides with
itself. Filed rather than fixed here: it lives in `scripts/build-run-payload.mjs`
and the triage skill's `normalizeSignature()`, not in this spec.

## Validation (nightly `1.12.0.dev40`, image `sha256:6bd73f58…` — identical to `langflowai/langflow-nightly:latest`)

- typecheck ✅ (`tsc --noEmit`, 0 errors) · eslint ✅ (0 errors) 
- **3 clean runs, `--retries=0 --workers=1`, no flake** ✅

```
run 1/3 filterSidebar.spec.ts: clean expected=1 unexpected=0 flaky=0 backendErrors=false skipped=0
run 2/3 filterSidebar.spec.ts: clean expected=1 unexpected=0 flaky=0 backendErrors=false skipped=0
run 3/3 filterSidebar.spec.ts: clean expected=1 unexpected=0 flaky=0 backendErrors=false skipped=0
typecheck=0 lint=0
```

- **force-fail** ✅ — flipping the closing assertion so the spec claims
  `processingSplit Text` (a component **not** in the `headers`/`Data` compatible
  set) is visible after the filter is removed failed as expected
  (`unexpected=1`); mutation reverted, `no FF-MUTATION markers in diff`, final
  green run 1/1.
- zero `🚨 Backend Error` ✅
- **0 orphan flows** ✅ — `GET /api/v1/flows/` back to the 26 starter templates
  after every run and every scout probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
