### PR TITLE
fix(ui-ux): displace the viewport in the test instead of borrowing the editor's (#1645)

### DIFF
--- a/docs/ui-ux/canvas-zoom-navigation.md
+++ b/docs/ui-ux/canvas-zoom-navigation.md
@@ -16,15 +16,31 @@ is the only observable that proves the canvas actually moved: a control that
 renders, is enabled and is clickable but no longer wired to the viewport passes a
 "button is visible" check and fails these.
 
-**Entry-state note (measured live, 1.12.0.dev6).** The editor does **not** open on
-the flow's persisted viewport: it opens clamped at the maximum zoom
-(`scale(2)`, `zoom_in` already `disabled`, the graph overflowing the pane),
-reproducibly across reloads, while `GET /api/v1/flows/{id}` still reports
-`viewport.zoom = 0.896`. That is why every test that measures *relative* zoom
-first normalizes the viewport with one `fit_view` click (`normalizeViewport`) —
-on a clamped viewport "zoom in raises the scale" is untestable. The tests assert
-the behavior of the controls, not this entry state; test 3 is the one that uses
-it, as a free "displaced viewport" to prove Fit View acts.
+**Entry-state note — the entry viewport is a product decision no test may depend
+on (#1645).** It has already changed once under this spec. On `1.12.0.dev6` the
+editor did **not** open on the flow's persisted viewport: it opened clamped at
+the maximum zoom (`scale(2)`, `zoom_in` already `disabled`, the graph
+overflowing the pane), reproducibly across reloads, while
+`GET /api/v1/flows/{id}` reported `viewport.zoom = 0.896`. On `1.12.0.dev44` it
+opens **fitted** instead — measured 3 runs of 3, byte-identical:
+`translate(-588.052px, -476.054px) scale(0.880331)`, every node contained in the
+pane, and all four controls enabled including `zoom_in`. That is the same
+transform one `fit_view` click produces, so the editor now applies the fit on
+hydration.
+
+The change is an improvement, not a regression: the old clamp was the anomaly and
+Fit View itself still refits correctly (measured below). What it broke was a test
+that consumed the entry state as a free "displaced viewport" — test 3's
+precondition `contained === false` read `true` and the toolbar Fit View path it
+guards went unexercised, silently, which is the failure #1645 was filed for.
+
+Two consequences encoded here. Every test that measures *relative* zoom still
+normalizes with one `fit_view` click (`normalizeViewport`) — its wait is on
+containment, the fit's real postcondition, so it survived the entry change
+untouched. And **every test that needs a displaced viewport now displaces it
+itself**, by clicking `zoom_in` to the `2` clamp: the precondition is then the
+test's own doing rather than a product quirk it borrowed. Tests 2 and 3 both do
+this.
 
 **Wait strategy — why a plain "the transform stopped changing" poll is not enough
 (#1094).** React Flow commits a viewport change in one frame (measured: the
@@ -84,15 +100,22 @@ Four independent tests:
 3. **Fit View button in toolbar** — the toolbar surface contract:
    `main_canvas_controls` is visible on flow entry while `fit_view`, `zoom_in`,
    `zoom_out` and `reset_zoom` are **absent** from the DOM; clicking
-   `canvas_controls_dropdown` renders all four visible (`fit_view` and
-   `reset_zoom` enabled — `zoom_in` is legitimately disabled at the entry clamp);
-   clicking `fit_view` from the toolbar on that displaced entry viewport changes
-   the transform, brings every node inside the pane and re-enables both zoom
-   buttons — proving the toolbar entry is wired, not decorative. Collapsing the
-   dropdown removes all four from the DOM again and it can be re-expanded. The
-   collapse click is `force: true`: while open, the Radix popover overlay covers
-   the trigger and a normal click fails Playwright's hit-test (the same forced
-   click `closeCanvasControls` issues in `helpers/ui/canvas-controls.ts`).
+   `canvas_controls_dropdown` renders all four visible, with `fit_view` and
+   `reset_zoom` enabled. The test then **displaces the viewport itself** through
+   the toolbar it is testing — `zoom_in` clicked to the `2` clamp, asserted as
+   landing at least one click — and only then asserts the precondition that the
+   graph overflows the pane. Clicking `fit_view` from the toolbar changes the
+   transform, brings every node inside the pane and re-enables both zoom buttons
+   — proving the toolbar entry is wired, not decorative. Collapsing the dropdown
+   removes all four from the DOM again and it can be re-expanded. The collapse
+   click is `force: true`: while open, the Radix popover overlay covers the
+   trigger and a normal click fails Playwright's hit-test (the same forced click
+   `closeCanvasControls` issues in `helpers/ui/canvas-controls.ts`).
+
+   No assertion is made on the enabled state of `zoom_in` / `zoom_out` at entry.
+   That is deliberate: it is exactly the entry-state dependency that broke this
+   test once, and the post-fit assertion below is the one that carries meaning,
+   because the test *knows* it just left the zoom bound.
 4. **Scroll to navigate canvas** — a mouse wheel over the pane navigates the
    canvas by zooming **anchored at the pointer**: `deltaY > 0` strictly decreases
    the scale, `deltaY < 0` restores it, and in both directions the flow-space
@@ -123,8 +146,9 @@ part of test 3's enabled-controls assertion), and the minimap.
 | Fit View centering | union box inside the pane rect (1 px tolerance) AND \|union center − pane center\| ≤ 4 px on both axes AND both node titles visible |
 | Fit View idempotence | second `fit_view` click leaves the `transform` string byte-identical — conditional on no node being **selected** between the clicks, since the handler's right padding jumps to `340px` when the inspection panel is open with a selection; this spec never selects a node |
 | Toolbar collapsed | `main_canvas_controls` visible; `fit_view`/`zoom_in`/`zoom_out`/`reset_zoom` `count() === 0` |
-| Toolbar expanded | all four controls visible after clicking `canvas_controls_dropdown`; `fit_view` and `reset_zoom` enabled |
-| Toolbar Fit View wired | nodes NOT contained before the click; after it the transform differs, every node is inside the pane, and `zoom_in`/`zoom_out` are both enabled |
+| Toolbar expanded | all four controls visible after clicking `canvas_controls_dropdown`; `fit_view` and `reset_zoom` enabled. Nothing is asserted about `zoom_in`/`zoom_out` here — the entry viewport is a product decision (#1645) |
+| Toolbar displacement | clicking the toolbar's own `zoom_in` to exhaustion lands ≥ 1 click, ends at scale `2`, and leaves the nodes' union box NOT contained in the pane |
+| Toolbar Fit View wired | nodes NOT contained before the click (from the displacement above, never from the entry state); after it the transform differs, every node is inside the pane, and `zoom_in`/`zoom_out` are both enabled |
 | Toolbar re-collapse | `count() === 0` for all four after a forced trigger click; all four visible again after re-expanding |
 | Scroll out | after `wheel(0, +300)` scale is strictly smaller AND the flow-space point under the cursor is unchanged (≤ 2 px) |
 | Scroll in | after `wheel(0, −300)` scale is strictly larger, back to the pre-scroll value (± 0.001), anchor preserved (≤ 2 px) |
@@ -202,21 +226,26 @@ the editor's event poll.
 - **Objective:** prove the canvas-controls toolbar exposes Fit View (and its
   sibling zoom controls) behind the collapsible dropdown, and that the exposed
   Fit View acts on the viewport.
-- **Precondition:** as above; controls NOT yet expanded and the viewport NOT
-  normalized (this test uses the displaced entry viewport on purpose).
+- **Precondition:** as above; controls NOT yet expanded. The test makes **no**
+  assumption about the entry viewport — it creates its own displacement (#1645).
 - **Step by step:**
   1. Assert `main_canvas_controls` is visible and each of `fit_view`, `zoom_in`,
      `zoom_out`, `reset_zoom` has `count() === 0`.
   2. Click `canvas_controls_dropdown`; assert the four controls are visible and
      that `fit_view` / `reset_zoom` are enabled.
-  3. Record the transform, assert the nodes are not contained, click `fit_view`.
-  4. Read the transform and the node/pane geometry; read both zoom buttons'
+  3. Click the toolbar's `zoom_in` until it reports `disabled` (bounded loop);
+     assert at least one click landed and that the settled scale is `2`.
+  4. Measure the union box of `.react-flow__node` against `.react-flow__pane` —
+     assert it overflows (the precondition, now the test's own doing).
+  5. Record the transform and click `fit_view`.
+  6. Read the transform and the node/pane geometry; read both zoom buttons'
      enabled state.
-  5. Click `canvas_controls_dropdown` (forced) and assert `count() === 0` for all
+  7. Click `canvas_controls_dropdown` (forced) and assert `count() === 0` for all
      four; click it once more and assert all four are visible again.
-- **Validation:** the step-4 transform differs from the step-3 one, every node is
-  inside the pane rect, `zoom_in` and `zoom_out` are both enabled, and the
-  collapse/expand transitions hold exactly as asserted in steps 1, 2 and 5.
+- **Validation:** step 3 ends at scale `2` after ≥ 1 click, step 4 reports the
+  nodes NOT contained, the step-6 transform differs from the step-5 one, every
+  node is inside the pane rect, `zoom_in` and `zoom_out` are both enabled, and
+  the collapse/expand transitions hold exactly as asserted in steps 1, 2 and 7.
 
 ### 15.5.4 Wheel scroll navigates the canvas anchored at the pointer [-]
 
@@ -242,4 +271,5 @@ the editor's event poll.
 
 ## Last validated
 
-1.12.x (nightly `1.12.0.dev9`; originally authored against `1.12.0.dev6`)
+1.12.x (nightly `1.12.0.dev44` for the #1645 entry-viewport change; previously
+`1.12.0.dev9`, originally authored against `1.12.0.dev6`)

--- a/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
@@ -173,17 +173,25 @@ async function openCanvasControls(page: Page): Promise<void> {
 /**
  * Brings the viewport to the canonical fitted state and collapses the controls.
  *
- * Needed because the editor does NOT open on the flow's persisted viewport: on
- * 1.12.0.dev6 it opens clamped at the maximum zoom (`scale(2)`, `zoom_in`
- * already disabled — reproducible across reloads). Without normalizing, "zoom in
- * raises the scale" is untestable, so each test that measures relative zoom
- * starts from the deterministic Fit View state instead.
+ * Needed because the entry viewport is a product decision, and it has already
+ * changed once under this spec (#1645). On 1.12.0.dev6 the editor did NOT open on
+ * the flow's persisted viewport: it opened clamped at the maximum zoom
+ * (`scale(2)`, `zoom_in` already disabled — reproducible across reloads). On
+ * 1.12.0.dev44 it opens FITTED instead — measured 3 runs of 3, byte-identical:
+ * `translate(-588.052px, -476.054px) scale(0.880331)`, every node contained, all
+ * four controls enabled. That is the transform one `fit_view` click produces, so
+ * the editor now applies the fit on hydration. Either way, "zoom in raises the
+ * scale" needs a known baseline, so each test that measures relative zoom starts
+ * from the deterministic Fit View state instead of from whatever the editor
+ * happens to open on.
  *
  * The wait is on containment rather than on "the transform changed" (#1094): the
  * baseline this returns is the divisor of every relative zoom assertion, so it
  * must be the fitted viewport and not whatever the transform happened to hold on
  * the first read. Containment is the postcondition regardless of the entry state,
- * so this keeps working if the editor ever stops opening clamped.
+ * which is why this helper survived the dev44 change untouched — and why the
+ * toolbar test below now creates its own displacement rather than borrowing the
+ * editor's.
  */
 async function normalizeViewport(page: Page): Promise<Viewport> {
   await openCanvasControls(page);
@@ -496,10 +504,8 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
       });
     });
 
-  // QUARANTINED for #1645 — the displaced entry viewport reads as already contained
-  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
-  test.fixme("Fit View is reachable from the canvas controls toolbar",
-    { tag: ["@workspace", "@ui-ux"] },
+  test("Fit View is reachable from the canvas controls toolbar",
+    { tag: ["@stable", "@workspace", "@ui-ux"] },
     async ({ page }) => {
       const controlTestIds = ["fit_view", "zoom_in", "zoom_out", "reset_zoom"];
 
@@ -516,16 +522,49 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
         for (const testId of controlTestIds) {
           await expect(page.getByTestId(testId)).toBeVisible({ timeout: 15000 });
         }
-        // Only these two are asserted enabled here: the editor opens clamped at
-        // the maximum zoom, so `zoom_in` is legitimately disabled until the
-        // viewport moves (asserted below, right after Fit View).
+        // Only these two are asserted enabled here, and the omission is the point
+        // (#1645): whether `zoom_in` / `zoom_out` are live on entry follows from
+        // the entry viewport, which is a product decision this test must not
+        // depend on — it read `disabled` on 1.12.0.dev6 (max-zoom clamp) and
+        // `enabled` on 1.12.0.dev44 (fitted on hydration). Their state IS
+        // asserted below, right after Fit View, where the test knows it just
+        // left the zoom bound because it put the viewport there itself.
         await expect(page.getByTestId("fit_view")).toBeEnabled();
         await expect(page.getByTestId("reset_zoom")).toBeEnabled();
       });
 
-      await test.step("the toolbar Fit View acts on the displaced entry viewport", async () => {
+      await test.step("the toolbar zoom controls displace the viewport off the fit", async () => {
+        // The displacement is the test's OWN doing (#1645). This step used to be
+        // absent: the test asserted `contained === false` straight off the entry
+        // viewport, which on 1.12.0.dev6 opened clamped at `scale(2)` with the
+        // graph overflowing the pane. On 1.12.0.dev44 the editor opens fitted, so
+        // that precondition read `true`, failed as the setup it is, and the
+        // toolbar Fit View path it guards went unexercised — silently, three
+        // attempts in a row (daily 2026-08-31, run 33410643882).
+        //
+        // Zooming to the clamp through the toolbar under test keeps the whole
+        // step inside this spec's subject, and makes the post-fit "both zoom
+        // buttons are enabled again" assertion below mean something: the test
+        // knows it parked the viewport ON the bound.
+        const before = await readTransform(page);
+        const clicks = await zoomUntilClamped(page, "zoom_in");
+        // Zero clicks would mean `zoom_in` was already disabled, which the
+        // `movedFrom` wait can only report as an opaque 15s timeout (#1099).
+        expect(clicks).toBeGreaterThan(0);
+        expect(clicks).toBeLessThan(MAX_ZOOM_CLICKS);
+        const clamped = await waitForViewportSettled(page, movedFrom(before));
+        expect(clamped.scale).toBeCloseTo(MAX_ZOOM, 4);
+      });
+
+      await test.step("the toolbar Fit View acts on the displaced viewport", async () => {
+        // Precondition with teeth, and now guaranteed to be the test's own state
+        // rather than the editor's: without it, an already-fitted canvas would
+        // let every assertion below pass on a dead Fit View button.
+        const overflowing = await measureGeometry(page);
+        expect(overflowing.nodeCount).toBeGreaterThan(0);
+        expect(overflowing.contained).toBe(false);
+
         const displacedTransform = await readTransform(page);
-        expect((await measureGeometry(page)).contained).toBe(false);
 
         await page.getByTestId("fit_view").click();
         await waitForViewportSettled(page, movedFrom(displacedTransform));


### PR DESCRIPTION
**Fixes #1645.** Closes #1645.

## Problem

`canvas-zoom-navigation.spec.ts` — "Fit View is reachable from the canvas controls toolbar" — failed 3/3 attempts on the 2026-08-31 daily ([run 33410643882](https://github.com/oriontech-me/langflow-e2e/actions/runs/33410643882)), first failure in the 21 dailies on record, on a file unchanged since 2026-07-29 (#1099). The assertion that failed is the **precondition**:

```
expect((await measureGeometry(page)).contained).toBe(false)   // received: true
```

so the toolbar Fit View path it guards was never exercised — silently, on every attempt.

**Root cause: the test consumed the editor's entry viewport as its displacement instead of creating one, and the entry viewport changed under it.** Measured on `1.12.0.dev44` — the exact image the failing daily ran (the run logged `FK_ENV_langflow_version=1.12.0.dev44`; the local pull resolves the same digest `sha256:35f7105`):

| | `1.12.0.dev6` (when the spec was written) | `1.12.0.dev44` (3 of 3 fresh contexts, byte-identical) |
|---|---|---|
| entry transform | `scale(2)` — clamped at the maximum zoom | `translate(-588.052px, -476.054px) scale(0.880331)` |
| `contained` | `false` (graph overflows the pane) | **`true`** |
| `zoom_in` on entry | `disabled` | `enabled` |

`0.880331` is exactly the transform one `fit_view` click produces, i.e. **the editor now applies the fit on hydration**. The spec file itself documented the old behaviour (`normalizeViewport`'s docstring), which is how the dependency went unnoticed.

**Fit View itself is intact and is not the defect.** On the same build: five `zoom_in` clicks reach `scale(2)` with `contained: false`, and one toolbar `fit_view` click returns exactly `translate(-588.052px, -476.054px) scale(0.880331)`, `contained: true`, both zoom buttons enabled. The guarded path still works — the test simply stopped reaching it.

**Environment ruled out independently of the day's wedge.** The 2026-08-31 daily did measure a real mid-run outage, but this cluster ran at **4% / 0% / 0%** of probes down on shard 3, and the failures are fast (7.3 s / 17.6 s / 11.2 s) — not timeouts. It reproduces deterministically on a healthy local instance.

## Fix

The test **creates its own displacement**, through the toolbar it is testing — `zoom_in` clicked to the `2` clamp, asserted as landing ≥ 1 and < 30 clicks and settling at `scale(2)` — and only then asserts `contained === false`. Same precondition, same teeth, no dependency on a product state the test does not own. This is the argument the sibling test at `:420` already makes in its own comment ("so the displacement is the test's own doing rather than the editor's entry state").

The test also **stops asserting anything about `zoom_in` / `zoom_out` on entry**. That was precisely the dependency that broke — `disabled` on dev6, `enabled` on dev44 — and their state is still asserted where it carries meaning: right after Fit View, where the test knows it just left the zoom bound because it put the viewport there itself.

Two now-false claims are corrected in the same file: `normalizeViewport`'s docstring and the step-2 comment, both stating the editor opens clamped at `scale(2)` with `zoom_in` disabled. The spec doc's entry-state note is rewritten with both measurements and the rule they imply — the entry viewport is a product decision no test may depend on.

**Rejected alternatives**, explicitly:

- *Assert `contained === true` on entry instead.* That re-encodes the same class of dependency, one product decision later.
- *Classify as `product-changed` and park the issue.* That verdict is for a premise that died (surface removed or renamed, spec not implementable). Nothing was removed here, the toolbar Fit View contract is fully testable, and the new entry state is an improvement over the old max-zoom clamp — so there is no upstream ticket and the issue closes with this PR.
- *Loosen the containment tolerance.* The precondition was right; what was wrong was where its state came from.

## Scope note

Unchanged: `measureGeometry`, `waitForViewportSettled` and its `#1094` / `#1099` contracts, `normalizeViewport`'s behaviour (its wait is on containment — the fit's real postcondition — which is why it survived the entry change untouched), the three sibling tests' assertions, and the `afterEach` id-scoped flow cleanup. No new helper, POM or testid: every selector used was already in the file and was re-confirmed live on dev44.

**Quarantine lifted** (#1647): `test.fixme` removed and `@stable` restored, so the tag array is `["@stable", "@workspace", "@ui-ux"]`, matching its three siblings.

## Validation (nightly `1.12.0.dev44`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ (exit 0) · `npm run lint` ✅ (0 errors)
- **3 clean runs**, no flake — each `expected=4 unexpected=0 flaky=0 skipped=0`, zero `🚨 Backend Error`:
  ```
  nightly: instance=1.12.0.dev44 latest=1.12.0.dev44
  run 1/3 canvas-zoom-navigation.spec.ts: clean expected=4 unexpected=0 flaky=0 backendErrors=false skipped=0
  run 2/3 canvas-zoom-navigation.spec.ts: clean expected=4 unexpected=0 flaky=0 backendErrors=false skipped=0
  run 3/3 canvas-zoom-navigation.spec.ts: clean expected=4 unexpected=0 flaky=0 backendErrors=false skipped=0
  ```
  `skipped=0` is part of the claim: no test in the file escaped through lane selection.
- **Force-fail: 4 of 4 tests**, each red under mutation (`unexpected=1`), all reverted, then a final green run:
  | Test | Mutation | Result |
  |---|---|---|
  | zoom in and zoom out step the canvas scale… | `zoom_in` click replaced by `zoom_out` in the ×1.2 step | ❌ as expected |
  | Fit View centers every node… | `fit_view` click replaced by a single `zoom_out` — viewport moves and scale drops below `2`, but the graph stays outside the pane | ❌ as expected |
  | **Fit View is reachable from the canvas controls toolbar** | an extra `fit_view` click inserted **before** the precondition measurement, so the graph is genuinely contained when `contained === false` is asserted | ❌ as expected |
  | wheel scroll navigates the canvas… | first gesture scrolls up (`-WHEEL_DELTA`) so the scale rises | ❌ as expected |

  The third row is the issue's own deliverable — *"a run where the graph really is contained must not silently pass the assert"* — proven rather than asserted.
- Final green after all reverts: `expected=4 unexpected=0 flaky=0 skipped=0`, no `FF-MUTATION` marker left in the diff.
- Flow cleanup audited: `GET /api/v1/flows/` on the instance lists **26 flows, all Langflow starter projects** — zero `Runnable Chat Flow …` orphans after ~32 creations across the burst, the four force-fail runs and the final green.

`QA-CHECKLIST.md` is untouched: the `§15.5` bullet already references this spec, and the generated blocks regenerate on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
