### PR TITLE
chore(triage): quarantine the 6 non-environmental hard failures of daily #1642

### DIFF
--- a/tests/tests-automations/regression/core-components/edit-tools.spec.ts
+++ b/tests/tests-automations/regression/core-components/edit-tools.spec.ts
@@ -440,9 +440,11 @@ test.describe("Edit tools (Tool Mode)", () => {
   // `name: "web_fetch"`, `ap: []`), it costs ~1 run in 6 here — the settle
   // barrier is what keeps it out of the test above. Approval persistence stays
   // asserted there.
-  test(
+  // QUARANTINED for #1644 — the stale-response park never engages, so this guard asserts on an unmeasured run
+  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
+  test.fixme(
     "a stale node-update response does not revert the action edits",
-    { tag: ["@stable", "@regression", "@components"] },
+    { tag: ["@regression", "@components"] },
     async ({ page, request }) => {
       const bearer = await getAuthToken(request);
       let flowId = "";

--- a/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
+++ b/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
@@ -274,8 +274,10 @@ test.describe("Human Input node configuration (HITL branch handles)", () => {
     },
   );
 
-  test("a stale refresh response does not revert a committed User Action",
-    { tag: ["@stable", "@regression", "@components", "@ui-ux"] },
+  // QUARANTINED for #1644 — the stale-response park never engages, so this guard asserts on an unmeasured run
+  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
+  test.fixme("a stale refresh response does not revert a committed User Action",
+    { tag: ["@regression", "@components", "@ui-ux"] },
     async ({ page }) => {
       let openGate: () => void = () => {};
       const gate = new Promise<void>((resolve) => {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
@@ -372,9 +372,11 @@ test.describe.configure({ mode: "serial" });
 // one, which needs no provider at all. Ordering it first makes the model-free
 // coverage independent of whatever the routed target does.
 test.describe("Context ID continuity — retrieval layer (model-free)", () => {
-  test(
+  // QUARANTINED for #1643 — an overlay at the canvas bottom intercepts the output-inspection-messages-memory click
+  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
+  test.fixme(
     "context-scoped retrieval returns all turns of the context and not the untagged control",
-    { tag: ["@stable", "@regression", "@agents", "@components"] },
+    { tag: ["@regression", "@agents", "@components"] },
     async ({ page, request }) => {
       const seeded = await seedContextSession(request);
       try {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -509,9 +509,11 @@ const targets = resolveTestTargets({ tier: "any-completion" });
 test.describe.configure({ mode: "serial" });
 
 test.describe("Context ID isolation — retrieval layer (model-free)", () => {
-  test(
+  // QUARANTINED for #1643 — an overlay at the canvas bottom intercepts the output-inspection-messages-memory click
+  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
+  test.fixme(
     "mirrored context-scoped retrievals return only their own context's messages",
-    { tag: ["@stable", "@regression", "@agents", "@components"] },
+    { tag: ["@regression", "@agents", "@components"] },
     async ({ page, request }) => {
       const seeded = await seedTwoContextSession(request);
       try {

--- a/tests/tests-automations/regression/i18n/locale-resilience.spec.ts
+++ b/tests/tests-automations/regression/i18n/locale-resilience.spec.ts
@@ -238,9 +238,11 @@ test.describe("i18n — a key the active bundle does not carry", () => {
     await deleteFlow(request, flowId, { headers: { Authorization: token } });
   });
 
-  test(
+  // QUARANTINED for #1646 — the English-fallback probe key no longer falls back
+  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
+  test.fixme(
     "a missing key falls back to English beside siblings the bundle translates",
-    { tag: ["@stable", "@regression", "@ui-ux", "@workspace"] },
+    { tag: ["@regression", "@ui-ux", "@workspace"] },
     async ({ page }) => {
       // On 1.12.0.dev33 all six non-English bundles are missing the same five
       // keys `en` carries (2387 vs 2382). Two of them render unconditionally in

--- a/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
@@ -496,8 +496,10 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
       });
     });
 
-  test("Fit View is reachable from the canvas controls toolbar",
-    { tag: ["@stable", "@workspace", "@ui-ux"] },
+  // QUARANTINED for #1645 — the displaced entry viewport reads as already contained
+  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
+  test.fixme("Fit View is reachable from the canvas controls toolbar",
+    { tag: ["@workspace", "@ui-ux"] },
     async ({ page }) => {
       const controlTestIds = ["fit_view", "zoom_in", "zoom_out", "reset_zoom"];
 


### PR DESCRIPTION
## What this is

Quarantine PR from the triage of daily run [33410643882](https://github.com/oriontech-me/langflow-e2e/actions/runs/33410643882) (2026-08-31, umbrella #1642). No test logic, no spec docs, no `QA-CHECKLIST.md` — six `test()` declarations, two edits each.

## Why the triage quarantined by hand

The run tripped the **mass-failure guard** (10 hard failures > threshold 5), so the workflow auto-removed **no** `@stable` tag. On a guard day the triage owes a verdict on the day, and that verdict is what decides the tags.

**Verdict: environmental IN PART, and demonstrably not in whole.** The in-run recorder measured a real mid-run wedge — 14 outages, 16.7 min of unreachable backend on 4 of 4 shards, shard 4 at 41.9% of its 24.2-minute span. Cross-referencing every failing attempt's window against its own shard's `backend-liveness.jsonl` (probe share down, ±20 s padding) splits the ten cleanly:

| Hard failure | att0 | att1 | att2 | Treatment |
|---|---|---|---|---|
| `api-health-check.spec.ts:7` | 50% | 100% | 100% | environmental — already exempt, `@stable` kept |
| `google-provider.spec.ts:165` | 48% | 47% | 44% | environmental — already exempt, `@stable` kept |
| `mcp-client-agent-gemini-tool-regression.spec.ts:139` | 40% | 46% | 47% | environmental — already exempt, `@stable` kept |
| `model-provider-model-toggle.spec.ts:296` | 44% | 49% | skipped | environmental, **not** exempt → recorded on #1589, `@stable` kept |
| `agent-context-id-isolation.spec.ts:512` | 18% | 14% | **3%** | **quarantined here** |
| `agent-context-id-continuity.spec.ts:375` | 20% | 12% | **0%** | **quarantined here** |
| `human-input-node-config.spec.ts:277` | 6% | 3% | **0%** | **quarantined here** |
| `edit-tools.spec.ts:443` | 0% | 0% | **0%** | **quarantined here** |
| `canvas-zoom-navigation.spec.ts:499` | 4% | 0% | **0%** | **quarantined here** |
| `locale-resilience.spec.ts:241` | 0% | 0% | **3%** | **quarantined here** |

Counter-evidence that a high down-share is not on its own a cause, which is why this is a per-attempt split and not a per-day one: **shard 1 measured 21% of its probes down (30.6% of its span) and passed every test it ran.**

## Why both edits, not just the tag

Applied together on each of the six:

1. **`@stable` removed.** `QA-CHECKLIST.md` Phase 0 is generated from `@stable` `test()` calls, so leaving the tag on keeps counting a quarantined test as validated.
2. **`test.fixme` added.** Removing the tag alone only silences `daily-stable.yml`. The `pr-validation.yml` impacted-specs gate selects specs **by file diff, not by tag**, so any PR touching these files would keep running the broken test and going red (#871). `test.fixme` skips it in every context.

| Spec:line | → issue | Tags after |
|---|---|---|
| `tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts:512` | #1643 | `@regression @agents @components` |
| `tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts:375` | #1643 | `@regression @agents @components` |
| `tests/tests-automations/regression/core-components/human-input-node-config.spec.ts:277` | #1644 | `@regression @components @ui-ux` |
| `tests/tests-automations/regression/core-components/edit-tools.spec.ts:443` | #1644 | `@regression @components` |
| `tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts:499` | #1645 | `@workspace @ui-ux` |
| `tests/tests-automations/regression/i18n/locale-resilience.spec.ts:241` | #1646 | `@regression @ui-ux @workspace` |

## Verification

Run locally against Langflow 1.12.0 on `http://localhost:7860`:

- `npm run typecheck` — clean.
- `npm run lint` — 0 errors (the `playwright/no-skipped-test` warnings on the new `test.fixme` calls are warnings; `eslint tests/` sets no `--max-warnings`).
- `npm run check:checklist-coverage` — passes. `✓ every @stable and every documented spec is referenced by a Part II bullet` (205 spec files carrying `@stable`, down from 206 — no bullet edits needed, the specs keep their docs and their bullets).
- **The tag is gone where it matters:** `npx playwright test --list --grep @stable` over the six files returns **none** of the six tests.
- **The `test.fixme` actually skips:** running the six by title reports `6 skipped`, 0 executed —

  ```
  [1/6] … edit-tools.spec.ts:445:8 › a stale node-update response does not revert the action edits @regression @components
  …
    6 skipped
  ```

  Note the tag list in that output: `@stable` is absent from all six, which is the same fact confirmed from the runner rather than from the diff.

## Side effect worth reviewing

`agent-context-id-isolation.spec.ts` and `agent-context-id-continuity.spec.ts` are both `test.describe.configure({ mode: "serial" })`, so each file's hard failure had been **skipping its own sibling** — 2 of the run's 4 genuine skips were this, not independent skips. With the failing test `fixme`d, those two siblings run again. They are the parametrized/routed tests, so expect them to produce signal of their own; that is a recovery of coverage, but it is new coverage in the daily and worth watching on the next run.

## Not done here, on purpose

- **No issue is closed.** Lifting each quarantine — remove `test.fixme`, restore `@stable`, re-validate per `CONTRIBUTING.md` — is a deliverable of #1643 / #1644 / #1645 / #1646, and each issue carries it as a checkbox.
- **No `@stable` is restored** and no already-exempt test is touched: the three wedge-collateral specs and `model-provider-model-toggle.spec.ts:296` keep their tags per the day's verdict.
- **`QA-CHECKLIST.md` untouched** — the generated blocks are regenerated on merge to `main` by `update-coverage-summary.yml` (#741).

Refs #1642, #1643, #1644, #1645, #1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)
