### PR TITLE
test(enterprise): cover the models screen, which needs no credential after all (#1660)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -1284,7 +1284,13 @@
 - [-] **Dismissing the reminder is not revocation** — it issues no write, the approval stands, and the provider stays listed under *Available Providers*. Both directions matter: silent revocation would surprise an operator into an outage, and dropping the row would hide an approved provider from the only screen listing it → `enterprise/admin-console/provider-approval-terms.spec.ts`
 - [ ] The provider screen's `Add provider` modal and the `Configure` credential flow — both need a real credential, which is what keeps the approval spec keyless and runnable on any Enterprise instance
 - [ ] `expected_revision` as optimistic concurrency over the policy bundle: a stale revision is refused. An API property rather than a screen one
-- [ ] Remaining per-tab operator behaviour — the model blocklist round trip, role assignment. One follow-up each, all gated on the shell above
+- [-] With no provider approved, the models screen **names what is missing and links the fix** — *No model providers available* plus a link to `/admin-ee/providers`. The state a fresh instance is in, and the only guidance an operator gets → `enterprise/admin-console/model-availability-terms.spec.ts`
+- [-] **Approving a provider populates the model catalog with no credential** — the assumption that this screen needed one is why it was scheduled last, and it is wrong → `enterprise/admin-console/model-availability-terms.spec.ts`
+- [-] **Approved is not available, and the row agrees with the policy** — `Pending` and `Hidden` while `enabled_model_keys` is empty. A row reading `Visible` over an empty policy, or the reverse, would tell an operator the platform offers models it cannot call, and neither surface alone catches it → `enterprise/admin-console/model-availability-terms.spec.ts`
+- [-] The expanded row **states the governance terms it inherited from the approval** — *All workspaces* / *All environments* — and lists every model `Disabled`. Two screens describing one decision; a drift between them is invisible from either alone → `enterprise/admin-console/model-availability-terms.spec.ts`
+- [!] `Edit Models` is an enabled button that opens nothing and collapses the row instead (#1659) — deliberately unasserted in either direction: asserting an editor opens would pin a defect, asserting the collapse would pin a behaviour nobody has called intended
+- [ ] `Edit provider access` and the `Configure` credential flow on both the providers and models screens — they need a real credential, which is what keeps these two specs keyless and runnable on any Enterprise instance
+- [ ] Role assignment as a per-tab flow — the last of the console follow-ups, gated on the shell above
 
 ---
 

--- a/docs/enterprise/admin-console/model-availability-terms.md
+++ b/docs/enterprise/admin-console/model-availability-terms.md
@@ -1,0 +1,115 @@
+# Enterprise — Approved Is Not Available, and Three Surfaces Have to Say So
+
+**Last validated:** Langflow Enterprise 1.12.0 (image built 2026-08-27 from `IBM-Langflow@release-1.12.0`)
+
+---
+
+## What this test validates *(required)*
+
+`/admin-ee/models` is where an operator decides which models the platform may offer. It is the
+last of the four per-tab follow-ups to the console shell, and it was scheduled last on an
+assumption that turned out to be **wrong**: that it needed a provider credential.
+
+Measured: approving a provider — itself keyless, as `provider-approval-terms` established —
+populates this screen with **44 models** and no key anywhere. The assumption is recorded because
+it is why this tab waited, and because the same assumption would send the next person looking for
+an API key they do not need.
+
+### The chain this screen exists to keep honest
+
+With a provider approved and no credentials configured:
+
+```
+Provider | Models    | Status  | Builder visibility | Action
+OpenAI   | 44 models | Pending | Hidden             | Review
+```
+
+and `GET /api/v1/model-availability-policy` reports `enabled_model_keys: []`, with all 44 models
+present under `providers[].models[]`. Expanding the row shows each of them marked **Disabled**.
+
+**Approved is not available**, and three surfaces have to agree about it: the row's `Hidden`, the
+models' `Disabled`, and the policy's empty `enabled_model_keys`. A build where any one drifted —
+a provider reported `Visible` while nothing is enabled, or models reading `Enabled` against an
+empty policy — would tell an operator the platform is offering models it cannot call.
+
+That chain is the point of the screen, and none of it needs a key.
+
+### The empty state is the state most instances are in
+
+With nothing approved the screen is not blank — it names the cause and links the fix:
+
+> No model providers available — You must **add a provider** before managing m…
+
+with the link pointing at `/admin-ee/providers`. That is the only guidance an operator gets on a
+fresh instance, so it is asserted rather than assumed.
+
+## What is deliberately not asserted
+
+**`Edit Models`, filed as #1659.** It is an enabled `<button>` that opens nothing: no dialog, no
+menu, no navigation, and the panel text shrinks from 1645 to 1295 characters — it collapses the
+expanded row instead.
+
+Left unasserted in **either** direction on purpose. Asserting that it opens an editor would pin a
+defect; asserting that it collapses the row would pin a behaviour nobody has said is intended. The
+provider is `Pending`, so an unavailable editor is a defensible product state — but then the
+control should say so, which is exactly what its neighbours on this screen do. That distinction
+needs a credential to settle, and this spec is keyless by design.
+
+`Edit provider access` and the `Configure` credential flow are out for the same reason the
+provider spec left them out: keeping this runnable on any Enterprise instance is worth more than
+the coverage they would add.
+
+## Tags *(required)*
+
+`@enterprise` `@regression` `@ui-ux`
+
+Not `@governance`: that tag is always paired with `@destructive`, and `@destructive` /
+`@enterprise` are mutually exclusive lane selectors — a test carrying both is unrunnable in every
+lane. The instance-global mutation is contained by the Enterprise lane's isolation plus the
+teardown below.
+
+No `@stable`: there is no scheduled Enterprise lane (#1010).
+
+## Step by step *(required)*
+
+1. Authenticate once, require the **RBAC variant**, seed the browser session from the cached
+   token.
+2. Revoke the provider approval **before** asserting anything, rather than assuming a clean
+   instance — a previous run that died between its approval and its teardown would otherwise make
+   the empty-state test read the wrong way round.
+3. **Empty state.** Open `/admin-ee/models` with nothing approved and assert it names the missing
+   providers and links to `/admin-ee/providers`.
+4. **Populate.** Approve the provider through `/admin-ee/providers`, return, and assert the row
+   appears reporting a model count.
+5. **The chain.** Assert the row reads `Pending` and `Hidden` while the policy's
+   `enabled_model_keys` is empty.
+6. **The expansion.** `Review` the row and assert the governance terms it inherited from the
+   approval — *All workspaces*, *All environments* — and that models are listed `Disabled`.
+7. Restore: `DELETE /api/v1/model-provider-governance/{provider_id}` carrying
+   `{"expected_revision": <revision from GET /api/v1/policy-bundle>}` → `204`.
+
+## Validation criterion *(required)*
+
+Fails when the empty state stops naming what is missing, when approving no longer populates the
+catalog, when the screen reports availability the policy does not hold, or when the expanded row
+stops stating the governance terms the approval set.
+
+## External dependencies *(required)*
+
+- A Langflow **Enterprise** instance on the RBAC variant:
+  `LANGFLOW_EE_RBAC=1 ./scripts/start-langflow-enterprise.sh`.
+- A browser.
+- **No credential of any kind**, no LLM provider, no network egress, no licence, no additional
+  login.
+- No Langflow **source** paths: the Enterprise frontend is not in `langflow-ai/langflow`.
+
+## Notes
+
+The teardown is the one `provider-approval-terms` established, and the warning there applies here
+unchanged: `PUT /api/v1/model-provider-policy` with an empty list clears the policy while leaving
+the governance record `active`, so the two surfaces disagree afterwards. Use the `DELETE` with
+`expected_revision`.
+
+The three non-2xx responses the console fires on every page load — `auto_login` `403`, `refresh`
+`401`, `store/tags` `500` — are covered in the shell spec's notes, including the measurement trap
+that the fixture prints `Backend Error` on **stdout**.

--- a/tests/tests-automations/regression/enterprise/admin-console/model-availability-terms.spec.ts
+++ b/tests/tests-automations/regression/enterprise/admin-console/model-availability-terms.spec.ts
@@ -1,0 +1,195 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  getEnterpriseAuthToken,
+  seedEnterpriseUiSession,
+} from "../../../../helpers/enterprise/enterprise-auth";
+import { requireRbacInstance } from "../../../../helpers/enterprise/rbac";
+
+/**
+ * `/admin-ee/models` — approved is not available, and three surfaces must agree.
+ *
+ * The last per-tab follow-up to the console shell, scheduled last on an
+ * assumption that turned out to be wrong: that this screen needs a provider
+ * credential. Approving a provider — itself keyless — populates it with 44
+ * models and no key anywhere.
+ *
+ * With a provider approved and nothing configured, the row reads `Pending` and
+ * `Hidden`, every model reads `Disabled`, and the policy's `enabled_model_keys`
+ * is empty. A build where any one of those drifted would tell an operator the
+ * platform is offering models it cannot call.
+ *
+ * `Edit Models` is deliberately NOT asserted here — see #1659 and the spec doc.
+ */
+
+const PROVIDER = { label: "OpenAI", alias: "openai" } as const;
+
+const GOVERNANCE = "/api/v1/model-provider-governance";
+const AVAILABILITY = "/api/v1/model-availability-policy";
+const BUNDLE = "/api/v1/policy-bundle";
+
+function modelsPanel(page: Page) {
+  return page.getByTestId("enterprise-admin-tab-models");
+}
+
+function providersPanel(page: Page) {
+  return page.getByTestId("enterprise-admin-tab-providers");
+}
+
+/** The provider's row in the Available Models table. */
+function providerRow(page: Page, label: string) {
+  return modelsPanel(page).getByRole("row").filter({ hasText: label }).first();
+}
+
+async function enabledModelKeys(
+  request: APIRequestContext,
+  auth: string,
+): Promise<string[]> {
+  const response = await request.get(AVAILABILITY, { headers: { Authorization: auth } });
+  expect(response.status()).toBe(200);
+  return ((await response.json()) as { enabled_model_keys: string[] }).enabled_model_keys;
+}
+
+/**
+ * Remove the approval the way the product does.
+ *
+ * NOT `PUT /api/v1/model-provider-policy` with an empty list: that clears the
+ * policy while leaving the governance record `active`, so the two surfaces
+ * disagree afterwards. Established in `provider-approval-terms`.
+ */
+async function revokeApproval(
+  request: APIRequestContext,
+  auth: string,
+  providerId: string,
+): Promise<void> {
+  const headers = { Authorization: auth };
+  const bundle = await request.get(BUNDLE, { headers });
+  if (!bundle.ok()) return;
+  const { revision } = (await bundle.json()) as { revision: number };
+  await request
+    .delete(`${GOVERNANCE}/${providerId}`, { headers, data: { expected_revision: revision } })
+    .catch(() => undefined);
+}
+
+/** Approve through the screen that owns approving, then come back. */
+async function approveThroughUi(page: Page, label: string): Promise<void> {
+  await page.goto("/admin-ee/providers");
+  await expect(providersPanel(page)).toBeVisible({ timeout: 30_000 });
+  const written = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname === GOVERNANCE &&
+      response.request().method() === "POST",
+    { timeout: 30_000 },
+  );
+  await providersPanel(page)
+    .getByRole("listitem")
+    .filter({ hasText: label })
+    .first()
+    .getByRole("button", { name: "Approve" })
+    .click();
+  expect((await written).status()).toBe(201);
+}
+
+async function openModelsScreen(page: Page) {
+  await page.goto("/admin-ee/models");
+  await expect(modelsPanel(page)).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe("Enterprise — the models screen reports availability the policy actually holds", () => {
+  let auth: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    auth = await getEnterpriseAuthToken(request);
+    await requireRbacInstance(request, auth);
+    await seedEnterpriseUiSession(page, request);
+    // Start from "nothing approved" rather than assuming it: a previous run that
+    // died between its approval and its teardown would make the empty-state test
+    // read the wrong way round.
+    await revokeApproval(request, auth, PROVIDER.alias);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await revokeApproval(request, auth, PROVIDER.alias);
+  });
+
+  test(
+    "with no provider approved, the screen names what is missing and links the fix",
+    { tag: ["@enterprise", "@regression", "@ui-ux"] },
+    async ({ page }) => {
+      await openModelsScreen(page);
+
+      // The state a fresh instance is in, and the only guidance an operator
+      // gets — so it is asserted rather than assumed to be a blank table.
+      await expect(modelsPanel(page)).toContainText(/No model providers available/i);
+      await expect(
+        modelsPanel(page).getByRole("link", { name: /add a provider/i }),
+      ).toHaveAttribute("href", "/admin-ee/providers");
+    },
+  );
+
+  test(
+    "approving a provider populates the catalog with no credential",
+    { tag: ["@enterprise", "@regression", "@ui-ux"] },
+    async ({ page }) => {
+      await approveThroughUi(page, PROVIDER.label);
+      await openModelsScreen(page);
+
+      // The measurement that made this whole spec possible: the catalog is a
+      // consequence of APPROVAL, not of configuration.
+      await expect(providerRow(page, PROVIDER.label)).toContainText(/\d+ models/);
+    },
+  );
+
+  test(
+    "approved is not available: the row and the policy agree that nothing is enabled",
+    { tag: ["@enterprise", "@regression", "@ui-ux"] },
+    async ({ page, request }) => {
+      await approveThroughUi(page, PROVIDER.label);
+      await openModelsScreen(page);
+
+      const row = providerRow(page, PROVIDER.label);
+
+      await test.step("the row reports pending credentials and hidden from builders", async () => {
+        await expect(row).toContainText(/Pending/i);
+        await expect(row).toContainText(/Hidden/i);
+      });
+
+      await test.step("and the policy holds nothing enabled", async () => {
+        // The pairing. A row reading `Visible` over an empty policy — or the
+        // reverse — would tell an operator the platform offers models it cannot
+        // call, and neither surface alone can catch it.
+        expect(await enabledModelKeys(request, auth)).toEqual([]);
+      });
+    },
+  );
+
+  test(
+    "the expanded row states the governance terms it inherited, and lists its models disabled",
+    { tag: ["@enterprise", "@regression", "@ui-ux"] },
+    async ({ page }) => {
+      await approveThroughUi(page, PROVIDER.label);
+      await openModelsScreen(page);
+
+      await providerRow(page, PROVIDER.label)
+        .getByRole("button", { name: /Review/i })
+        .click();
+
+      await test.step("the terms match the approval that created it", async () => {
+        // Set on the providers screen, read here: the two screens describe one
+        // decision, and a drift between them is invisible from either alone.
+        await expect(modelsPanel(page)).toContainText(/All workspaces/i);
+        await expect(modelsPanel(page)).toContainText(/All environments/i);
+      });
+
+      await test.step("and every model it offers is disabled", async () => {
+        const models = modelsPanel(page).getByRole("list", { name: "Models" });
+        await expect(models).toBeVisible();
+        const entries = await models.getByRole("listitem").allInnerTexts();
+        expect(entries.length, "the expanded row listed no models").toBeGreaterThan(0);
+        for (const entry of entries) {
+          expect(entry, "a model is offered while the policy enables none").toMatch(/Disabled/i);
+        }
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1660. Completes the per-tab follow-ups to the console shell (#1630) — after `users-groups`
(#1633), `audit-logs` (#1640) and `providers` (#1656).

## 1. The assumption that made this last was wrong

This tab was scheduled last because it looked like the one needing a provider credential — its
empty state reads *No model providers available*.

**It needs none.** Approving a provider — itself keyless, as #1656 established — populates this
screen with **44 models** and no key anywhere. Recorded in the doc, because the same assumption
would send the next person hunting an API key they do not need.

## 2. The claim worth pinning: approved is not available

With a provider approved and nothing configured, three surfaces have to agree:

| Surface | Says |
|---|---|
| the row | `Pending`, `Builder visibility: Hidden` |
| each model in the expanded row | `Disabled` |
| `GET /api/v1/model-availability-policy` | `enabled_model_keys: []` |

A build where any one drifted — a provider reported `Visible` over an empty policy, or models
reading `Enabled` against it — would tell an operator the platform is offering models it cannot
call. **No single surface catches that**, which is the whole reason this test pairs the screen
with the policy.

## 3. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `with no provider approved, the screen names what is missing and links the fix` | *No model providers available* plus a link resolving to `/admin-ee/providers`. The state a fresh instance is in, and the only guidance an operator gets — asserted rather than assumed to be a blank table. |
| 2 | `approving a provider populates the catalog with no credential` | The catalog is a consequence of **approval**, not configuration. |
| 3 | `approved is not available: the row and the policy agree that nothing is enabled` | The pairing in §2. |
| 4 | `the expanded row states the governance terms it inherited, and lists its models disabled` | *All workspaces* / *All environments*, set on the providers screen and read here. Two screens describing one decision; a drift between them is invisible from either alone. |

## 4. What is deliberately not asserted — #1659

**`Edit Models`** is an enabled `<button>` that opens **nothing**: no dialog, no menu, no
navigation, and the panel text shrinks from **1645 → 1295** characters — it collapses the expanded
row instead. Four negatives, all measured.

Left unasserted in **either** direction. Asserting that it opens an editor would pin a defect;
asserting that it collapses the row would pin a behaviour nobody has said is intended. The
provider is `Pending`, so an unavailable editor is a defensible product state — **but then the
control should say so**, which is exactly what its neighbours on this screen do (*Pending —
Configure credentials to finish setting up*). Distinguishing those needs a credential, and this
spec is keyless by design. Filed as **#1659** with the reproduction.

## 5. Force-fail — four mutations, all falsify

| Mutation | Result |
|---|---|
| the empty-state test run **with** a provider approved | **red** |
| the catalog test without approving | **red** |
| the row asserted `Visible` instead of `Hidden` | **red** |
| models asserted `Enabled` instead of `Disabled` | **red** |

## 6. Validation

`langflow-enterprise:latest` (2026-08-27), RBAC variant.

- Spec alone: **4 passed**, ~16 s.
- Whole `admin-console/`: **25 passed**, twice, ~1.2 min, **0 backend errors**.
- Instance left clean: `approved_provider_ids: []`, no governance records.

## 7. Notes for the reviewer

- **Teardown** is the one #1656 established — `DELETE /api/v1/model-provider-governance/{id}` with
  `expected_revision`, never `PUT` on the policy, which clears the policy while leaving the
  governance record `active` and makes the two surfaces disagree. Each test also **revokes before
  it asserts** rather than assuming a clean instance; the empty-state test needs that most, since
  a previous run that died mid-teardown would make it read the wrong way round.
- **Not `@governance`** — that tag is always paired with `@destructive`, and `@destructive` /
  `@enterprise` are mutually exclusive lane selectors, so a test carrying both is unrunnable in
  every lane. The instance-global mutation is contained by the Enterprise lane's isolation plus the
  teardown.
- No `@stable` (#1010).
- `QA-CHECKLIST.md` § 22.7 gains four `[-]`, one `[!]` for `Edit Models` pointing at #1659, and two
  `[ ]` for the credential-gated flows and role assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
