### PR TITLE
test(enterprise): cover the admin console shell across its seven screens (#1630)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -1247,6 +1247,25 @@
 - [-] **Revoking on the screen removes the assignment at the API** — the confirm dialog names the role and the user losing it, and the state is read from the admin listing afterwards rather than from the row disappearing. Both buttons are named exactly `Revoke`, so the row's and the dialog's are addressed separately → `enterprise/authz/access-control-ui.spec.ts`
 - [ ] Cross-replica convergence — needs Redis and a second replica: without one `invalidation.listener_connected` is `false` while the policy still resolves `active`, so a single-container assertion would measure nothing. **Recipe measured out; blocked only on machine memory** (a second Langflow replica costs ~1.1 GiB against an 8 GiB local Docker VM already holding six): the variable is `LANGFLOW_AUTHZ_REDIS_URL` (`src/authz/policy_invalidation.py`), so it takes a `redis:7-alpine` on `langflow-ee-net`, the RBAC container recreated with `LANGFLOW_AUTHZ_REDIS_URL=redis://redis-ee:6379/0`, and a second replica on another port sharing the same `LANGFLOW_DATABASE_URL`. The assertions are then `listener_connected: true` on both, and a grant written through replica A flipping replica B's enforcement with no restart, `seen_revision` / `observed_revision` converging
 
+#### 22.7 Admin Console Shell (`/admin-ee`)
+
+> The console is the surface § 21 names as Enterprise-owned; its seven screens are governed
+> from here and nowhere else. This subsection is the **shell** contract only — that each
+> screen resolves, is the one its tab claims, and loaded its own data. What each screen lets
+> an operator *do* is a follow-up per tab, and every one of those depends on this: an
+> assertion about a filter or a dialog passes vacuously against a screen that never rendered.
+> Needs the RBAC variant (§ 22.6) — `access-control` and `audit-logs` read `/authz/*` and
+> have nothing to load without it. The seven-tab strip is what the build under test serves:
+> `access-control-ui.spec.ts` records `/admin-ee/access-control` redirecting away and no such
+> tab existing, and on this build the redirect runs the other way — `/settings/access-control`
+> lands on `/admin-ee/access-control`. That spec still passes, because it asserts on the
+> tables rather than the route; its header is what went stale.
+
+- [-] Each of the seven screens deep-links to itself: the URL does not redirect to a default tab, `enterprise-admin-tab-<route>` marks it selected, its own subtitle renders — the screen's header copy, because four of the seven candidate testids describe an instance *state* and a fifth is shared with a neighbouring tab — **and the one API read no other tab performs answered 2xx** — all seven paint the same chrome, so an assertion on chrome would pass against any of them → `enterprise/admin-console/console-tab-contract.spec.ts`
+- [-] The tab strip opens the screen each label names, asserted over all seven rather than assumed from the label — `Components` is `/admin-ee/catalog`, so the mapping is already not derivable from the text → `enterprise/admin-console/console-tab-contract.spec.ts`
+- [-] No screen in the console renders an unresolved i18n key, failing with every offending screen and string named. The guard of #1563, where `users-groups` shipped 17 raw `admin.*` keys; fixed on the 2026-08-27 image and unwitnessed until now. Matching is unanchored and covers `aria-label`/`title`, because the serious one — the delete-account button's accessible name — reaches the DOM composed (`admin.deleteTitle — langflow`) and an anchored pattern finds only the harmless column headers. Measured against the build that shipped the defect: 9 keys; against the current one: 0 → `enterprise/admin-console/console-tab-contract.spec.ts`
+- [ ] Per-tab operator behaviour — audit filters that actually filter, provider add/deactivate, the model blocklist round trip, user lifecycle with its confirmation dialog, role assignment. One follow-up each, all gated on the shell above
+
 ---
 
 ## serving/ — Serving-Plane End-User Identity (1.12)

--- a/docs/enterprise/admin-console/console-tab-contract.md
+++ b/docs/enterprise/admin-console/console-tab-contract.md
@@ -1,0 +1,238 @@
+# Enterprise — Every Screen of the Admin Console Resolves and Loads Its Own Data
+
+**Last validated:** Langflow Enterprise 1.12.0 (image built 2026-08-27 from `IBM-Langflow@release-1.12.0`)
+
+---
+
+## What this test validates *(required)*
+
+`/admin-ee` is the console an operator uses to govern an Enterprise instance, and § 21
+names the admin **UI** as the part Enterprise exclusively owns — every enforcement
+mechanism behind it is already covered from the API side. It has seven screens. Before
+this spec, one of them was covered (the catalog tab, for one field), so nothing would have
+noticed a screen that stopped loading, a route that stopped resolving, or a tab whose label
+opened the wrong screen.
+
+This is the **shell** contract, and it is deliberately shallow: it says nothing about what
+any screen lets an operator *do*. It says that each screen exists, is reachable both ways,
+is the one its tab claims, and fetched its own data. Every deeper spec in this directory
+depends on that — an assertion about an audit filter passes vacuously against a screen that
+never rendered.
+
+### The seven screens, measured
+
+Each has its own heading, its own subtitle, and one API read no other tab performs. The read is the load-bearing column: all seven render the same chrome, so an
+assertion on chrome would pass against any of them.
+
+| Route | Tab label | Own subtitle (the screen's body) | Read only it performs |
+|---|---|---|---|
+| `users-groups` | Users & groups | *Manage users and their access to this Langflow instance.* | `GET /api/v1/users/` |
+| `access-control` | Access control | *Define roles, grant them to people and teams, and review who has access.* | `GET /api/v1/authz/roles` |
+| `catalog` | **Components** | *Manage the approved component catalog, builder visibility, and policy.* | `GET /api/v1/enterprise-admin/catalog/components` |
+| `models` | Models | *Choose which models are available in this Langflow instance.* | `GET /api/v1/model-availability-policy` |
+| `providers` | Providers | *Approve model providers globally for this Langflow installation.* | `GET /api/v1/model-provider-policy` |
+| `security` | Security | *Configure login connections, recovery access, and security defaults.* | `GET /api/v1/sso/connections` |
+| `audit-logs` | Audit logs | *Sign-on and access-control events for this Langflow instance, newest first.* | `GET /api/v1/authz/audit` |
+
+### Why the subtitle and not a testid
+
+The first draft of this spec anchored each screen on a `data-testid`, and measuring the
+candidates refuted the choice twice over. Four of the seven — `models-empty-state`,
+`providers-recommended-state`, `login-connections-empty-state`, `audit-details-cell` —
+describe an instance **state**, not a screen: they exist because this container has no
+providers, no SSO connection and some audit rows, and the same screen on a configured
+instance renders none of them. And `admin-sub-tabs`, the candidate for `users-groups`,
+is also present on `access-control`, so it identifies nothing.
+
+The subtitle is the screen's own header copy, rendered by that route's component and
+independent of how much data the instance holds. Measured across all seven: exactly one
+occurrence on its own screen and **zero on the other six**. It carries the pair this spec
+needs — the subtitle proves *this* screen mounted, the 2xx read proves it fetched its own
+data — where a state-dependent testid would make the spec fail on a configured instance
+for a reason that has nothing to do with the console.
+
+The label and the route disagree for one screen — **Components** is `/admin-ee/catalog` —
+which is why the strip test asserts the mapping rather than assuming a tab named X lands
+on `/admin-ee/x`.
+
+### Two DOM facts that decide the spec's shape
+
+Both are the opposite of the obvious guess, and getting either wrong produces a spec that
+looks reasonable and asserts nothing:
+
+- The strip `enterprise-admin-tabs` holds seven `role="tab"` **buttons**, not links, named
+  by their visible label and carrying no `data-testid` at all. Navigation is
+  `getByRole("tab", { name })`; which one is current is `aria-selected="true"`.
+- `data-testid="enterprise-admin-tab-<route>"` is **not on the tab**. Despite its name it
+  sits on the screen's own `<section role="tabpanel">`, whose `aria-label` is the tab's
+  visible label, and **only the active route's panel exists in the DOM** — the other six
+  are not rendered.
+
+  The first version of this spec read that testid as the active-tab marker and asserted
+  `aria-selected` on it. All nine tests failed, on a console where nothing was wrong: the
+  attribute is on the button, and the button has no testid. The name is misleading enough
+  that inferring the owner from a list of a page's testids gets it backwards, so it is
+  recorded here rather than left to be rediscovered.
+
+  The correction is an improvement, not a workaround. A container is a stronger anchor than
+  a marker: the panel being visible says *this screen's content region mounted*, its
+  uniqueness in the DOM says *no other screen mounted with it*, and its `aria-label` ties
+  the route to the label the strip shows — which is the label→route mapping this spec
+  exists to pin, asserted at the DOM rather than inferred from a click.
+
+### Why an unresolved-i18n test lives in the shell spec
+
+It is the one defect class this console has actually shipped. Issue #1563 measured
+`/admin-ee/users-groups` rendering **17** raw `admin.*` keys: every column header, the
+search box, the two toggles that deactivate an account and grant superuser, and the
+delete-confirmation dialog's title, body and both buttons — so the last thing between a
+click and a deleted account stated nothing, and a screen-reader user was told
+`admin.deleteTitle` before deleting a user.
+
+That is fixed on the image this spec is validated against: zero raw keys across all seven
+screens. The guard is written now precisely because the fix is unwitnessed — a locale
+resource is among the easiest things in a frontend to drop again, and the failure is
+silent everywhere except on screen.
+
+## Assertions of absence, and how each is kept honest
+
+Two of the three tests assert that something is **not** there, which is the failure mode
+this repo has paid for most often: a predicate that can no longer match anything stays
+green forever and reads as coverage.
+
+- **The screen must be there before its absence means anything.** The i18n test requires
+  each tab's own subtitle to be visible *before* it inspects any text. Without that, a blank
+  screen satisfies "no raw keys" perfectly.
+- **The predicate has a real negative control, not a synthetic one.** The older
+  `langflow-enterprise:local` image (2026-08-18) still ships the defect, so the predicate is
+  proven to fail on a build where it must — rather than trusted because it is green on the
+  build where it should pass. Measured, pointing the spec at that image: **9 distinct keys
+  on `users-groups`**, and **0** on the build this spec is validated against. That is the
+  force-fail this spec records, and it is why the test names every offending screen and key
+  rather than the first — the count is how the control is read.
+
+### What the predicate matches, and the two ways it was wrong first
+
+Both corrections came out of running the negative control, and neither is visible from the
+passing side:
+
+- **Anchoring it to the whole string reports the harmless findings and misses the serious
+  one.** #1563's `admin.deleteTitle` is the accessible name of the **delete-account**
+  button, and it reaches the DOM composed — `"admin.deleteTitle — langflow"`. An anchored
+  `^…$` pattern found the seven column headers and not that. The same is true of the two
+  toggles that deactivate an account and grant superuser. So the match is unanchored, and
+  it reads `aria-label` / `title` / `placeholder` alongside rendered text: half of what
+  this defect class costs is paid by someone who cannot see the screen.
+- **Matching anywhere costs exactly one false positive, and it is a product name.**
+  *Approve IBM watsonx.ai models for use across Langflow.* — `watsonx.ai` is
+  `namespace.token` in shape. So a candidate counts only if some segment is camelCase
+  (`deleteTitle`, `columnUsername`, `cannotDeactivateSelf`) or it is nested more than one
+  level deep. `watsonx.ai` is neither.
+
+  That filter can miss an all-lowercase single-dot key, and that is the right direction to
+  be wrong in: a locale regression drops a namespace rather than one string, so the
+  camelCase siblings still fail the test — while a fabricated finding sends someone to read
+  a screen that is correct.
+
+### What this test does not reach
+
+Nine of #1563's seventeen keys are found; the other eight are not rendered in the default
+state of the screen. They belong to the **delete-confirmation dialog** (its title, body and
+both buttons), the **empty state**, and the clear-search control — all behind an
+interaction this shell spec deliberately does not perform. Recorded rather than glossed,
+because the dialog's copy is the most consequential of the seventeen, and covering it is
+part of what the `users-groups` follow-up spec is for.
+
+## Tags *(required)*
+
+`@enterprise` `@regression` `@ui-ux`
+
+`@regression` is not decoration: #1563 was a real defect on this console, and the third
+test is its guard. `@ui-ux` is the functional tag — this is console navigation and
+rendering, not the governance semantics its API siblings cover, so `@governance` would
+overstate it.
+
+No `@stable`: there is no scheduled Enterprise lane, so a `@stable` test here would
+silently never run (#1010).
+
+## Step by step *(required)*
+
+1. Authenticate once against the Enterprise instance and require the **RBAC variant** —
+   `authz_enabled: true` and `superuser_bypass: false`. Skip, naming the start command,
+   otherwise: `access-control` and `audit-logs` read `/authz/*` and have nothing to load
+   on a container without it, so two of the seven screens would report an environment
+   choice as a product failure.
+2. Seed the browser session from the cached token rather than filling the login form —
+   the instance rate-limits `/api/v1/login` to 5 per minute per IP for the whole machine.
+   The login form is `enterprise/auth/login-surface.spec.ts`'s subject, not this spec's.
+3. **Per tab (seven tests):** start recording responses, `goto /admin-ee/<route>`, then
+   assert, in this order:
+   - the URL is still `/admin-ee/<route>` — a screen that redirected to a default tab
+     would satisfy every remaining assertion of the *default* tab;
+   - the strip marks it current — the `role="tab"` button named by its label carries
+     `aria-selected="true"`;
+   - its panel `enterprise-admin-tab-<route>` is visible and its `aria-label` is that
+     label, which is where the route↔label mapping is actually pinned;
+   - the tab's own subtitle from the table above is visible — the panel proves the
+     container mounted, the subtitle proves its body rendered;
+   - the tab's own API read was performed **and** answered `2xx`.
+4. **The strip (one test):** open one screen, then click each of the other six by
+   `getByRole("tab", { name })`; after each click assert the URL is that tab's route and
+   that screen's panel is the one now mounted.
+5. **Unresolved keys (one test):** walk all seven screens; on each, wait for that screen's
+   own subtitle, then collect every visible leaf text and match it against
+   `^[a-z][a-zA-Z0-9]*(\.[a-zA-Z0-9]+)+$`. Fail naming every screen and string that
+   matched.
+
+## Validation criterion *(required)*
+
+The per-tab tests fail when a screen stops resolving, redirects away, renders another
+screen's content, loses the selected state on its tab, or paints its shell without
+performing the read that populates it. The
+strip test fails when a tab's label stops opening the screen it names. The i18n test fails
+when any screen in the console renders an unresolved translation key.
+
+## External dependencies *(required)*
+
+- A Langflow **Enterprise** instance on the RBAC variant:
+  `LANGFLOW_EE_RBAC=1 ./scripts/start-langflow-enterprise.sh` (port 7891 by default).
+- A browser.
+- **One** unit of the per-IP login budget, spent by the shared token cache and reused by
+  all nine tests.
+- No LLM provider, no network egress, and no licence — `security` is asserted on its
+  empty state, which is what an unlicensed instance correctly shows.
+- No Langflow **source** paths, and that is not an omission: the Enterprise frontend does
+  not live in `langflow-ai/langflow`, so there is no upstream path this doc could name that
+  `scripts/watch-upstream-areas.mjs` would resolve. Every sibling doc under
+  `docs/enterprise/` is in the same position.
+
+## Notes
+
+Four non-2xx responses are expected here and are not defects. The first is declared to the
+fixture with `page.expectKnownHttpError()`; the other three are globally exempt already:
+
+- `GET /api/v1/sso/entitlements` -> `503`, on the screens that reach `security`. An
+  Enterprise instance with no licence refuses that read by design, and
+  `enterprise/auth/entitlement-fail-closed.spec.ts` asserts that exact refusal as the
+  product's contract. It is declared per screen rather than silenced with
+  `allowHttpErrors()`, which would take the whole test's advisory log with it — and the
+  declaration is verified in both directions: against a **licensed** instance the 503 stops
+  firing, and the fixture fails naming the entry to delete, which is the right signal since
+  this list would then be out of date.
+
+The remaining three fire on every page load of the console:
+
+- `GET /api/v1/auto_login` → `403`, correct on a password-first instance; the HTTP error
+  policy already exempts auth endpoints.
+- `POST /api/v1/refresh` → `401`, because the session is seeded with an access token and
+  deliberately no refresh token.
+- `GET /api/v1/store/tags` → `500`, the external Langflow Store, unreachable in this
+  environment and already exempt.
+
+The per-tab tests scope their response assertion to that tab's own read, so none of these
+can satisfy or break it.
+
+One measurement trap, recorded because it produced a wrong validation claim once: the
+fixture prints `Backend Error` on **stdout**. Under `--reporter=json` that is the JSON
+file, so grepping the run's stderr for it reports zero on a run that logged two. Capture
+both streams (`2>&1`) when checking step 4 of the validation checklist.

--- a/tests/tests-automations/regression/enterprise/admin-console/console-tab-contract.spec.ts
+++ b/tests/tests-automations/regression/enterprise/admin-console/console-tab-contract.spec.ts
@@ -1,0 +1,382 @@
+import type { Page } from "@playwright/test";
+import type { PageWithErrorHooks } from "../../../../fixtures/fixtures";
+import type { KnownHttpDefect } from "../../../../fixtures/http-error-policy";
+import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  getEnterpriseAuthToken,
+  seedEnterpriseUiSession,
+} from "../../../../helpers/enterprise/enterprise-auth";
+import { requireRbacInstance } from "../../../../helpers/enterprise/rbac";
+
+/**
+ * The shell contract of the Enterprise admin console.
+ *
+ * `/admin-ee` is the console an operator governs an instance from, and § 21 of
+ * the checklist names the admin UI as the part Enterprise exclusively owns —
+ * every enforcement mechanism behind it is already covered from the API side.
+ * It has seven screens; before this spec one of them was covered, for one
+ * field, so nothing would have noticed a screen that stopped loading, a route
+ * that stopped resolving, or a tab whose label opened the wrong screen.
+ *
+ * This file is deliberately shallow. It says nothing about what any screen lets
+ * an operator DO — that is a follow-up per tab, and every one of those depends
+ * on this one, because an assertion about a filter or a confirmation dialog
+ * passes vacuously against a screen that never rendered.
+ *
+ * Two DOM facts decide its shape, and both are the opposite of the obvious
+ * guess. Getting either wrong produces a spec that looks reasonable and asserts
+ * nothing:
+ *
+ *  - The strip holds seven `role="tab"` BUTTONS, not links, named by their
+ *    visible label and carrying no testid at all — so navigation is by role and
+ *    name, and which one is current is `aria-selected`.
+ *  - `data-testid="enterprise-admin-tab-<route>"` is NOT on the tab. Despite its
+ *    name it sits on the screen's own `<section role="tabpanel">`, whose
+ *    `aria-label` is the tab's visible label, and only the active route's panel
+ *    exists in the DOM. The first version of this file read it as the active-tab
+ *    marker and failed all nine tests against a console where nothing was wrong.
+ *    The correction is an improvement: a container anchors more than a marker —
+ *    visible says this screen's content region mounted, unique says no other
+ *    mounted with it, and `aria-label` ties the route to the label the strip
+ *    shows, which is the mapping this spec exists to pin.
+ *
+ * Full reasoning, including why each screen is anchored on its subtitle rather
+ * than on a testid, in `docs/enterprise/admin-console/console-tab-contract.md`.
+ */
+
+interface AdminTab {
+  /** Path segment under `/admin-ee/`. */
+  route: string;
+  /** Visible label on the tab strip. NOT derivable from the route: see `catalog`. */
+  label: string;
+  /**
+   * The screen's own header copy.
+   *
+   * Anchoring on this rather than on a `data-testid` is measured, not stylistic:
+   * four of the seven candidate testids (`models-empty-state`,
+   * `providers-recommended-state`, `login-connections-empty-state`,
+   * `audit-details-cell`) describe an instance STATE and vanish on a configured
+   * instance, and a fifth (`admin-sub-tabs`) is shared with a neighbouring tab.
+   * Each subtitle was measured to appear exactly once on its own screen and on
+   * none of the other six.
+   */
+  subtitle: string;
+  /**
+   * The one API read no other tab performs.
+   *
+   * The load-bearing assertion of this file. All seven screens paint the same
+   * chrome, so "something rendered" is satisfied by any of them; only this
+   * separates a screen that loaded from a shell that painted.
+   */
+  read: string;
+  /**
+   * 4xx/5xx this screen provokes on purpose, declared so the advisory log stays
+   * worth reading.
+   *
+   * Empty for six of the seven. A declaration that never fires FAILS its test,
+   * so this belongs per tab rather than once for the file — and it is data here
+   * rather than a branch inside a test body.
+   */
+  knownHttpErrors: KnownHttpDefect[];
+}
+
+const TABS: AdminTab[] = [
+  {
+    route: "users-groups",
+    label: "Users & groups",
+    subtitle: "Manage users and their access to this Langflow instance.",
+    read: "/api/v1/users/",
+    knownHttpErrors: [],
+  },
+  {
+    route: "access-control",
+    label: "Access control",
+    subtitle: "Define roles, grant them to people and teams, and review who has access.",
+    read: "/api/v1/authz/roles",
+    knownHttpErrors: [],
+  },
+  {
+    // The one screen whose label does not name its route.
+    route: "catalog",
+    label: "Components",
+    subtitle: "Manage the approved component catalog, builder visibility, and policy.",
+    read: "/api/v1/enterprise-admin/catalog/components",
+    knownHttpErrors: [],
+  },
+  {
+    route: "models",
+    label: "Models",
+    subtitle: "Choose which models are available in this Langflow instance.",
+    read: "/api/v1/model-availability-policy",
+    knownHttpErrors: [],
+  },
+  {
+    route: "providers",
+    label: "Providers",
+    subtitle: "Approve model providers globally for this Langflow installation.",
+    read: "/api/v1/model-provider-policy",
+    knownHttpErrors: [],
+  },
+  {
+    route: "security",
+    label: "Security",
+    subtitle: "Configure login connections, recovery access, and security defaults.",
+    read: "/api/v1/sso/connections",
+    // The screen also reads entitlements, and an Enterprise instance with no
+    // licence refuses that with 503 — correctly, by design. Not this spec's
+    // finding: `enterprise/auth/entitlement-fail-closed.spec.ts` asserts that
+    // exact refusal as the product's contract. Declared rather than silenced
+    // with `allowHttpErrors()`, which would take the whole test's advisory log
+    // with it, and verified in both directions: against a LICENSED instance the
+    // 503 stops firing and the fixture fails naming this entry to delete.
+    knownHttpErrors: [
+      {
+        pathname: "/api/v1/sso/entitlements",
+        status: 503,
+        reason:
+          "an unlicensed Enterprise instance refuses the entitlements read by design — " +
+          "the contract asserted by enterprise/auth/entitlement-fail-closed.spec.ts",
+      },
+    ],
+  },
+  {
+    route: "audit-logs",
+    label: "Audit logs",
+    subtitle: "Sign-on and access-control events for this Langflow instance, newest first.",
+    read: "/api/v1/authz/audit",
+    knownHttpErrors: [],
+  },
+];
+
+/**
+ * A `namespace.someKey` token appearing anywhere in a string.
+ *
+ * Anywhere, not anchored, and that is measured rather than cautious: the most
+ * serious of #1563's findings reaches the DOM as the COMPOSED accessible name
+ * `"admin.deleteTitle — langflow"` on the delete-account button. An anchored
+ * pattern reports the seven harmless column headers and misses that one.
+ */
+const I18N_KEY_TOKEN = /(?:^|\s)([a-z][a-zA-Z0-9]*(?:\.[a-zA-Z0-9]+)+)(?=\s|$)/g;
+
+/**
+ * Every unresolved translation key in one string.
+ *
+ * The shape filter is the price of matching anywhere. Measured on the console:
+ * unanchored matching produces exactly one false positive, *Approve IBM
+ * watsonx.ai models for use across Langflow.* — a product name that is
+ * `namespace.token` in shape. An i18n key names a message, so some segment of
+ * it is camelCase (`deleteTitle`, `columnUsername`, `cannotDeactivateSelf`) or
+ * it is nested more than one level deep; `watsonx.ai` is neither.
+ *
+ * The filter can miss an all-lowercase single-dot key, and that is the right
+ * direction to be wrong in: a locale regression drops a namespace, not one
+ * string, so its camelCase siblings still fail this test — while a fabricated
+ * finding would send someone to read a screen that is correct.
+ *
+ * Measured both ways: 0 on the build this spec is validated against, 9 distinct
+ * keys on the 2026-08-18 build that shipped the defect.
+ */
+function unresolvedI18nKeys(text: string): string[] {
+  const keys: string[] = [];
+  for (const match of text.matchAll(I18N_KEY_TOKEN)) {
+    const key = match[1];
+    const segments = key.split(".");
+    if (segments.length > 2 || segments.some((segment) => /[A-Z]/.test(segment))) {
+      keys.push(key);
+    }
+  }
+  return keys;
+}
+
+/**
+ * The screen's own content region.
+ *
+ * Named `...-tab-...` but mounted on the `role="tabpanel"` section, and only for
+ * the active route — see the note at the top of this file.
+ */
+function screenPanel(page: Page, route: string) {
+  return page.getByTestId(`enterprise-admin-tab-${route}`);
+}
+
+/** The strip button for one screen. Carries no testid; named by its label. */
+function stripTab(page: Page, label: string) {
+  return page.getByRole("tab", { name: label, exact: true });
+}
+
+/**
+ * Open one screen and assert it is the one that rendered.
+ *
+ * Shared by the strip test and the i18n test so neither can inspect a screen
+ * that never arrived — the failure mode that makes an assertion of absence pass
+ * forever.
+ */
+async function expectScreenRendered(page: Page, tab: AdminTab): Promise<void> {
+  await expect(
+    screenPanel(page, tab.route),
+    `'${tab.route}' did not mount its own panel`,
+  ).toBeVisible();
+  await expect(
+    page.getByText(tab.subtitle, { exact: true }),
+    `'${tab.route}' mounted its panel but not its body — the subtitle '${tab.subtitle}' is absent`,
+  ).toBeVisible();
+}
+
+/**
+ * Apply a screen's declared 4xx/5xx to the running test.
+ *
+ * Table-driven so six of the seven pass an empty list and no test body needs a
+ * branch. See `AdminTab.knownHttpErrors` for why a blanket declaration is wrong.
+ */
+function declareKnownHttpErrors(page: Page, tabs: AdminTab[]): void {
+  for (const defect of tabs.flatMap((tab) => tab.knownHttpErrors)) {
+    (page as PageWithErrorHooks).expectKnownHttpError(defect);
+  }
+}
+
+test.describe("Enterprise — every screen of the admin console resolves and loads its own data", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const auth = await getEnterpriseAuthToken(request);
+    // `access-control` and `audit-logs` read `/authz/*` and have nothing to load
+    // on a container without authorization, so two of the seven screens would
+    // report an environment choice as a product failure.
+    await requireRbacInstance(request, auth);
+    // Seeded, not filled: the instance rate-limits login to 5/min for the whole
+    // machine, and the login form is `enterprise/auth/login-surface`'s subject.
+    await seedEnterpriseUiSession(page, request);
+  });
+
+  for (const tab of TABS) {
+    test(
+      `the ${tab.label} screen deep-links to itself and performs its own read`,
+      { tag: ["@enterprise", "@regression", "@ui-ux"] },
+      async ({ page }) => {
+        declareKnownHttpErrors(page, [tab]);
+
+        // Armed BEFORE navigating: the read fires during the load, and asking
+        // afterwards would be a race the screen usually wins.
+        const read = page.waitForResponse(
+          (response) =>
+            new URL(response.url()).pathname === tab.read &&
+            response.request().method() === "GET",
+          { timeout: 30_000 },
+        );
+
+        await page.goto(`/admin-ee/${tab.route}`);
+
+        await test.step("the route resolves to itself rather than a default tab", async () => {
+          // Asserted first and separately. A screen that redirected would go on
+          // to satisfy every remaining assertion — of the DEFAULT tab.
+          await expect(page).toHaveURL(new RegExp(`/admin-ee/${tab.route}(?:[?#]|$)`));
+        });
+
+        await test.step("the strip marks it as the current screen", async () => {
+          await expect(stripTab(page, tab.label)).toHaveAttribute("aria-selected", "true");
+        });
+
+        await test.step("its own panel mounted, labelled as the tab that opens it", async () => {
+          // The panel is where the route<->label mapping is actually pinned:
+          // `Components` is `/admin-ee/catalog`, so the label cannot be derived.
+          await expect(screenPanel(page, tab.route)).toBeVisible();
+          await expect(screenPanel(page, tab.route)).toHaveAttribute("aria-label", tab.label);
+        });
+
+        await test.step("and its body rendered inside it", async () => {
+          await expect(page.getByText(tab.subtitle, { exact: true })).toBeVisible();
+        });
+
+        await test.step(`and it performed its own read of ${tab.read}`, async () => {
+          // The assertion that separates a loaded screen from a painted shell.
+          const response = await read;
+          expect(
+            response.status(),
+            `${tab.route} read ${tab.read} and the instance answered ${response.status()}`,
+          ).toBeLessThan(300);
+        });
+      },
+    );
+  }
+
+  test(
+    "the tab strip opens the screen each label names",
+    { tag: ["@enterprise", "@regression", "@ui-ux"] },
+    async ({ page }) => {
+      declareKnownHttpErrors(page, TABS);
+
+      // Start somewhere the walk does not begin on, so the first click is a real
+      // navigation rather than a no-op on the already-selected tab.
+      const [first, ...rest] = TABS;
+      await page.goto(`/admin-ee/${first.route}`);
+      await expectScreenRendered(page, first);
+
+      for (const tab of rest) {
+        await test.step(`'${tab.label}' opens /admin-ee/${tab.route}`, async () => {
+          // By role and name: the strip buttons carry no testid, and the label
+          // does not name the route for `Components` -> `catalog`.
+          await stripTab(page, tab.label).click();
+          await expect(page).toHaveURL(new RegExp(`/admin-ee/${tab.route}(?:[?#]|$)`));
+          await expectScreenRendered(page, tab);
+        });
+      }
+    },
+  );
+
+  test(
+    "no screen in the console renders an unresolved i18n key",
+    { tag: ["@enterprise", "@regression", "@ui-ux"] },
+    async ({ page }) => {
+      // The guard of #1563, where `users-groups` shipped seventeen raw `admin.*`
+      // keys — every column header, the two account toggles, and the
+      // delete-confirmation dialog's title, body and both buttons, so the last
+      // thing between a click and a deleted account stated nothing.
+      declareKnownHttpErrors(page, TABS);
+
+      const findings: string[] = [];
+
+      for (const tab of TABS) {
+        await page.goto(`/admin-ee/${tab.route}`);
+        // Required before inspecting text: a blank screen satisfies "no raw
+        // keys" perfectly, and would keep satisfying it forever.
+        await expectScreenRendered(page, tab);
+
+        const raw = await page.evaluate(() => {
+          const elements = Array.from(document.querySelectorAll("body *"));
+          const strings: string[] = [];
+
+          for (const element of elements) {
+            // Visible text: what the operator reads.
+            if (element.children.length === 0) {
+              strings.push((element.textContent ?? "").trim());
+            }
+            // Accessible names: what a screen-reader user is told instead. This
+            // half is not decoration — #1563's `admin.deleteTitle` was the
+            // accessible name of the DELETE-ACCOUNT button, and the two toggles
+            // that deactivate an account and grant superuser were named the same
+            // way. None of them is leaf text, so a scan of rendered copy alone
+            // reports the harmless keys and misses every serious one.
+            for (const attribute of ["aria-label", "title", "placeholder"]) {
+              strings.push((element.getAttribute(attribute) ?? "").trim());
+            }
+          }
+
+          return Array.from(new Set(strings.filter(Boolean)));
+        });
+
+        // Deduplicated by KEY, not by the string carrying it: the same key
+        // reaches the DOM both bare and composed into an accessible name, and
+        // reporting it twice would make the control's count read as noise.
+        for (const key of new Set(raw.flatMap(unresolvedI18nKeys))) {
+          findings.push(`${tab.route}: ${key}`);
+        }
+      }
+
+      // Reported all at once, not one at a time: the negative control for this
+      // predicate is the 2026-08-18 image, where it must produce nine keys on
+      // `users-groups`, and the count is how that control is read.
+      expect(
+        findings,
+        `the admin console rendered ${findings.length} unresolved translation key(s):\n` +
+          findings.map((finding) => `  - ${finding}`).join("\n"),
+      ).toEqual([]);
+    },
+  );
+});


### PR DESCRIPTION
Closes #1630.

Opens `QA-CHECKLIST.md` § 22.7 for the **admin console shell**. `/admin-ee` is the console an
operator governs an Enterprise instance from, and § 21 names the admin UI as the part
Enterprise exclusively owns. It has seven screens; one of them was covered
(`admin-ui-read-only-policy`, the catalog tab, for one field). Nothing would have noticed a
screen that stopped loading, a route that stopped resolving, or a tab whose label opened the
wrong screen.

Deliberately shallow, and that is the point: what each screen lets an operator *do* is a
follow-up per tab, and every one of those depends on this — an assertion about a filter or a
confirmation dialog passes vacuously against a screen that never rendered.

**Not redundant with `enterprise/authz/access-control-ui.spec.ts`** (#1562). That spec asserts
what the Access Control screen *does* — system-role immutability, the assignments listing,
project-scoped assignment, revocation. This one asserts that all seven screens resolve and
load. Confirmed by running that spec against this branch's instance: **4/4 green**, see
Validation below for one stale premise it carries.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1–7 | `the <label> screen deep-links to itself and performs its own read`, one per tab | Four assertions in order: the URL did **not** redirect to a default tab (a screen that redirected goes on to satisfy every remaining assertion — of the *default* tab); the `role="tab"` button named by its label carries `aria-selected="true"`; the screen's own `role="tabpanel"` mounted with `aria-label` equal to that label; and **the one API read no other tab performs answered 2xx**. The last is load-bearing: all seven paint the same chrome, so an assertion on chrome would pass against any of them. |
| 8 | `the tab strip opens the screen each label names` | Clicks the other six by role and name, pinning the label→route map at the DOM. It is not derivable: **`Components` is `/admin-ee/catalog`**. |
| 9 | `no screen in the console renders an unresolved i18n key` | Fails naming every offending screen and key. The guard of #1563, where `users-groups` shipped 17 raw `admin.*` keys — every column header, the two toggles that deactivate an account and grant superuser, and the delete-confirmation dialog's title, body and both buttons, so the last thing between a click and a deleted account stated nothing. |

Per-tab reads: `users-groups` → `/users/`, `access-control` → `/authz/roles`, `catalog` →
`/enterprise-admin/catalog/components`, `models` → `/model-availability-policy`, `providers` →
`/model-provider-policy`, `security` → `/sso/connections`, `audit-logs` → `/authz/audit`.

## 2. How the test was built

**Every anchor measured on the running instance, and two first attempts were wrong.** Both
corrections are recorded in the spec doc rather than quietly fixed, because each is a trap the
next person hits:

- **`enterprise-admin-tab-<route>` is NOT on the tab.** Despite the name it sits on the
  screen's own `<section role="tabpanel">`, and only the active route's panel exists in the
  DOM; the strip's seven buttons carry no testid at all. Reading it as the active-tab marker
  and asserting `aria-selected` on it failed **all nine tests against a console where nothing
  was wrong**. The correction is stronger than the original: a container anchors more than a
  marker — visible says this screen's region mounted, unique says no other mounted with it,
  and `aria-label` ties the route to the label.
- **Four of the seven candidate testids describe an instance STATE, not a screen.**
  `models-empty-state`, `providers-recommended-state`, `login-connections-empty-state` and
  `audit-details-cell` exist because this container has no providers, no SSO connection and
  some audit rows; the same screens on a configured instance render none of them. A fifth,
  `admin-sub-tabs`, is shared with a neighbouring tab. Each screen is anchored on its subtitle
  instead — measured to appear exactly once on its own screen and **zero** times on the other
  six.

**The i18n predicate matches unanchored and reads accessible names**, and that too came out of
running the negative control rather than from review: the serious finding reaches the DOM
**composed** — `"admin.deleteTitle — langflow"`, the accessible name of the delete-account
button. An anchored `^…$` pattern found the seven harmless column headers and missed it.
Matching anywhere costs exactly one false positive, the product name `watsonx.ai`, so a
candidate counts only if some segment is camelCase or it nests more than one level deep. The
filter can miss an all-lowercase single-dot key, which is the right direction to be wrong in:
a locale regression drops a namespace rather than one string, so the camelCase siblings still
fail — while a fabricated finding sends someone to read a screen that is correct.

**One declared HTTP state.** `security` reads entitlements and an unlicensed instance refuses
with `503` by design — the contract `enterprise/auth/entitlement-fail-closed.spec.ts` already
asserts. Declared with `page.expectKnownHttpError()` on the three tests that reach that screen,
not silenced with `allowHttpErrors()`, which would take the whole test's advisory log with it.
It lives in the `TABS` table rather than as a branch in a test body, because a declaration that
never fires **fails** its test and so cannot be hoisted to all seven.

**Login budget.** One unit for the whole file: the session is seeded from the cached token as
the `access_token_lf` cookie via the existing `seedEnterpriseUiSession`, never by filling the
form. EE rate-limits `/api/v1/login` to 5/min for the whole machine, and
`enterprise/auth/login-surface` owns that form.

## 3. Validation

Run against `langflow-enterprise:latest` (built 2026-08-27, `1.12.0`), RBAC variant:
`LANGFLOW_EE_RBAC=1 ./scripts/start-langflow-enterprise.sh`.

- **9/9 green, ~26 s**, five consecutive runs including one after rebasing onto current `main`.
- **Backend errors: 0**, with **3 `📌 Known backend defect`** — the declaration firing on
  exactly the three tests that reach `security`. *(Measured capturing both streams. An earlier
  check grepped stderr only and reported zero on a run that logged two: the fixture prints on
  **stdout**, which `--reporter=json` redirects into the JSON file. That trap is now recorded
  in the spec doc's Notes.)*
- Walked in `--debug` end to end: 9 passed headed.

**Force-fail — four mutations, all falsify:**

| Mutation | Expected | Measured |
|---|---|---|
| one tab's API read points at a path that never fires | only that test | **1 red** |
| label `Components` remapped to route `models` | that tab + strip + i18n | **3 red** |
| declared `503` changed to a status the instance never answers | the three tests carrying it | **3 red**, naming the call to delete |
| the spec pointed at the build that shipped #1563 | i18n red, naming the keys | **9 keys, incl. `admin.deleteTitle`** |

The last is not a mutation of the test — it is the older `langflow-enterprise:local` image
(2026-08-18) that still ships the defect. **9 keys there, 0 on the build under test.** An
assertion of absence needs a build where it must fail, and this one has a real one.

**Reach, stated rather than glossed:** 9 of #1563's 17 keys. The other 8 are not rendered in
the screen's default state — they belong to the delete-confirmation dialog, the empty state and
the clear-search control, all behind an interaction this shell spec does not perform. The
dialog's copy is the most consequential of the 17, and covering it is part of what the
`users-groups` follow-up is for.

## 4. Notes for the reviewer

- **No `@stable`**: there is no scheduled Enterprise lane, so a `@stable` test here would
  silently never run (#1010). Tags are `@enterprise @regression @ui-ux`.
- **`access-control-ui.spec.ts` carries a premise that is now stale**, found while checking for
  overlap and left alone here (one issue per branch). Its header records
  `/admin-ee/access-control` redirecting to `/admin-ee/users-groups` and the tab list having no
  Access Control tab. On this build the redirect runs the **other way** —
  `/settings/access-control` lands on `/admin-ee/access-control` — and the strip has seven tabs
  including it. Its four tests still pass, because they assert on the tables rather than on the
  route; only the comment is wrong. Noted in § 22.7's blockquote.
- **#1563 appears fixed** on the 2026-08-27 image: 0 raw keys across all seven screens, and the
  screen now reads *Search Username / Add User / Id / Username / Active / Superuser*. Not closed
  here — separate issue, separate branch.
- `QA-CHECKLIST.md` § 22.7 edits the **manual bullets only**; no generated block is touched
  (guard green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
