### PR TITLE
fix(i18n): create the missing-key gap instead of borrowing it from the bundle (#1646)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -1009,9 +1009,12 @@
       → i18n/locale-resilience.spec.ts
 - [x] A locale bundle missing individual keys falls back to English for those keys instead of
       failing the render — asserted in the Create Memory modal under `pt`, on the two
-      `memory.dbProvider*` keys only `en` carries (`shortcuts.modifierOnly` is a decoy: its
-      call site passes an inline `defaultValue`, so it renders English even with the
-      fallback broken)
+      `memory.dbProvider*` keys the test itself strips from the served `pt` chunk. The gap is
+      created rather than borrowed since #1646: upstream translated those keys 10 days after
+      the spec landed, so a probe chosen from the shipped bundle's gaps expires on upstream's
+      schedule (`shortcuts.modifierOnly` remains a decoy and must not be the key removed — its
+      call site passes an inline `defaultValue`, so it renders English even with the fallback
+      broken)
       → i18n/locale-resilience.spec.ts
 
 ---

--- a/docs/i18n/locale-resilience.md
+++ b/docs/i18n/locale-resilience.md
@@ -1,6 +1,6 @@
 # i18n — Locale resilience
 
-**Last validated:** Langflow 1.12.x (measured on nightly `1.12.0.dev33`)
+**Last validated:** Langflow 1.12.x (measured on nightly `1.12.0.dev44`)
 
 ---
 
@@ -25,12 +25,14 @@ individual keys.
    reads `en`, and `localStorage.languagePreference` is **unset** — the browser
    locale never becomes a language preference.
 3. **should fall back to English for a key the active bundle lacks, next to
-   siblings it translates** — with the interface in Portuguese, the flow
-   editor's Create Memory modal renders `Criar Memória`, `Nome` and
-   `Tamanho do lote` in Portuguese while the `Vector Database` label and its
-   description — two keys the Portuguese bundle does not carry — render their
-   English text. No raw i18n key (`memory.dbProviderLabel`) appears anywhere in
-   the dialog.
+   siblings it translates** — with the interface in Portuguese, and with
+   `memory.dbProviderLabel` and `memory.dbProviderDescription` **removed from the
+   `pt` chunk the browser is served**, the flow editor's Create Memory modal
+   renders `Criar Memória`, `Nome` and `Tamanho do lote` in Portuguese while
+   those two keys render their English text (`Vector Database` and its
+   description). No raw i18n key (`memory.dbProviderLabel`) appears anywhere in
+   the dialog. The gap is **created by the test**, not borrowed from whatever the
+   shipped bundle happens to be missing that week — see **Validation criterion**.
 
 ---
 
@@ -83,9 +85,11 @@ id-scoped.
   becomes a boot risk again and test 1's table becomes reachable from the
   browser. It uses `withLocale()` — the sanctioned opt-in — never a bare
   `test.use({ locale })`.
-- **Test 3's vehicle is chosen, not convenient — and one obvious candidate is a
-  decoy.** On `1.12.0.dev33` all six non-English bundles are missing the **same
-  five** keys that `en` carries: `shortcuts.modifierOnly`, `memory.backendLabel`,
+- **Test 3's vehicle is chosen, not convenient, and one obvious candidate is a
+  decoy.** This still governs which key the test may REMOVE: a key whose call
+  site supplies its own English default proves nothing about `fallbackLng`,
+  whether the gap is the bundle's or the test's. On `1.12.0.dev33` all six
+  non-English bundles were missing the **same five** keys that `en` carries: `shortcuts.modifierOnly`, `memory.backendLabel`,
   `memory.dbProviderLabel`, `memory.dbProviderDescription` and
   `memory.dbProviderNotConfigured`. `shortcuts.modifierOnly` **must not be
   used**: its call site passes an inline
@@ -105,12 +109,31 @@ id-scoped.
   render the key itself: the dialog's text must not contain
   `memory.dbProviderLabel`. Two different broken states — key echoed, or empty
   string — are excluded by the pair of assertions.
-- **This test has a known expiry and says so in its own failure.** If upstream
-  translates those keys, the English assertion goes red on a healthy product.
-  The assertion therefore carries a message naming that possibility and pointing
-  at how to re-measure (diff the `en` translation object in
-  `assets/index-*.js` against `assets/pt-*.js`), so the next reader is not left
-  diagnosing a phantom i18n regression.
+- **The gap is CREATED, not borrowed — this is what #1646 changed.** The first
+  version of this test asserted English on keys the shipped `pt` bundle happened
+  not to carry, and said so in its own failure message together with the
+  procedure to re-measure. That procedure worked exactly as written and the
+  answer was that the probe had expired: on `1.12.0.dev44`
+  `memory.dbProviderLabel` reads `Vector Database` in `en` and **`Banco de dados
+  vetorial`** in `pt`, and its description is likewise translated. The key is now
+  present in all six non-English bundles. The measured lifetime of that design
+  was **10 days** — the spec landed 2026-08-21 (PR #1541), was green on 7
+  dailies, and failed 3/3 on 2026-08-31 (run 33410643882). Re-measured 5/5
+  failing on `1.12.0.dev44` before the fix.
+- **So the test now removes the keys itself.** It intercepts the separately
+  served `pt-*.js` chunk (measured: `HTTP 200`, 146 373 bytes) and deletes the
+  two `"key":"value"` pairs from the body before the browser parses it. What is
+  asserted is unchanged — same dialog, same English strings, same Portuguese
+  siblings, same raw-key check — but the precondition is now under the test's
+  control, so it cannot expire and needs no dated re-measurement. It also tests
+  `fallbackLng` more directly than the old form did: a gap that upstream might
+  fill at any moment was never the contract, the fallback behaviour is.
+- **The interception must be PROVEN to have happened, or the test is vacuous.**
+  If upstream removes those keys from `pt` again, the strip matches nothing while
+  the dialog still shows English, and the test would pass without ever exercising
+  its own mechanism — the silent-pass shape #1012 exists to stop. The test
+  therefore asserts that exactly **two** pairs were stripped from a chunk it
+  actually intercepted, and fails naming that count when it is not two.
 
 ---
 
@@ -130,9 +153,11 @@ id-scoped.
 - `src/frontend/src/i18n.ts` — the normaliser ladder test 1 transcribes, the
   `fallbackLng: "en"` configuration test 3 exercises, and the absence of a
   language-detector plugin that test 2 pins.
-- `src/frontend/src/locales/pt.json` — the bundle whose five-key gap against
-  `en` is test 3's subject; if upstream fills it, the test says how to
-  re-measure (see Validation criterion).
+- `src/frontend/src/locales/pt.json` — the bundle test 3 intercepts and removes
+  two keys from. It depends on the two keys still being PRESENT there (they are,
+  since upstream translated them — measured on `1.12.0.dev44`), not on them being
+  absent, which is the inversion #1646 introduced. A build that drops them again
+  is caught by the strip-count assertion rather than passing silently.
 
 ---
 

--- a/tests/tests-automations/regression/i18n/locale-resilience.spec.ts
+++ b/tests/tests-automations/regression/i18n/locale-resilience.spec.ts
@@ -203,9 +203,52 @@ test.describe("i18n — an unshipped browser locale", () => {
   );
 });
 
+/**
+ * The keys test 3 removes from the `pt` chunk to create the gap it asserts on.
+ *
+ * Both are real `memory.*` keys whose call sites pass NO `defaultValue`, so the
+ * English text the dialog shows for them can only come from `fallbackLng: "en"`.
+ * They are also currently PRESENT in `pt` — upstream translated them, which is
+ * what retired the previous design (#1646) — and that presence is the thing
+ * `stripPtKeys` asserts, not something it assumes.
+ */
+const STRIPPED_KEYS = ["memory.dbProviderLabel", "memory.dbProviderDescription"] as const;
+
+/**
+ * Removes `STRIPPED_KEYS` from the `pt` locale chunk on its way to the browser.
+ *
+ * The chunk is a separately served asset (measured on 1.12.0.dev44: `HTTP 200`,
+ * 146 373 bytes), so it can be rewritten before i18next ever parses it. The
+ * returned counter is the load-bearing half: if a future build drops these keys
+ * from `pt` again, the strip matches nothing while the dialog still renders
+ * English, and the test would pass without ever exercising its own mechanism —
+ * an unevaluated test is unknown, not clean (#1012). The caller asserts the
+ * count, so that state fails and says why.
+ */
+async function stripPtKeys(page: Page): Promise<{ stripped: () => number }> {
+  let stripped = 0;
+  await page.route("**/assets/pt-*.js", async (route) => {
+    const response = await route.fetch();
+    const body = await response.text();
+    let patched = body;
+    for (const key of STRIPPED_KEYS) {
+      // The whole `"key":"value"` pair, trailing comma included — an emptied
+      // value is not a missing key and i18next would render "" instead of
+      // falling back, which is the state this test must not silently produce.
+      const pair = new RegExp(`"${key.replace(".", "\\.")}":"(?:[^"\\\\]|\\\\.)*",?`, "g");
+      const next = patched.replace(pair, "");
+      if (next !== patched) stripped++;
+      patched = next;
+    }
+    await route.fulfill({ response, body: patched });
+  });
+  return { stripped: () => stripped };
+}
+
 test.describe("i18n — a key the active bundle does not carry", () => {
   let token: string;
   let flowId: string;
+  let ptChunk: { stripped: () => number };
 
   test.beforeEach(async ({ page, request }) => {
     token = await getAuthToken(request);
@@ -225,6 +268,9 @@ test.describe("i18n — a key the active bundle does not carry", () => {
     await page.addInitScript(() =>
       localStorage.setItem("languagePreference", "pt"),
     );
+    // Installed BEFORE that navigation too — the chunk is requested during it,
+    // and a route registered afterwards would miss it entirely (#1646).
+    ptChunk = await stripPtKeys(page);
     await openFlowById(page, flowId);
     await expect(page.locator("html")).toHaveAttribute("lang", "pt", {
       timeout: 30000,
@@ -238,28 +284,51 @@ test.describe("i18n — a key the active bundle does not carry", () => {
     await deleteFlow(request, flowId, { headers: { Authorization: token } });
   });
 
-  // QUARANTINED for #1646 — the English-fallback probe key no longer falls back
-  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
-  test.fixme(
+  test(
     "a missing key falls back to English beside siblings the bundle translates",
-    { tag: ["@regression", "@ui-ux", "@workspace"] },
+    { tag: ["@stable", "@regression", "@ui-ux", "@workspace"] },
     async ({ page }) => {
-      // On 1.12.0.dev33 all six non-English bundles are missing the same five
-      // keys `en` carries (2387 vs 2382). Two of them render unconditionally in
-      // this modal, on an instance with nothing configured.
+      // The gap this test needs is CREATED here, not borrowed from whatever the
+      // shipped `pt` bundle happens to be missing this week (#1646). The first
+      // version asserted English on keys upstream had not translated yet, and
+      // carried its own expiry hint telling the reader to re-measure the bundle
+      // diff. That hint worked exactly as written and the answer was that the
+      // probe had expired: on 1.12.0.dev44 `memory.dbProviderLabel` reads
+      // "Vector Database" in `en` and "Banco de dados vetorial" in `pt`, and its
+      // description is translated too. The design lasted 10 days — landed
+      // 2026-08-21 (#1541), green on 7 dailies, 3/3 red on 2026-08-31 (run
+      // 33410643882), re-measured 5/5 red on dev44 before this change.
       //
-      // A third, `shortcuts.modifierOnly`, is a DECOY and must not be used: its
-      // call site passes an inline `defaultValue`, so it renders English whether
-      // or not `fallbackLng` works. These two are called with no defaultValue at
-      // all, so English here can only come from the fallback.
+      // So the keys are stripped from the `pt` chunk on its way to the browser.
+      // What is asserted below is unchanged; only the precondition moved under
+      // this test's control, and `fallbackLng` is exercised more directly than a
+      // bundle gap upstream may close at any moment ever exercised it.
+      //
+      // The DECOY rule still governs WHICH key may be removed: `shortcuts.
+      // modifierOnly` passes an inline `defaultValue` at its call site, so it
+      // renders English whether or not `fallbackLng` works. These two are called
+      // with no defaultValue at all, so English here can only come from the
+      // fallback.
       const FALLBACK_LABEL = "Vector Database";
       const FALLBACK_DESCRIPTION =
         "Where this memory base stores vectors. Configured providers come from DB Providers settings.";
       const FALLBACK_KEY = "memory.dbProviderLabel";
-      const EXPIRY_HINT =
-        `if upstream has translated ${FALLBACK_KEY}, re-measure by diffing the en translation ` +
-        `object in the container's langflow/frontend/assets/index-*.js against assets/pt-*.js and ` +
-        `pick another key present only in en`;
+      const DESCRIPTION_KEY = "memory.dbProviderDescription";
+      const STRIP_HINT =
+        `the ${STRIPPED_KEYS.length} key(s) this test removes from the served pt chunk are what ` +
+        `create the gap — check the strip count reported above before suspecting i18next`;
+
+      // Before anything is read from the dialog: prove the gap is the one this
+      // test created. A pass on an un-intercepted chunk would be measuring
+      // upstream's bundle again, which is exactly what #1646 retired.
+      expect(
+        ptChunk.stripped(),
+        `the pt chunk was not patched as expected — ${ptChunk.stripped()} of ` +
+          `${STRIPPED_KEYS.length} key(s) removed. Either the route did not match the ` +
+          `served asset, or upstream dropped ${STRIPPED_KEYS.join(" / ")} from pt again, ` +
+          `in which case the dialog would render English for a reason this test did not ` +
+          `create and the assertions below would prove nothing (#1646/#1012)`,
+      ).toBe(STRIPPED_KEYS.length);
 
       await page.getByTestId("sidebar-nav-memories").click();
       // `/^Mem/` covers the English and Portuguese headings alike, so the
@@ -287,11 +356,11 @@ test.describe("i18n — a key the active bundle does not carry", () => {
       await test.step("the two keys the bundle lacks render their English text", async () => {
         await expect(
           dialog.getByText(FALLBACK_LABEL, { exact: false }).first(),
-          `${FALLBACK_LABEL} did not fall back to English — ${EXPIRY_HINT}`,
+          `${FALLBACK_LABEL} did not fall back to English — ${STRIP_HINT}`,
         ).toBeVisible({ timeout: 15000 });
         await expect(
           dialog.getByText(FALLBACK_DESCRIPTION, { exact: false }),
-          `the description did not fall back to English — ${EXPIRY_HINT}`,
+          `the description did not fall back to English — ${STRIP_HINT}`,
         ).toBeVisible();
       });
 
@@ -302,6 +371,10 @@ test.describe("i18n — a key the active bundle does not carry", () => {
           await dialog.innerText(),
           `the dialog rendered the raw key instead of a string — fallbackLng is not doing its job`,
         ).not.toContain(FALLBACK_KEY);
+        expect(
+          await dialog.innerText(),
+          `the dialog rendered the raw ${DESCRIPTION_KEY} instead of a string`,
+        ).not.toContain(DESCRIPTION_KEY);
       });
 
       // Nothing is created: the modal is only read, then dismissed.


### PR DESCRIPTION
**Fixes #1646.** Closes #1646.

## Problem

The §18.2 fallback test failed **3/3 attempts** in daily [33410643882](https://github.com/oriontech-me/langflow-e2e/actions/runs/33410643882) (2026-08-31) — `getByRole('dialog').getByText('Vector Database')` not found after 15 s. First failure since the spec landed on 2026-08-21 (#1541); green on the 7 dailies in between.

The spec **predicted this in writing** and left the re-measurement procedure in its own error string. That procedure works, and the answer is that the probe expired. Measured on the current nightly `1.12.0.dev44`, diffing the container's shipped assets exactly as the hint says:

| key | `en` | `pt` |
|---|---|---|
| `memory.dbProviderLabel` | `Vector Database` | **`Banco de dados vetorial`** |
| `memory.dbProviderDescription` | `Where this memory base stores vectors…` | **`Onde esta base de memória armazena os vetores…`** |

Both keys are now present in **all six** non-English bundles. There is nothing left to fall back for — the dialog opens and renders, in Portuguese, which is why the English matcher found nothing. **The fallback mechanism is intact**, so branch 3 of the issue's directive (a moved or renamed dialog) is refuted by the same observation, and branch 4 (environment) was already ruled out by the issue's own liveness cross-reference (0% / 0% / 3% of probes down across the three attempts, on shard 2, while shard 1 measured 21% down and passed everything).

Re-measured **5/5 failing (100%, 0 environment voids)** on `1.12.0.dev44` before the fix, so this is a hard deterministic failure and not a flake.

The gap set did not merely shrink, it **turned over**: 5 en-only keys on `1.12.0.dev33` — the measurement the probe was chosen from — against **17** on `dev44`, none of them these two.

## Fix

The load-bearing number is the **lifetime**: landed 08-21, green on 7 dailies, red on 08-31. **Ten days.** Picking another en-only key from the current 17 restarts the same clock, so the design changes instead.

**The test now creates the gap rather than borrowing it.** It intercepts the separately served `pt-*.js` chunk (measured: `HTTP 200`, 146 373 bytes), strips the two `"key":"value"` pairs from the body, and fulfils with the patched text before the browser parses it.

**Every assertion is unchanged** — same dialog, same English strings, same Portuguese siblings (`Criar Memória`, `Tamanho do lote`), same raw-key check. Only the precondition moves under the test's control. It also exercises `fallbackLng` more directly than a bundle gap upstream may close at any moment ever did: a gap in the shipped bundle was never §18.2's contract, the fallback behaviour is.

Two things are added, both load-bearing:

- **A strip-count gate.** If a future build drops these keys from `pt` again, the strip matches nothing while the dialog still renders English, and the test would pass without ever exercising its own mechanism — the silent-pass shape #1012 exists to stop. The test asserts **exactly two** pairs removed from a chunk it really intercepted, and fails naming the count. This is asserted *before* the dialog is opened.
- **A replacement failure message.** The old one told the reader to re-measure the bundle gap, which is no longer how the gap is produced; the new one names the interception and the count, so the next failure points at the route rather than at a phantom i18n regression.

The **decoy rule is kept and re-framed**: it now governs which key may be *removed*, since a key whose call site supplies its own inline `defaultValue` (`shortcuts.modifierOnly`) proves nothing about `fallbackLng` whether the gap is the bundle's or the test's.

`page.route` was chosen over patching a local bundle because the chunk is a real served asset — the interception is the only point where the test can control what i18next sees without touching the image.

## Scope note

- **Quarantine lifted**, which is the issue's own deliverable: `test.fixme` back to `test` and `@stable` back in the tag array, reverting exactly what triage commit `377a251b` applied.
- Tests 1 and 2 of the file (the normaliser ladder and the browser-locale axis) are **untouched** — they are in scope for validation and force-fail only because the whole-file rule says so.
- No new helper, no new POM, no new tag. No LLM and no provider key: test 3 opens the Create Memory modal and never selects an embedding model.
- Cleanup unchanged — one empty flow per test via `POST /api/v1/flows/`, editor unmounted then deleted id-scoped in `afterEach`.
- **Nothing filed upstream**, deliberately: translating a key is correct product behaviour, not a regression, so the issue's `Upstream: not filed` line stands.
- The `QA-CHECKLIST.md` §18 bullet is updated because its text had become false — it claimed the two keys are ones "only `en` carries". Manual Part II bullet only; no generated block touched.

## Validation (nightly `1.12.0.dev44`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ 0 errors · `npm run lint` ✅ 0 errors
- QA-CHECKLIST guard ✅ (`no auto-generated blocks were edited`) · coverage guard ✅ (`every @stable and every documented spec is referenced by a Part II bullet`)
- **Pre-fix baseline: 5/5 failed (100%), 0 voided on environment signatures** — recorded on the unmodified spec with the quarantine lifted, ~20–23 s per run
- Determinism burst, whole file — **3/3 clean**, `expected=3 unexpected=0 flaky=0 skipped=0`
- Final green after reverts — **1/1 clean**, `expected=3`, ~21 s
- Zero `🚨 Backend Error` ✅ · zero orphan flows on the instance ✅
- `--trace=on` not run: it hangs locally well beyond the template family (#518). Covered by the bursts and the force-fails instead.

### Force-fail — 3/3 executed, scope is the whole file

- **FF:** `stripPtKeys` builds a regex matching nothing, so the chunk is served untouched — the pre-#1646 precondition → *a missing key falls back to English…* **failed** (`unexpected=1`). It failed on the **strip-count gate**, which is the proof that the new guard fires rather than the visible assertion catching it downstream.
- **FF:** the ladder assertion demands the wrong resolved language on every row (`en` ↔ `pt`) → *the application boots into a shipped language…* **failed** (`unexpected=1`)
- **FF:** the load-bearing assertion demands `localStorage.languagePreference === "nb-NO"`, i.e. that the browser locale *did* become a stored preference → *the application boots in English and never adopts…* **failed** (`unexpected=1`)
- **Revert proven:** `git diff | grep -c FF-MUTATION` → **0**, followed by the final green run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
