### PR TITLE
fix(provider-setup): let the model-toggle batch flush before closing the panel (#1649)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-context-id-continuity.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-continuity.md
@@ -1,6 +1,6 @@
 # Agent context_id — continuity between session messages
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev15`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev44`)
 
 ---
 
@@ -65,6 +65,15 @@ surface; `@components` — Message History node drives the retrieval assert.
   declared first so a routed failure cannot skip it (this file is `mode: "serial"`).
 - Run with `--workers=1` — test 1 loads the Simple Agent template (agent-area
   rule). Flows are id-scoped-deleted in cleanup (`deleteFlow` helper).
+- The provider setup this test depends on may have to **enable** models, not just
+  find them enabled: a container whose `Collect models` sweep did not land leaves
+  the provider at its `MIN_DEFAULT_MODELS = 5` default. That path goes through the
+  provider panel's debounced toggle queue, and closing the panel on top of an
+  unflushed batch leaves the model picker on the pre-toggle set — the
+  `MODEL_PICKER_DEFECT` this spec reported five times on 2026-08-31 (#1649). The
+  wait and its ~30 s refresh budget live in `tests/helpers/provider-setup/`; the
+  measurement is in the agent-area `CLAUDE.md` § 5. **This does not change what
+  this test validates** — it is a precondition of reaching the assertions at all.
 
 ---
 

--- a/tests/helpers/provider-setup/collect-models.test.ts
+++ b/tests/helpers/provider-setup/collect-models.test.ts
@@ -49,6 +49,7 @@ import {
   waitForButtonIdle,
   waitForToggleChecked,
   type ProviderRecord,
+  confirmEnabledOnServer,
 } from "./collect-models";
 
 // ─── Verbatim provider errors ────────────────────────────────────────────────
@@ -1277,4 +1278,60 @@ test("#1355: waitedMs is what lets the caller bound the SUM, not just each write
   assert.equal(slow.waitedMs, 500);
   assert.equal(fast.waitedMs, 0);
   assert.ok(slow.waitedMs > fast.waitedMs, "a slow confirmation must cost the budget more than a fast one");
+});
+
+// --- #1649: the toggle confirmation was reading the OPTIMISTIC client cache ---
+//
+// `waitForToggleChecked` polls `aria-checked`, and `useModelToggleQueue` flips that
+// synchronously at click time via `queryClient.setQueryData` — before any request
+// leaves the browser. Measured on 1.12.0.dev44: all 36 clicks reported "confirmed"
+// while the POST only went out at t=8132 ms. So a write that never reaches the
+// server is indistinguishable from one that lands, the #1355 shortfall warning
+// cannot fire, and the next spec inherits a provider it believes is fully enabled.
+// The server is the only source that settles it, and it is read ONCE after the
+// batch has flushed — polling it during the write was measured stalling a
+// single-worker backend (`apiRequestContext.get: Timeout 20000ms exceeded`).
+test("a server that answered confirms every model the loop expected", () => {
+  const v = confirmEnabledOnServer({ "gpt-4o": true, "gpt-4o-mini": true }, ["gpt-4o", "gpt-4o-mini"]);
+  assert.equal(v.kind, "confirmed");
+  if (v.kind === "confirmed") assert.equal(v.expected, 2);
+});
+
+test("a write that never landed is a SHORTFALL naming the models, not a pass", () => {
+  const v = confirmEnabledOnServer({ "gpt-4o": true, "gpt-4o-mini": false }, [
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-4.1",
+  ]);
+  assert.equal(v.kind, "shortfall");
+  if (v.kind === "shortfall") {
+    assert.deepEqual(v.missing, ["gpt-4o-mini", "gpt-4.1"]);
+    assert.equal(v.enabled, 1);
+    assert.equal(v.expected, 3);
+    assert.match(v.message, /1 of 3/);
+    assert.match(v.message, /gpt-4o-mini/);
+    assert.match(v.message, /#1649/);
+  }
+});
+
+test("a model missing from the response entirely counts as NOT enabled", () => {
+  // Absence is not `true`. The endpoint lists every model of a configured
+  // provider, so a key the loop expected and the response does not carry means
+  // the write did not land — the exact state the optimistic read hid.
+  const v = confirmEnabledOnServer({ "gpt-4o": true }, ["gpt-4o", "gpt-4o-mini"]);
+  assert.equal(v.kind, "shortfall");
+  if (v.kind === "shortfall") assert.deepEqual(v.missing, ["gpt-4o-mini"]);
+});
+
+test("a server that did not answer is UNAVAILABLE, never a silent confirmation", () => {
+  // #1012: an unevaluated check is unknown, not clean. Reporting `confirmed` here
+  // would be the same false green the optimistic read produced.
+  const v = confirmEnabledOnServer(undefined, ["gpt-4o"]);
+  assert.equal(v.kind, "unavailable");
+  if (v.kind === "unavailable") assert.match(v.message, /could not be confirmed/i);
+});
+
+test("expecting nothing is confirmed, not unavailable — there was nothing to write", () => {
+  const v = confirmEnabledOnServer(undefined, []);
+  assert.equal(v.kind, "confirmed");
 });

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -402,6 +402,12 @@ const SAVE_IDLE_POLL_MS = 250;
  */
 const TOGGLE_CONFIRM_TIMEOUT_MS = 5_000;
 const TOGGLE_CONFIRM_BUDGET_MS = 60_000;
+/**
+ * Quiet period allowed for the toggle queue's 1000 ms debounce to flush before the
+ * server is asked what actually landed. Same constant the provider-setup helpers
+ * wait on (`model-toggle-batch.ts`), for the same product reason (#1649).
+ */
+const TOGGLE_FLUSH_QUIET_MS = 1500;
 const TOGGLE_CONFIRM_POLL_MS = 100;
 
 /**
@@ -732,6 +738,66 @@ export interface ButtonStateLocator {
   isEnabled(): Promise<boolean>;
 }
 
+/** What the server said about the models this sweep tried to enable (#1649). */
+export type ServerConfirmation =
+  | { kind: "confirmed"; expected: number }
+  | { kind: "shortfall"; expected: number; enabled: number; missing: string[]; message: string }
+  | { kind: "unavailable"; message: string };
+
+/**
+ * Confirms the toggle batch against the SERVER, which is the only source that can.
+ *
+ * `waitForToggleChecked` below reads `aria-checked`, and the provider modal flips
+ * that synchronously at click time (`useModelToggleQueue` applies an optimistic
+ * `setQueryData` before any request leaves the browser). Measured on 1.12.0.dev44:
+ * all 36 clicks were "confirmed" while the POST only went out at t=8132 ms. So the
+ * client read cannot distinguish a write that landed from one that never did — and
+ * a sweep that silently enabled nothing hands the next spec a provider still on its
+ * `MIN_DEFAULT_MODELS` default, which is what turned #1649's latent defect into five
+ * red attempts in one daily.
+ *
+ * Pure, and read ONCE by the caller after the batch has flushed — never polled:
+ * polling this endpoint while the write is in flight was measured stalling a
+ * single-worker backend at 20 s.
+ */
+export function confirmEnabledOnServer(
+  serverEnabled: Record<string, boolean> | undefined,
+  expected: string[],
+): ServerConfirmation {
+  if (expected.length === 0) return { kind: "confirmed", expected: 0 };
+
+  if (serverEnabled === undefined) {
+    return {
+      kind: "unavailable",
+      message:
+        `collect-models: the enabled state of ${expected.length} model(s) could not be confirmed ` +
+        `against the server — the read did not answer. Reported as UNKNOWN rather than ` +
+        `confirmed: an unevaluated check is unknown, not clean (#1012/#1649).`,
+    };
+  }
+
+  // Absence is not `true`: the endpoint lists every model of a configured
+  // provider, so a key it does not carry is one the write never created.
+  const missing = expected.filter((model) => serverEnabled[model] !== true);
+  if (missing.length === 0) return { kind: "confirmed", expected: expected.length };
+
+  const enabled = expected.length - missing.length;
+  return {
+    kind: "shortfall",
+    expected: expected.length,
+    enabled,
+    missing,
+    message:
+      `collect-models: the server confirms only ${enabled} of ${expected.length} model(s) this ` +
+      `sweep tried to enable. Missing: ${missing.slice(0, 10).join(", ")}` +
+      `${missing.length > 10 ? ` (+${missing.length - 10} more)` : ""}. ` +
+      `The panel's own toggles report the OPTIMISTIC client state and cannot see this, so a ` +
+      `sweep that wrote nothing used to look identical to one that wrote everything. Specs on ` +
+      `this instance will find the provider on its MIN_DEFAULT_MODELS default and have to ` +
+      `enable it themselves (#1649/#1355).`,
+  };
+}
+
 /**
  * Wait for a model toggle to report itself enabled after a click (#1355).
  *
@@ -1009,6 +1075,14 @@ function chargeBudget(budget: SweepBudget, provider: string, ms: number): void {
 interface ProviderCollection {
   models: ModelRecord[];
   stall: string | null;
+  /**
+   * Models this sweep CLICKED to enable, so the caller can confirm them against
+   * the server once the whole sweep is idle (#1649). Never confirmed here: the
+   * read has to happen while the backend is not busy with the very write it is
+   * being asked about — measured timing out at 20 s when issued inside the loop
+   * on a `LANGFLOW_WORKERS=1` instance.
+   */
+  attempted: string[];
 }
 
 async function collectModelsForProvider(
@@ -1297,6 +1371,9 @@ async function collectModelsForProvider(
   // than silently dropped (#1012).
   let unconfirmed = 0;
   let confirmBudgetLeft = TOGGLE_CONFIRM_BUDGET_MS;
+  // Every model this loop CLICKED, so the server read below can answer the one
+  // question `aria-checked` cannot: did the write actually land (#1649)?
+  const attempted: string[] = [];
   for (let i = 0; i < toggleCount; i++) {
     const toggle = toggles.nth(i);
     const modelName = await toggle.locator("..").locator("span.text-sm").textContent();
@@ -1305,6 +1382,7 @@ async function collectModelsForProvider(
     }
     const isChecked = (await toggle.getAttribute("aria-checked")) === "true";
     if (!isChecked) {
+      if (modelName?.trim()) attempted.push(modelName.trim());
       await toggle.click();
       if (confirmBudgetLeft > 0) {
         const confirm = await waitForToggleChecked(toggle, {
@@ -1345,7 +1423,7 @@ async function collectModelsForProvider(
 
   await page.getByTestId("sidebar-nav-Model Providers").click();
 
-  return { models, stall };
+  return { models, stall, attempted };
 }
 
 async function collectModels(page: Page): Promise<{
@@ -1358,6 +1436,8 @@ async function collectModels(page: Page): Promise<{
 
   const allModels: ModelRecord[] = [];
   const stalls = new Map<string, string>();
+  /** Provider DISPLAY name -> the models this sweep clicked to enable (#1649). */
+  const attempted = new Map<string, string[]>();
 
   // One budget for the whole sweep, spent down as each provider's post-Save
   // waits actually run (#1370), with a per-provider ledger so a collateral stall
@@ -1380,6 +1460,36 @@ async function collectModels(page: Page): Promise<{
     );
     allModels.push(...collection.models);
     if (collection.stall) stalls.set(provider, collection.stall);
+    if (collection.attempted.length > 0) {
+      // Keyed by the DISPLAY name, which is how `enabled_models` keys its map
+      // ("OpenAI", not "openai") — derived from the testid rather than restated,
+      // so a new provider needs no second table (the `displayNameOf` shape
+      // `preconfigure-routed-provider.ts` already uses).
+      attempted.set(config.providerTestId.replace(/^provider-item-/, ""), collection.attempted);
+    }
+  }
+
+  // Confirm the toggle writes against the SERVER, once, now that the sweep is
+  // idle (#1649). The panel's own `aria-checked` confirmation is the OPTIMISTIC
+  // client state — `useModelToggleQueue` flips it synchronously at click time,
+  // before any request leaves the browser — so a write that never landed is
+  // indistinguishable from one that did, and the #1355 shortfall warning cannot
+  // fire. This read has to be LAST: issued inside the provider loop it competes
+  // with the very write it asks about and was measured timing out at 20 s on a
+  // `LANGFLOW_WORKERS=1` instance, turning an honest check into a warning on
+  // every sweep. Reporting only — never fails the sweep (#980).
+  if (attempted.size > 0) {
+    const enabledByProvider = await page
+      .request.get("/api/v1/models/enabled_models?purpose=configure", { timeout: 30000 })
+      .then((r) => (r.ok() ? r.json() : null))
+      .then((body) => body?.enabled_models as Record<string, Record<string, boolean>> | undefined)
+      .catch(() => undefined);
+    for (const [provider, models] of attempted) {
+      const confirmation = confirmEnabledOnServer(enabledByProvider?.[provider], models);
+      if (confirmation.kind !== "confirmed") {
+        console.warn(`⚠️  [${provider}] ${confirmation.message}`);
+      }
+    }
   }
 
   // Printed on EVERY sweep, not only a failing one (#1385). The budget is the

--- a/tests/helpers/provider-setup/model-option.test.ts
+++ b/tests/helpers/provider-setup/model-option.test.ts
@@ -156,7 +156,8 @@ test("a provider name carrying spaces still parses from the testid alone", () =>
 
 test("a model enabled in the provider panel but missing from the picker FAILS loudly", () => {
   const verdict = resolveModelOption("claude-haiku-4-5", [option("OpenAI", "gpt-4o-mini")], {
-    enabledModels: ["claude-opus-5", "claude-haiku-4-5"],
+    listedModels: ["claude-opus-5", "claude-haiku-4-5"],
+    checkedModels: ["claude-opus-5", "claude-haiku-4-5"],
     providerLabel: "Anthropic",
   });
   assert.equal(verdict.kind, "unmatchable");
@@ -174,7 +175,8 @@ test("an EMPTY picker proves nothing and FAILS loudly", () => {
 
 test("an established absence skips, and the message carries what was seen", () => {
   const verdict = resolveModelOption("claude-haiku-3-5", DEV26_PICKER, {
-    enabledModels: ["claude-opus-5", "claude-haiku-4-5"],
+    listedModels: ["claude-opus-5", "claude-haiku-4-5"],
+    checkedModels: ["claude-opus-5", "claude-haiku-4-5"],
     providerLabel: "Anthropic",
   });
   assert.equal(verdict.kind, "absent");
@@ -299,3 +301,68 @@ test("hasOptionIdentity accepts an option carrying either attribute alone", () =
 // the provider specs, whose pinned model only resolves when the strip works, plus
 // the force-fail that reverts it. What this file pins is the half a live spec
 // cannot reproduce on demand: the verdict.
+
+// --- #1649: the panel LISTS a model and the panel ENABLES it are different facts ---
+//
+// `enumerateEnabledModels` returns every rendered `llm-toggle-*` id regardless of
+// `aria-checked` — its own docstring says so, and says a count taken from it is
+// never a count of enabled models. It was nonetheless passed as the single
+// `enabledModels` source, so the loud verdict announced "is ENABLED in the provider
+// panel" from evidence that only proves the panel LISTS it. On 2026-08-31 that
+// claim happened to be true; the reason it was true was a separate defect (#1649:
+// setup-openai closed the panel inside the toggle queue's 1000 ms debounce, so the
+// picker kept the pre-toggle set). The split below makes the message state what it
+// measured, and — the load-bearing half — keeps the new branch LOUD: a model the
+// panel lists with its toggle OFF is a setup failure, never a skip.
+
+test("a model whose toggle is ON but which the picker omits FAILS, and says ENABLED truthfully", () => {
+  const verdict = resolveModelOption("claude-haiku-4-5", [option("OpenAI", "gpt-4o-mini")], {
+    listedModels: ["claude-opus-5", "claude-haiku-4-5"],
+    checkedModels: ["claude-opus-5", "claude-haiku-4-5"],
+    providerLabel: "Anthropic",
+  });
+  assert.equal(verdict.kind, "unmatchable");
+  assert.ok(!verdict.message.startsWith("MODEL_NOT_AVAILABLE"));
+  assert.match(verdict.message, /is ENABLED in the provider panel/);
+  assert.match(verdict.message, /llm-toggle-claude-haiku-4-5/);
+});
+
+test("a model the panel LISTS with its toggle OFF is a setup failure, not a picker defect", () => {
+  const verdict = resolveModelOption("claude-haiku-4-5", [option("OpenAI", "gpt-4o-mini")], {
+    listedModels: ["claude-opus-5", "claude-haiku-4-5"],
+    checkedModels: ["claude-opus-5"],
+    providerLabel: "Anthropic",
+  });
+  assert.equal(verdict.kind, "not-enabled");
+  // Never the skip prefix, and never the picker-defect prefix either: the picker is
+  // not disagreeing with anything — it is correctly omitting a disabled model.
+  assert.ok(!verdict.message.startsWith("MODEL_NOT_AVAILABLE"));
+  assert.ok(!verdict.message.startsWith("MODEL_PICKER_DEFECT"));
+  assert.match(verdict.message, /MODEL_NOT_ENABLED/);
+  assert.match(verdict.message, /toggle is OFF/);
+  // The count that separates "the setup enabled nothing" from "it missed one".
+  assert.match(verdict.message, /1 of 2 listed/);
+});
+
+test("the not-enabled verdict outranks absence — a listed model is never reported missing", () => {
+  // `claude-haiku-3-5` is NOT in the picker, and the nearest-model machinery would
+  // happily produce a plausible `MODEL_NOT_AVAILABLE` for it. The panel listing it
+  // outranks that: absent means nobody knows the model.
+  const verdict = resolveModelOption("claude-haiku-3-5", DEV26_PICKER, {
+    listedModels: ["claude-haiku-3-5", "claude-opus-5"],
+    checkedModels: ["claude-opus-5"],
+    providerLabel: "Anthropic",
+  });
+  assert.equal(verdict.kind, "not-enabled");
+  assert.ok(!verdict.message.startsWith("MODEL_NOT_AVAILABLE"));
+});
+
+test("with only listedModels observed the message says so instead of claiming ENABLED", () => {
+  const verdict = resolveModelOption("claude-haiku-4-5", [option("OpenAI", "gpt-4o-mini")], {
+    listedModels: ["claude-haiku-4-5"],
+    providerLabel: "Anthropic",
+  });
+  assert.equal(verdict.kind, "unmatchable");
+  assert.match(verdict.message, /listed by the provider panel/);
+  assert.ok(!/is ENABLED in the provider panel/.test(verdict.message));
+});

--- a/tests/helpers/provider-setup/model-option.ts
+++ b/tests/helpers/provider-setup/model-option.ts
@@ -51,17 +51,33 @@ export type ModelOptionVerdict =
   | { kind: "match"; option: ModelOption }
   | { kind: "unmatchable"; message: string; evidence: string[] }
   | { kind: "empty"; message: string }
+  | { kind: "not-enabled"; message: string }
   | { kind: "absent"; message: string };
 
 export type ResolveContext = {
   /**
-   * Model ids observed as `llm-toggle-<model>` in the provider panel, when the
-   * caller enabled them. The second independent source the picker can be
-   * contradicted by: a model enabled there but missing here is not an absence.
-   * `undefined` means "not observed" and is reported as such — an unobserved
-   * source must never read as a negative one (#1012).
+   * Every `llm-toggle-<model>` id the provider panel RENDERED, whatever its
+   * `aria-checked` state — what `enumerateEnabledModels` returns. It proves the
+   * provider LISTS the model and nothing more. `undefined` means "not observed"
+   * and is reported as such — an unobserved source must never read as a negative
+   * one (#1012).
    */
-  enabledModels?: string[];
+  listedModels?: string[];
+  /**
+   * The subset whose toggle is actually ON — what `enumerateCheckedModels`
+   * returns. This is the second independent source the picker can be
+   * CONTRADICTED by: a model enabled here but missing from the picker is not an
+   * absence, it is a disagreement.
+   *
+   * Kept separate from `listedModels` because the two answer different
+   * questions and the resolver's loudest message asserts the stronger one. Until
+   * #1649 the listed set was passed as the only source and the message said
+   * "is ENABLED in the provider panel" on evidence that could not establish it —
+   * true by luck on 2026-08-31, where the real cause was the panel being closed
+   * inside its own toggle-queue debounce. `undefined` again means "not observed":
+   * the message then says LISTED, and no branch infers a toggle is off from it.
+   */
+  checkedModels?: string[];
   /** Provider the caller is configuring, for the message only. */
   providerLabel?: string;
 };
@@ -72,6 +88,12 @@ const MODEL_NOT_AVAILABLE = "MODEL_NOT_AVAILABLE";
  * prefix into `test.skip`, so a suite-side defect carrying it would be silent.
  */
 const MODEL_PICKER_DEFECT = "MODEL_PICKER_DEFECT";
+/**
+ * Also deliberately NOT prefixed `MODEL_NOT_AVAILABLE`: a model the panel LISTS
+ * is not absent, so this must never reach a caller as a skip. It is the setup's
+ * own failure to enable it (#1649).
+ */
+const MODEL_NOT_ENABLED = "MODEL_NOT_ENABLED";
 
 /** Derives the model identity from the attributes, text last. */
 export function toModelOption(raw: RawModelOption): ModelOption {
@@ -195,8 +217,12 @@ export function resolveModelOption(
     };
   }
 
-  const enabled = context.enabledModels;
-  if (enabled?.includes(requested)) {
+  // The panel is TWO sources, not one, and which of them knows the model decides
+  // how loud the verdict is and what it may claim (#1649).
+  const listed = context.listedModels;
+  const checked = context.checkedModels;
+
+  if (checked?.includes(requested)) {
     return {
       kind: "unmatchable",
       evidence: [`llm-toggle-${requested} in the provider panel`],
@@ -210,11 +236,48 @@ export function resolveModelOption(
     };
   }
 
+  if (listed?.includes(requested)) {
+    // The toggle state was never read, so the strongest true statement is LISTED.
+    // Saying ENABLED here is the overclaim #1649 removed: an unobserved source
+    // must not be reported as a stronger one (#1012).
+    if (checked === undefined) {
+      return {
+        kind: "unmatchable",
+        evidence: [`llm-toggle-${requested} in the provider panel`],
+        message:
+          `${MODEL_PICKER_DEFECT}: "${requested}" is listed by the provider panel ` +
+          `(llm-toggle-${requested})${provider} but the model picker does not offer it — ` +
+          `${options.length} option(s) enumerated (${providerCounts(options)}). ` +
+          `Its toggle state was NOT observed on this path, so this is reported on the ` +
+          `listing alone: the model is not absent, and the picker either did not refresh ` +
+          `after the panel closed or the option list is filtered. Reported as a FAILURE, ` +
+          `not a skip (#1461).`,
+      };
+    }
+
+    // Listed, toggle OFF, absent from the picker: all three agree, and the picker
+    // is RIGHT to omit a disabled model. Nothing about the product is wrong here —
+    // the setup did not enable it. Loud anyway: a listed model is not absent, so
+    // this may never reach a caller as `test.skip`.
+    return {
+      kind: "not-enabled",
+      message:
+        `${MODEL_NOT_ENABLED}: "${requested}" is listed by the provider panel ` +
+        `(llm-toggle-${requested})${provider} but its toggle is OFF — ` +
+        `${checked.length} of ${listed.length} listed model(s) are enabled, and the picker ` +
+        `offers ${options.length} option(s) (${providerCounts(options)}). ` +
+        `The picker is correct to omit a disabled model, so this is NOT a picker defect: ` +
+        `the setup failed to enable it. On a freshly configured provider the enabled set ` +
+        `is the ${"`"}MIN_DEFAULT_MODELS${"`"} default, which is what a panel closed inside its own ` +
+        `toggle-queue debounce leaves behind (#1649). Reported as a FAILURE, never a skip.`,
+    };
+  }
+
   const nearest = nearestModels(requested, options);
   const toggleEvidence =
-    enabled === undefined
+    listed === undefined
       ? "provider toggles were not observed on this path"
-      : `${enabled.length} provider toggle(s) observed, none of them "${requested}"`;
+      : `${listed.length} provider toggle(s) observed, none of them "${requested}"`;
 
   return {
     kind: "absent",
@@ -352,6 +415,27 @@ export async function enumerateEnabledModels(page: Page): Promise<string[]> {
 }
 
 /**
+ * The subset of `enumerateEnabledModels` whose toggle is actually ON.
+ *
+ * This is the one that may be reported as ENABLED. Its sibling above returns every
+ * rendered id regardless of `aria-checked`, and passing that as the resolver's
+ * only source is how the loud verdict came to assert "is ENABLED in the provider
+ * panel" from evidence that established only "is listed" (#1649). Both are read
+ * because the two together separate three states a single count cannot: the
+ * picker disagreeing with an enabled model, the setup having failed to enable it,
+ * and the model genuinely being gone.
+ *
+ * `:visible` is deliberately NOT applied: the deprecated disclosure's toggles are
+ * collapsed, not absent, and one that is checked is genuinely enabled.
+ */
+export async function enumerateCheckedModels(page: Page): Promise<string[]> {
+  const ids = await page
+    .locator('[data-testid^="llm-toggle-"][aria-checked="true"]')
+    .evaluateAll((els) => els.map((el) => el.getAttribute("data-testid") ?? ""));
+  return ids.map((id) => id.replace(/^llm-toggle-/, "")).filter(Boolean);
+}
+
+/**
  * Clicks an enumerated option by identity.
  *
  * Prefers the testid and falls back to the cmdk value, so a build that drops one
@@ -371,7 +455,7 @@ export type PinnedSelection =
 /**
  * Selects a pinned model in the OPEN picker, or reports what the picker proved.
  *
- * Loud verdicts (`empty`, `unmatchable`) always throw: they are the suite's own
+ * Loud verdicts (`empty`, `unmatchable`, `not-enabled`) always throw: they are the suite's own
  * defects and must never reach a caller that would skip on them. Only an
  * *established* absence is handed back, and even then the caller decides —
  * `absentBehavior: "return"` exists for `setup-openai`'s `fallbackToRanking`
@@ -381,7 +465,8 @@ export async function selectPinnedModelOption(
   page: Page,
   opts: {
     requested: string;
-    enabledModels?: string[];
+    listedModels?: string[];
+    checkedModels?: string[];
     providerLabel?: string;
     absentBehavior?: "throw" | "return";
     timeout?: number;
@@ -389,7 +474,8 @@ export async function selectPinnedModelOption(
 ): Promise<PinnedSelection> {
   const options = await enumerateModelOptions(page, opts.timeout ?? 10000);
   const verdict = resolveModelOption(opts.requested, options, {
-    enabledModels: opts.enabledModels,
+    listedModels: opts.listedModels,
+    checkedModels: opts.checkedModels,
     providerLabel: opts.providerLabel,
   });
 

--- a/tests/helpers/provider-setup/model-toggle-batch.test.ts
+++ b/tests/helpers/provider-setup/model-toggle-batch.test.ts
@@ -1,0 +1,108 @@
+// Unit tests for the provider panel's toggle-batch flush gate (#1649).
+// Run with: npm run test:units
+//
+// What rides on this predicate is not a wait, it is WHICH of the product's two
+// send paths carries the toggles. `useModelToggleQueue` debounces every toggle by
+// 1000 ms; the debounced flush refreshes the model picker (its `onSettled` calls
+// `refreshAllModelInputs`), while the close-path flush does not. Closing the panel
+// inside the debounce window therefore leaves the picker on the PRE-toggle enabled
+// set — on a freshly configured provider, the `MIN_DEFAULT_MODELS = 5` default —
+// and the picker read that follows raises `MODEL_PICKER_DEFECT`.
+//
+// Measured on 1.12.0.dev44, one clean container, three runs of the identical
+// sequence differing only in the pause before Close, server at enabled=41 in all
+// three: 0 ms -> picker offers 5; 1200 ms -> 35; 2000 ms -> 35.
+//
+// The predicate is pure so every branch is reachable without a browser — the same
+// reason `resolveModelOption` and `censusForTarget` are.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { flushVerdict, type ToggleBatchObservation } from "./model-toggle-batch";
+
+const OPTS = { quietMs: 1500, deadlineAt: 100_000 };
+
+function obs(over: Partial<ToggleBatchObservation> = {}): ToggleBatchObservation {
+  return {
+    clicked: 3,
+    lastClickAt: 1_000,
+    postsStarted: 1,
+    postsFinished: 1,
+    lastPostStartedAt: 1_200,
+    ...over,
+  };
+}
+
+test("a panel nobody changed needs no flush at all", () => {
+  // The normal CI path: `Collect models` already enabled everything, the loop
+  // clicks nothing, and there is no batch to wait for. This branch is what keeps
+  // the fix free on every run that does not hit the defect.
+  const v = flushVerdict(obs({ clicked: 0, postsStarted: 0, postsFinished: 0 }), 1_000, OPTS);
+  assert.equal(v.kind, "nothing-to-flush");
+});
+
+test("the debounce window still being open is not settled", () => {
+  const v = flushVerdict(obs({ lastClickAt: 5_000 }), 5_900, OPTS);
+  assert.equal(v.kind, "waiting");
+  if (v.kind === "waiting") assert.match(v.reason, /debounce/i);
+});
+
+test("a write that was issued but has not answered is not settled", () => {
+  const v = flushVerdict(obs({ postsStarted: 2, postsFinished: 1 }), 9_000, OPTS);
+  assert.equal(v.kind, "waiting");
+  if (v.kind === "waiting") assert.match(v.reason, /in flight/i);
+});
+
+test("clicks with NO write issued yet are not settled — the queue has not fired", () => {
+  const v = flushVerdict(
+    obs({ postsStarted: 0, postsFinished: 0, lastPostStartedAt: null }),
+    9_000,
+    OPTS,
+  );
+  assert.equal(v.kind, "waiting");
+  if (v.kind === "waiting") assert.match(v.reason, /no write/i);
+});
+
+test("a write that answered but only just started leaves room for a follow-up batch", () => {
+  // The queue splits into several batches when the loop is slow: a POST finishing
+  // does not prove the LAST one has been sent. Requiring quiet since the last
+  // start too is what makes this a quiescence check rather than a first-response
+  // check — `waitForResponse` on the first POST was measured returning while the
+  // batch was still being sent.
+  const v = flushVerdict(obs({ lastPostStartedAt: 8_500 }), 9_000, OPTS);
+  assert.equal(v.kind, "waiting");
+  if (v.kind === "waiting") assert.match(v.reason, /quiet/i);
+});
+
+test("clicks flushed, answered and quiet on both clocks is settled", () => {
+  const v = flushVerdict(obs({ lastClickAt: 1_000, lastPostStartedAt: 2_000 }), 4_000, OPTS);
+  assert.equal(v.kind, "settled");
+});
+
+test("past the deadline it gives up NAMING what it saw, never silently", () => {
+  // Giving up is not a failure: the picker read that follows is the real gate and
+  // it fails loudly with the right message. What must not happen is giving up
+  // without a trace — an unevaluated wait is unknown, not clean (#1012).
+  const v = flushVerdict(
+    obs({ clicked: 7, postsStarted: 2, postsFinished: 1 }),
+    100_001,
+    OPTS,
+  );
+  assert.equal(v.kind, "gave-up");
+  if (v.kind === "gave-up") {
+    assert.match(v.message, /7 toggle\(s\) clicked/);
+    assert.match(v.message, /2 write\(s\) started/);
+    assert.match(v.message, /1 finished/);
+    assert.match(v.message, /#1649/);
+  }
+});
+
+test("the deadline never overrides nothing-to-flush", () => {
+  // An unchanged panel past the deadline is still nothing to flush — reporting a
+  // give-up there would put a scary line in every healthy run's log.
+  const v = flushVerdict(
+    obs({ clicked: 0, postsStarted: 0, postsFinished: 0, lastClickAt: null }),
+    100_001,
+    OPTS,
+  );
+  assert.equal(v.kind, "nothing-to-flush");
+});

--- a/tests/helpers/provider-setup/model-toggle-batch.ts
+++ b/tests/helpers/provider-setup/model-toggle-batch.ts
@@ -1,0 +1,228 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Enabling a provider's models is a TRANSACTION, and the panel must not be closed
+ * on top of it (#1649).
+ *
+ * The three provider-setup helpers used to carry the same loop — click every
+ * unchecked `:visible` toggle, then immediately click Close. That is not a slow
+ * test being impatient; it selects a different code path in the product. Every
+ * toggle feeds `useModelToggleQueue`, which applies an optimistic cache update and
+ * batches the write behind a **1000 ms debounce**, and the batch can leave through
+ * either of two paths:
+ *
+ *   debounced flush (`flushModelToggles`)   1000 ms after the last toggle
+ *       -> onSettled: invalidateQueries AND refreshAllModelInputs  -> picker updates
+ *   close-path flush (`flushPendingChanges`)  on the modal's Close
+ *       -> invalidateQueries only; handleClose's own refreshAllModelInputs runs
+ *          AFTER onClose already unmounted the modal                -> picker does NOT
+ *
+ * So closing inside the debounce window leaves the picker rendering the PRE-toggle
+ * enabled set — on a freshly configured provider that is the `MIN_DEFAULT_MODELS`
+ * default of five — and the picker read that follows correctly reports the
+ * disagreement as `MODEL_PICKER_DEFECT`. Measured on 1.12.0.dev44, one clean
+ * container, three runs differing ONLY in the pause before Close, with the server
+ * reporting `enabled=41` in all three:
+ *
+ *   pause before Close   model_model visible after   picker offers
+ *   0 ms                 4 327 ms                    5    <- the daily's failure
+ *   1 200 ms             30 020 ms                   35
+ *   2 000 ms             29 640 ms                   35
+ *
+ * A person cannot close a dialog under a second after their last click, which is
+ * why this never reproduced by hand and reproduced every time from the suite.
+ *
+ * ## Why quiescence and not a simpler wait
+ *
+ * Two narrower conditions were measured and rejected:
+ *
+ *   - `waitForResponse` on the toggle POST **races**. A slow loop lets the debounce
+ *     fire mid-loop, so the write is often already sent before the wait is armed:
+ *     measured returning `landed=false` while the write had in fact landed. It also
+ *     cannot tell the FIRST batch from the LAST one.
+ *   - polling `GET /models/enabled_models` **stalls the backend** that is busy with
+ *     the very write being waited on: measured `apiRequestContext.get: Timeout
+ *     20000ms exceeded` against a single-worker instance.
+ *
+ * What is left is quiescence over the product's own writes, observed passively:
+ * at least one write answered, and quiet on BOTH clocks — no click and no new
+ * write for longer than the debounce.
+ */
+
+/** What the listeners saw while the toggles were being clicked. */
+export type ToggleBatchObservation = {
+  /** Toggles this loop actually clicked. Zero means there is no batch. */
+  clicked: number;
+  /** `Date.now()` of the last click, or null when nothing was clicked. */
+  lastClickAt: number | null;
+  /** `POST /models/enabled_models` requests observed starting. */
+  postsStarted: number;
+  /** …and answering (success or failure — either settles the mutation). */
+  postsFinished: number;
+  /** `Date.now()` of the most recent POST start, or null. */
+  lastPostStartedAt: number | null;
+};
+
+export type FlushVerdict =
+  | { kind: "nothing-to-flush" }
+  | { kind: "settled" }
+  | { kind: "waiting"; reason: string }
+  | { kind: "gave-up"; message: string };
+
+export type FlushOptions = {
+  /** Quiet period required on both clocks. Must exceed the product's 1000 ms. */
+  quietMs: number;
+  /** `Date.now()` past which the wait reports `gave-up`. */
+  deadlineAt: number;
+};
+
+/**
+ * Decides whether the toggle batch has left through the debounced path.
+ *
+ * PURE — no page, no clock — so every branch is reachable from a unit test, the
+ * same reason `resolveModelOption` and `censusForTarget` are pure. The ordering is
+ * load-bearing: `nothing-to-flush` is checked FIRST and outranks the deadline,
+ * because an unchanged panel is not a timeout and must not print one on every
+ * healthy run.
+ */
+export function flushVerdict(
+  observation: ToggleBatchObservation,
+  now: number,
+  options: FlushOptions,
+): FlushVerdict {
+  const { clicked, lastClickAt, postsStarted, postsFinished, lastPostStartedAt } = observation;
+
+  if (clicked === 0) return { kind: "nothing-to-flush" };
+
+  const expired = now > options.deadlineAt;
+  const giveUp = (): FlushVerdict => ({
+    kind: "gave-up",
+    message:
+      `provider panel: the model-toggle batch did not settle in time — ` +
+      `${clicked} toggle(s) clicked, ${postsStarted} write(s) started, ` +
+      `${postsFinished} finished. Closing the panel now takes the flush path that ` +
+      `does NOT refresh the model picker, so the picker may still show the ` +
+      `pre-toggle set. Not failing here: the picker read that follows is the real ` +
+      `gate and names the disagreement itself (#1649).`,
+  });
+
+  if (lastClickAt !== null && now - lastClickAt < options.quietMs) {
+    return expired
+      ? giveUp()
+      : { kind: "waiting", reason: "the 1000 ms toggle debounce window is still open" };
+  }
+
+  if (postsStarted === 0) {
+    return expired
+      ? giveUp()
+      : { kind: "waiting", reason: "no write has been issued yet — the queue has not fired" };
+  }
+
+  if (postsFinished < postsStarted) {
+    return expired ? giveUp() : { kind: "waiting", reason: "a write is still in flight" };
+  }
+
+  if (lastPostStartedAt !== null && now - lastPostStartedAt < options.quietMs) {
+    return expired
+      ? giveUp()
+      : { kind: "waiting", reason: "not quiet yet — a follow-up batch may still be queued" };
+  }
+
+  return { kind: "settled" };
+}
+
+/** What one pass over the open provider panel's model toggles did. */
+export type ToggleBatchResult = {
+  /** `:visible` toggles found (the collapsed deprecated section is excluded). */
+  visible: number;
+  /** How many were clicked because `aria-checked` was not "true". */
+  clicked: number;
+  /** How many report `aria-checked="true"` after the pass. */
+  checked: number;
+  /** How the flush ended — `gave-up` is logged, never thrown. */
+  verdict: FlushVerdict["kind"];
+};
+
+/**
+ * Enables every visible model toggle in the OPEN provider panel, then waits for
+ * the product's own write to settle so the caller can close the panel safely.
+ *
+ * The `:visible` filter excludes the toggles inside the collapsed "deprecated
+ * models" disclosure: they are in the DOM but not displayed, and `.click()` on one
+ * retry-loops to a timeout.
+ *
+ * The wait runs ONLY when something was clicked, so the common path — a provider
+ * `Collect models` already enabled, where the loop clicks nothing — pays nothing.
+ */
+export async function enableAndSettleModelToggles(
+  page: Page,
+  options: { quietMs?: number; timeoutMs?: number } = {},
+): Promise<ToggleBatchResult> {
+  const quietMs = options.quietMs ?? 1500;
+  // 90 s, because the write itself is slow on the single-worker instances the
+  // lanes run: measured 36 toggles producing one POST that had not answered 30 s
+  // later on a local `LANGFLOW_WORKERS=1` container. The budget is NOT additive
+  // with the caller's `model_model` wait — it is the same wall clock, paid here
+  // where the give-up message can name what it saw instead of there where a
+  // visibility timeout cannot. Waiting for the write to ANSWER (not merely to be
+  // issued) is what proves the mutation settled while the modal was still
+  // mounted, which is where `onSettled` -> `refreshAllModelInputs` runs (#1649).
+  const timeoutMs = options.timeoutMs ?? 90000;
+
+  const observation: ToggleBatchObservation = {
+    clicked: 0,
+    lastClickAt: null,
+    postsStarted: 0,
+    postsFinished: 0,
+    lastPostStartedAt: null,
+  };
+
+  const isToggleWrite = (url: string, method: string): boolean =>
+    method === "POST" && url.includes("/models/enabled_models");
+  const onRequest = (r: { url(): string; method(): string }) => {
+    if (isToggleWrite(r.url(), r.method())) {
+      observation.postsStarted += 1;
+      observation.lastPostStartedAt = Date.now();
+    }
+  };
+  const onFinished = (r: { url(): string; method(): string }) => {
+    if (isToggleWrite(r.url(), r.method())) observation.postsFinished += 1;
+  };
+  // `requestfailed` counts too: an aborted write settles the mutation just as a
+  // 200 does, and not counting it would hold the wait open to its deadline.
+  page.on("request", onRequest);
+  page.on("requestfinished", onFinished);
+  page.on("requestfailed", onFinished);
+
+  try {
+    const toggles = page.locator('[data-testid^="llm-toggle"]:visible');
+    await toggles.first().waitFor({ state: "visible", timeout: 15000 }).catch(() => {});
+    const visible = await toggles.count();
+
+    for (let i = 0; i < visible; i++) {
+      const toggle = toggles.nth(i);
+      if ((await toggle.getAttribute("aria-checked")) !== "true") {
+        await toggle.click();
+        observation.clicked += 1;
+        observation.lastClickAt = Date.now();
+      }
+    }
+
+    const deadlineAt = Date.now() + timeoutMs;
+    let verdict = flushVerdict(observation, Date.now(), { quietMs, deadlineAt });
+    while (verdict.kind === "waiting") {
+      await page.waitForTimeout(250);
+      verdict = flushVerdict(observation, Date.now(), { quietMs, deadlineAt });
+    }
+    if (verdict.kind === "gave-up") console.warn(`⚠️  ${verdict.message}`);
+
+    const checked = await page
+      .locator('[data-testid^="llm-toggle"]:visible[aria-checked="true"]')
+      .count();
+    return { visible, clicked: observation.clicked, checked, verdict: verdict.kind };
+  } finally {
+    page.off("request", onRequest);
+    page.off("requestfinished", onFinished);
+    page.off("requestfailed", onFinished);
+  }
+}

--- a/tests/helpers/provider-setup/setup-anthropic.ts
+++ b/tests/helpers/provider-setup/setup-anthropic.ts
@@ -2,10 +2,12 @@ import type { Page } from "@playwright/test";
 import { hideInspectorPanel } from "../ui/hide-inspector-panel";
 import {
   clickModelOption,
+  enumerateCheckedModels,
   enumerateEnabledModels,
   enumerateModelOptions,
   selectPinnedModelOption,
 } from "./model-option";
+import { enableAndSettleModelToggles } from "./model-toggle-batch";
 import { openProviderPanel } from "./provider-panel-entry";
 import { waitForProviderRow } from "./provider-list-state";
 
@@ -49,35 +51,42 @@ export async function setupAnthropic(
       .catch(() => {});
   }
 
-  // Step 5: Enable all available Anthropic models.
+  // Step 5: Enable all available models — and let the write settle.
   // Toggles only render after the provider is authenticated — waitFor retries until visible.
-  // The `:visible` filter excludes toggles inside the collapsed "deprecated
-  // models" section, which are mounted in the DOM but not displayed until the
-  // section's "Show N deprecated models" button is clicked. Without the
-  // filter, `.click()` on a hidden toggle retry-loops to a timeout.
-  const toggles = page.locator('[data-testid^="llm-toggle"]:visible');
-  await toggles.first().waitFor({ state: "visible", timeout: 15000 }).catch(() => {});
-  const toggleCount = await toggles.count();
-
-  for (let i = 0; i < toggleCount; i++) {
-    const toggle = toggles.nth(i);
-    const isChecked = (await toggle.getAttribute("aria-checked")) === "true";
-    if (!isChecked) {
-      await toggle.click();
-    }
-  }
+  // Enabling is a TRANSACTION: the toggles are batched behind a 1000 ms debounce,
+  // and closing the panel inside that window takes the flush path that never
+  // refreshes the model picker (#1649). The helper clicks and then waits for the
+  // product's own write to go quiet, so Step 6 below cannot close on top of it.
+  // Costs nothing when nothing was clicked, which is the normal CI path.
+  await enableAndSettleModelToggles(page);
 
   // Read the panel's toggles BEFORE closing it: they are the second, independent
-  // source for "this model exists and is enabled", and a picker miss that this
-  // list contradicts is not an absence (#1461).
-  const enabledModels = await enumerateEnabledModels(page);
+  // source the picker can be contradicted by, and a picker miss that they
+  // contradict is not an absence (#1461). BOTH are read, because "the panel lists
+  // it" and "its toggle is on" are different facts and only the second one may be
+  // reported as ENABLED (#1649).
+  const listedModels = await enumerateEnabledModels(page);
+  const checkedModels = await enumerateCheckedModels(page);
 
   // Step 6: Close the provider management panel
   await page.getByRole("button", { name: "Close" }).click();
 
   // Step 7: Select model — uses modelTestId if provided, otherwise selects the first available
   await hideInspectorPanel(page);
-  await page.getByTestId("model_model").click();
+  // Closing the panel (Step 6) puts the model dropdown into a post-close refresh
+  // state where the `model_model` trigger is briefly replaced by a (testid-less)
+  // "Loading models…" button while providers and enabled models refetch. Both
+  // budgets below are 60 s, and NOT to make a stall pass: taking the correct
+  // flush path in Step 5 means the product genuinely re-fetches, measured at
+  // 30 020 ms and 29 640 ms against the 4 327 ms the broken path returned in.
+  // The click carries its own budget because it otherwise falls back to the 20 s
+  // `actionTimeout` and the trigger can re-enter the loading state between
+  // "visible" and the click — measured failing exactly there
+  // (`locator.click: Timeout 20000ms exceeded ... getByTestId('model_model')`)
+  // on the cold path with the provider on its MIN_DEFAULT_MODELS default (#1649).
+  const modelTrigger = page.getByTestId("model_model");
+  await modelTrigger.waitFor({ state: "visible", timeout: 60000 });
+  await modelTrigger.click({ timeout: 60000 });
   if (modelTestId) {
     // Resolved by option IDENTITY (data-value / data-testid), never by the option's
     // text: 1.12.0.dev26 renders a `sr-only` "N of M" counter inside each option, so
@@ -85,7 +94,8 @@ export async function setupAnthropic(
     // helper reported a model it could not match as one that does not exist (#1459).
     await selectPinnedModelOption(page, {
       requested: modelTestId,
-      enabledModels,
+      listedModels,
+      checkedModels,
       providerLabel: "Anthropic",
     });
   } else {

--- a/tests/helpers/provider-setup/setup-google.ts
+++ b/tests/helpers/provider-setup/setup-google.ts
@@ -2,10 +2,12 @@ import type { Page } from "@playwright/test";
 import { hideInspectorPanel } from "../ui/hide-inspector-panel";
 import {
   clickModelOption,
+  enumerateCheckedModels,
   enumerateEnabledModels,
   enumerateModelOptions,
   selectPinnedModelOption,
 } from "./model-option";
+import { enableAndSettleModelToggles } from "./model-toggle-batch";
 import { openProviderPanel } from "./provider-panel-entry";
 import { waitForProviderRow } from "./provider-list-state";
 import { providerAlreadyConfigured } from "./provider-config-state";
@@ -85,36 +87,47 @@ export async function setupGoogle(
       .catch(() => {});
   }
 
-  // Step 5: Enable all available Google Generative AI models.
+  // Step 5: Enable all available models — and let the write settle.
   // Toggles only render after the provider is authenticated — waitFor retries until visible.
   // The `:visible` filter excludes toggles inside the collapsed "deprecated
   // models" section, which are mounted in the DOM but not displayed until the
   // section's "Show N deprecated models" button is clicked. Without the
   // filter, `.click()` on a hidden toggle (e.g. gemini-2.0-flash on 1.11.x)
   // retry-loops to a timeout.
-  const toggles = page.locator('[data-testid^="llm-toggle"]:visible');
-  await toggles.first().waitFor({ state: "visible", timeout: 15000 }).catch(() => {});
-  const toggleCount = await toggles.count();
-
-  for (let i = 0; i < toggleCount; i++) {
-    const toggle = toggles.nth(i);
-    const isChecked = (await toggle.getAttribute("aria-checked")) === "true";
-    if (!isChecked) {
-      await toggle.click();
-    }
-  }
+  // Enabling is a TRANSACTION: the toggles are batched behind a 1000 ms debounce,
+  // and closing the panel inside that window takes the flush path that never
+  // refreshes the model picker (#1649). The helper clicks and then waits for the
+  // product's own write to go quiet, so Step 6 below cannot close on top of it.
+  // Costs nothing when nothing was clicked, which is the normal CI path.
+  await enableAndSettleModelToggles(page);
 
   // Read the panel's toggles BEFORE closing it: they are the second, independent
-  // source for "this model exists and is enabled", and a picker miss that this
-  // list contradicts is not an absence (#1461).
-  const enabledModels = await enumerateEnabledModels(page);
+  // source the picker can be contradicted by, and a picker miss that they
+  // contradict is not an absence (#1461). BOTH are read, because "the panel lists
+  // it" and "its toggle is on" are different facts and only the second one may be
+  // reported as ENABLED (#1649).
+  const listedModels = await enumerateEnabledModels(page);
+  const checkedModels = await enumerateCheckedModels(page);
 
   // Step 6: Close the provider management panel
   await page.getByRole("button", { name: "Close" }).click();
 
   // Step 7: Select model — uses modelTestId if provided, otherwise selects the first available
   await hideInspectorPanel(page);
-  await page.getByTestId("model_model").click();
+  // Closing the panel (Step 6) puts the model dropdown into a post-close refresh
+  // state where the `model_model` trigger is briefly replaced by a (testid-less)
+  // "Loading models…" button while providers and enabled models refetch. Both
+  // budgets below are 60 s, and NOT to make a stall pass: taking the correct
+  // flush path in Step 5 means the product genuinely re-fetches, measured at
+  // 30 020 ms and 29 640 ms against the 4 327 ms the broken path returned in.
+  // The click carries its own budget because it otherwise falls back to the 20 s
+  // `actionTimeout` and the trigger can re-enter the loading state between
+  // "visible" and the click — measured failing exactly there
+  // (`locator.click: Timeout 20000ms exceeded ... getByTestId('model_model')`)
+  // on the cold path with the provider on its MIN_DEFAULT_MODELS default (#1649).
+  const modelTrigger = page.getByTestId("model_model");
+  await modelTrigger.waitFor({ state: "visible", timeout: 60000 });
+  await modelTrigger.click({ timeout: 60000 });
   if (modelTestId) {
     // Resolved by option IDENTITY (data-value / data-testid), never by the option's
     // text: 1.12.0.dev26 renders a `sr-only` "N of M" counter inside each option, so
@@ -123,7 +136,8 @@ export async function setupGoogle(
     // whose trace shows the model present at option 22 of 90 (#1459).
     await selectPinnedModelOption(page, {
       requested: modelTestId,
-      enabledModels,
+      listedModels,
+      checkedModels,
       providerLabel: "Google Generative AI",
     });
   } else {

--- a/tests/helpers/provider-setup/setup-openai.ts
+++ b/tests/helpers/provider-setup/setup-openai.ts
@@ -2,10 +2,12 @@ import type { Page } from "@playwright/test";
 import { hideInspectorPanel } from "../ui/hide-inspector-panel";
 import {
   clickModelOption,
+  enumerateCheckedModels,
   enumerateEnabledModels,
   enumerateModelOptions,
   selectPinnedModelOption,
 } from "./model-option";
+import { enableAndSettleModelToggles } from "./model-toggle-batch";
 import { openProviderPanel } from "./provider-panel-entry";
 import { waitForProviderRow } from "./provider-list-state";
 
@@ -65,27 +67,21 @@ export async function setupOpenAI(
     }
   }
 
-  // Step 5: Enable all available OpenAI models.
-  // The `:visible` filter excludes toggles inside the collapsed "deprecated
-  // models" section, which are mounted in the DOM but not displayed until the
-  // section's "Show N deprecated models" button is clicked. Without the
-  // filter, `.click()` on a hidden toggle retry-loops to a timeout.
-  const toggles = page.locator('[data-testid^="llm-toggle"]:visible');
-  await toggles.first().waitFor({ state: "visible", timeout: 15000 }).catch(() => {});
-  const toggleCount = await toggles.count();
-
-  for (let i = 0; i < toggleCount; i++) {
-    const toggle = toggles.nth(i);
-    const isChecked = (await toggle.getAttribute("aria-checked")) === "true";
-    if (!isChecked) {
-      await toggle.click();
-    }
-  }
+  // Step 5: Enable all available models — and let the write settle.
+  // Enabling is a TRANSACTION: the toggles are batched behind a 1000 ms debounce,
+  // and closing the panel inside that window takes the flush path that never
+  // refreshes the model picker (#1649). The helper clicks and then waits for the
+  // product's own write to go quiet, so Step 6 below cannot close on top of it.
+  // Costs nothing when nothing was clicked, which is the normal CI path.
+  await enableAndSettleModelToggles(page);
 
   // Read the panel's toggles BEFORE closing it: they are the second, independent
-  // source for "this model exists and is enabled", and a picker miss that this
-  // list contradicts is not an absence (#1461).
-  const enabledModels = await enumerateEnabledModels(page);
+  // source the picker can be contradicted by, and a picker miss that they
+  // contradict is not an absence (#1461). BOTH are read, because "the panel lists
+  // it" and "its toggle is on" are different facts and only the second one may be
+  // reported as ENABLED (#1649).
+  const listedModels = await enumerateEnabledModels(page);
+  const checkedModels = await enumerateCheckedModels(page);
 
   // Step 6: Close the provider management panel
   await page.getByRole("button", { name: "Close" }).click();
@@ -98,8 +94,22 @@ export async function setupOpenAI(
   // attached — so the click does not race that loading swap.
   await hideInspectorPanel(page);
   const modelTrigger = page.getByTestId("model_model");
-  await modelTrigger.waitFor({ state: "visible", timeout: 15000 });
-  await modelTrigger.click();
+  // 60 s, not the 15 s this used to allow, and NOT to make a stall pass: taking the
+  // correct flush path above means the product genuinely re-fetches, measured at
+  // 30 020 ms and 29 640 ms against the 4 327 ms the broken path returned in
+  // (#1649). The old budget would turn the fix into a model_model timeout.
+  await modelTrigger.waitFor({ state: "visible", timeout: 60000 });
+  // The click carries its own 60 s budget for the same measured reason as the
+  // waitFor above, and NOT as a retry bolted on to make a red pass: `click()`
+  // otherwise falls back to the 20 s `actionTimeout`, and the trigger re-enters the
+  // loading state between "visible" and the click while the refresh this helper
+  // correctly triggered is still running. Measured failing exactly there —
+  // `locator.click: Timeout 20000ms exceeded ... waiting for
+  // getByTestId('model_model')` — on the cold path with the provider on its
+  // MIN_DEFAULT_MODELS default (#1649). The locator is re-resolved on every
+  // actionability retry, so this survives the element being replaced, and nothing
+  // about the assertion that follows is weakened.
+  await modelTrigger.click({ timeout: 60000 });
   let pickByRanking = !modelTestId;
   if (modelTestId) {
     // Resolved by option IDENTITY (data-value / data-testid), never by the option's
@@ -112,7 +122,8 @@ export async function setupOpenAI(
     // degrading there would hide a suite defect behind a healthy-looking run (#1461).
     const selection = await selectPinnedModelOption(page, {
       requested: modelTestId,
-      enabledModels,
+      listedModels,
+      checkedModels,
       providerLabel: "OpenAI",
       absentBehavior: opts?.fallbackToRanking ? "return" : "throw",
     });
@@ -124,8 +135,8 @@ export async function setupOpenAI(
       pickByRanking = true;
       // The Escape that reported the absence closed the dropdown; reopen it for the
       // ranking pass below.
-      await modelTrigger.waitFor({ state: "visible", timeout: 15000 });
-      await modelTrigger.click();
+      await modelTrigger.waitFor({ state: "visible", timeout: 60000 });
+      await modelTrigger.click({ timeout: 60000 });
     }
   }
   if (pickByRanking) {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/CLAUDE.md
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/CLAUDE.md
@@ -89,7 +89,54 @@ trace. Resolve a model through
 `tests/helpers/provider-setup/model-option.ts` (identity from `data-value` /
 `data-testid`), never through the option's rendered text.
 
-### 5. Run with --workers=1
+### 5. Enabling models leaves the panel mid-transaction — never close on top of it
+
+The provider panel's model toggles are **not** written per click. Every toggle
+feeds `useModelToggleQueue`, which applies an optimistic cache update and then
+sends the whole batch through a **1000 ms debounce**. Which of the two send paths
+ends up carrying the batch decides whether the model picker sees the result at
+all, and only one of them refreshes it:
+
+| Path | Runs on | Refreshes the picker |
+|---|---|---|
+| debounced flush (`flushModelToggles`) | 1000 ms after the last toggle | **yes** — its `onSettled` invalidates *and* calls `refreshAllModelInputs` |
+| close-path flush (`flushPendingChanges`) | the modal's Close | **no** — it only invalidates; `handleClose`'s own `refreshAllModelInputs` runs *after* `onClose` already unmounted the modal |
+
+So closing the panel **within** the debounce window takes the path that never
+refreshes the picker, and the picker then renders the **pre-toggle** enabled set
+— which on a freshly configured provider is the `MIN_DEFAULT_MODELS = 5` default
+(`lfx/base/models/model_utils.py`). That is a genuine picker/panel disagreement,
+so `MODEL_PICKER_DEFECT` fires, correctly (§4) — and the cause is ours.
+
+Measured on `1.12.0.dev44`, one clean container, three runs of the identical
+sequence differing **only** in the pause between the last toggle click and Close,
+with the server reporting `enabled=41` in all three (#1649):
+
+| Pause before Close | `model_model` visible after | Picker offers |
+|---|---|---|
+| 0 ms | 4 327 ms | **5** ❌ |
+| 1 200 ms | 30 020 ms | 35 ✅ |
+| 2 000 ms | 29 640 ms | 35 ✅ |
+
+Two consequences for anything that drives this panel:
+
+1. **Wait for the batch to flush before clicking Close.** A person never closes a
+   dialog under a second after their last click, which is why this is unreachable
+   by hand and reproduces every time from automation.
+2. **Budget for the refresh.** Taking the correct path makes `model_model` take
+   **~30 s** to come back, not the ~4 s the broken path returns in. A 15 s budget
+   turns the fix into a `model_model` visibility timeout.
+
+Two conditions were measured and rejected as the wait: `waitForResponse` on the
+toggle POST **races** — the batch is often already sent mid-loop, so the wait
+times out while the write has in fact landed — and polling `GET enabled_models`
+**stalls the backend** that is busy with the very write being waited on
+(`apiRequestContext.get: Timeout 20000ms exceeded`).
+
+This is handled for you inside `tests/helpers/provider-setup/` — do not
+re-implement the toggle loop in a spec.
+
+### 6. Run with --workers=1
 
 ```bash
 npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/my-test.spec.ts --workers=1


### PR DESCRIPTION
**Fixes #1649.** Closes #1649.

## Problem

`MODEL_PICKER_DEFECT` fired **five times on 2026-08-31** and on no other day — 0 occurrences across the 16 prior dailies (2026-08-06 → 08-28), read from the per-run Playwright JSON rather than `error_signature`, as the issue's last Done-when clause asks. Four in daily [33410643882](https://github.com/oriontech-me/langflow-e2e/actions/runs/33410643882) (one per shard), the fifth on PR #1647's lane. All `attempt#0`, all recovered on retry.

The informative part was the count: **exactly 5 options per provider**. That is `MIN_DEFAULT_MODELS = 5` (`src/lfx/src/lfx/base/models/model_utils.py:40`) — the set Langflow marks `default=True` when a provider is configured. Verified directly against the API on a fresh instance:

```
before configuring OpenAI:  OpenAI: 58 listed, 0 enabled
after  writing the key:     OpenAI: 58 listed, 5 enabled
                            ['gpt-5.6-sol','gpt-5.6','gpt-5.6-luna','gpt-5.6-terra','gpt-realtime-2.1']
```

So the picker was showing the **pre-toggle** enabled set.

`setup-openai.ts` clicked every model toggle and then clicked Close with no pause. That is not impatience — it selects a different code path. Every toggle feeds `useModelToggleQueue`, which batches the write behind a **1000 ms debounce**, and the batch can leave through either of two paths, only one of which refreshes the picker:

| Path | Runs on | Refreshes the picker |
|---|---|---|
| `flushModelToggles` (debounce) | 1000 ms after the last toggle | **yes** — `onSettled` invalidates *and* calls `refreshAllModelInputs` |
| `flushPendingChanges` (close) | the modal's Close | **no** — invalidate only; `handleClose`'s own `refreshAllModelInputs` runs *after* `onClose` already unmounted the modal |

Measured on a clean `1.12.0.dev44` container, three runs of the identical sequence differing **only** in the pause before Close, with the server reporting `enabled=41` in all three:

| Pause before Close | `model_model` visible after | Picker offers |
|---|---|---|
| **0 ms** — what the helper did | 4 327 ms | **5** ❌ |
| 1 200 ms | 30 020 ms | 35 ✅ |
| 2 000 ms | 29 640 ms | 35 ✅ |

A person cannot close a dialog under a second after their last click, which is why this **never reproduced by hand** and reproduced every time from the suite. The first characterization on the issue called it a user-facing product regression; a manual walkthrough falsified that, and the verdict was corrected to `test-defect` ([comment](https://github.com/oriontech-me/langflow-e2e/issues/1649#issuecomment-5484710672)). No upstream issue was filed, because the drafted one claimed a defect it cannot demonstrate.

Why 2026-08-31 and not the other openai days (the rotation is Mon/Thu): the defect only bites when a spec **itself** changes the enabled set. All five occurrences enumerated the default set of freshly configured providers, so the sweep's enables were not in effect when those specs read the picker — that day all four shards were wedged (gunicorn `WORKER TIMEOUT` → SIGKILL, `/api/v1/auto_login` timing out at 20 s, two shards needing `Backend answered /api/v1/version on attempt 8 after 91s`).

## Fix

Three changes, **no `.spec.ts` touched**.

1. **`model-toggle-batch.ts` (new)** owns the toggle loop the three setup helpers copied verbatim, and waits for **quiescence on the product's own writes** before returning: at least one write answered, and quiet on both the click clock and the write clock for longer than the debounce. The decision is a pure `flushVerdict()` so every branch is unit-testable without a browser — the `resolveModelOption` / `censusForTarget` shape. It costs **nothing** when nothing was clicked, which is the normal CI path (measured: 8 245 ms warm vs 91 680 ms on the cold path).

   *Rejected alternatives, both measured:* `waitForResponse` on the toggle POST **races** — the batch is often already sent mid-loop, measured returning `landed=false` while the write had in fact landed, and it cannot tell the first batch from the last. Polling `GET enabled_models` **stalls the backend** busy with the very write being waited on, measured `apiRequestContext.get: Timeout 20000ms exceeded` on a `LANGFLOW_WORKERS=1` instance.

2. **`model-option.ts` stops overclaiming.** `enumerateEnabledModels` returns every rendered `llm-toggle-*` id regardless of `aria-checked` — its own docstring says a count taken from it is never a count of enabled models — yet it was passed as the single source behind a message asserting *"is ENABLED in the provider panel"*. `ResolveContext` now splits into `listedModels` + `checkedModels` (new `enumerateCheckedModels`), and `resolveModelOption` gains a **third loud verdict**: listed with the toggle OFF is `MODEL_NOT_ENABLED` — a setup failure, not a picker defect, because the picker is correct to omit a disabled model. **Nothing that used to fail becomes a skip**; `selectPinnedModelOption` throws on it.

3. **`collect-models.ts` stops confirming toggles against the optimistic client cache.** `waitForToggleChecked` polls `aria-checked`, which `useModelToggleQueue` flips synchronously at click time via `setQueryData`, before any request leaves the browser — measured: all 36 clicks "confirmed" while the POST went out at t=8132 ms. A write that never landed was indistinguishable from one that did, and the #1355 shortfall warning could not fire. The server is now read **once, after the whole sweep**, when it is idle (inside the loop it competes with the write it asks about).

The `model_model` budgets go to **60 s** in all three helpers, on both the `waitFor` **and** the `click`. Not to make a stall pass: taking the correct flush path means the product genuinely re-fetches, and `click()` otherwise falls back to the 20 s `actionTimeout` while the trigger re-enters its loading state — measured failing exactly there (`locator.click: Timeout 20000ms exceeded ... waiting for getByTestId('model_model')`) on the cold path, before this was added. `setup-anthropic` and `setup-google` had no `waitFor` at all and are aligned with `setup-openai`.

`setup-language-model-openai.ts` is deliberately **out of scope**: it enables a single toggle and already gates downstream by polling for an OpenAI option (`isOpenAIOffered` → reconfigure → poll), so it self-heals.

## Scope note

- The **#1461 assertion is untouched** and was correct throughout — its own hypothesis line ("the picker did not refresh after the panel closed") names the real cause.
- No spec file changed; no test title, step or validation criterion changed. What changed is the **precondition**: the setup no longer closes the panel on top of its own pending write.
- `@stable` is unchanged on all five affected specs — none was ever removed, since every failure was `attempt#0` and recovered.
- No quarantine to lift: the `test.fixme` at `agent-context-id-continuity.spec.ts:377` belongs to #1643.
- Docs: the mechanism and its measurements are recorded in the agent-area `CLAUDE.md` § 5; `agent-context-id-continuity.md` records it as a precondition and moves `Last validated` to `1.12.0.dev44`.

## Follow-up found, not fixed here

The new server-side confirmation immediately surfaced something on a local sweep: `Anthropic: 5 enabled`, `OpenAI: 5 enabled`, `Google Generative AI: 36 enabled` — only the **last** provider swept persisted. Two competing explanations and **neither is measured**: the provider switch may discard the pending batch (`useModelToggleQueue` cancels and discards when `currentContextIdentity` changes), or it may be key state (on that machine openai and anthropic were both drained and google was the only live key — exactly the one that persisted). Reported as an observation, not a cause; it needs its own issue.

## Validation (nightly `1.12.0.dev44`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ 0 errors · `npm run lint` ✅ 0 errors (1408 pre-existing warnings, unchanged)
- `npm run test:units` ✅ **839 pass, 0 fail** (13 new: 8 for `flushVerdict`, 4 for the third verdict + the two enumerators, 5 for `confirmEnabledOnServer`)
- Determinism burst, `agent-input-sources.spec.ts` — **3/3 clean**, `expected=2 unexpected=0 flaky=0 skipped=0`
- Determinism burst, `model-provider-model-toggle.spec.ts` (drives the toggles directly) — **3/3 clean**, same stats
- **Cold path** (provider reset to its `MIN_DEFAULT_MODELS` default so the spec has to enable) — **3/3 green**, 140 s / 176 s / 160 s
- Zero `🚨 Backend Error` ✅ · zero orphan flows on the instance ✅
- `--trace=on` **not run**: it hangs indefinitely on Simple Agent–template specs (#490/#518). Covered by the `--retries=0` bursts and the force-fails below instead.

### Force-fail — behavioural (the diff carries no `.spec.ts`)

The pipeline's FF gate passed **vacuously** (0 touched spec files). Not accepted: per the helper rule, the mechanism was mutated and a real spec watched go red, with the cold precondition arranged by resetting the provider to its default 5.

- **FF:** `model-toggle-batch.ts` with the flush wait removed (the pre-fix behaviour) → `input via the Agent's direct field drives the agent response` **failed** (`unexpected=1`)
- **FF:** same mutation → `input via ChatInput handle drives the agent response` **failed** (`unexpected=1`)
- **Revert proven:** `git diff | grep -c FF-MUTATION` → **0**, followed by the 3 cold green runs above.

Between the two force-fails the reset reported google going **36 → 5**, i.e. the mutated run *did* write the models to the server and the test failed anyway — the write lands, the picker is what goes stale.

**Provider caveat:** on the machine this was validated on, the **openai and anthropic keys are out of credit** ("You have no credits remaining" / "credit balance is too low"), so every spec run above used **google** — which exercises `setup-google`, one of the three changed helpers. The openai path was proven separately by driving `setupOpenAI(page, "gpt-4o-mini")` directly: pre-fix it threw the verbatim `MODEL_PICKER_DEFECT` **3/3** on a fresh container while the server reported `enabled=41, gpt-4o-mini=true`; post-fix it returns OK with the trigger reading `gpt-4o-mini`. The openai lane verdict is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
