### PR TITLE
fix(provider-setup): name the provider list's state instead of timing out anonymously (#1648)

### DIFF
--- a/docs/core-functionality/llm-agents/model-provider-model-toggle.md
+++ b/docs/core-functionality/llm-agents/model-provider-model-toggle.md
@@ -1,6 +1,6 @@
 # Model Provider Model Toggle
 
-**Last validated:** Langflow 1.12.x (measured on `1.12.0.dev30`)
+**Last validated:** Langflow 1.12.x (measured on `1.12.0.dev30`; the provider-list wait re-measured on `1.12.0.dev44`, #1648)
 
 ---
 
@@ -31,7 +31,7 @@ Both tests resolve a single provider — `MODEL_TEST_PROVIDER` when its env keys
 ### Test 1 — toggle changes immediately and persists across reopen
 
 1. `SimpleAgentTemplatePage.load({ provider })` — configures the provider's API key globally and enables all its models (the known baseline). `MODEL_NOT_AVAILABLE` is caught and turned into a skip.
-2. Navigate to **Settings → Model Providers**, expand the provider (`provider-item-...`), and wait for `model-provider-selection` and `llm-models-section`.
+2. Navigate to **Settings → Model Providers**, expand the provider through `waitForProviderRow()` (see *Waiting for the provider list* below — never a bare `provider-item-...` wait), and wait for `model-provider-selection` and `llm-models-section`.
 3. Read the first visible `llm-toggle-<model>` to derive a model name, filter the list to it via `model-search-input`, and assert it is enabled (`aria-checked="true"`).
 4. Disable it: click the toggle, assert `aria-checked="false"` immediately (optimistic), and wait for the `POST .../enabled_models` response (debounced persistence flush).
 5. Reload the app, reopen Model Providers, re-expand the provider, search for the same model and assert its toggle is still `aria-checked="false"` (persisted).
@@ -52,7 +52,8 @@ Both tests resolve a single provider — `MODEL_TEST_PROVIDER` when its env keys
    (#1461). **The dropdown mixes models from every configured provider** (#597 — with
    Google configured by sibling specs it listed `gemini-3.5-flash` first while the
    test's provider was OpenAI), so the options alone cannot pick the target.
-3. In **Settings → Model Providers**, open the test's provider and read its
+3. In **Settings → Model Providers**, open the test's provider through
+   `waitForProviderRow()` and read its
    `llm-toggle-<model>` ids via `enumerateEnabledModels()` — every toggle the panel
    renders, in the **bare** ids the picker's testid does not use. (The helper's name
    is narrower than its behavior: it returns all of them regardless of
@@ -87,6 +88,56 @@ Both tests resolve a single provider — `MODEL_TEST_PROVIDER` when its env keys
 
 ---
 
+## Waiting for the provider list *(required)*
+
+Both tests reach the provider row through `waitForProviderRow()`
+(`tests/helpers/provider-setup/provider-list-state.ts`), never through a bare
+`page.getByTestId("provider-item-<Name>")` wait. The reason is attribution, not
+timing, and the budgets are deliberately **unchanged** — raising them would hide
+the state this wait exists to name.
+
+The list is one component (`provider-list-loading` appears exactly once in the
+1.12.0.dev44 bundle) shared by the Settings page and the Agent node's **Model
+providers** modal, and it renders four mutually exclusive states, each with its
+own testid:
+
+| testid | state |
+|---|---|
+| `provider-list-loading` | still fetching (`GET /api/v1/models?purpose=configure`), or React Query `paused` |
+| `provider-list-error` | the fetch failed |
+| `provider-list-empty` | the search box filtered every provider out |
+| `provider-list` | settled, holding the `provider-item-*` rows |
+
+Waiting only for the row discards all four, and the resulting
+`TimeoutError: locator.click … waiting for getByTestId('provider-item-OpenAI')`
+cannot distinguish an unresponsive instance from a provider Langflow stopped
+shipping. Measured on #1648: **20 attempts across 8 of 25 dailies**
+(2026-08-04 → 2026-08-31), 12 spec files, three providers (Google 9, OpenAI 8,
+Anthropic 3) — and in **0 of 20** did the call log get past `waiting for
+<locator>`. The failure-time screenshot of daily `33410643882` shows
+**`Loading providers...`** on screen while the aria snapshot captured moments
+later shows all nine rows, which is why the same artifacts read as a product
+defect at triage and as an environment stall on review. None of the five
+patterns in `scripts/lib/infra-signature-patterns.json` match a locator timeout,
+so `infra_signature` came back `null` for every one of them (#1589), and
+`reports/daily-history.jsonl` stores only the normalized first error line, so a
+search for `provider-item` across all 21 August dailies returns **zero**
+(#1626). The helper is what makes those 20 occurrences say what they are.
+
+`providerRowVerdict()` is a **pure** function over the snapshot, unit-tested in
+`provider-list-state.test.ts`, because the branches that matter are otherwise
+reachable only from an instance that is misbehaving on purpose. Its verdicts:
+
+| kind | when | reads as |
+|---|---|---|
+| `stalled` | `provider-list-loading` still on screen | an INSTANCE stall — the backend has not answered |
+| `errored` | `provider-list-error` | the fetch failed; a backend verdict, not a missing provider |
+| `filtered` | `provider-list-empty`, or a non-empty search box | a SUITE defect — a previous step left the filter set |
+| `absent` | `provider-list` rendered, the row is not among its rows | a PRODUCT finding — it names the providers that DID render |
+| `unreached` | none of the four states present | the page or the modal never opened (`openProviderPanel` returns `"opened"` without verifying) |
+
+---
+
 ## Validation criterion *(required)*
 
 - Toggling a model flips `aria-checked` immediately (optimistic update).
@@ -95,6 +146,11 @@ Both tests resolve a single provider — `MODEL_TEST_PROVIDER` when its env keys
 - Every dropdown verdict is reached from the option's **identity**, never its text, and a
   negative verdict is only accepted from a picker that is populated and still parsable —
   so "the model is gone" can fail, and cannot be satisfied by an empty or renamed list.
+- A provider row that never appears fails with the product state named — `stalled`,
+  `errored`, `filtered`, `absent` or `unreached` — never as a bare locator timeout.
+  Force-failable in both directions: hold `GET /api/v1/models?purpose=configure` past
+  the budget and the failure must say `PROVIDER_LIST_STALLED`; render the list without
+  the target provider and it must say `PROVIDER_ABSENT` and list the ones that rendered.
 - The baseline is restored at the end of each test (model left enabled) so sibling specs are unaffected.
 
 ---
@@ -140,6 +196,10 @@ flow count grows.
 - `src/frontend/src/hooks/use-refresh-model-inputs.ts` — refreshes component model dropdowns when toggles change (the propagation behavior in Test 2).
 - `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/` — renders the Agent's `model_model` trigger, `value-dropdown-model_model` value span, and the `-option` dropdown entries. `components/ModelList.tsx` owns `getModelOptionTestId(provider, modelName)` = `${provider}-${modelName}-option` and the cmdk `value` = `${provider}::${modelName}` that surfaces as `data-value` — the two attributes this spec resolves a model by.
 - `tests/helpers/provider-setup/model-option.ts` — the shared identity reader (#1463): `enumerateModelOptions()`, `enumerateEnabledModels()`, `ModelOption`, plus `censusForTarget()` / `hasOptionIdentity()` (#1464). Test 2 matches options exclusively through it; the classification is pure and unit-tested in `model-option.test.ts`, because the branch that must not regress ("a `target: 0` verdict counts only with `total > 0` and `providerOthers > 0`") is otherwise reachable only from a live run.
+- `tests/helpers/provider-setup/provider-list-state.ts` — `waitForProviderRow()` and the pure `providerRowVerdict()` (#1648). Reads the four provider-list states listed above; `provider-list-state.test.ts` covers the classification.
+- `src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx` — owns all four state testids (`provider-list-loading` line 82, `provider-list-error` 94, `provider-list-empty` 105, `provider-list` 119 on `release-1.12.0`). Renaming any of them turns the verdict into `unreached`, which is a loud failure rather than a silent one.
+- `src/frontend/src/modals/modelProviderModal/components/ProviderListItem.tsx` — the row itself, whose testid is built as `provider-item-` plus the provider's display name. Single source of the name this suite waits on.
+- `src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx` — hosts `provider-search-input`, read by the `filtered` verdict so a filter a previous step left set is reported as a SUITE defect and not as a missing provider.
 - `tests/helpers/provider-setup/provider-config.ts` — `langflowProviderName()` supplies the provider as Langflow spells it (`OpenAI`, `Google Generative AI`), which is what the picker groups options by and what the restore payload sends.
 - `tests/helpers/provider-setup/` and `data/models.json` — provider setup and model source of truth (populated by `collect-models`).
 

--- a/docs/core-functionality/model-provider/google-provider.md
+++ b/docs/core-functionality/model-provider/google-provider.md
@@ -1,6 +1,6 @@
 # Google Provider — configure key, select Gemini
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.12.x (provider-row wait + Test 1 flow cleanup measured on `1.12.0.dev44`, #1648)
 
 ---
 
@@ -182,13 +182,23 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
   completion. Tool execution stays covered by `agent-component-regression.spec.ts`.
   The Playground builds the *persisted* flow, so the deletion is followed by
   `waitForFlowSaveSettled`.
-- **Flow cleanup (id-scoped, issue #605):** Test 2 creates a flow via
-  `SimpleAgentTemplatePage.load()`, which does NO cleanup (post-#553 contract).
-  The spec tracks every `POST /api/v1/flows` → 201 id fired during load and
-  deletes them by id in `test.afterEach` (transient ids 404 harmlessly —
+- **Flow cleanup (id-scoped, issue #605; extended in #1648):** Test 2 creates a
+  flow via `SimpleAgentTemplatePage.load()`, which does NO cleanup (post-#553
+  contract). The spec tracks every `POST /api/v1/flows` → 201 id fired during
+  load and deletes them by id in `test.afterEach` (transient ids 404 harmlessly —
   `deleteFlow` treats 404 as done). Never a name-based or delete-all cleanup
   (cross-worker wiper class, #553/#520). Same pattern as
   `anthropic-provider.spec.ts`.
+
+  **Test 1 registers the same tracker, and until #1648 it did not.** It never
+  calls `loadAgent`, so the listener that `loadAgent` installs was never armed
+  for it — while the test still created flows: `awaitBootstrapTest` calls
+  `addFlowToTestOnEmptyLangflow` whenever the current project renders
+  `new_project_btn_empty_page`, which a fresh instance does. Measured on
+  `1.12.0.dev44`: from an empty default project this file left `New Flow` +
+  `Basic Prompting` behind, **2 flows per run**, and 0 after the fix — verified
+  on three consecutive runs and on a deliberately failed one, since a teardown
+  that only runs on the happy path is the leak it was meant to close.
 - **Per-run sentinel** proves *this* execution produced the output.
 - **Shared global key:** the Google key is global and persists across runs. Test 1
   is idempotent — it re-saves and asserts the request outcomes, not a fresh start.

--- a/docs/core-functionality/model-provider/provider-management.md
+++ b/docs/core-functionality/model-provider/provider-management.md
@@ -1,6 +1,6 @@
 # Provider Management — modal, provider count, components, add/remove API key
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev17`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev17`; the provider-list wait re-measured on `1.12.0.dev44`, #1648)
 
 ---
 
@@ -143,9 +143,16 @@ configured providers show a **"N models"** suffix in their list item and a
    renders).
 
 **`model-provider-api-key.spec.ts`**
-1. *OpenAI listed* — `provider-item-OpenAI` visible (exact testid, no
-   text-match fallback).
-2. *Anthropic listed* — `provider-item-Anthropic` visible.
+
+All three tests reach the row through `waitForProviderRow()`
+(`tests/helpers/provider-setup/provider-list-state.ts`) rather than asserting
+`provider-item-<Name>` directly — see *Waiting for the provider list* below. The
+assertion is unchanged and the budget is unchanged; what changes is that a row
+that never arrives says **which** of the list's four states was on screen.
+
+1. *OpenAI listed* — the OpenAI row resolves from a settled provider list (exact
+   testid, no text-match fallback).
+2. *Anthropic listed* — the Anthropic row resolves the same way.
 3. *Configured provider exposes the key edit surface* (skip with a reason if
    the instance has no stored `OPENAI_API_KEY`) — the OpenAI item shows the
    `N models` badge, `provider-variable-input-OPENAI_API_KEY` is visible, and
@@ -291,6 +298,38 @@ sidebar entry to the canonical **Language Model** component:
 
 ---
 
+## Waiting for the provider list *(required)*
+
+The provider list is one component shared by the Settings page and the Agent
+node's **Model providers** modal, and it renders four mutually exclusive states,
+each with a testid: `provider-list-loading` (fetching
+`GET /api/v1/models?purpose=configure`, or React Query `paused`),
+`provider-list-error`, `provider-list-empty` (the search box filtered everything
+out) and `provider-list` (settled, holding the rows).
+
+Every spec and helper in this area waits through
+`waitForProviderRow()` instead of a bare `provider-item-<Name>` locator, so a row
+that does not arrive is reported as `stalled` / `errored` / `filtered` / `absent`
+/ `unreached` rather than as an anonymous timeout. Budgets are deliberately
+**unchanged**: raising them would mask the instance stall this exists to name.
+
+Why it was worth a helper (#1648): a bare wait produced **20 attempts across 8 of
+25 dailies** (2026-08-04 → 2026-08-31) over 12 spec files and three providers
+(Google 9, OpenAI 8, Anthropic 3), and in **0 of 20** did the call log get past
+`waiting for <locator>`. The failure-time screenshot of daily `33410643882` shows
+`Loading providers...` while the aria snapshot taken moments later shows all nine
+rows — the same artifacts read as a product defect at triage and as an
+environment stall on review. No pattern in
+`scripts/lib/infra-signature-patterns.json` matches a locator timeout, so
+`infra_signature` was `null` for all of them (#1589), and since
+`reports/daily-history.jsonl` records only the normalized first error line, a
+search for `provider-item` across all 21 August dailies returns zero (#1626).
+
+The classification lives in the pure `providerRowVerdict()` and is unit-tested in
+`provider-list-state.test.ts`; the async wrapper only reads the DOM.
+
+---
+
 ## Validation criterion *(required)*
 
 Every test asserts a **specific, live-scouted observable** (testid visibility,
@@ -328,7 +367,35 @@ accepted / fake rejected), remove key — are each pinned by at least one test.
 
 ---
 
+## Flow cleanup *(required)*
+
+`model-provider-api-key.spec.ts` looks like it creates nothing — all three tests
+only open Settings — and it created two flows per run. `awaitBootstrapTest` calls
+`addFlowToTestOnEmptyLangflow` whenever the current project renders
+`new_project_btn_empty_page`, which a fresh instance does, so the file's FIRST
+test left `New Flow` + `Basic Prompting` behind while the two later ones added
+none. Measured on `1.12.0.dev44` (#1648).
+
+It now tracks every `POST /api/v1/flows` → 201 id fired from `openModelProviders`
+and deletes them by id in `test.afterEach` — **id-scoped**, never by name and
+never delete-all, because the seeded starter projects carry both of those exact
+names and a name-based cleanup here would be a cross-worker wiper (#553/#520).
+
+Verified in both directions: 26 flows before and 26 after, over three consecutive
+runs AND over a deliberately failed one — a teardown that only fires on the happy
+path is the leak it was written to close.
+
+Behavioral force-fail contract: no-op the `afterEach` and the flow count grows by
+2 on the first run against an empty project.
+
+---
+
 ## External dependencies *(required)*
+
+- `tests/helpers/provider-setup/provider-list-state.ts` — `waitForProviderRow()` + the pure `providerRowVerdict()` (#1648), used by every spec and setup helper in this area.
+- `src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx` — owns the four state testids (`provider-list-loading`, `provider-list-error`, `provider-list-empty`, `provider-list`).
+- `src/frontend/src/modals/modelProviderModal/components/ProviderListItem.tsx` — the row, whose testid is `provider-item-` plus the provider's display name.
+- `src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx` — hosts `provider-search-input`, read by the `filtered` verdict.
 
 - `src/frontend/src/pages/SettingsPage/` — Model Providers page
   (`provider-list`, `provider-item-*`, `provider-variable-input-*`,

--- a/tests/helpers/provider-setup/provider-list-state.test.ts
+++ b/tests/helpers/provider-setup/provider-list-state.test.ts
@@ -1,0 +1,225 @@
+// Unit tests for the provider-list verdict (issue #1648).
+// Run with: npm run test:units
+//
+// What rides on this file: `providerRowVerdict` is the difference between a
+// provider-row failure that names the instance and one that names nothing. The
+// measured cost of naming nothing was 20 attempts across 8 of 25 dailies, over
+// 12 spec files and three providers, every one of them reported as
+//
+//   TimeoutError: locator.click: Timeout 20000ms exceeded.
+//   Call log:
+//     - waiting for getByTestId('provider-item-OpenAI')
+//
+// — a string that matches none of the five patterns in
+// `scripts/lib/infra-signature-patterns.json`, so the wedge exemption could not
+// claim any of them (#1589), and that `reports/daily-history.jsonl` stores as a
+// first-error line carrying no locator at all (#1626).
+//
+// The classification is pure precisely so these branches are reachable here. On
+// a live instance you can only produce `stalled` by wedging the backend and
+// `errored` by breaking the catalog endpoint — neither is something a spec may
+// do — which is the same argument `censusForTarget` (#1464) and
+// `decideEntryPoint` (#1465) settled for their own decisions.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PROVIDER_LIST_TESTIDS,
+  providerNameFromTestId,
+  providerRowVerdict,
+  type ProviderListSnapshot,
+} from "./provider-list-state";
+
+const EMPTY: ProviderListSnapshot = {
+  loading: false,
+  errored: false,
+  filteredEmpty: false,
+  listed: false,
+  rows: [],
+  searchTerm: "",
+};
+
+const snapshot = (over: Partial<ProviderListSnapshot>): ProviderListSnapshot => ({
+  ...EMPTY,
+  ...over,
+});
+
+test("a list still loading is an INSTANCE stall, and says so", () => {
+  const v = providerRowVerdict(
+    snapshot({ loading: true }),
+    "provider-item-OpenAI",
+    20000,
+  );
+  assert.equal(v.kind, "stalled");
+  assert.match(v.message, /PROVIDER_LIST_STALLED/);
+  assert.match(v.message, /"OpenAI"/);
+  assert.match(v.message, /20000ms/);
+  // The endpoint is named because that is what a triager has to go look at.
+  assert.match(v.message, /GET \/api\/v1\/models\?purpose=configure/);
+  // And the temptation this whole module exists to refuse is refused in text.
+  assert.match(v.message, /Do not raise this timeout/);
+});
+
+test("stalled outranks every other state — a list that never arrived has no content to judge", () => {
+  // The real 2026-08-31 shape: loading on screen, nothing else rendered. But
+  // assert the precedence with every other flag ALSO set, because the ordering
+  // is the actual invariant: a mid-refetch list can carry stale rows, and
+  // reporting "PROVIDER_ABSENT — the list settled" about a list that is still
+  // fetching is the false product finding this issue was filed as.
+  const v = providerRowVerdict(
+    snapshot({
+      loading: true,
+      errored: true,
+      filteredEmpty: true,
+      listed: true,
+      rows: ["Anthropic"],
+      searchTerm: "gpt-4o-mini",
+    }),
+    "provider-item-OpenAI",
+    10000,
+  );
+  assert.equal(v.kind, "stalled");
+});
+
+test("a failed catalog fetch is reported as a backend verdict, not a missing provider", () => {
+  const v = providerRowVerdict(
+    snapshot({ errored: true }),
+    "provider-item-Anthropic",
+    20000,
+  );
+  assert.equal(v.kind, "errored");
+  assert.match(v.message, /PROVIDER_LIST_ERROR/);
+  assert.match(v.message, /"Anthropic"/);
+  assert.match(v.message, /not a missing provider/);
+});
+
+test("a search box left filled is a SUITE defect — even when the list itself rendered", () => {
+  // `model-provider-model-toggle.spec.ts` fills `model-search-input` two steps
+  // before it reopens the panel; a sibling filling `provider-search-input` and
+  // not clearing it would empty the list with the backend perfectly healthy.
+  const v = providerRowVerdict(
+    snapshot({ listed: true, rows: ["Ollama"], searchTerm: "gpt-4o-mini" }),
+    "provider-item-OpenAI",
+    20000,
+  );
+  assert.equal(v.kind, "filtered");
+  assert.match(v.message, /PROVIDER_LIST_FILTERED/);
+  assert.match(v.message, /"gpt-4o-mini"/);
+  assert.match(v.message, /SUITE defect/);
+});
+
+test("the empty-state testid alone is enough — the search value may not have been read", () => {
+  const v = providerRowVerdict(
+    snapshot({ filteredEmpty: true }),
+    "provider-item-OpenAI",
+    20000,
+  );
+  assert.equal(v.kind, "filtered");
+  assert.match(v.message, /down to nothing/);
+});
+
+test("a SETTLED list without the row is a PRODUCT finding, and names who did render", () => {
+  const v = providerRowVerdict(
+    snapshot({
+      listed: true,
+      rows: ["Anthropic", "Google Generative AI", "Ollama"],
+      searchTerm: "",
+    }),
+    "provider-item-OpenAI",
+    20000,
+  );
+  assert.equal(v.kind, "absent");
+  assert.match(v.message, /PROVIDER_ABSENT/);
+  assert.match(v.message, /PRODUCT finding/);
+  // Naming the rows is the load-bearing half: a count alone leaves the reader
+  // hand-diffing, which is the failure `component-catalog-drift.ts` had to fix
+  // for the same reason.
+  assert.match(v.message, /Anthropic, Google Generative AI, Ollama/);
+  assert.match(v.message, /3 provider\(s\)/);
+});
+
+test("a settled but EMPTY list is still `absent`, and does not claim rows it never saw", () => {
+  const v = providerRowVerdict(
+    snapshot({ listed: true, rows: [] }),
+    "provider-item-OpenAI",
+    20000,
+  );
+  assert.equal(v.kind, "absent");
+  assert.match(v.message, /0 provider\(s\) \[\] \(none\)/);
+});
+
+test("no state at all means the panel never opened — not that the provider is gone", () => {
+  // `openProviderPanel()` returns "opened" the moment it clicks, without
+  // checking the panel mounted (provider-panel-entry.ts). A dropped click lands
+  // here, and reporting it as PROVIDER_ABSENT would blame the product for a
+  // click the suite lost.
+  const v = providerRowVerdict(EMPTY, "provider-item-OpenAI", 20000);
+  assert.equal(v.kind, "unreached");
+  assert.match(v.message, /PROVIDER_LIST_UNREACHED/);
+  assert.match(v.message, /never opened/);
+  // All four testids are named so a rename is diagnosable from the message.
+  for (const id of [
+    PROVIDER_LIST_TESTIDS.loading,
+    PROVIDER_LIST_TESTIDS.error,
+    PROVIDER_LIST_TESTIDS.empty,
+    PROVIDER_LIST_TESTIDS.list,
+  ]) {
+    assert.match(v.message, new RegExp(id.replace(/-/g, "\\-")));
+  }
+});
+
+test("every verdict carries a distinct, greppable prefix", () => {
+  const cases: Array<[Partial<ProviderListSnapshot>, string]> = [
+    [{ loading: true }, "PROVIDER_LIST_STALLED"],
+    [{ errored: true }, "PROVIDER_LIST_ERROR"],
+    [{ filteredEmpty: true }, "PROVIDER_LIST_FILTERED"],
+    [{ listed: true }, "PROVIDER_ABSENT"],
+    [{}, "PROVIDER_LIST_UNREACHED"],
+  ];
+  const seen = new Set<string>();
+  for (const [over, prefix] of cases) {
+    const message = providerRowVerdict(
+      snapshot(over),
+      "provider-item-OpenAI",
+      20000,
+    ).message;
+    assert.ok(
+      message.startsWith(prefix),
+      `expected message to start with ${prefix}, got: ${message.slice(0, 60)}`,
+    );
+    seen.add(prefix);
+  }
+  // A shared prefix would make two situations one `error_signature`, which is
+  // the collapse (#1626) this issue is undoing.
+  assert.equal(seen.size, cases.length);
+});
+
+test("the provider display name survives spaces and is never mangled", () => {
+  // `provider-item-Google Generative AI` — the testid carries the display name
+  // verbatim, spaces included (provider-config.ts derives one from the other).
+  assert.equal(
+    providerNameFromTestId("provider-item-Google Generative AI"),
+    "Google Generative AI",
+  );
+  // A caller that already passes a bare name gets it back untouched rather than
+  // a silently truncated one.
+  assert.equal(providerNameFromTestId("OpenAI"), "OpenAI");
+  const v = providerRowVerdict(
+    snapshot({ loading: true }),
+    "provider-item-Google Generative AI",
+    20000,
+  );
+  assert.match(v.message, /"Google Generative AI"/);
+});
+
+test("the row prefix matches what ProviderListItem.tsx renders", () => {
+  // Measured on langflow-ai/langflow@release-1.12.0: the row testid is built as
+  // `provider-item-${provider.provider}`. If upstream changes the prefix, the
+  // verdict degrades to `unreached` (loud) rather than to `absent` (a false
+  // product finding) — but this pins the constant the whole module keys on.
+  assert.equal(PROVIDER_LIST_TESTIDS.rowPrefix, "provider-item-");
+  assert.equal(PROVIDER_LIST_TESTIDS.loading, "provider-list-loading");
+  assert.equal(PROVIDER_LIST_TESTIDS.error, "provider-list-error");
+  assert.equal(PROVIDER_LIST_TESTIDS.empty, "provider-list-empty");
+  assert.equal(PROVIDER_LIST_TESTIDS.list, "provider-list");
+  assert.equal(PROVIDER_LIST_TESTIDS.search, "provider-search-input");
+});

--- a/tests/helpers/provider-setup/provider-list-state.ts
+++ b/tests/helpers/provider-setup/provider-list-state.ts
@@ -1,0 +1,239 @@
+import type { Locator, Page } from "@playwright/test";
+
+/**
+ * Waiting for a provider row without discarding what the product already says
+ * (#1648).
+ *
+ * `ProviderList.tsx` renders FOUR mutually exclusive states, each with its own
+ * `data-testid` (measured on `langflow-ai/langflow@release-1.12.0`, lines
+ * 82/94/105/119 — one component, shared by the Settings page AND the Agent
+ * node's "Model providers" modal, which is why `provider-list-loading` appears
+ * exactly once in the 1.12.0.dev44 bundle):
+ *
+ *   provider-list-loading  still fetching GET /api/v1/models?purpose=configure
+ *                          (React Query `paused` renders here too)
+ *   provider-list-error    the fetch failed
+ *   provider-list-empty    the search box filtered every provider out
+ *   provider-list          settled, holding the `provider-item-*` rows
+ *
+ * Waiting only for `provider-item-<Name>` throws all four away, and the
+ * resulting
+ *
+ *   TimeoutError: locator.click: Timeout 20000ms exceeded.
+ *   Call log:
+ *     - waiting for getByTestId('provider-item-OpenAI')
+ *
+ * cannot tell an unresponsive instance from a provider Langflow stopped
+ * shipping. That is not hypothetical: across the 25 dailies from 2026-08-04 to
+ * 2026-08-31 the bare wait produced **20 attempts** over 12 spec files and three
+ * providers (Google 9, OpenAI 8, Anthropic 3), and in **0 of 20** did the call
+ * log get past `waiting for <locator>`. The failure-time screenshot of daily
+ * 33410643882 shows `Loading providers...` on screen while the aria snapshot
+ * captured moments later shows all nine rows — the same artifacts read as a
+ * product defect at triage and as an environment stall on review.
+ *
+ * The cost of that ambiguity is measurable in two places. None of the five
+ * patterns in `scripts/lib/infra-signature-patterns.json` matches a locator
+ * timeout, so `infra_signature` came back `null` for every one of the 20 and the
+ * wedge exemption could not claim them (#1589). And `reports/daily-history.jsonl`
+ * stores only the normalized FIRST error line, so searching all 21 August
+ * dailies for `provider-item` returns zero while the per-run Playwright JSON
+ * returns 20 (#1626).
+ *
+ * The budgets are passed through UNCHANGED on purpose. Raising them would hide
+ * the stall this module exists to name, and the failures are a wedged backend —
+ * something the suite should keep reporting, only in words a human and
+ * `infra_signature` can both read.
+ */
+
+/** The four state testids `ProviderList.tsx` owns, plus the row prefix. */
+export const PROVIDER_LIST_TESTIDS = {
+  loading: "provider-list-loading",
+  error: "provider-list-error",
+  empty: "provider-list-empty",
+  list: "provider-list",
+  search: "provider-search-input",
+  rowPrefix: "provider-item-",
+} as const;
+
+/** What the provider list was showing at one instant. */
+export type ProviderListSnapshot = {
+  /** `provider-list-loading` present — the fetch has not answered. */
+  loading: boolean;
+  /** `provider-list-error` present — the fetch failed. */
+  errored: boolean;
+  /** `provider-list-empty` present — the search filtered everything out. */
+  filteredEmpty: boolean;
+  /** `provider-list` present — the list settled. */
+  listed: boolean;
+  /** Display names of the rows actually rendered (testid minus the prefix). */
+  rows: string[];
+  /** Current value of `provider-search-input` (`""` when absent or empty). */
+  searchTerm: string;
+};
+
+export type ProviderRowVerdictKind =
+  | "stalled"
+  | "errored"
+  | "filtered"
+  | "absent"
+  | "unreached";
+
+export type ProviderRowVerdict = {
+  kind: ProviderRowVerdictKind;
+  message: string;
+};
+
+/** Strips the `provider-item-` prefix; returns the input when it has none. */
+export function providerNameFromTestId(testId: string): string {
+  return testId.startsWith(PROVIDER_LIST_TESTIDS.rowPrefix)
+    ? testId.slice(PROVIDER_LIST_TESTIDS.rowPrefix.length)
+    : testId;
+}
+
+/**
+ * Classifies a provider row that did not arrive. PURE — no page, no clock — so
+ * every branch is reachable from a unit test. The branches that matter are
+ * otherwise only reachable from an instance misbehaving on purpose, which is
+ * exactly the shape `censusForTarget` (#1464) and `decideEntryPoint` (#1465)
+ * settled on for the same reason.
+ *
+ * Order is load-bearing. `loading` is checked FIRST because it is the only
+ * state that says "the instance has not answered": every other verdict claims
+ * something about the CONTENT of a list, and a list that never arrived has no
+ * content to claim anything about. `unreached` is checked LAST for the mirrored
+ * reason — absence of all four states is only meaningful once none of them
+ * applies.
+ */
+export function providerRowVerdict(
+  snapshot: ProviderListSnapshot,
+  wantedTestId: string,
+  timeoutMs: number,
+): ProviderRowVerdict {
+  const name = providerNameFromTestId(wantedTestId);
+  const budget = `${timeoutMs}ms`;
+
+  if (snapshot.loading) {
+    return {
+      kind: "stalled",
+      message:
+        `PROVIDER_LIST_STALLED: "${name}" never rendered because the provider list is ` +
+        `STILL in its "${PROVIDER_LIST_TESTIDS.loading}" state after ${budget} — the ` +
+        `instance has not answered GET /api/v1/models?purpose=configure. This is an ` +
+        `INSTANCE stall, not a missing provider: the row is not absent, the list never ` +
+        `arrived. Do not raise this timeout to make it pass (#1648).`,
+    };
+  }
+
+  if (snapshot.errored) {
+    return {
+      kind: "errored",
+      message:
+        `PROVIDER_LIST_ERROR: "${name}" never rendered because the provider list is in ` +
+        `its "${PROVIDER_LIST_TESTIDS.error}" state after ${budget} — the catalog fetch ` +
+        `FAILED. That is a backend verdict, not a missing provider; check the run's ` +
+        `backend-error log for the response behind it (#1648).`,
+    };
+  }
+
+  if (snapshot.filteredEmpty || snapshot.searchTerm !== "") {
+    return {
+      kind: "filtered",
+      message:
+        `PROVIDER_LIST_FILTERED: "${name}" never rendered because the provider search ` +
+        `box holds "${snapshot.searchTerm}", so the list is filtered` +
+        (snapshot.filteredEmpty ? " down to nothing" : "") +
+        `. This is a SUITE defect — an earlier step left the filter set — not a product ` +
+        `finding (#1648).`,
+    };
+  }
+
+  if (snapshot.listed) {
+    const rendered = snapshot.rows.length
+      ? `[${snapshot.rows.join(", ")}]`
+      : "[] (none)";
+    return {
+      kind: "absent",
+      message:
+        `PROVIDER_ABSENT: the provider list SETTLED and rendered ${snapshot.rows.length} ` +
+        `provider(s) ${rendered}, and "${name}" is not among them. The list answered, so ` +
+        `this is a PRODUCT finding — the image no longer offers this provider, or its ` +
+        `display name changed — and not an instance stall (#1648).`,
+    };
+  }
+
+  return {
+    kind: "unreached",
+    message:
+      `PROVIDER_LIST_UNREACHED: "${name}" never rendered and NONE of the provider ` +
+      `list's four states is on the page after ${budget} ` +
+      `("${PROVIDER_LIST_TESTIDS.loading}", "${PROVIDER_LIST_TESTIDS.error}", ` +
+      `"${PROVIDER_LIST_TESTIDS.empty}", "${PROVIDER_LIST_TESTIDS.list}"). The Settings ` +
+      `page or the "Model providers" modal never opened — openProviderPanel() returns ` +
+      `"opened" as soon as it clicks, without checking that the panel mounted — or ` +
+      `ProviderList.tsx renamed every one of those testids (#1648).`,
+  };
+}
+
+/** Reads the four states, the rendered rows and the search term in one pass. */
+export async function readProviderListState(
+  page: Page,
+): Promise<ProviderListSnapshot> {
+  return page.evaluate((ids) => {
+    const has = (id: string) =>
+      document.querySelector(`[data-testid="${id}"]`) !== null;
+    const search = document.querySelector<HTMLInputElement>(
+      `[data-testid="${ids.search}"]`,
+    );
+    return {
+      loading: has(ids.loading),
+      errored: has(ids.error),
+      filteredEmpty: has(ids.empty),
+      listed: has(ids.list),
+      rows: Array.from(
+        document.querySelectorAll(`[data-testid^="${ids.rowPrefix}"]`),
+      )
+        .map((el) => el.getAttribute("data-testid") ?? "")
+        .filter((id) => id !== "")
+        .map((id) => id.slice(ids.rowPrefix.length)),
+      searchTerm: search?.value ?? "",
+    };
+  }, PROVIDER_LIST_TESTIDS as unknown as Record<string, string>);
+}
+
+/**
+ * Waits for one provider row and returns its locator.
+ *
+ * On success this is exactly the wait it replaces — same locator, same budget.
+ * On timeout it reads the list state ONCE and throws the verdict, so the run
+ * records which of the five situations it was in instead of a bare
+ * `waiting for getByTestId(...)`.
+ *
+ * The state read is itself guarded: a page that has navigated away or a context
+ * that is closing makes `page.evaluate` throw, and losing the original timeout
+ * to a secondary error would replace one unattributed failure with a worse one.
+ */
+export async function waitForProviderRow(
+  page: Page,
+  providerTestId: string,
+  timeout = 20000,
+): Promise<Locator> {
+  const row = page.getByTestId(providerTestId);
+  try {
+    await row.waitFor({ state: "visible", timeout });
+    return row;
+  } catch (waitError) {
+    let snapshot: ProviderListSnapshot;
+    try {
+      snapshot = await readProviderListState(page);
+    } catch (readError) {
+      throw new Error(
+        `PROVIDER_LIST_UNREADABLE: "${providerNameFromTestId(providerTestId)}" did not ` +
+          `render within ${timeout}ms, and the provider list's state could not be read ` +
+          `to say why (${readError instanceof Error ? readError.message.split("\n")[0] : String(readError)}). ` +
+          `The original wait failed with: ${waitError instanceof Error ? waitError.message.split("\n")[0] : String(waitError)}`,
+      );
+    }
+    throw new Error(providerRowVerdict(snapshot, providerTestId, timeout).message);
+  }
+}

--- a/tests/helpers/provider-setup/setup-anthropic.ts
+++ b/tests/helpers/provider-setup/setup-anthropic.ts
@@ -7,6 +7,7 @@ import {
   selectPinnedModelOption,
 } from "./model-option";
 import { openProviderPanel } from "./provider-panel-entry";
+import { waitForProviderRow } from "./provider-list-state";
 
 export async function setupAnthropic(
   page: Page,
@@ -18,8 +19,10 @@ export async function setupAnthropic(
   // addressable by role+name — see provider-panel-entry.ts (#1465).
   if ((await openProviderPanel(page, "Anthropic")) === "no-agent") return;
 
-  // Step 3: Select the Anthropic provider
-  await page.getByTestId("provider-item-Anthropic").click();
+  // Step 3: Select the Anthropic provider.
+  // Through waitForProviderRow (#1648) — same reason as the OpenAI and Google
+  // helpers; Anthropic carries 3 of the 20 measured occurrences. Budget unchanged.
+  await (await waitForProviderRow(page, "provider-item-Anthropic", 20000)).click();
 
   // Step 4: Configure the API key — but only if the provider is not already set up.
   // A configured provider shows a "Disconnect" button with the key field masked;

--- a/tests/helpers/provider-setup/setup-google.ts
+++ b/tests/helpers/provider-setup/setup-google.ts
@@ -7,6 +7,7 @@ import {
   selectPinnedModelOption,
 } from "./model-option";
 import { openProviderPanel } from "./provider-panel-entry";
+import { waitForProviderRow } from "./provider-list-state";
 import { providerAlreadyConfigured } from "./provider-config-state";
 
 export async function setupGoogle(
@@ -19,8 +20,13 @@ export async function setupGoogle(
   // addressable by role+name — see provider-panel-entry.ts (#1465).
   if ((await openProviderPanel(page, "Google Generative AI")) === "no-agent") return;
 
-  // Step 3: Select the Google Generative AI provider
-  await page.getByTestId("provider-item-Google Generative AI").click();
+  // Step 3: Select the Google Generative AI provider.
+  // Through waitForProviderRow (#1648): this exact call site is 8 of the 20
+  // provider-row timeouts measured across the 2026-08 dailies, and every one of
+  // them reported only "waiting for getByTestId(...)". Budget unchanged.
+  await (
+    await waitForProviderRow(page, "provider-item-Google Generative AI", 20000)
+  ).click();
 
   // Step 4: Configure the API key — but only if the provider is not already set up.
   // A configured provider shows a "Disconnect" button with the key field masked;

--- a/tests/helpers/provider-setup/setup-language-model-openai.ts
+++ b/tests/helpers/provider-setup/setup-language-model-openai.ts
@@ -1,5 +1,6 @@
 import { type Locator, type Page, expect } from "@playwright/test";
 import { enumerateModelOptions } from "./model-option";
+import { waitForProviderRow } from "./provider-list-state";
 
 // Cheap, fast chat models in priority order. `gpt-4o-mini` is kept first so older
 // Langflow builds still match; the `gpt-5.x` entries cover newer builds (1.11.0+)
@@ -144,8 +145,10 @@ export async function setupLanguageModelOpenAI(page: Page): Promise<void> {
     // Setup Provider button and intercepts the click (issue #580). dispatchEvent
     // targets the button directly and bypasses that interception.
     await page.getByRole("button", { name: "Setup Provider" }).dispatchEvent("click");
-    await page.waitForSelector('[data-testid="provider-item-OpenAI"]', { timeout: 10000 });
-    await page.getByTestId("provider-item-OpenAI").click();
+    // Through waitForProviderRow (#1648) so a list that never settles reports
+    // PROVIDER_LIST_STALLED instead of an anonymous locator timeout. Budget
+    // unchanged at the 10 s this call site already used.
+    await (await waitForProviderRow(page, "provider-item-OpenAI", 10000)).click();
 
     const apiKeyInput = page.getByPlaceholder("sk-...");
     // Wait for the form panel to animate in before checking visibility
@@ -280,9 +283,11 @@ async function configureOpenAIProviderFromDropdown(page: Page): Promise<void> {
   }
 
   await page.getByTestId("manage-model-providers").click();
-  // The provider list is fetched when the modal mounts (`provider-list-loading`).
-  await page.waitForSelector('[data-testid="provider-item-OpenAI"]', { timeout: 15000 });
-  await page.getByTestId("provider-item-OpenAI").click();
+  // The provider list is fetched when the modal mounts (`provider-list-loading`)
+  // — waitForProviderRow reads that state and names it when the row does not
+  // arrive, rather than leaving the reader with a bare locator timeout (#1648).
+  // Budget unchanged at the 15 s this call site already used.
+  await (await waitForProviderRow(page, "provider-item-OpenAI", 15000)).click();
 
   const apiKeyInput = page.getByPlaceholder("sk-...");
   await apiKeyInput.waitFor({ state: "visible", timeout: 10000 });

--- a/tests/helpers/provider-setup/setup-openai.ts
+++ b/tests/helpers/provider-setup/setup-openai.ts
@@ -7,6 +7,7 @@ import {
   selectPinnedModelOption,
 } from "./model-option";
 import { openProviderPanel } from "./provider-panel-entry";
+import { waitForProviderRow } from "./provider-list-state";
 
 export async function setupOpenAI(
   page: Page,
@@ -27,8 +28,13 @@ export async function setupOpenAI(
   // addressable by role+name — see provider-panel-entry.ts (#1465).
   if ((await openProviderPanel(page, "OpenAI")) === "no-agent") return;
 
-  // Step 3: Select the OpenAI provider
-  await page.getByTestId("provider-item-OpenAI").click();
+  // Step 3: Select the OpenAI provider.
+  // Waited through waitForProviderRow so a row that never arrives names the
+  // provider list's own state instead of timing out anonymously (#1648): the
+  // 20 s budget below is `actionTimeout`, unchanged — what changes is that a
+  // wedged instance says PROVIDER_LIST_STALLED rather than
+  // "waiting for getByTestId('provider-item-OpenAI')".
+  await (await waitForProviderRow(page, "provider-item-OpenAI", 20000)).click();
 
   // Step 4: Save the API key if the config panel is visible.
   // The config panel animates in (300ms) and requires a backend fetch after the provider

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-api-key.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-api-key.spec.ts
@@ -1,7 +1,10 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { navigateSettingsPages } from "../../../../helpers/ui/go-to-settings";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { waitForProviderRow } from "../../../../helpers/provider-setup/provider-list-state";
 
 // Provider API key management (QA-CHECKLIST §7.5 "Add new provider via
 // modal"). Hardened for @stable (issue #505): text-match fallbacks replaced by
@@ -19,7 +22,46 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 //  - the configured-provider edit surface (masked key + the `Replace`-labelled
 //    submit arming only once a value is typed) is proven here with zero writes.
 
-async function openModelProviders(page: any): Promise<void> {
+// Flows this file's own navigation creates, tracked by id and deleted in
+// `afterEach` (#605 pattern, the same one `model-provider-model-toggle.spec.ts`
+// carries). This file looks like it creates nothing — every test only opens
+// Settings — but `awaitBootstrapTest` calls `addFlowToTestOnEmptyLangflow`
+// whenever the current project renders `new_project_btn_empty_page`, and on a
+// fresh instance it does: measured on 1.12.0.dev44, the first test of this file
+// left `New Flow` + `Basic Prompting` behind, 2 flows per run, with the two
+// later tests adding none (#1648). Id-scoped on purpose — never by name and
+// never delete-all: the seeded starter projects share both of those names.
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(
+      () => {},
+    );
+  }
+});
+
+async function openModelProviders(page: Page): Promise<void> {
+  trackCreatedFlows(page);
   await awaitBootstrapTest(page, { skipModal: true });
   await navigateSettingsPages(page, "Settings", "Model Providers");
   await expect(page.getByTestId("settings_menu_header").last()).toContainText(
@@ -34,9 +76,14 @@ test.describe("Model Provider API Key Management", () => {
     { tag: ["@stable", "@release", "@workspace", "@regression", "@model-provider"] },
     async ({ page }) => {
       await openModelProviders(page);
-      await expect(page.getByTestId("provider-item-OpenAI")).toBeVisible({
-        timeout: 10000,
-      });
+      // Asserted through waitForProviderRow, not a bare toBeVisible (#1648).
+      // The assertion and the 10 s budget are unchanged; what changes is that a
+      // row that does not arrive says WHICH of the provider list's four states
+      // was on screen. This call site recorded 2 of the 20 timeouts measured
+      // across the 2026-08 dailies, every one of them as `element(s) not found`
+      // — a string that cannot distinguish "the instance never answered" from
+      // "Langflow stopped shipping OpenAI".
+      await waitForProviderRow(page, "provider-item-OpenAI", 10000);
     },
   );
 
@@ -45,9 +92,9 @@ test.describe("Model Provider API Key Management", () => {
     { tag: ["@stable", "@release", "@workspace", "@regression", "@model-provider"] },
     async ({ page }) => {
       await openModelProviders(page);
-      await expect(page.getByTestId("provider-item-Anthropic")).toBeVisible({
-        timeout: 10000,
-      });
+      // Same wait as the OpenAI case above (#1648). This call site carries 3 of
+      // the 20 measured occurrences — the single largest in any spec file.
+      await waitForProviderRow(page, "provider-item-Anthropic", 10000);
     },
   );
 
@@ -78,7 +125,7 @@ test.describe("Model Provider API Key Management", () => {
       );
 
       await openModelProviders(page);
-      await page.getByTestId("provider-item-OpenAI").click();
+      await (await waitForProviderRow(page, "provider-item-OpenAI", 10000)).click();
 
       // There is no distinct "Replace" button (#1431). The panel has ONE submit
       // control, `provider-save-button`, whose label is picked at render time:

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
@@ -12,6 +12,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
+import { waitForProviderRow } from "../../../../helpers/provider-setup/provider-list-state";
 import {
   censusForTarget,
   enumerateEnabledModels,
@@ -177,8 +178,12 @@ async function openProviderModelList(page: Page): Promise<void> {
     "Model Providers",
     { timeout: 10000 },
   );
-  const providerItem = page.getByTestId(providerItemTestId);
-  await providerItem.waitFor({ state: "visible", timeout: 10000 });
+  // Through waitForProviderRow (#1648). The 10 s budget is unchanged and
+  // deliberately NOT raised: on the 2026-08-31 daily this line failed twice with
+  // `waiting for getByTestId('provider-item-OpenAI') to be visible` while the
+  // page was showing "Loading providers..." — an instance stall the run had no
+  // way to say. Raising the budget would hide it; naming it is the fix.
+  const providerItem = await waitForProviderRow(page, providerItemTestId, 10000);
   await providerItem.click();
   await page
     .getByTestId("model-provider-selection")

--- a/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
@@ -12,6 +12,7 @@ import {
   missingProviderEnvKeys,
 } from "../../../../helpers/provider-setup";
 import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
+import { waitForProviderRow } from "../../../../helpers/provider-setup/provider-list-state";
 import { resolveGeminiModel } from "../../../../helpers/provider-setup/resolve-gemini-model";
 
 /**
@@ -42,7 +43,14 @@ const PROVIDER = "google";
 // creates (POST /api/v1/flows → 201) and delete those ids in afterEach (#605).
 const createdFlowIds: string[] = [];
 
-async function loadAgent(page: Page, model?: string): Promise<void> {
+// Registered by BOTH entry points, not just `loadAgent` (#1648). Test 1 never
+// loads the Agent template — it only opens Settings — so it used to leave the
+// tracker unregistered while still creating flows: `awaitBootstrapTest` calls
+// `addFlowToTestOnEmptyLangflow` whenever the current project renders
+// `new_project_btn_empty_page`, which it does on a fresh instance. Measured on
+// 1.12.0.dev44: running this file against an empty default project left
+// `New Flow` + `Basic Prompting` behind, 2 flows per run.
+function trackCreatedFlows(page: Page): void {
   page.on("response", (resp) => {
     if (
       resp.url().includes("/api/v1/flows") &&
@@ -57,6 +65,10 @@ async function loadAgent(page: Page, model?: string): Promise<void> {
         .catch(() => {}); // non-JSON / batch payloads
     }
   });
+}
+
+async function loadAgent(page: Page, model?: string): Promise<void> {
+  trackCreatedFlows(page);
   try {
     await new SimpleAgentTemplatePage(page).load({ provider: PROVIDER, model });
   } catch (e: any) {
@@ -106,6 +118,7 @@ test.describe("Google Provider", () => {
       // {valid: true} and this test still passes. Gating it would trade real
       // coverage of the Settings save path for nothing on exactly the days the
       // account is down. Test 2, which does call the model, IS gated.
+      trackCreatedFlows(page);
       await awaitBootstrapTest(page, { skipModal: true });
 
       await test.step("open Settings → Model Providers → Google Generative AI", async () => {
@@ -115,7 +128,12 @@ test.describe("Google Provider", () => {
           "Model Providers",
           { timeout: 10000 },
         );
-        await page.getByTestId("provider-item-Google Generative AI").click();
+        // Through waitForProviderRow (#1648): this call site recorded 1 of the
+        // 20 provider-row timeouts measured across the 2026-08 dailies. Budget
+        // unchanged (20 s `actionTimeout`).
+        await (
+          await waitForProviderRow(page, "provider-item-Google Generative AI", 20000)
+        ).click();
       });
 
       await test.step("enter the key and save — assert the save requests succeed", async () => {


### PR DESCRIPTION
Closes #1648

## The issue's premise was false, and the recurrence is 3× wider than filed

#1648 groups three failures on `getByTestId('provider-item-OpenAI')` and argues the daily's wedge cannot explain two of them because PR #1647's lane was *"a dedicated PR runner, 2 workers, 9 tests passing alongside … and no wedge"*. That lane's own health gate says otherwise:

```
17:11:27  Collect models ends
17:12:40    Still waiting: attempt 6, last failure TIMEOUT, 347s left of 420s.
17:12:59    Backend answered /api/v1/version on attempt 8 after 92s
17:13:04  Running 17 tests using 2 workers
17:13:59  ⚠️ auth: /api/v1/auto_login did not answer (Timeout 20000ms exceeded) — retry 1/3
```

92 s of wedge immediately before the run, and another 20 s `auto_login` timeout 35 s into it. The daily's trace shows the same shape: the click times out 10.8 s → 30.8 s, then **three** `auto_login` requests each time out at 20 s.

**Real recurrence, from the per-run Playwright JSON of all 25 dailies (2026-08-04 → 08-31)** — the deliverable the issue asked for, because `daily-history.jsonl` stores only the normalized first error line and a search for `provider-item` in `error_signature` across all 21 August dailies returns **zero** (#1626):

| | |
|---|---|
| attempts | **20** |
| dailies affected | **8 of 25** |
| spec files | **12** |
| providers | **Google 9 · OpenAI 8 · Anthropic 3** — not OpenAI-specific |
| call logs that got past `waiting for <locator>` | **0 of 20** |

## Root cause

The row never renders because the **list** is still loading. The failure-time screenshot of daily `33410643882` shows `Loading providers...`; the aria snapshot captured moments later shows all nine rows — which is why the same artifacts read as a product defect at triage and as an environment stall on review.

`ProviderList.tsx` (verified on `langflow-ai/langflow@release-1.12.0`, lines 82/94/105/119) renders **four** mutually exclusive states, each with a testid, from **one** component shared by the Settings page and the Agent node's *Model providers* modal:

| testid | state |
|---|---|
| `provider-list-loading` | fetching `GET /api/v1/models?purpose=configure` (React Query `paused` renders here too) |
| `provider-list-error` | the fetch failed |
| `provider-list-empty` | the search box filtered everything out |
| `provider-list` | settled, holding the `provider-item-*` rows |

The suite read none of them.

## What this PR does

`tests/helpers/provider-setup/provider-list-state.ts` adds `waitForProviderRow()`: the same locator, the **same budget**, and on timeout one read of the list's state and a named verdict from the pure `providerRowVerdict()`.

| kind | when | reads as |
|---|---|---|
| `stalled` | `provider-list-loading` on screen | an INSTANCE stall — the backend has not answered |
| `errored` | `provider-list-error` | a backend verdict, not a missing provider |
| `filtered` | `provider-list-empty`, or a filled search box | a SUITE defect — an earlier step left the filter set |
| `absent` | `provider-list` settled, row not among its rows | a PRODUCT finding — and it names the providers that DID render |
| `unreached` | none of the four | the page or modal never opened (`openProviderPanel` returns `"opened"` without checking) |

**Budgets are deliberately unchanged.** Raising them would hide the stall this exists to name. Two things the ambiguity cost, both now addressable: no pattern in `scripts/lib/infra-signature-patterns.json` matches a locator timeout, so `infra_signature` came back `null` for all 20 (#1589); and the history cannot see the control at all (#1626).

The classification is a **pure function with unit tests** — `stalled` and `errored` are only reachable from an instance misbehaving on purpose, the same argument `censusForTarget` (#1464) and `decideEntryPoint` (#1465) settled for their own decisions.

Applied at **18 of the 20** measured call sites: helpers `setup-openai` (3), `setup-google` (8), `setup-anthropic`, `setup-language-model-openai`, and specs `model-provider-api-key` (5), `model-provider-model-toggle` (1), `google-provider` (1).

**`openai-provider.spec.ts` (2 occurrences) is excluded and named**: both its tests gate on `providerGate.skip` and the local OpenAI key returned `You have no credits remaining` from `collect-models`, so a validation burst there would be a green all-skip — the `no-evidence` state #1593 exists to refuse. Dropping the gate to make it run was not an option.

## Two flow leaks closed on the way

The audit of the specs this touches found both leaking `New Flow` + `Basic Prompting`, **2 flows per run**, whenever the default project is empty — `awaitBootstrapTest` calls `addFlowToTestOnEmptyLangflow` and the id tracker was either absent (`model-provider-api-key.spec.ts`) or armed only inside `loadAgent()`, which `google-provider.spec.ts`'s Test 1 never calls. Both now track `POST /api/v1/flows` → 201 and delete by id in `afterEach` — id-scoped, never by name: the seeded starter projects carry both of those exact names.

Verified 26 → 26 over three consecutive runs **and** over a deliberately failed one, since a teardown that only fires on the happy path is the leak it was written to close.

## Symptom rows — one verdict each

| Row | Verdict |
|---|---|
| `model-provider-model-toggle.spec.ts:296` | **transient-saturation** — wedge measured (44 %/49 % probes down in the daily; trace shows 3× `auto_login` 20 s) |
| `agent-context-id-continuity.spec.ts:407` | **owned by #1649** — it never failed on `provider-item`. It failed `MODEL_PICKER_DEFECT` at `setup-openai.ts:107`. The scan found 4 more occurrences, all on 2026-08-31, all enumerating exactly 5 options per provider against a panel reporting 49 |
| `agent-context-id-isolation.spec.ts:559` | **transient-saturation** — the same PR-lane wedge |

Nothing was quarantined by this issue: the `test.fixme` at `agent-context-id-continuity.spec.ts:377` and `agent-context-id-isolation.spec.ts:514` belong to #1643 (a different control), so there is nothing to lift.

## Mechanism proof

Re-running does not falsify — **0 of 16** executions of the unmodified spec reproduced the symptom on a healthy instance. Forced deterministically instead, with `page.route` holding `GET /api/v1/models?purpose=configure` for 25 s against `1.12.0.dev44`:

```
The suite reports today:
  locator.waitFor: Timeout 10000ms exceeded. | Call log:
    - waiting for getByTestId('provider-item-Google Generative AI') to be visible
At that same instant the product state was:
  {"loading":true,"errored":false,"filteredEmpty":false,"listed":false,
   "rows":[],"loadingText":"Loading providers."}
```

1/1 by forcing, 0/16 by re-running.

## Validation (nightly 1.12.0.dev44, `--retries=0 --workers=1`)

- typecheck ✅ · eslint ✅ (0 errors) · QA-CHECKLIST guard ✅ · coverage guard ✅
- `npm run test:units` **822/822** ✅ (11 new) · `npm run test:scripts` **858/858** ✅
- 3 clean runs per touched spec file, zero `🚨 Backend Error` ✅
- force-fail **7/7** — every `test()` in all three touched spec files, with `no FF-MUTATION markers in diff ✓` and `final green run after reverts ✓ (3 file(s))`
- unit-test mutation control: reordering the `loading` branch kills 3 of the 11; revert restores 11/11
- flow ledger 26 → 26 (only the seeded starters remain)

The force-fail output is what the change buys:

```
Error: PROVIDER_ABSENT: the provider list SETTLED and rendered 9 provider(s)
[Anthropic, Google Generative AI, OpenAI, Azure AI Foundry, IBM WatsonX, Ollama,
OpenAI Compatible, OpenRouter, vLLM], and "OpenAI-FF" is not among them. The list
answered, so this is a PRODUCT finding — the image no longer offers this provider,
or its display name changed — and not an instance stall (#1648).
```

`--trace=on` was **not** used: it hangs UI specs on this Colima host, so the runs above use the config's `retain-on-failure`.

## Out of scope, filed rather than folded in

- **#1649** — the `MODEL_PICKER_DEFECT` row.
- `tests/helpers/ui/go-to-settings.ts:15` navigates by visible text (`getByText('Model Providers').first()`) when `sidebar-nav-Model Providers` exists and `google-provider.spec.ts` already uses it. It cost one red run during this PR's validation burst. Same defect class, different control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
