### PR TITLE
fix(core-components): match the parked endpoint by pathname, not by a URL glob (#1644)

### DIFF
--- a/docs/core-components/edit-tools.md
+++ b/docs/core-components/edit-tools.md
@@ -2,7 +2,8 @@
 
 **Test file:** `tests/tests-automations/regression/core-components/edit-tools.spec.ts`
 
-**Last validated:** Langflow 1.12.x (`1.12.0.dev39`)
+**Last validated:** Langflow 1.12.x (`1.12.0.dev39`; §2.2.2 re-validated on
+`1.12.0.dev44` after #1644 — see *Notes*)
 
 **Status:** active, `@stable`. The quarantine from the triage of daily #1517 was
 lifted in #1536 (wait design rebuilt on an observable); the product race behind
@@ -170,11 +171,16 @@ fail; with the upstream fix both hold.
   on `dev38` and earlier it fails, which is the intended signal.
 - **Step by step:**
   1. Create a blank flow via the API; open it; add the URL component.
-  2. Install a route handler on `POST /api/v1/custom_component/update` that
-     **claims the pre-edit `tools_metadata` refresh** — discriminated on the
-     request payload (`field === "tools_metadata"` and the action still carrying
-     the default slug), never on arrival order — fetches its response
-     immediately, and parks the fulfilment behind a gate.
+  2. Install a route handler on `POST /api/v1/custom_component/update`,
+     matching on the request's **pathname**
+     (`url => new URL(url).pathname === UPDATE_PATH`) and **never** on a URL
+     glob: a glob has to match the WHOLE URL, and this endpoint carries a
+     `?flow_id=<uuid>` query string it did not carry when this test was written
+     (#1644 — see *External dependencies*). The handler **claims the pre-edit
+     `tools_metadata` refresh** — discriminated on the request payload
+     (`field === "tools_metadata"` and the action still carrying the default
+     slug), never on arrival order — fetches its response immediately, and parks
+     the fulfilment behind a gate.
   3. Switch the node to Tool Mode; open the actions editor; confirm the held
      response is parked before editing (an unparked run would measure nothing).
   4. Edit slug + description — and **not** *Requires Approval*: LE-2272 reverts
@@ -255,6 +261,11 @@ mechanism under test.
   `auth/get-auth-token.ts`.
 - The core **URL** component (non-bundle); no model-provider credentials (no run
   — edits are asserted on the node/editor, not by executing the tool).
+- `POST /api/v1/custom_component/update` — the node round trip both the §2.2.1
+  barrier and the §2.2.2 hold key on. **It carries a `?flow_id=<uuid>` query
+  string**, added upstream in a nightly built between 2026-08-28 and 2026-08-31,
+  so anything matching this endpoint must match on the **pathname**, never with
+  a URL glob spelled as the bare path (#1644).
 - `GET /api/v1/flows/<id>` — read back the persisted `tools_metadata` (the
   `approval_actions` observable). No new helper is needed if an existing
   flow-read helper covers it; otherwise it is a planned task, not an inline
@@ -308,6 +319,19 @@ Field testids confirmed live on `langflow-nightly 1.11.0.dev45` during authoring
 
 ## Notes
 
+- **§2.2.2 was quarantined for #1644 and is not any more, and the cause was neither the
+  product nor the wait strategy.** On the 2026-08-31 daily (run 33410643882) it failed 3
+  of 3 attempts on its own precondition — `expect.poll(() => parked).toBe(true)` false for
+  the full 20 s — so it asserted nothing at all. Upstream had added a `?flow_id=<uuid>`
+  query string to `POST /api/v1/custom_component/update` in a nightly built between the
+  2026-08-28 daily (green) and that one, and a Playwright URL glob must match the
+  **entire** URL, so the handler's `**/api/v1/custom_component/update` stopped matching
+  and the park never engaged. Measured on `1.12.0.dev44`: the pre-edit refresh still
+  fires, still carrying `field: "tools_metadata"` with `name: "fetch_content"` and
+  `approval_actions: []`. Baseline before the fix: 5 of 5 failures at
+  `--retries=0 --workers=1`. The fix matches on the **pathname** rather than adding a
+  trailing wildcard, which is what this file's own `waitForComponentUpdateSettled` already
+  did — and why §2.2.1, which shares the endpoint, stayed green through the change.
 - **Force-fail probes (executed during validation):** §2.2.1 —
   `APPROVAL_DECISION` changed to a value Langflow never writes, so the
   persisted-flow poll can never match (failed, reverted). §2.2.2 — three: the

--- a/docs/core-components/human-input-node-config.md
+++ b/docs/core-components/human-input-node-config.md
@@ -3,7 +3,8 @@
 **Test file:** `tests/tests-automations/regression/core-components/human-input-node-config.spec.ts`
 
 **Last validated:** Langflow 1.12.x (scouted on `1.12.0.dev10`; the live-rebuild test
-re-validated on `1.12.0.dev39`, the first nightly carrying the LE-2278 fix)
+re-validated on `1.12.0.dev39`, the first nightly carrying the LE-2278 fix; the
+stale-refresh test re-validated on `1.12.0.dev44` after #1644 — see *Notes*)
 
 ---
 
@@ -152,10 +153,14 @@ for it.
    the output-handle count back at `3`.
 
 **Test 4 — a stale refresh response does not revert a committed choice (LE-2278)**
-1. Install a `page.route` on `**/api/v1/custom_component/update` **before** the node is
-   added. It claims the **first** request whose body has `field: "decisions"` and a
-   `field_value` of length `2` — the on-mount refresh, measured on `1.12.0.dev39` as
-   firing ~230 ms after the node lands, carrying `["Approve", "Reject"]`. Every other
+1. Install a `page.route` on the refresh endpoint **before** the node is added, matching
+   on the request's **pathname** (`url => new URL(url).pathname === COMPONENT_REFRESH_PATH`)
+   and **never** on a URL glob. A glob has to match the WHOLE URL, and this endpoint
+   carries a query string (`?flow_id=<uuid>`) that it did not carry when this test was
+   written — see *External dependencies*. The handler claims the **first** request whose
+   body has `field: "decisions"` and a `field_value` of length `2` — the on-mount
+   refresh, measured on `1.12.0.dev39` as firing ~230 ms after the node lands, carrying
+   `["Approve", "Reject"]`. Every other
    request on that route, including the commit's own `["Approve", "Reject", "Request
    Changes"]`, passes straight through with `route.continue()`.
 2. For the claimed request: `route.fetch()` to obtain the real response, flag it **parked**,
@@ -217,7 +222,10 @@ for it.
   on every Human Input output is what makes each branch render its **own** handle instead
   of the single selectable output most components show (`NodeOutputParameter/NodeOutputs.tsx`).
 - **`POST /api/v1/custom_component/update`** — the round trip behind the live rebuild
-  (`real_time_refresh` on `decisions`). Not asserted directly: the DOM assertion is the
+  (`real_time_refresh` on `decisions`). **It carries a `?flow_id=<uuid>` query string**,
+  added upstream in a nightly built between 2026-08-28 and 2026-08-31, so anything
+  matching this endpoint must match on the **pathname**, never with a URL glob spelled as
+  the bare path (#1644). Not asserted directly: the DOM assertion is the
   user-visible outcome, and pinning the endpoint would couple the spec to a refresh
   mechanism upstream may change. It **is** used as a timing signal for the LE-2278 guard —
   the spec waits for it to go quiet before re-reading the chip — which is a weaker
@@ -262,6 +270,22 @@ for it.
 
 ## Notes
 
+- **The stale-refresh test was quarantined for #1644 and is not any more, and the cause
+  was neither the product nor the wait strategy.** On the 2026-08-31 daily
+  (run 33410643882) it failed 3 of 3 attempts on its own precondition —
+  `expect.poll(() => parked).toBe(true)` false for the full 20 s — so it asserted nothing
+  at all. Upstream had added a `?flow_id=<uuid>` query string to
+  `POST /api/v1/custom_component/update` in a nightly built between the 2026-08-28 daily
+  (green) and that one, and a Playwright URL glob must match the **entire** URL, so the
+  handler's `**/api/v1/custom_component/update` stopped matching and the park never
+  engaged. Measured on `1.12.0.dev44`: the request still fires ~820 ms after the node
+  lands, still carrying `field: "decisions"` with `["Approve", "Reject"]`, and a
+  four-pattern A/B over that same traffic had the bare glob matching **0** calls while
+  `**…/update**`, `**/custom_component/**` and `**/api/**` matched every one. Baseline
+  before the fix: 5 of 5 failures at `--retries=0 --workers=1`. The fix matches on the
+  **pathname** rather than adding a trailing wildcard, which is what
+  `helpers/ui/watch-node-refresh.ts` already did — and why every other test in this file
+  stayed green through the change.
 - Everything above was scouted against the running nightly (`1.12.0.dev10`) before the
   spec was written: the node's testids were harvested from the live DOM, and the
   persisted shape (`decisions: ["Approve","Reject","Request Changes"]` →

--- a/tests/tests-automations/regression/core-components/edit-tools.spec.ts
+++ b/tests/tests-automations/regression/core-components/edit-tools.spec.ts
@@ -72,6 +72,26 @@ const APPROVAL_DECISION = "approve";
 // (§2.2.2) key on it.
 const UPDATE_PATH = "/api/v1/custom_component/update";
 
+/**
+ * Matches that endpoint by PATHNAME — never as a URL glob.
+ *
+ * A Playwright glob has to match the WHOLE url, and this endpoint carries a
+ * `?flow_id=<uuid>` query string that upstream added in a nightly built between
+ * 2026-08-28 and 2026-08-31. The bare-path glob the hold below used to install
+ * matched every call before that and none after, so the park silently stopped
+ * engaging and the LE-2272 guard failed on its own precondition for 20 s while
+ * measuring nothing (#1644 — 3 of 3 attempts on the 2026-08-31 daily, 5 of 5
+ * locally). A trailing wildcard would fix today's url and still match a future
+ * `/update/batch`; the pathname is what this spec actually means, and it is
+ * what `waitForComponentUpdateSettled` below already compares — which is why
+ * the barrier test went through the change green while the hold did not.
+ *
+ * Hoisted to a module constant because `page.unroute()` needs the SAME function
+ * reference the route was installed with; two structurally-equal arrows do not
+ * unroute each other.
+ */
+const matchesUpdatePath = (url: URL): boolean => url.pathname === UPDATE_PATH;
+
 // The Requires Approval switch renders instantly but writes onto the grid row
 // ~200 ms after the click, deliberately, so the ag-Grid cell does not remount
 // mid-animation (upstream #14741 records this as a separate, smaller defect,
@@ -440,11 +460,9 @@ test.describe("Edit tools (Tool Mode)", () => {
   // `name: "web_fetch"`, `ap: []`), it costs ~1 run in 6 here — the settle
   // barrier is what keeps it out of the test above. Approval persistence stays
   // asserted there.
-  // QUARANTINED for #1644 — the stale-response park never engages, so this guard asserts on an unmeasured run
-  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
-  test.fixme(
+  test(
     "a stale node-update response does not revert the action edits",
-    { tag: ["@regression", "@components"] },
+    { tag: ["@stable", "@regression", "@components"] },
     async ({ page, request }) => {
       const bearer = await getAuthToken(request);
       let flowId = "";
@@ -473,7 +491,7 @@ test.describe("Edit tools (Tool Mode)", () => {
           // fetching at release time makes the response arrive after the window
           // has already closed, which degrades this test into the
           // aborted-response control where the edits always survive.
-          await page.route(`**${UPDATE_PATH}`, async (route: Route) => {
+          await page.route(matchesUpdatePath, async (route: Route) => {
             const body = route.request().postDataJSON();
             const action = body?.field_value?.[0];
             const isPreEdit =
@@ -553,7 +571,7 @@ test.describe("Edit tools (Tool Mode)", () => {
         // from leaving a route handler awaiting a promise nobody resolves, and
         // the unroute keeps a refresh fired during cleanup from being held.
         openGate();
-        await page.unroute(`**${UPDATE_PATH}`);
+        await page.unroute(matchesUpdatePath);
       }
     },
   );

--- a/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
+++ b/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
@@ -63,6 +63,27 @@ const CUSTOM_HANDLE = "handle-humaninput-shownode-request changes-right";
 // Output names the persisted flow must carry once the custom choice is added.
 const PERSISTED_OUTPUTS = ["branch_approve", "branch_reject", CUSTOM_CHOICE_OUTPUT];
 
+/**
+ * Matches the refresh endpoint by PATHNAME — never as a URL glob.
+ *
+ * A Playwright glob has to match the WHOLE url, and this endpoint carries a
+ * `?flow_id=<uuid>` query string that upstream added in a nightly built between
+ * 2026-08-28 and 2026-08-31. The bare-path glob this used to be matched every
+ * call before that and none after, so the park below silently stopped engaging
+ * and the guard failed on its own precondition for 20 s while measuring nothing
+ * (#1644 — 3 of 3 attempts on the 2026-08-31 daily, 5 of 5 locally). A trailing
+ * wildcard would fix today's url and still match a future `/update/batch`; the
+ * pathname is what this test actually means, and it is what
+ * `helpers/ui/watch-node-refresh.ts` already compares — which is why every
+ * other test in this file went through the change green.
+ *
+ * Hoisted to a module constant because `page.unroute()` needs the SAME function
+ * reference the route was installed with; two structurally-equal arrows do not
+ * unroute each other.
+ */
+const matchesRefreshPath = (url: URL): boolean =>
+  url.pathname === COMPONENT_REFRESH_PATH;
+
 /** The Human Input node on the canvas. */
 const humanInputNode = (page: Page): Locator =>
   page.locator('.react-flow__node:has([data-testid="title-Human Input"])');
@@ -274,10 +295,8 @@ test.describe("Human Input node configuration (HITL branch handles)", () => {
     },
   );
 
-  // QUARANTINED for #1644 — the stale-response park never engages, so this guard asserts on an unmeasured run
-  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
-  test.fixme("a stale refresh response does not revert a committed User Action",
-    { tag: ["@regression", "@components", "@ui-ux"] },
+  test("a stale refresh response does not revert a committed User Action",
+    { tag: ["@stable", "@regression", "@components", "@ui-ux"] },
     async ({ page }) => {
       let openGate: () => void = () => {};
       const gate = new Promise<void>((resolve) => {
@@ -299,7 +318,7 @@ test.describe("Human Input node configuration (HITL branch handles)", () => {
           // the window has already closed, which degrades this test into the
           // aborted-response control where the add always sticks (measured —
           // the first version of this released nothing and still passed).
-          await page.route(`**${COMPONENT_REFRESH_PATH}`, async (route: Route) => {
+          await page.route(matchesRefreshPath, async (route: Route) => {
             const body = route.request().postDataJSON();
             const isOnMount =
               !claimed &&
@@ -353,7 +372,7 @@ test.describe("Human Input node configuration (HITL branch handles)", () => {
         // the unroute keeps a refresh fired during the cleanup navigation from
         // being held by it.
         openGate();
-        await page.unroute(`**${COMPONENT_REFRESH_PATH}`);
+        await page.unroute(matchesRefreshPath);
       }
     },
   );


### PR DESCRIPTION
**Fixes #1644.** Closes #1644.

Lifts the quarantine PR #1647 applied at the triage of daily #1642.

## Problem

Both deterministic stale-response guards failed **3 of 3 attempts each** on the
2026-08-31 daily ([run 33410643882](https://github.com/oriontech-me/langflow-e2e/actions/runs/33410643882)),
on the same assertion — and that assertion is the guard's own **precondition**:

```
expect.poll(() => parked, { timeout: 20000, intervals: [100] }).toBe(true)   → false, for the full 20 s
```

- `core-components/human-input-node-config.spec.ts:277` — *a stale refresh response does not revert a committed User Action* (LE-2278)
- `core-components/edit-tools.spec.ts:443` — *a stale node-update response does not revert the action edits* (LE-2272)

Failing there means the deterministic race was never set up, so **neither run
observed a revert or its absence — they measured nothing**. Both tests landed on
2026-08-26 (#1612 and #1617) and this was their first failure ever.

### Root cause — `product-changed`, one cause for both rows

Upstream added a **`?flow_id=<uuid>` query string** to
`POST /api/v1/custom_component/update`. A Playwright `page.route()` URL glob has
to match the **entire** url, so `**/api/v1/custom_component/update` — the pattern
both specs installed — stopped matching, the interception never fired, and
`parked` stayed `false`.

Measured on `Langflow Nightly 1.12.0.dev44`:

1. **The request is still emitted, unchanged in substance.** A `page.on("request")`
   listener (no glob involved) sees it in both flows at ~820 ms, carrying exactly
   what each predicate discriminates on — `field: "decisions"` with
   `field_value: ["Approve", "Reject"]` (length 2), and `field: "tools_metadata"`
   with `action.name: "fetch_content"` and `approval_actions: []`. So the product
   behaviour the guards protect is intact; nothing moved, was coalesced or dropped.

2. **Four-pattern A/B over that same traffic**, same session:

   | pattern | matched |
   |---|---|
   | `**/api/v1/custom_component/update` — what the specs used | **0 calls** |
   | `**/api/v1/custom_component/update**` | every call |
   | `**/custom_component/**` | every call |
   | `**/api/**` | every call |

   Full url seen: `http://localhost:7870/api/v1/custom_component/update?flow_id=1fc78670-…`

3. **The spec's own park logic, replicated against both patterns:**
   `bare → parked=false claimed=false`, `trailing wildcard → parked=true claimed=true`.

4. **Dated from `reports/daily-history.jsonl`**: zero failures on either file on
   08-24, 08-25, 08-26, 08-27 and 08-28, and 3/3 on both on 08-31. A glob that
   never matches cannot produce a park, so the parameter landed in a nightly built
   between the 08-28 daily ([33205785035](https://github.com/oriontech-me/langflow-e2e/actions/runs/33205785035))
   and the 08-31 one.

5. **Endpoint-specific, not a global interceptor** — `PATCH /api/v1/flows/{id}`
   in the same runs carries no query string, so no other `page.route` in the suite
   is broken today.

6. **Environment is ruled out by measurement, twice.** The triage already recorded
   these as the run's cleanest failures on that axis (`edit-tools` 0 % of probes
   down on all three attempts, `human-input-node-config` 6/3/0 %). Locally, on an
   idle backend, they reproduce **10 out of 10**.

**Not a Langflow regression**, so no upstream re-open: nothing user-facing broke,
the request and its payload are substantively unchanged, and the LE-2278/LE-2272
fixes are untouched (shown able to fail below). **Not a pure test defect** either —
the glob was correct against the product as it stood when the specs landed. What
turned a benign product change into a silent loss of the park is the bare-path
glob.

### Pre-fix baseline (`--retries=0 --workers=1`, `1.12.0.dev44`)

```
human-input-node-config   repro 1..5/5: real-failure   → 5/5 failed (100%), 0 voided
edit-tools                repro 1..5/5: real-failure   → 5/5 failed (100%), 0 voided
```

Measuring it required lifting the quarantine first: with `test.fixme` in place
every run classifies as `no-evidence` and the baseline would have been banked as
a false `0/N failed`. The quarantine is a mute, not a fix, so the un-muted spec
**is** the pre-fix code that failed in the daily.

## Fix

Match the endpoint by **pathname**, never as a URL glob:

```ts
const matchesRefreshPath = (url: URL): boolean => url.pathname === COMPONENT_REFRESH_PATH;
…
await page.route(matchesRefreshPath, async (route: Route) => { … });
await page.unroute(matchesRefreshPath);
```

Two things about that shape are load-bearing and are written into both files as
comments, which is the issue's last deliverable:

- **Pathname, not a trailing wildcard.** `**…/update**` fixes today's url and would
  still match a future `/update/batch`. The pathname is what these tests actually
  mean — and it is what `helpers/ui/watch-node-refresh.ts` (`new URL(url).pathname
  === COMPONENT_REFRESH_PATH`) and this file's own `waitForComponentUpdateSettled`
  (`pathname.includes(UPDATE_PATH)`) already compared. **That is exactly why every
  other test in both files went through the change green**, and it leaves one
  convention per file instead of two.
- **The matcher is a module constant**, because `page.unroute()` needs the *same*
  function reference the route was installed with; two structurally-equal arrows do
  not unroute each other.

**Rejected alternatives.** Adding `**` to the glob — two characters, verified
working, declined for the substring-matching reason above. A repo-wide sweep of the
other ~25 `page.route` call sites and a lint/unit guard against bare-path globs —
none of them is red today (the parameter is endpoint-specific), so both were
declined as out of this issue's scope.

## Quarantine lift

`test.fixme` → `test` and `@stable` restored on both titles, so they run again in
the daily, the PR impacted-specs gate and the full suite. No `test.fixme` remains
in either file.

## Scope note

**No assertion changed.** Every observable both guards assert is byte-identical:
the LE-2278 test still requires 3 chips **and** 3 branch handles after the stale
response is released, and the LE-2272 test still requires `WEB_FETCH` plus the
edited description in the reopened editor **and** `name: "web_fetch"` in the
persisted flow. Only the interception mechanism moved. The other four tests in
these two files are untouched apart from being re-run as regression cover.

Spec docs updated in step with the code (SDD): both record the `?flow_id=<uuid>`
query string as a fact of the endpoint under **External dependencies**, both state
the pathname rule in the park step, and both carry a **Notes** entry with the
measurement above. `Last validated` now names `1.12.0.dev44`.

`QA-CHECKLIST.md` is deliberately untouched — both behaviours already have their
manual Part II bullets at `[x]`, and #1647 never changed them. The generated
`Phase 0` block picks the two titles back up on merge.

## Validation (nightly `1.12.0.dev44`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ (`tsc --noEmit`, 0 errors) · `npm run lint` ✅ (0 errors)
- **3 clean runs per file, no flake, zero `🚨 Backend Error`:**

  ```
  run 1..3/3 edit-tools.spec.ts:              clean expected=2 unexpected=0 flaky=0 backendErrors=false skipped=0
  run 1..3/3 human-input-node-config.spec.ts: clean expected=4 unexpected=0 flaky=0 backendErrors=false skipped=0
  ```

- **Force-fail: 6 of 6 tests in the two touched files, each verified red and
  reverted**, with a final green run per file afterwards. The two guards were
  mutated into the *defect's own signature* rather than into arbitrary breakage,
  which is what shows they are still able to fail:

  | Test | Mutation | Result |
  |---|---|---|
  | Human Input renders the default Approve and Reject branch handles… | exact branch-handle count `2 → 3` | failed (`unexpected=1`) |
  | adding a custom User Action creates its branch handle without a reload | post-quiet chip count `3 → 2` (the LE-2278 reverted state) | failed (`unexpected=1`) |
  | a stale refresh response does not revert a committed User Action | post-release chip count `3 → 2` (the LE-2278 mixed state, 2 chips vs 3 handles) | failed (`unexpected=1`) |
  | the configured branch handles persist after save and reload | expected outputs swap `branch_request_changes` for a slug the backend never writes | failed (`unexpected=1`) |
  | user can edit a URL tool action in Tool Mode and the edits persist | persisted slug `web_fetch → fetch_content` (the #1519 clobber) | failed (`unexpected=1`) |
  | a stale node-update response does not revert the action edits | persisted slug after the stale release `web_fetch → fetch_content` (the LE-2272 revert) | failed (`unexpected=1`) |

  ```
  no FF-MUTATION markers in diff ✓
  final green run after reverts ✓ (2 file(s))
  ```

- **LE-2278 / LE-2272 still hold, and the guards can still fail.** Two independent
  proofs: the force-fail rows above only pass if the released stale response
  actually reverted the edit, and the 5/5 pre-fix baseline shows a park that does
  not engage is caught rather than passing quietly.
- `--trace=on` deliberately not run locally — it hangs UI specs under Colima on
  this host; `--trace=retain-on-failure` is the local substitute.
- Flow cleanup audited: both files delete their flows id-scoped, and
  `GET /api/v1/flows/` after the whole session reports 26 flows, all starter
  templates, **0 leaked**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
