### PR TITLE
fix(provider-setup): enable the model the run targets, not every model (#1666)

### DIFF
--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -1,6 +1,6 @@
 # Collect Models
 
-**Last validated:** Langflow 1.12.x (1.12.0.dev19)
+**Last validated:** Langflow 1.12.x (1.12.0.dev45)
 
 ---
 
@@ -9,7 +9,7 @@
 This is a utility spec — not a regression assertion test. It exists to populate two local data files used by LLM agent and model-provider specs as preconditions:
 
 - `tests/helpers/provider-setup/data/models.json` — list of models available per provider (collected from Settings → Model Providers UI)
-- `tests/helpers/provider-setup/data/providers.json` — provider status (`active` / `inactive`), validated on two independent axes: the raw API key works, **and** the running Langflow build can actually instantiate that provider's component
+- `tests/helpers/provider-setup/data/providers.json` — provider status (`active` / `inactive`), validated on two independent axes: the raw API key works, **and** the running Langflow build can actually instantiate that provider's component. Each record also carries `targetEnablement` — whether the model this run will TARGET is enabled on the instance (#1666)
 
 If this spec is not run before the LLM agent specs, those specs fall back to a hardcoded model and may skip or fail due to missing provider configuration.
 
@@ -70,8 +70,9 @@ surface (the #505 lesson).
    c. Wait for the credential **write** to answer and for the panel to reach the
       configured state, both **against a sweep-wide deadline** rather than a
       per-provider clock — see *A stalling provider must not cost the sweep* below
-   d. Wait for model toggles to load; enable any that are unchecked
-   e. Record each model name paired with the provider
+   d. Wait for model toggles to load and **read** each model name paired with the
+      provider. The sweep does **not** click those toggles — see *Enabling the
+      target model, not every model* below
 4. Write the collected model list to `data/models.json`
 5. **Probe the KEY axis:** for each provider, call its API directly to confirm the
    key is active. The probe walks the collected catalog in preference order rather
@@ -79,10 +80,14 @@ surface (the #505 lesson).
    whole provider (#570). It stops early on the first model that validates — or, when
    the SAME error repeats 3× in a row, on the conclusion that the error does not
    depend on the model at all (#1011; see Validation criterion).
-6. Write the provider status records to `data/providers.json`, merging both axes:
+6. **Enable the run's TARGET models** — one `POST /api/v1/models/enabled_models`
+   per ACTIVE provider, for the model the key axis settled on — then read
+   `GET /api/v1/models/enabled_models?purpose=configure` **once** to confirm what
+   actually landed. See *Enabling the target model, not every model* (#1666)
+7. Write the provider status records to `data/providers.json`, merging both axes:
    a build-axis failure records `inactive` with a reason that names the missing
    **layer** (distribution vs. runtime package) and, when Langflow reports it, the
-   exact module
+   exact module, plus each provider's `targetEnablement`
 
 ---
 
@@ -103,7 +108,10 @@ contract; the SPEC now verifies the outcome):
   non-empty `error` (the probe's reason is visible, never silently dropped);
 - a provider the **collector** never managed to configure is reported as that,
   and never as a key/account/config failure — see *A stalling provider must not
-  cost the sweep* (#1370).
+  cost the sweep* (#1370);
+- every provider recorded `active` has its **target model enabled** on the
+  instance, confirmed against the server — see *Enabling the target model, not
+  every model* (#1666).
 
 A provider with a key that genuinely fails its probe (e.g. a model the
 account cannot access) is a legitimate `inactive` — recorded, logged, not a
@@ -265,6 +273,155 @@ exists to prevent. Two consequences, both load-bearing:
   early exit uses: a model-scoped message names its model and so occurs once,
   while an account-scoped one occurs for every candidate.
 
+### Enabling the target model, not every model (#1666)
+
+`MIN_DEFAULT_MODELS` leaves **five** models enabled per provider, and the model the
+key axis settles on is routinely not one of them — measured on a clean
+`1.12.0.dev45` container, openai settled `gpt-4o-mini` and google `gemini-2.5-flash`,
+neither a default. A run whose target model is not enabled takes the **cold path**:
+every parametrized spec has to enable the model through the provider panel itself,
+which is the fragile path #1649 documents and which cost the 2026-09-01 daily four
+attempts across three specs.
+
+The sweep used to click every unchecked toggle in the panel. Every toggle feeds
+`useModelToggleQueue`, which batches the write behind a 1000 ms debounce and cancels +
+**discards** the pending batch on both paths the sweep takes — its unmount cleanup
+(*"an explicit close already consumes its batch through `flushPendingChanges` before
+unmount"*) and its identity effect, which fires the moment the selected provider
+changes. The loop clicks faster than the debounce, so the timer never fired mid-loop,
+and the sweep then navigated straight to the next provider.
+
+Measured with every `enabled_models` call logged: **74 toggles across three providers
+produced ZERO `POST /models/enabled_models` for the whole duration of the sweep** —
+including past the confirmation read at the end of it. Only the **last** provider's
+batch left at all, ~5 s after the sweep had moved on, so openai's 36 and anthropic's 9
+were discarded outright while google's 30 landed too late for any verdict. That is why
+#1651's own server read reported `0 of 30` for a google whose 30 models were enabled
+seconds later, and why the `0 of 74` had to be established rather than assumed: one of
+its three readings was a race, the other two were real.
+
+Making those 74 writes land was tried and **rejected on measured cost**, not on
+difficulty. `POST /api/v1/models/enabled_models` calls `validate_model_provider_key`
+once **per model** being enabled, synchronously, inside the request — and the lanes
+run `LANGFLOW_WORKERS=1`. Measured on an **idle** `1.12.0.dev45` container:
+
+| Operation | Cost |
+|---|---|
+| enable 1 model | 0.42–1.01 s |
+| enable 30 models | **103 s** |
+| **disable** the same 30 models | **0.02 s** (that path does no validation) |
+
+So the full sweep would cost ~250 s of a blocked backend, twice per shard — the
+`Collect models` wedge the lanes already carry a health gate for (#922/#927/#1045).
+A prototype that waited for the batches confirmed it: the sweep grew from 40 s to
+120 s+, google's write did not answer inside 45 s, and the confirmation read itself
+then timed out.
+
+What the run actually needs is the **settled model per provider**, so that is what is
+written: one request per provider (never one batch for all — the endpoint raises on
+the first update it rejects, before persisting any, so a batch lets one provider's
+rejection cost every other provider its enable), followed by **one** confirmation
+read. Measured cost of the whole step: ~2 s, and the sweep is faster than before
+(27 s against 40 s) because it no longer clicks 74 toggles for nothing.
+
+#### The four states, and why the write outranks the read
+
+`providers.json` records `targetEnablement` per provider — not a boolean, because two
+of the states send a reader to different places and collapsing them is the ambiguity
+this issue had to spend an investigation resolving:
+
+| State | Meaning | Gate |
+|---|---|---|
+| `enabled` | the server confirms the target model as enabled | pass |
+| `off` | the server **lists** the model for that provider and reports it disabled | **fail** |
+| `absent` | the answered response does not list the model for that provider at all — a name/catalog mismatch, or a policy-hidden provider, not a failed enable | **fail** |
+| `unknown` | this run has no verdict | warn |
+| `null` | there was no target to enable (an inactive provider) | — |
+
+`targetEnablementVerdict` gives the **write** precedence over a negative read, and
+getting that backwards is a false positive on the one lane where this pre-flight is a
+hard gate. Two states leave a model reading "not enabled" and only one is a defect:
+
+- the write answered 2xx and the model still reads off/absent — a real negative, the
+  run **is** on the cold path;
+- the write never answered 2xx — the read is then describing the state *before* an
+  enable that never happened. On 2026-09-01 the daily measured 19 outages and four
+  `WORKER TIMEOUT` → SIGKILL cycles, so a dropped write is the likely shape of a bad
+  day, not an exotic one.
+
+A **refused** write is in the second branch on purpose. `HTTP 400 Cannot enable not
+supported model: o3` is a definite answer that the model can never be enabled —
+reachable whenever the key axis settles on one of OpenAI's `not_supported` entries,
+which do render in the panel and do reach `models.json` — but the cause is the
+*candidate choice*, not a lost enable, and calling it `off` would print "the enable did
+not take effect" about a server that refused on purpose. It is `unknown` carrying the
+server's own words. Making `rankCandidates` avoid `not_supported` models is a separate
+improvement.
+
+#### Why this one FAILS the pre-flight
+
+`Collect models` normally warns rather than fails, because failing re-couples the run
+to provider and backend health — the #915/#910/#911 cost, and the trade #980 records.
+This check is the exception, and three things keep the trade narrow:
+
+- an **inactive** provider has no settled model and never reaches the check, so a
+  drained key still cannot redden it;
+- `unknown` is **not a failure** — it covers both a wedged backend and a refused
+  enable, is warned about loudly, and never reads as clean (#1012);
+- it is **scoped** to the providers the lane cannot run without, through the same
+  `COLLECT_REQUIRED_PROVIDERS` mechanism the collector-stall step uses.
+  `pr-validation.yml` pins its run to one provider (#1169), so an enable failure on a
+  provider that lane will never target must not kill an E2E job where this pre-flight
+  is a hard gate. Unset — the daily, `manual.yml`, every local run — still requires
+  every env-keyed provider, and a non-required provider's cold state is still
+  **reported**, since it costs every spec parametrized on it wherever this
+  `providers.json` is consumed.
+
+What is left to fail on is a definite server answer, for a provider this lane will
+use, that the model it targets is off — a state in which the run measures the wrong
+thing, and which used to be one warning line in a job log nobody reads (the
+`mode=count` lesson, #1252).
+
+The enablement state is printed on **every** run, green included, and recorded per
+provider — so whoever triages the next daily can tell from the report whether the run's
+specs ran with the sweep's enables in effect, instead of inferring it from a warning's
+absence.
+
+#### Two consequences worth knowing
+
+**Both data files are written BEFORE this step**, and `providers.json` is then patched
+with the verdict. The step spends up to one write per keyed provider plus a read
+against a single-worker backend, at the very end of a sweep that has already spent
+minutes — so a `test.setTimeout` abort inside it would otherwise discard the entire
+sweep output, and `resolveTestTargets()` with no `models.json` resolves one
+`(fallback)` target while every parametrized spec skips green (the #570/#1012 trap).
+Written first, an abort costs the verdict, not the catalog. The per-call ceiling is
+also counted explicitly against the pre-flight's own timeout in
+`collect-models.test.ts`, because a per-call constant can be raised without anyone
+noticing it broke the #1385 sizing invariant.
+
+**The three `setup-*.ts` helpers now pay for google too, and that is a real cost this
+change introduces.** They mass-enable through the panel via
+`enableAndSettleModelToggles` (#1651), and the measurement above is *why* they give up:
+their 90 s deadline is under the ~103 s the write takes. That give-up is the same
+`30 toggle(s) clicked, 1 write(s) started, 0 finished` #1672 saw eight times on the
+2026-09-01 daily and taught the picker read to name instead of blaming
+`MODEL_PICKER_DEFECT` — the per-model synchronous validation above is the mechanism
+behind those eight. Google is the last keyed provider, so under the old behaviour its
+~30 models were left enabled by the escaping batch and `setupGoogle` clicked nothing;
+now it clicks ~24 and spends the give-up budget — observed live at the identical
+`29 toggle(s) clicked, 1 write(s) started, 0 finished`.
+
+The cost is bounded, and measured: the write **does** land, just after the give-up, so
+it is paid **once per instance per provider**, not once per spec. Two consecutive runs
+of `agent-current-date-tool.spec.ts` against the same container measured 3.3 min then
+**1.1 min**, and the server ended at openai 41 / google 35 enabled — the second run
+clicked nothing. With the target model already enabled by this sweep, none of it costs
+a spec its model any more; what it does is move wall clock (and a blocking write) out
+of the pre-flight, which has a post-sweep health gate on all four lanes, and into the
+first spec that configures that provider, which has none. Pointing those helpers at
+the target model too is the follow-up; it is #1651's surface, not this one's.
+
 ### A stalling provider must not cost the sweep (#1370)
 
 One provider's credential write can stay in flight far longer than the others' —
@@ -424,6 +581,24 @@ the default.
     **long-poll**: it blocks until the build finishes and then returns the whole
     event list at once. There is no incremental read to lean on, which is why the
     budget is enforced per component and paired with `cancel`
+- `GET|POST /api/v1/models/enabled_models` — model-level enablement, the surface the
+  target-model step writes and confirms. Three properties, all measured on
+  `1.12.0.dev45` rather than assumed: the POST body is a **bare array** of
+  `{provider, model_id, model_type, enabled}` (an `{updates: [...]}` envelope answers
+  422); the GET keys its `enabled_models` map by provider **display** name
+  (`Google Generative AI`) and then by `model_name`, which is the same string the
+  panel renders in the toggle's row; and the **enable** path calls
+  `validate_model_provider_key` once per model, synchronously, so its cost is per
+  model (0.42–1.01 s for one, 103 s for thirty) while the disable path does no
+  validation at all (0.02 s for the same thirty)
+- `src/backend/base/langflow/api/v1/models.py` — `update_enabled_models` (the
+  per-model validation above) and `_get_enabled_models_result` (the map shape). A
+  change to either invalidates the target-model step's cost model or its key shape
+- `src/frontend/src/modals/modelProviderModal/hooks/useModelToggleQueue.ts` — the
+  1000 ms debounce plus the unmount/identity effects that cancel and **discard** a
+  pending batch. This is why the sweep does not enable through the panel at all
+  (#1666); if the queue ever flushes on navigation, the toggle sweep becomes viable
+  again — at the cost measured above
 - The component keys themselves — `ext:openai:OpenAIModelComponent@official`,
   `ext:openai:OpenAIEmbeddingsComponent@official`,
   `ext:anthropic:AnthropicModelComponent@official`,

--- a/tests/collect-models.spec.ts
+++ b/tests/collect-models.spec.ts
@@ -97,6 +97,96 @@ test(
       }
     });
 
+    await test.step("every ACTIVE provider's target model is ENABLED on this instance", async () => {
+      // The #1666 gate. `MIN_DEFAULT_MODELS` leaves five models enabled per
+      // provider and the model the key axis SETTLES on is routinely not one of
+      // them (measured on 1.12.0.dev45: openai settled `gpt-4o-mini`, google
+      // `gemini-2.5-flash`, neither among the defaults). A run whose target model
+      // is not enabled takes the COLD PATH — every parametrized spec has to enable
+      // it through the provider panel itself, which is the fragile path #1649
+      // documents and which cost the 2026-09-01 daily four attempts.
+      //
+      // FAIL rather than warn, and the trade is narrower than it looks (#980).
+      // Three things keep it off the provider-health coupling `Collect models`
+      // spent #915/#910/#911 learning to avoid:
+      //
+      //   - an INACTIVE provider has no settled model and never reaches the check,
+      //     so a drained key still cannot redden it;
+      //   - `unknown` is not a failure. It covers a wedged backend AND an enable
+      //     the server refused, both of which leave this run without a verdict —
+      //     `targetEnablementVerdict` gives the WRITE precedence over a negative
+      //     read precisely so a dropped POST is not reported as a lost enable
+      //     (#1012: reported loudly, never as clean);
+      //   - it is SCOPED to the providers this lane cannot run without, the same
+      //     `COLLECT_REQUIRED_PROVIDERS` mechanism the collector-stall step below
+      //     uses. `pr-validation.yml` pins its run to one provider (#1169), so an
+      //     enable failure on a provider that lane will never target must not kill
+      //     an E2E job where this pre-flight is a hard gate. Unset (the daily,
+      //     manual.yml, every local run) still requires every env-keyed provider.
+      //
+      // What is left to fail on is a definite server answer, for a provider this
+      // lane will use, that the model it targets is off — a state in which the run
+      // measures the wrong thing, and which used to be one warning line in a job
+      // log nobody reads (the `mode=count` lesson, #1252).
+      const providers = JSON.parse(fs.readFileSync(PROVIDERS_PATH, "utf-8")) as ProviderRecord[];
+      const targets = providers.filter((p) => p.status === "active" && p.model);
+
+      // Printed on EVERY run, green included: whoever triages the next daily has to
+      // be able to tell from the report whether the run's specs ran with the
+      // sweep's enables in effect, without re-deriving it from a warning's absence.
+      console.log(
+        `   collect-models: target-model enablement — ` +
+          (targets.length === 0
+            ? "no ACTIVE provider settled a model, so no target was written"
+            : targets
+                .map((p) => `${p.provider}/${p.model}: ${p.targetEnablement ?? "unknown"}`)
+                .join(", ")),
+      );
+
+      for (const p of targets.filter((r) => (r.targetEnablement ?? "unknown") === "unknown")) {
+        console.warn(
+          `⚠️  collect-models: whether provider "${p.provider}"'s target model "${p.model}" is enabled ` +
+            `on this instance is UNKNOWN — its specs may run on the cold path, and this is unknown, ` +
+            `not clean (#1012/#1666): ${p.targetEnablementDetail ?? "no detail recorded"}`,
+        );
+      }
+
+      const keyed = providers
+        .filter((p) => {
+          const envKeys = providerConfigMap[p.provider as Provider]?.envKeys ?? [];
+          return envKeys.some((k: string) => !!process.env[k]);
+        })
+        .map((p) => p.provider);
+      const { required } = resolveRequiredProviders(process.env.COLLECT_REQUIRED_PROVIDERS, keyed);
+
+      // Reported whether or not it is fatal on THIS lane, for the same reason the
+      // collector-stall step reports its own: a cold provider still costs every
+      // spec parametrized on it, wherever this providers.json is consumed.
+      const cold = targets.filter(
+        (p) => p.targetEnablement === "off" || p.targetEnablement === "absent",
+      );
+      for (const p of cold.filter((r) => !required.includes(r.provider))) {
+        console.warn(
+          `⚠️  collect-models: provider "${p.provider}"'s target model "${p.model}" is NOT enabled ` +
+            `(${p.targetEnablement}) — its specs run the cold path wherever this providers.json is ` +
+            `used. Not fatal on this lane, which does not require it: ${p.targetEnablementDetail}`,
+        );
+      }
+
+      const fatal = cold.filter((p) => required.includes(p.provider));
+      expect(
+        fatal.map((p) => `${p.provider}/${p.model} (${p.targetEnablement})`),
+        `the model this run will TARGET is not enabled on this instance, so every spec parametrized ` +
+          `on it runs the cold path — it finds the provider on its MIN_DEFAULT_MODELS default and has ` +
+          `to enable the model itself through the provider panel (#1649/#1666). "off" means the ` +
+          `server listed it and reports it disabled; "absent" means the server does not list it for ` +
+          `that provider at all, which is a name/catalog mismatch rather than a failed enable. ` +
+          `Neither is a provider-health verdict — an inactive provider never reaches this check, and ` +
+          `an enable that did not answer is reported UNKNOWN, not here: ` +
+          fatal.map((p) => `${p.provider} — ${p.targetEnablementDetail}`).join(" | "),
+      ).toEqual([]);
+    });
+
     await test.step("an env-keyed provider that probed inactive carries the probe error", async () => {
       const providers = JSON.parse(fs.readFileSync(PROVIDERS_PATH, "utf-8")) as ProviderRecord[];
       for (const p of providers.filter((r) => r.status === "inactive")) {

--- a/tests/helpers/provider-setup/collect-models.test.ts
+++ b/tests/helpers/provider-setup/collect-models.test.ts
@@ -43,14 +43,17 @@ import {
   planIdleWait,
   planSaveWait,
   sweepSaveBudgetMs,
+  enableTargetsTimeoutMs,
+  targetEnablementVerdict,
+  ensureTargetModelsEnabled,
   rankCandidates,
   resolveRequiredProviders,
   validateProviderWithFallback,
   waitForButtonIdle,
-  waitForToggleChecked,
   type ProviderRecord,
   confirmEnabledOnServer,
 } from "./collect-models";
+import { keyedProviders } from "./provider-config";
 
 // ─── Verbatim provider errors ────────────────────────────────────────────────
 
@@ -739,56 +742,13 @@ test("#1355: a zero timeout still OBSERVES once instead of reporting a state it 
   assert.equal(verdict.ariaBusy, "true");
 });
 
-// ─── waitForToggleChecked (#1355, second half) ────────────────────────────────
-//
-// The measured cause behind the busy Save: enabling a model is a WRITE, and the
-// collector enables every model of every provider. With a funded OpenAI key the
-// panel exposes 41 visible models where a drained key exposed none worth
-// toggling, so one provider went from ~0 writes to 41 against a backend the
-// lanes run with LANGFLOW_WORKERS=1 — and the NEXT provider's Save queued behind
-// them and never settled. Confirming each toggle is what serialises them.
-
-/** A toggle whose `aria-checked` readings are scripted per poll. */
-function fakeToggle(readings: Array<string | null>) {
-  let i = -1;
-  return {
-    getAttribute: async () => {
-      i += 1;
-      return readings[Math.min(i, readings.length - 1)] ?? null;
-    },
-  };
-}
-
-test("#1355: a toggle already checked confirms on the first poll, without sleeping", async () => {
-  const clock = fakeClock();
-  const result = await waitForToggleChecked(fakeToggle(["true"]), { ...clock, timeoutMs: 5_000 });
-  assert.equal(result.checked, true);
-  assert.equal(result.polls, 1);
-  assert.equal(result.waitedMs, 0, "the healthy path must not add wall clock per model");
-});
-
-test("#1355: a toggle that lands a moment later is waited out, serialising the write", async () => {
-  const clock = fakeClock();
-  const result = await waitForToggleChecked(fakeToggle(["false", "false", "true"]), {
-    ...clock,
-    timeoutMs: 5_000,
-    pollMs: 100,
-  });
-  assert.equal(result.checked, true);
-  assert.equal(result.polls, 3);
-  assert.equal(result.waitedMs, 200);
-});
-
-test("#1355: a toggle that never confirms gives up at its own timeout and says so", async () => {
-  const clock = fakeClock();
-  const result = await waitForToggleChecked(fakeToggle(["false"]), {
-    ...clock,
-    timeoutMs: 500,
-    pollMs: 100,
-  });
-  assert.equal(result.checked, false);
-  assert.ok(result.waitedMs >= 500, "must not return before its own deadline");
-});
+// `waitForToggleChecked` is GONE (#1666). It polled `aria-checked`, which
+// `useModelToggleQueue` flips synchronously at click time — before any request
+// leaves the browser — so it could only ever confirm the OPTIMISTIC client cache.
+// #1651 recorded that in a comment; #1666 measured the consequence: 74 toggles
+// "confirmed" by it produced ZERO `POST /models/enabled_models`. The sweep no
+// longer clicks those toggles at all, so there is nothing left for it to wait on.
+// What replaced it is `confirmEnabledOnServer` over the run's TARGET models, below.
 
 // ─── classifyWaitFailure (#1370) ─────────────────────────────────────────────
 //
@@ -1150,9 +1110,17 @@ test("#1385: the sweep budget fits inside the pre-flight's own test timeout", ()
   // navigation, toggle sweeps, key probes and file writes.
   const PREFLIGHT_TIMEOUT_MS = 12 * 60 * 1000;
   const NON_WAIT_RESERVE_MS = 90_000;
+  // The target-model step (#1666) is the reserve's only UNBOUNDED-BY-BUDGET part:
+  // its ceiling is PER CALL, and the worst case is one write per keyed provider plus
+  // the single confirmation read. Counted explicitly rather than assumed to fit
+  // inside the 90 s, because a per-call constant can be raised without anyone
+  // noticing it broke this invariant — which is exactly what happened at 60 s
+  // (450 + 90 + 240 = 780 > 720) while this assertion still passed.
+  const ENABLE_TARGETS_WORST_CASE_MS = enableTargetsTimeoutMs * (keyedProviders.length + 1);
   assert.ok(
-    sweepSaveBudgetMs + NON_WAIT_RESERVE_MS < PREFLIGHT_TIMEOUT_MS,
-    `${sweepSaveBudgetMs}ms of waits plus ${NON_WAIT_RESERVE_MS}ms of everything else must fit in ` +
+    sweepSaveBudgetMs + NON_WAIT_RESERVE_MS + ENABLE_TARGETS_WORST_CASE_MS < PREFLIGHT_TIMEOUT_MS,
+    `${sweepSaveBudgetMs}ms of waits plus ${NON_WAIT_RESERVE_MS}ms of everything else plus ` +
+      `${ENABLE_TARGETS_WORST_CASE_MS}ms of target-model enablement must fit in ` +
       `${PREFLIGHT_TIMEOUT_MS}ms, or the budget is decorative and the test timeout is the real bound`,
   );
 
@@ -1263,75 +1231,336 @@ test("#1370: separators and case do not change the selection", () => {
   ]);
 });
 
-test("#1355: waitedMs is what lets the caller bound the SUM, not just each write", async () => {
-  // The per-item timeout never sees the total. 41 toggles each taking 5s would
-  // spend 205s and blow the spec's own 5-minute budget, so the caller subtracts
-  // `waitedMs` from an aggregate budget — this asserts the field it needs to do
-  // that is real, and measured, not a constant.
-  const clock = fakeClock();
-  const slow = await waitForToggleChecked(fakeToggle(["false", "false", "true"]), {
-    ...clock,
-    timeoutMs: 5_000,
-    pollMs: 250,
-  });
-  const fast = await waitForToggleChecked(fakeToggle(["true"]), { ...fakeClock(), timeoutMs: 5_000 });
-  assert.equal(slow.waitedMs, 500);
-  assert.equal(fast.waitedMs, 0);
-  assert.ok(slow.waitedMs > fast.waitedMs, "a slow confirmation must cost the budget more than a fast one");
-});
-
-// --- #1649: the toggle confirmation was reading the OPTIMISTIC client cache ---
+// --- #1649/#1666: enablement is confirmed against the SERVER, never the panel ---
 //
-// `waitForToggleChecked` polls `aria-checked`, and `useModelToggleQueue` flips that
-// synchronously at click time via `queryClient.setQueryData` — before any request
-// leaves the browser. Measured on 1.12.0.dev44: all 36 clicks reported "confirmed"
-// while the POST only went out at t=8132 ms. So a write that never reaches the
-// server is indistinguishable from one that lands, the #1355 shortfall warning
-// cannot fire, and the next spec inherits a provider it believes is fully enabled.
-// The server is the only source that settles it, and it is read ONCE after the
-// batch has flushed — polling it during the write was measured stalling a
-// single-worker backend (`apiRequestContext.get: Timeout 20000ms exceeded`).
-test("a server that answered confirms every model the loop expected", () => {
-  const v = confirmEnabledOnServer({ "gpt-4o": true, "gpt-4o-mini": true }, ["gpt-4o", "gpt-4o-mini"]);
+// `aria-checked` is flipped synchronously at click time via
+// `queryClient.setQueryData` — before any request leaves the browser. Measured on
+// 1.12.0.dev44: all 36 clicks reported "confirmed" while the POST only went out at
+// t=8132 ms; measured again on a clean 1.12.0.dev45 in #1666: 74 clicks produced
+// ZERO writes at all, because the queue cancels + discards its batch when the panel
+// navigates away. So the server is the only source that settles it, and it is read
+// ONCE — polling it during the write was measured stalling a single-worker backend
+// (`apiRequestContext.get: Timeout 20000ms exceeded`).
+//
+// The subject is now the run's TARGET models (the settled model per provider), which
+// is what `ensureTargetModelsEnabled` writes and what every spec actually picks.
+test("a server that answered confirms every target model", () => {
+  const v = confirmEnabledOnServer({ "gpt-4o": true, "gpt-4o-mini": true }, ["gpt-4o", "gpt-4o-mini"], true);
   assert.equal(v.kind, "confirmed");
   if (v.kind === "confirmed") assert.equal(v.expected, 2);
 });
 
-test("a write that never landed is a SHORTFALL naming the models, not a pass", () => {
-  const v = confirmEnabledOnServer({ "gpt-4o": true, "gpt-4o-mini": false }, [
-    "gpt-4o",
-    "gpt-4o-mini",
-    "gpt-4.1",
-  ]);
+test("a target the provider LISTS but reports false is OFF — the enable did not take effect", () => {
+  const v = confirmEnabledOnServer({ "gpt-4o": true, "gpt-4o-mini": false }, ["gpt-4o", "gpt-4o-mini"], true);
   assert.equal(v.kind, "shortfall");
   if (v.kind === "shortfall") {
-    assert.deepEqual(v.missing, ["gpt-4o-mini", "gpt-4.1"]);
+    assert.deepEqual(v.off, ["gpt-4o-mini"]);
+    assert.deepEqual(v.absent, [], "a listed model is not an absent one");
     assert.equal(v.enabled, 1);
-    assert.equal(v.expected, 3);
-    assert.match(v.message, /1 of 3/);
-    assert.match(v.message, /gpt-4o-mini/);
-    assert.match(v.message, /#1649/);
+    assert.equal(v.expected, 2);
+    assert.match(v.message, /1 of 2/);
+    assert.match(v.message, /did not take effect/i);
+    assert.match(v.message, /COLD PATH/);
   }
 });
 
-test("a model missing from the response entirely counts as NOT enabled", () => {
-  // Absence is not `true`. The endpoint lists every model of a configured
-  // provider, so a key the loop expected and the response does not carry means
-  // the write did not land — the exact state the optimistic read hid.
-  const v = confirmEnabledOnServer({ "gpt-4o": true }, ["gpt-4o", "gpt-4o-mini"]);
+test("a target the provider does not LIST is ABSENT — a name mismatch, not a failed enable", () => {
+  // The distinction #1666 had to spend an investigation establishing: `0 of 36
+  // missing` reads identically whether the writes were dropped or whether the names
+  // are not the keys the endpoint uses, and the two demand opposite fixes. Absence
+  // is still NOT `true` — the endpoint lists every model of a configured provider.
+  const v = confirmEnabledOnServer({ "gpt-4o": true }, ["gpt-4o", "gpt-4o-mini"], true);
   assert.equal(v.kind, "shortfall");
-  if (v.kind === "shortfall") assert.deepEqual(v.missing, ["gpt-4o-mini"]);
+  if (v.kind === "shortfall") {
+    assert.deepEqual(v.absent, ["gpt-4o-mini"]);
+    assert.deepEqual(v.off, []);
+    assert.match(v.message, /NOT an enable that failed/i);
+    assert.doesNotMatch(v.message, /did not take effect/i, "must not claim an enable failed");
+  }
+});
+
+test("off and absent are reported TOGETHER, each named as what it is", () => {
+  const v = confirmEnabledOnServer(
+    { "gpt-4o": true, "gpt-4o-mini": false },
+    ["gpt-4o", "gpt-4o-mini", "gpt-4.1"],
+    true,
+  );
+  assert.equal(v.kind, "shortfall");
+  if (v.kind === "shortfall") {
+    assert.deepEqual(v.off, ["gpt-4o-mini"]);
+    assert.deepEqual(v.absent, ["gpt-4.1"]);
+    assert.equal(v.enabled, 1);
+    assert.match(v.message, /gpt-4o-mini/);
+    assert.match(v.message, /gpt-4\.1/);
+  }
+});
+
+test("an ANSWERED read that does not list the provider is a definite negative, not UNKNOWN", () => {
+  // The only path where a definite negative used to pass the gate. `undefined` for a
+  // provider means two unrelated things — the read failed, or the read answered and
+  // the provider is unconfigured / hidden by a model-provider policy — and reporting
+  // the second as "the read did not answer" is both false and the softer verdict.
+  const v = confirmEnabledOnServer(undefined, ["gpt-4o"], true);
+  assert.equal(v.kind, "shortfall");
+  if (v.kind === "shortfall") {
+    assert.deepEqual(v.absent, ["gpt-4o"]);
+    assert.equal(v.enabled, 0);
+    assert.match(v.message, /ANSWERED and does not list this provider/);
+    assert.doesNotMatch(v.message, /read did not answer/);
+  }
+});
+
+test("expecting nothing is confirmed even when the read failed — there was nothing to enable", () => {
+  assert.equal(confirmEnabledOnServer(undefined, [], false).kind, "confirmed");
+});
+
+// ─── targetEnablementVerdict: the WRITE outranks a negative read (#1666) ──────
+//
+// The precedence that keeps this gate off `pr-validation.yml`'s hard-gate lane for a
+// transient. Two states leave a model reading "not enabled" and only one is a defect.
+
+const OK: { ok: boolean; detail: string | null } = { ok: true, detail: null };
+
+test("a confirmed read is enabled, whatever the write said", () => {
+  const v = targetEnablementVerdict(OK, { kind: "confirmed", expected: 1 });
+  assert.equal(v.state, "enabled");
+  assert.equal(v.detail, "");
+});
+
+test("a 2xx write plus a model reading OFF is a real negative the gate must fail on", () => {
+  const v = targetEnablementVerdict(OK, {
+    kind: "shortfall",
+    expected: 1,
+    enabled: 0,
+    off: ["gpt-4o-mini"],
+    absent: [],
+    message: "listed but off",
+  });
+  assert.equal(v.state, "off");
+  assert.equal(v.detail, "listed but off");
+});
+
+test("a 2xx write plus a model the server does not list at all is ABSENT, not off", () => {
+  const v = targetEnablementVerdict(OK, {
+    kind: "shortfall",
+    expected: 1,
+    enabled: 0,
+    off: [],
+    absent: ["gpt-4o-mini"],
+    message: "not listed",
+  });
+  assert.equal(v.state, "absent");
+});
+
+test("a write that never answered makes a negative read UNKNOWN, never a lost enable", () => {
+  // The 2026-09-01 shape: 19 outages and four WORKER TIMEOUT -> SIGKILL cycles, so a
+  // dropped POST is the likely shape of a bad day. The read then describes the state
+  // BEFORE an enable that never happened, and failing on it would redden a whole
+  // E2E job for a transient.
+  const v = targetEnablementVerdict(
+    { ok: false, detail: "no HTTP status (apiRequestContext.post: Timeout 30000ms exceeded)" },
+    {
+      kind: "shortfall",
+      expected: 1,
+      enabled: 0,
+      off: ["gpt-4o-mini"],
+      absent: [],
+      message: "listed but off",
+    },
+  );
+  assert.equal(v.state, "unknown", "a dropped write must not be reported as a lost enable");
+  assert.match(v.detail, /did not answer 2xx/);
+  assert.match(v.detail, /Timeout 30000ms/, "the transport's own words must survive");
+  assert.match(v.detail, /listed but off/, "and so must the read it is qualifying");
+});
+
+test("a REFUSED enable is UNKNOWN carrying the server's words, not 'the enable did not take effect'", () => {
+  // `HTTP 400 Cannot enable not supported model: o3` is a definite answer that the
+  // model can never be enabled — reachable whenever the key axis settles on one of
+  // OpenAI's `not_supported` entries, which do render in the panel and do reach
+  // models.json. The cause is the CANDIDATE CHOICE, so reporting it as `off` would
+  // print "the enable did not take effect" about a server that refused on purpose.
+  const v = targetEnablementVerdict(
+    { ok: false, detail: "HTTP 400 Cannot enable not supported model: o3" },
+    { kind: "shortfall", expected: 1, enabled: 0, off: ["o3"], absent: [], message: "listed but off" },
+  );
+  assert.equal(v.state, "unknown");
+  assert.match(v.detail, /not supported model: o3/);
+});
+
+test("an unavailable read is UNKNOWN even when the write answered 2xx", () => {
+  const v = targetEnablementVerdict(OK, { kind: "unavailable", message: "the read did not answer" });
+  assert.equal(v.state, "unknown");
+  assert.match(v.detail, /did not answer/);
+});
+
+// ─── ensureTargetModelsEnabled (#1666) ────────────────────────────────────────
+
+/** A duck-typed APIRequestContext that records what it was asked, like the sibling probes do. */
+function fakeRequest(options: {
+  postStatus?: number | ((n: number) => number);
+  postThrows?: boolean;
+  getBody?: unknown;
+  getStatus?: number;
+  getThrows?: boolean;
+} = {}) {
+  const posts: Array<{ url: string; data: unknown; timeout?: number }> = [];
+  const gets: Array<{ url: string }> = [];
+  let n = 0;
+  return {
+    posts,
+    gets,
+    request: {
+      async post(url: string, init?: { data?: unknown; timeout?: number }) {
+        posts.push({ url, data: init?.data, timeout: init?.timeout });
+        if (options.postThrows) throw new Error("apiRequestContext.post: Timeout 30000ms exceeded");
+        n += 1;
+        const status =
+          typeof options.postStatus === "function"
+            ? options.postStatus(n)
+            : (options.postStatus ?? 200);
+        return {
+          ok: () => status >= 200 && status < 300,
+          status: () => status,
+          text: async () => `body for ${status}`,
+        };
+      },
+      async get(url: string) {
+        gets.push({ url });
+        if (options.getThrows) throw new Error("apiRequestContext.get: Timeout 30000ms exceeded");
+        const status = options.getStatus ?? 200;
+        return {
+          ok: () => status >= 200 && status < 300,
+          status: () => status,
+          json: async () => options.getBody,
+        };
+      },
+    },
+  };
+}
+
+const TWO_TARGETS = [
+  { providerDisplayName: "OpenAI", model: "gpt-4o-mini" },
+  { providerDisplayName: "Google Generative AI", model: "gemini-2.5-flash" },
+];
+
+test("no target means no request at all — the sweep must not pay for an empty enable", async () => {
+  const f = fakeRequest();
+  const verdicts = await ensureTargetModelsEnabled(f.request as never, []);
+  assert.equal(verdicts.size, 0);
+  assert.equal(f.posts.length, 0);
+  assert.equal(f.gets.length, 0, "not even the confirmation read");
+});
+
+test("ONE write per provider, never one batch for all of them", async () => {
+  // The isolation argument the change reasons hardest about: the endpoint validates
+  // per model and raises on the FIRST update it rejects, BEFORE persisting any — so
+  // a single batch lets one provider's rejected model cost every other provider its
+  // enable. Collapsing the loop into one request passes every other test here.
+  const f = fakeRequest({
+    getBody: {
+      enabled_models_by_type: {
+        OpenAI: { llm: { "gpt-4o-mini": true } },
+        "Google Generative AI": { llm: { "gemini-2.5-flash": true } },
+      },
+    },
+  });
+  const verdicts = await ensureTargetModelsEnabled(f.request as never, TWO_TARGETS);
+  assert.equal(f.posts.length, 2, "one write per provider");
+  assert.equal(f.gets.length, 1, "and exactly one confirmation read");
+  for (const post of f.posts) {
+    const data = post.data as Array<{ provider: string }>;
+    assert.equal(data.length, 1, "a provider's write must not carry another provider's models");
+  }
+  assert.equal(verdicts.get("OpenAI")?.state, "enabled");
+  assert.equal(verdicts.get("Google Generative AI")?.state, "enabled");
+});
+
+test("the write is the shape the endpoint accepts, and the read is scoped to configure", async () => {
+  // Measured on 1.12.0.dev45: an `{updates: [...]}` envelope answers 422 — the body
+  // is a BARE array — and the enable needs `model_type` for the typed identity.
+  const f = fakeRequest({ getBody: { enabled_models: { OpenAI: { "gpt-4o-mini": true } } } });
+  await ensureTargetModelsEnabled(f.request as never, [TWO_TARGETS[0]]);
+  assert.equal(f.posts[0].url, "/api/v1/models/enabled_models");
+  assert.deepEqual(f.posts[0].data, [
+    { provider: "OpenAI", model_id: "gpt-4o-mini", model_type: "llm", enabled: true },
+  ]);
+  assert.equal(f.posts[0].timeout, enableTargetsTimeoutMs);
+  assert.match(f.gets[0].url, /\?purpose=configure$/);
+});
+
+test("the same model asked for twice is written once", async () => {
+  const f = fakeRequest({ getBody: { enabled_models: { OpenAI: { "gpt-4o-mini": true } } } });
+  await ensureTargetModelsEnabled(f.request as never, [TWO_TARGETS[0], TWO_TARGETS[0]]);
+  assert.equal(f.posts.length, 1);
+  assert.deepEqual((f.posts[0].data as unknown[]).length, 1);
+});
+
+test("the TYPED map wins over the flat one, which ORs across model types", async () => {
+  // The backend says so about its own shapes: "Per-type map is exact; flat map ORs
+  // rows that share provider/name". So a name enabled only as `embeddings` reads
+  // `true` in the flat map while the llm picker offers nothing — a false negative on
+  // the cold path, which is what this gate exists to detect. The product's own
+  // `isModelEnabled` prefers the typed map for the same reason.
+  const f = fakeRequest({
+    getBody: {
+      enabled_models: { OpenAI: { "gpt-4o-mini": true } },
+      enabled_models_by_type: { OpenAI: { llm: { "gpt-4o-mini": false } } },
+    },
+  });
+  const verdicts = await ensureTargetModelsEnabled(f.request as never, [TWO_TARGETS[0]]);
+  assert.equal(verdicts.get("OpenAI")?.state, "off");
+});
+
+test("one provider's refused write does not change another provider's verdict", async () => {
+  const f = fakeRequest({
+    postStatus: (n) => (n === 1 ? 400 : 200),
+    getBody: {
+      enabled_models_by_type: {
+        OpenAI: { llm: { "gpt-4o-mini": false } },
+        "Google Generative AI": { llm: { "gemini-2.5-flash": true } },
+      },
+    },
+  });
+  const verdicts = await ensureTargetModelsEnabled(f.request as never, TWO_TARGETS);
+  assert.equal(verdicts.get("OpenAI")?.state, "unknown", "a refused write is not a lost enable");
+  assert.equal(verdicts.get("Google Generative AI")?.state, "enabled");
+});
+
+test("a write that THROWS is reported, never rethrown out of a report-only helper", async () => {
+  const f = fakeRequest({
+    postThrows: true,
+    getBody: { enabled_models_by_type: { OpenAI: { llm: { "gpt-4o-mini": false } } } },
+  });
+  const verdicts = await ensureTargetModelsEnabled(f.request as never, [TWO_TARGETS[0]]);
+  assert.equal(verdicts.get("OpenAI")?.state, "unknown");
+  assert.match(verdicts.get("OpenAI")?.detail ?? "", /Timeout 30000ms/);
+});
+
+test("a read that THROWS is UNKNOWN, never rethrown and never a silent confirmation", async () => {
+  const f = fakeRequest({ getThrows: true });
+  const verdicts = await ensureTargetModelsEnabled(f.request as never, [TWO_TARGETS[0]]);
+  assert.equal(verdicts.get("OpenAI")?.state, "unknown");
+  assert.match(verdicts.get("OpenAI")?.detail ?? "", /could not be confirmed/i);
+});
+
+test("a non-2xx read is UNKNOWN, not an answered response that lists nothing", async () => {
+  const f = fakeRequest({ getStatus: 503 });
+  const verdicts = await ensureTargetModelsEnabled(f.request as never, [TWO_TARGETS[0]]);
+  assert.equal(verdicts.get("OpenAI")?.state, "unknown");
+  assert.match(verdicts.get("OpenAI")?.detail ?? "", /read did not answer/);
+});
+
+test("a 2xx read that omits the provider is a definite negative, not UNKNOWN", async () => {
+  const f = fakeRequest({ getBody: { enabled_models: { Anthropic: {} } } });
+  const verdicts = await ensureTargetModelsEnabled(f.request as never, [TWO_TARGETS[0]]);
+  assert.equal(verdicts.get("OpenAI")?.state, "absent");
 });
 
 test("a server that did not answer is UNAVAILABLE, never a silent confirmation", () => {
   // #1012: an unevaluated check is unknown, not clean. Reporting `confirmed` here
   // would be the same false green the optimistic read produced.
-  const v = confirmEnabledOnServer(undefined, ["gpt-4o"]);
+  const v = confirmEnabledOnServer(undefined, ["gpt-4o"], false);
   assert.equal(v.kind, "unavailable");
   if (v.kind === "unavailable") assert.match(v.message, /could not be confirmed/i);
-});
-
-test("expecting nothing is confirmed, not unavailable — there was nothing to write", () => {
-  const v = confirmEnabledOnServer(undefined, []);
-  assert.equal(v.kind, "confirmed");
 });

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -1,9 +1,14 @@
 // Test spec that runs this helper: tests/collect-models.spec.ts
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
 import { SettingsPage } from "../../pages/SettingsPage";
-import { keyedProviders, keyedProviderNames, type Provider } from "./provider-config";
+import {
+  keyedProviders,
+  keyedProviderNames,
+  langflowProviderName,
+  type Provider,
+} from "./provider-config";
 import { probeBuildAxis, type ProviderVerdict } from "./probe-component-buildable";
 
 const DATA_DIR = path.join(__dirname, "data");
@@ -18,6 +23,24 @@ export interface ProviderRecord {
   status: "active" | "inactive";
   error: string | null;
   checkedAt: string;
+  /**
+   * Whether `model` is ENABLED on this instance — the difference between a run
+   * whose specs find their target model in the picker and one that takes the cold
+   * path and has to enable it itself (#1666).
+   *
+   * Four states, not a boolean, because `off` and `absent` send a reader to
+   * different places and collapsing them is the ambiguity #1666 had to spend an
+   * investigation resolving. `unknown` is never "fine" and never a failure: the
+   * provider was never probed, the enable did not answer, or the confirmation read
+   * did not (#1012). `null` means there was no target to enable at all.
+   *
+   * Written by `ensureTargetModelsEnabled` via `targetEnablementVerdict` and read by
+   * `collect-models.spec.ts`, which is what makes the cold path a recorded fact of
+   * the run rather than one warning line in a job log.
+   */
+  targetEnablement?: TargetEnablementState | null;
+  /** What was observed, for a state that is not `enabled`. */
+  targetEnablementDetail?: string | null;
 }
 
 interface ModelRecord {
@@ -392,23 +415,22 @@ const SAVE_IDLE_TIMEOUT_MS = 60_000;
 const SAVE_IDLE_POLL_MS = 250;
 
 /**
- * Per-toggle and whole-provider ceilings for confirming a model was enabled (#1355).
+ * Ceiling for EACH `enabled_models` call that makes the run's target models usable
+ * (#1666).
  *
- * Two bounds, not one, for the reason the token-attribution sidecar gives (#1197
- * §4.4): the per-item timeout bounds ONE write and never sees the sum, so 41
- * slow-but-succeeding confirmations would spend 41 x TIMEOUT and blow the spec's
- * own 5-minute budget. The aggregate bounds that sum. Against a healthy panel a
- * confirmation costs tens of milliseconds, so neither fires.
+ * Generous against the measurement, not against a hang: `POST
+ * /api/v1/models/enabled_models` calls `validate_model_provider_key` once PER MODEL
+ * being enabled, synchronously, inside the request — measured on an idle
+ * 1.12.0.dev45 container, 0.42–1.01 s for one model against 103 s for thirty, and
+ * 0.02 s to DISABLE the same thirty (no validation on that path). One target model
+ * per provider is what keeps this affordable; see `ensureTargetModelsEnabled`.
+ *
+ * It is PER CALL, so the worst case is one write per keyed provider plus the single
+ * confirmation read. That total is part of the pre-flight's non-wait reserve and is
+ * asserted against the spec's own timeout in `collect-models.test.ts` — the sizing
+ * invariant #1385 pinned, which a per-call ceiling can silently break.
  */
-const TOGGLE_CONFIRM_TIMEOUT_MS = 5_000;
-const TOGGLE_CONFIRM_BUDGET_MS = 60_000;
-/**
- * Quiet period allowed for the toggle queue's 1000 ms debounce to flush before the
- * server is asked what actually landed. Same constant the provider-setup helpers
- * wait on (`model-toggle-batch.ts`), for the same product reason (#1649).
- */
-const TOGGLE_FLUSH_QUIET_MS = 1500;
-const TOGGLE_CONFIRM_POLL_MS = 100;
+const ENABLE_TARGETS_TIMEOUT_MS = 30_000;
 
 /**
  * Ceiling for the credential write a `Save` click issues (#1355, resized #1385).
@@ -683,6 +705,8 @@ export function planConfiguredWait(remainingMs: number, providersLeftAfterThis: 
 
 /** The sweep's starting budget, exported so a test asserts the live value. */
 export const sweepSaveBudgetMs = SWEEP_SAVE_BUDGET_MS;
+/** Exposed for the sizing invariant in `collect-models.test.ts` (#1385/#1666). */
+export const enableTargetsTimeoutMs = ENABLE_TARGETS_TIMEOUT_MS;
 
 /**
  * Marks a provider the COLLECTOR never managed to configure — as opposed to one
@@ -738,35 +762,67 @@ export interface ButtonStateLocator {
   isEnabled(): Promise<boolean>;
 }
 
-/** What the server said about the models this sweep tried to enable (#1649). */
+/** What the server said about the models the run is going to target (#1649/#1666). */
 export type ServerConfirmation =
   | { kind: "confirmed"; expected: number }
-  | { kind: "shortfall"; expected: number; enabled: number; missing: string[]; message: string }
+  | {
+      kind: "shortfall";
+      expected: number;
+      enabled: number;
+      /** Present in the provider's map, reported `false`. */
+      off: string[];
+      /** Not a key of the provider's map at all — a name/visibility mismatch. */
+      absent: string[];
+      message: string;
+    }
   | { kind: "unavailable"; message: string };
 
 /**
- * Confirms the toggle batch against the SERVER, which is the only source that can.
+ * Confirms enablement against the SERVER, which is the only source that can.
  *
- * `waitForToggleChecked` below reads `aria-checked`, and the provider modal flips
- * that synchronously at click time (`useModelToggleQueue` applies an optimistic
- * `setQueryData` before any request leaves the browser). Measured on 1.12.0.dev44:
- * all 36 clicks were "confirmed" while the POST only went out at t=8132 ms. So the
- * client read cannot distinguish a write that landed from one that never did — and
- * a sweep that silently enabled nothing hands the next spec a provider still on its
- * `MIN_DEFAULT_MODELS` default, which is what turned #1649's latent defect into five
- * red attempts in one daily.
+ * The panel's `aria-checked` cannot: `useModelToggleQueue` applies an optimistic
+ * `setQueryData` before any request leaves the browser, so a write that never
+ * landed is indistinguishable from one that did (#1649, measured on 1.12.0.dev44 —
+ * all 36 clicks "confirmed" while the POST only went out at t=8132 ms).
  *
- * Pure, and read ONCE by the caller after the batch has flushed — never polled:
- * polling this endpoint while the write is in flight was measured stalling a
- * single-worker backend at 20 s.
+ * `off` and `absent` are separated because they have different causes and the first
+ * version of this check could not tell them apart. #1666 spent an investigation on
+ * exactly that ambiguity: `0 of 36 missing` reads identically whether the write was
+ * lost or whether the names the sweep collected are not the keys the endpoint uses.
+ * Neither counts as enabled — the endpoint lists every model of a configured,
+ * policy-visible provider, so a key it does not carry is one no spec can pick — but
+ * they send a reader to different places.
+ *
+ * `readAnswered` is a separate argument rather than inferred from `serverEnabled`
+ * being undefined, because those are two different states with opposite severity: a
+ * read that never answered is UNKNOWN, while an answered read that does not list the
+ * provider is a DEFINITE negative (the provider is not configured, or a model
+ * provider policy hides it — `provider_policy.allows()` in `api/v1/models.py`).
+ * Collapsing them reported the second as "the read did not answer", which is false
+ * and is the only path where a definite negative used to pass the gate.
+ *
+ * It is a REQUIRED argument, with no default: whichever way a default fell it would
+ * make an omission silently pick a severity, and one of the two is the harsher
+ * verdict on a state the caller may not have observed.
+ *
+ * Pure, and read ONCE by the caller — never polled: polling this endpoint while a
+ * write is in flight was measured stalling a single-worker backend at 20 s.
  */
 export function confirmEnabledOnServer(
   serverEnabled: Record<string, boolean> | undefined,
   expected: string[],
+  readAnswered: boolean,
 ): ServerConfirmation {
   if (expected.length === 0) return { kind: "confirmed", expected: 0 };
 
-  if (serverEnabled === undefined) {
+  const list = (models: string[]): string =>
+    `${models.slice(0, 10).join(", ")}${models.length > 10 ? ` (+${models.length - 10} more)` : ""}`;
+  const coldPath =
+    ` Every spec that targets one of these runs on the COLD PATH — it finds the provider on its ` +
+    `MIN_DEFAULT_MODELS default and has to enable the model itself, which is the fragile path ` +
+    `#1649 documents.`;
+
+  if (!readAnswered) {
     return {
       kind: "unavailable",
       message:
@@ -776,67 +832,247 @@ export function confirmEnabledOnServer(
     };
   }
 
-  // Absence is not `true`: the endpoint lists every model of a configured
-  // provider, so a key it does not carry is one the write never created.
-  const missing = expected.filter((model) => serverEnabled[model] !== true);
-  if (missing.length === 0) return { kind: "confirmed", expected: expected.length };
+  if (serverEnabled === undefined) {
+    return {
+      kind: "shortfall",
+      expected: expected.length,
+      enabled: 0,
+      off: [],
+      absent: [...expected],
+      message:
+        `collect-models: the server ANSWERED and does not list this provider at all, so none of its ` +
+        `${expected.length} target model(s) can be enabled: ${list(expected)}. This is not a failed ` +
+        `read — the provider is either unconfigured on this instance or hidden by a model-provider ` +
+        `policy (\`provider_policy.allows()\`).` + coldPath,
+    };
+  }
 
-  const enabled = expected.length - missing.length;
+  const off = expected.filter((model) => model in serverEnabled && serverEnabled[model] !== true);
+  const absent = expected.filter((model) => !(model in serverEnabled));
+  if (off.length === 0 && absent.length === 0) {
+    return { kind: "confirmed", expected: expected.length };
+  }
+
+  const enabled = expected.length - off.length - absent.length;
   return {
     kind: "shortfall",
     expected: expected.length,
     enabled,
-    missing,
+    off,
+    absent,
     message:
-      `collect-models: the server confirms only ${enabled} of ${expected.length} model(s) this ` +
-      `sweep tried to enable. Missing: ${missing.slice(0, 10).join(", ")}` +
-      `${missing.length > 10 ? ` (+${missing.length - 10} more)` : ""}. ` +
-      `The panel's own toggles report the OPTIMISTIC client state and cannot see this, so a ` +
-      `sweep that wrote nothing used to look identical to one that wrote everything. Specs on ` +
-      `this instance will find the provider on its MIN_DEFAULT_MODELS default and have to ` +
-      `enable it themselves (#1649/#1355).`,
+      `collect-models: the server confirms only ${enabled} of ${expected.length} target model(s) as ` +
+      `enabled.` +
+      (off.length > 0 ? ` Listed but OFF (the enable did not take effect): ${list(off)}.` : "") +
+      (absent.length > 0
+        ? ` Not listed for this provider at all (a model-name/provider-key mismatch, or a model the ` +
+          `catalog no longer exposes — NOT an enable that failed): ${list(absent)}.`
+        : "") +
+      coldPath,
+  };
+}
+
+/** How the write went, as `targetEnablementVerdict` needs to weigh it. */
+export interface EnableWriteOutcome {
+  /** The POST answered 2xx. */
+  ok: boolean;
+  /** Why it did not, verbatim from the server or the transport. `null` when ok. */
+  detail: string | null;
+}
+
+/**
+ * One provider's target-model state, as `providers.json` records it and the
+ * pre-flight gate reads it (#1666).
+ *
+ * `unknown` is deliberately NOT a synonym for "not enabled": it is the state in
+ * which this run has no verdict, and the gate must not fail on it (#1012 —
+ * reported loudly, never as clean).
+ */
+export type TargetEnablementState = "enabled" | "off" | "absent" | "unknown";
+
+export interface TargetEnablement {
+  state: TargetEnablementState;
+  /** What was observed. Empty only for `enabled`. */
+  detail: string;
+}
+
+/**
+ * Combines the write's outcome with the confirmation read into ONE verdict, with
+ * the WRITE taking precedence over a negative read.
+ *
+ * That precedence is the whole point, and getting it backwards is a false positive
+ * on the lane where `Collect models` is a hard gate. Two states produce a model the
+ * server reports as not enabled, and only one of them is a defect:
+ *
+ *   - the write answered 2xx and the model still reads off/absent — a real negative,
+ *     the run IS on the cold path, and the gate should fail;
+ *   - the write never answered 2xx (dropped into a wedged backend, or refused) — the
+ *     read is then describing the state BEFORE an enable that never happened. On
+ *     2026-09-01 the daily measured 19 outages and four `WORKER TIMEOUT` -> SIGKILL
+ *     cycles, so a dropped write is the likely shape of a bad day, not an exotic
+ *     one; failing on it would redden `pr-validation.yml`'s whole E2E job for a
+ *     transient (#980/#1012).
+ *
+ * The refusal case is included in the second branch on purpose. `HTTP 400 Cannot
+ * enable not supported model: o3` is a definite answer that the model can never be
+ * enabled — reachable whenever the key axis settles on one of OpenAI's
+ * `not_supported` entries, which render in the panel and reach `models.json` — but
+ * the cause is the CANDIDATE CHOICE, not a lost enable, and reporting it as `off`
+ * would print "the enable did not take effect" about a server that refused on
+ * purpose. It is `unknown` carrying the server's own words, which is what a reader
+ * needs, and it is warned about rather than silently tolerated.
+ *
+ * PURE, so both branches of the precedence are reachable from a unit test.
+ */
+export function targetEnablementVerdict(
+  write: EnableWriteOutcome,
+  confirmation: ServerConfirmation,
+): TargetEnablement {
+  if (confirmation.kind === "confirmed") return { state: "enabled", detail: "" };
+
+  if (confirmation.kind === "unavailable") {
+    return { state: "unknown", detail: confirmation.message };
+  }
+
+  if (!write.ok) {
+    return {
+      state: "unknown",
+      detail:
+        `the enable itself did not answer 2xx (${write.detail ?? "no detail"}), so the read below ` +
+        `describes the state BEFORE it: ${confirmation.message}`,
+    };
+  }
+
+  return {
+    state: confirmation.off.length > 0 ? "off" : "absent",
+    detail: confirmation.message,
   };
 }
 
 /**
- * Wait for a model toggle to report itself enabled after a click (#1355).
+ * Makes the models this run will actually TARGET enabled, and confirms it (#1666).
  *
- * This is the serialiser. Enabling a model is a write, and the collector enables
- * every model of every provider; firing those as fast as the clicks land is what
- * queues up behind the next provider's Save. Waiting for `aria-checked="true"`
- * makes each write land before the next is issued.
+ * ## Why the sweep no longer enables every model through the panel
  *
- * Reports rather than throws, for the same reason {@link waitForButtonIdle}
- * does: an unconfirmed toggle is worth counting, not worth failing the whole
- * pre-flight over — the model may well be enabled anyway, and the run is more
- * useful finishing.
+ * `collectModelsForProvider` used to click every unchecked toggle. Those writes did
+ * not reach the server while the sweep was running. Every toggle feeds
+ * `useModelToggleQueue`, which batches behind a 1000 ms debounce and CANCELS +
+ * DISCARDS the pending batch both on its unmount cleanup ("an explicit close already
+ * consumes its batch through flushPendingChanges before unmount") and on its
+ * identity effect, which fires the moment the selected provider changes. The loop
+ * clicks faster than the debounce, so the timer never fired mid-loop, and the sweep
+ * then navigated straight to the next provider.
+ *
+ * Measured on a clean 1.12.0.dev45 container with every `enabled_models` call
+ * logged: **74 toggles across three providers produced ZERO
+ * `POST /models/enabled_models` for the whole duration of the sweep** — including
+ * past the confirmation read at the end of it, which is why #1651's server read
+ * reported `0 of 30` for google. Only the LAST provider's batch left at all, ~5 s
+ * after the sweep had moved on, so openai's 36 and anthropic's 9 were discarded
+ * outright while google's 30 landed too late for any verdict.
+ *
+ * Waiting for those batches to leave was tried and REJECTED on cost, not on
+ * difficulty. `POST /api/v1/models/enabled_models` calls
+ * `validate_model_provider_key` once per model being enabled, synchronously, inside
+ * the request — and the lanes run `LANGFLOW_WORKERS=1`. Measured on an idle
+ * 1.12.0.dev45 container: 30 models enabled in **103 s**, the same 30 DISABLED in
+ * **0.02 s** (that path does no validation), one model in 0.42–1.01 s. Making all
+ * 74 land therefore costs ~250 s of a blocked backend per sweep, twice per shard —
+ * the `Collect models` wedge the lanes already carry a health gate for
+ * (#922/#927/#1045). The prototype confirmed it: the sweep went from 40 s to 120 s+,
+ * google's write did not answer inside 45 s, and the confirmation read then timed
+ * out as well. The panel enables its five defaults on its own, and the suite only
+ * ever picks the SETTLED model per provider out of `models.json`, so one write per
+ * provider buys everything the run needs for ~1 s each.
+ *
+ * Never throws: like every other verdict in this file it reports, and the caller
+ * decides (`collect-models.spec.ts` fails the pre-flight on a definite negative).
  */
-export async function waitForToggleChecked(
-  toggle: Pick<ButtonStateLocator, "getAttribute">,
-  options: {
-    timeoutMs?: number;
-    pollMs?: number;
-    now?: () => number;
-    sleep?: (ms: number) => Promise<void>;
-  } = {},
-): Promise<{ checked: boolean; waitedMs: number; polls: number }> {
-  const timeoutMs = options.timeoutMs ?? TOGGLE_CONFIRM_TIMEOUT_MS;
-  const pollMs = options.pollMs ?? TOGGLE_CONFIRM_POLL_MS;
-  const now = options.now ?? Date.now;
-  const sleep = options.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+export async function ensureTargetModelsEnabled(
+  request: Pick<APIRequestContext, "get" | "post">,
+  targets: Array<{ providerDisplayName: string; model: string }>,
+): Promise<Map<string, TargetEnablement>> {
+  const byProvider = new Map<string, string[]>();
+  for (const { providerDisplayName, model } of targets) {
+    const models = byProvider.get(providerDisplayName) ?? [];
+    if (!models.includes(model)) models.push(model);
+    byProvider.set(providerDisplayName, models);
+  }
 
-  const startedAt = now();
-  let polls = 0;
-  do {
-    polls += 1;
-    if ((await toggle.getAttribute("aria-checked")) === "true") {
-      return { checked: true, waitedMs: now() - startedAt, polls };
+  const verdicts = new Map<string, TargetEnablement>();
+  if (byProvider.size === 0) return verdicts;
+
+  // ONE request per provider, not one for every target. The endpoint validates
+  // per model and raises on the FIRST update it rejects, before persisting any of
+  // them — so a single batch lets one provider's rejected model cost every other
+  // provider its enable. Round trips are milliseconds against a write measured at
+  // ~1 s, which makes the isolation free (#980: coverage first).
+  const writes = new Map<string, EnableWriteOutcome>();
+  for (const [provider, models] of byProvider) {
+    const write: EnableWriteOutcome = await request
+      .post("/api/v1/models/enabled_models", {
+        data: models.map((model) => ({
+          provider,
+          model_id: model,
+          model_type: "llm" as const,
+          enabled: true,
+        })),
+        timeout: ENABLE_TARGETS_TIMEOUT_MS,
+      })
+      .then(async (r) => ({
+        ok: r.ok(),
+        detail: r.ok() ? null : `HTTP ${r.status()} ${(await r.text()).slice(0, 300)}`,
+      }))
+      .catch((error: unknown) => ({
+        ok: false,
+        detail: `no HTTP status (${error instanceof Error ? error.message : String(error)})`,
+      }));
+    writes.set(provider, write);
+
+    if (!write.ok) {
+      // Reported, not thrown: the model may already be enabled from an earlier
+      // sweep against the same instance, and the read below is what decides.
+      console.warn(
+        `⚠️  collect-models: enabling [${provider}] ${models.join(", ")} answered ${write.detail}. ` +
+          `The confirmation read below is what says whether the run is on the cold path (#1666).`,
+      );
     }
-    if (now() - startedAt >= timeoutMs) break;
-    await sleep(pollMs);
-  } while (now() - startedAt < timeoutMs);
+  }
 
-  return { checked: false, waitedMs: now() - startedAt, polls };
+  // `readAnswered` is tracked separately from the payload so an answered response
+  // that omits a provider is not reported as a failed read (see
+  // `confirmEnabledOnServer`). The per-type map is preferred over the flat one for
+  // the reason the backend states about its own shapes: "Per-type map is exact; flat
+  // map ORs rows that share provider/name", so the flat map can read `true` for an
+  // `llm` target whose only enabled row is `embeddings` — which is also why the
+  // product's own `isModelEnabled` prefers the typed map.
+  const read = await request
+    .get("/api/v1/models/enabled_models?purpose=configure", { timeout: ENABLE_TARGETS_TIMEOUT_MS })
+    .then(async (r) => ({ answered: r.ok(), body: r.ok() ? await r.json() : null }))
+    .catch(() => ({ answered: false, body: null }));
+  const flat = read.body?.enabled_models as Record<string, Record<string, boolean>> | undefined;
+  const typed = read.body?.enabled_models_by_type as
+    | Record<string, Record<string, Record<string, boolean>>>
+    | undefined;
+  const mapFor = (provider: string): Record<string, boolean> | undefined =>
+    typed?.[provider]?.llm ?? flat?.[provider];
+
+  for (const [provider, models] of byProvider) {
+    const confirmation = confirmEnabledOnServer(mapFor(provider), models, read.answered);
+    const verdict = targetEnablementVerdict(
+      writes.get(provider) ?? { ok: false, detail: "no write was issued" },
+      confirmation,
+    );
+    verdicts.set(provider, verdict);
+    if (verdict.state === "enabled") {
+      console.log(
+        `   collect-models: [${provider}] ${models.join(", ")} confirmed enabled on the server.`,
+      );
+    } else {
+      console.warn(`⚠️  [${provider}] ${verdict.detail}`);
+    }
+  }
+  return verdicts;
 }
 
 export interface ButtonIdleVerdict {
@@ -1075,14 +1311,6 @@ function chargeBudget(budget: SweepBudget, provider: string, ms: number): void {
 interface ProviderCollection {
   models: ModelRecord[];
   stall: string | null;
-  /**
-   * Models this sweep CLICKED to enable, so the caller can confirm them against
-   * the server once the whole sweep is idle (#1649). Never confirmed here: the
-   * read has to happen while the backend is not busy with the very write it is
-   * being asked about — measured timing out at 20 s when issued inside the loop
-   * on a `LANGFLOW_WORKERS=1` instance.
-   */
-  attempted: string[];
 }
 
 async function collectModelsForProvider(
@@ -1344,64 +1572,31 @@ async function collectModelsForProvider(
     .catch(() => {});
 
   // Scope to visible toggles only — the providers panel renders deprecated models
-  // in DOM but collapses them under a "Show N deprecated models" button. Iterating
-  // the hidden toggles makes `.click()` retry-loop until timeout (see PR #330).
+  // in DOM but collapses them under a "Show N deprecated models" button, and a
+  // hidden row's model name is not one this catalog should carry (see PR #330).
   const toggles = page.locator('[data-testid^="llm-toggle"]:visible');
   const toggleCount = await toggles.count();
   const models: ModelRecord[] = [];
 
-  // Each enable is a WRITE, and this loop used to fire them as fast as the clicks
-  // land. Confirming each one before moving on serialises them.
+  // READ ONLY. This loop used to click every unchecked toggle as well, and #1666
+  // measured that none of those writes ever landed: `useModelToggleQueue` batches
+  // them behind a 1000 ms debounce and cancels + DISCARDS the batch when the panel
+  // unmounts or the selected provider changes, which is exactly what this function
+  // does next. 74 clicks across three providers produced ZERO
+  // `POST /models/enabled_models` on a clean 1.12.0.dev45 container.
   //
-  // Honest about what this is worth: it was added believing these 41 writes were
-  // what wedged the next provider's Save, and the very next CI run REFUTED that —
-  // the failure was byte-identical with the serialisation in place. The measured
-  // cause is the credential write above, which stays in flight past 60s. This is
-  // kept because a burst of 41 unconfirmed writes against a backend the lanes run
-  // with `LANGFLOW_WORKERS=1` is worth avoiding on its own and costs nothing
-  // measurable (23.9s against 24.9s locally) — not because it fixed anything.
-  //
-  // The pair of bounds mirrors the token-attribution sidecar (#1197 §4.4): a
-  // per-toggle timeout bounds ONE write, and an aggregate budget bounds the sum —
-  // a per-item timeout alone would let 41 slow-but-succeeding writes spend
-  // 41 x TIMEOUT and blow the spec's own 5-minute budget.
-  //
-  // Past the budget the clicks CONTINUE unconfirmed: enabling a model is still
-  // worth attempting, and the count of unconfirmed ones is reported below rather
-  // than silently dropped (#1012).
-  let unconfirmed = 0;
-  let confirmBudgetLeft = TOGGLE_CONFIRM_BUDGET_MS;
-  // Every model this loop CLICKED, so the server read below can answer the one
-  // question `aria-checked` cannot: did the write actually land (#1649)?
-  const attempted: string[] = [];
+  // Making them land was rejected on measured COST, not difficulty: the endpoint
+  // validates the provider key once per model, synchronously, so those 74 writes
+  // cost ~250 s of a `LANGFLOW_WORKERS=1` backend per sweep (103 s for 30 models
+  // against 0.02 s to disable the same 30). The panel enables its five defaults on
+  // its own and the suite only ever picks the SETTLED model per provider, so
+  // `ensureTargetModelsEnabled` writes those — one per provider, ~1 s each — after
+  // the key axis has settled them. See its docstring for the full measurement.
   for (let i = 0; i < toggleCount; i++) {
-    const toggle = toggles.nth(i);
-    const modelName = await toggle.locator("..").locator("span.text-sm").textContent();
+    const modelName = await toggles.nth(i).locator("..").locator("span.text-sm").textContent();
     if (modelName?.trim()) {
       models.push({ provider: providerName, model: modelName.trim() });
     }
-    const isChecked = (await toggle.getAttribute("aria-checked")) === "true";
-    if (!isChecked) {
-      if (modelName?.trim()) attempted.push(modelName.trim());
-      await toggle.click();
-      if (confirmBudgetLeft > 0) {
-        const confirm = await waitForToggleChecked(toggle, {
-          timeoutMs: Math.min(TOGGLE_CONFIRM_TIMEOUT_MS, confirmBudgetLeft),
-        });
-        confirmBudgetLeft -= confirm.waitedMs;
-        if (!confirm.checked) unconfirmed += 1;
-      } else {
-        unconfirmed += 1;
-      }
-    }
-  }
-
-  if (unconfirmed > 0) {
-    console.warn(
-      `⚠️  collect-models: ${unconfirmed} of ${toggleCount} model toggle(s) for provider ` +
-        `"${providerName}" were clicked but never confirmed enabled within the budget. The panel ` +
-        `is slow or wedged, and the NEXT provider's Save is what pays for it (#1355).`,
-    );
   }
 
   console.log(`Models found (${providerName}):`, models.map((m) => m.model));
@@ -1423,7 +1618,7 @@ async function collectModelsForProvider(
 
   await page.getByTestId("sidebar-nav-Model Providers").click();
 
-  return { models, stall, attempted };
+  return { models, stall };
 }
 
 async function collectModels(page: Page): Promise<{
@@ -1436,8 +1631,6 @@ async function collectModels(page: Page): Promise<{
 
   const allModels: ModelRecord[] = [];
   const stalls = new Map<string, string>();
-  /** Provider DISPLAY name -> the models this sweep clicked to enable (#1649). */
-  const attempted = new Map<string, string[]>();
 
   // One budget for the whole sweep, spent down as each provider's post-Save
   // waits actually run (#1370), with a per-provider ledger so a collateral stall
@@ -1460,36 +1653,6 @@ async function collectModels(page: Page): Promise<{
     );
     allModels.push(...collection.models);
     if (collection.stall) stalls.set(provider, collection.stall);
-    if (collection.attempted.length > 0) {
-      // Keyed by the DISPLAY name, which is how `enabled_models` keys its map
-      // ("OpenAI", not "openai") — derived from the testid rather than restated,
-      // so a new provider needs no second table (the `displayNameOf` shape
-      // `preconfigure-routed-provider.ts` already uses).
-      attempted.set(config.providerTestId.replace(/^provider-item-/, ""), collection.attempted);
-    }
-  }
-
-  // Confirm the toggle writes against the SERVER, once, now that the sweep is
-  // idle (#1649). The panel's own `aria-checked` confirmation is the OPTIMISTIC
-  // client state — `useModelToggleQueue` flips it synchronously at click time,
-  // before any request leaves the browser — so a write that never landed is
-  // indistinguishable from one that did, and the #1355 shortfall warning cannot
-  // fire. This read has to be LAST: issued inside the provider loop it competes
-  // with the very write it asks about and was measured timing out at 20 s on a
-  // `LANGFLOW_WORKERS=1` instance, turning an honest check into a warning on
-  // every sweep. Reporting only — never fails the sweep (#980).
-  if (attempted.size > 0) {
-    const enabledByProvider = await page
-      .request.get("/api/v1/models/enabled_models?purpose=configure", { timeout: 30000 })
-      .then((r) => (r.ok() ? r.json() : null))
-      .then((body) => body?.enabled_models as Record<string, Record<string, boolean>> | undefined)
-      .catch(() => undefined);
-    for (const [provider, models] of attempted) {
-      const confirmation = confirmEnabledOnServer(enabledByProvider?.[provider], models);
-      if (confirmation.kind !== "confirmed") {
-        console.warn(`⚠️  [${provider}] ${confirmation.message}`);
-      }
-    }
   }
 
   // Printed on EVERY sweep, not only a failing one (#1385). The budget is the
@@ -1555,13 +1718,68 @@ export async function collectAll(page: Page): Promise<void> {
 
   // Step 3: Validate the key axis and merge both verdicts
   const providers = await collectProviders(models, buildAxis, stalls);
+
+  // BOTH data files are written BEFORE the target-model step, and providers.json is
+  // then patched with its verdict. Order matters more than it looks: step 3b spends
+  // up to one write per keyed provider plus a read against a single-worker backend,
+  // and it sits at the very end of a sweep that has already spent minutes — so a
+  // `test.setTimeout` abort inside it used to discard the ENTIRE sweep output.
+  // `resolveTestTargets()` with no models.json resolves one `(fallback)` target and
+  // every parametrized spec skips green, which is the #570/#1012 trap this file
+  // works hard elsewhere to prevent. Written first, an abort costs the verdict, not
+  // the catalog.
   fs.writeFileSync(PROVIDERS_PATH, JSON.stringify(providers, null, 2), "utf-8");
   console.log(`providers.json saved with ${providers.length} providers.`);
 
-  // Step 3: Persist models with each provider's settled model first, so
-  // "one model per provider" spec parametrization targets the model that
-  // actually validated.
+  // Persist models with each provider's settled model first, so "one model per
+  // provider" spec parametrization targets the model that actually validated.
   const ordered = promoteSettledModels(models, providers);
   fs.writeFileSync(MODELS_PATH, JSON.stringify(ordered, null, 2), "utf-8");
   console.log(`models.json saved with ${ordered.length} models.`);
+
+  // Step 3b: make the models this run will TARGET actually usable (#1666).
+  //
+  // Deliberately after step 3, not inside the UI sweep: the target model is
+  // whatever the key axis SETTLED on, which is not known until here, and
+  // `promoteSettledModels` above is what puts it in front of every consumer. Only
+  // ACTIVE providers get a write — an inactive one has no settled model, and
+  // enabling into a dead key answers 400 (the endpoint validates per model).
+  //
+  // The display name is looked up through `keyedProviders` rather than cast from
+  // `record.provider`, so a record naming a provider this map does not know falls
+  // through with no verdict instead of reaching `langflowProviderName`. That
+  // function still throws by contract if a `providerTestId` loses its prefix, which
+  // is the loud failure it is for — and now costs only the verdict, since both data
+  // files are already on disk.
+  const displayNames = new Map(
+    keyedProviders.map(([provider]) => [provider as string, langflowProviderName(provider)]),
+  );
+  const enablement = await ensureTargetModelsEnabled(
+    page.request,
+    providers.flatMap((record) => {
+      const providerDisplayName = displayNames.get(record.provider);
+      return record.status === "active" && record.model && providerDisplayName
+        ? [{ providerDisplayName, model: record.model }]
+        : [];
+    }),
+  );
+  for (const record of providers) {
+    const providerDisplayName = displayNames.get(record.provider);
+    const verdict = providerDisplayName ? enablement.get(providerDisplayName) : undefined;
+    if (record.status !== "active" || !record.model) {
+      // No target to enable at all, which is not the same claim as "unknown".
+      record.targetEnablement = null;
+      record.targetEnablementDetail = null;
+      continue;
+    }
+    record.targetEnablement = verdict?.state ?? "unknown";
+    record.targetEnablementDetail =
+      verdict === undefined
+        ? `no target-model verdict was produced for provider "${record.provider}" — it is not in ` +
+          `providerConfigMap, or the enable step did not reach it`
+        : verdict.detail || null;
+  }
+  // Rewritten with the verdict attached. The first write above is what survives an
+  // abort; this one is what the pre-flight gate reads.
+  fs.writeFileSync(PROVIDERS_PATH, JSON.stringify(providers, null, 2), "utf-8");
 }


### PR DESCRIPTION
Closes #1666

## Verdict: writes lost, reader right, product not at fault

#1666 left two readings open — the writes were genuinely lost, or the server-side
confirmation added the day before could not report anything else — and required the
product to be ruled out first.

**Reproduced on a clean `langflowai/langflow-nightly:latest` (`1.12.0.dev45`), local, no
load, `--workers=1`: `0 of 36 / 0 of 9 / 0 of 30`, identical to the daily.** So the
environment was not the cause.

With every `enabled_models` call logged, the sweep's **74 toggles produced ZERO
`POST /api/v1/models/enabled_models` for its whole duration**. Langflow never received a
write, so this is **not a product regression**, and the #1651 reader is right in
substance. `useModelToggleQueue` batches behind a 1000 ms debounce and cancels +
**discards** the pending batch on both paths the sweep takes — its unmount cleanup
(*"an explicit close already consumes its batch through `flushPendingChanges` before
unmount"*) and its identity effect, which fires the moment the selected provider
changes. The loop clicks faster than the debounce, so the timer never fired mid-loop.

Only the **last** provider's batch left at all, ~5 s after the sweep had moved on — which
is why #1651's read reported `0 of 30` for a google whose 30 models were enabled seconds
later. One of the three readings was a race; the other two were real.

## Why the fix is not "make the 74 writes land"

That was prototyped and **rejected on measured cost**. `update_enabled_models` calls
`validate_model_provider_key` once **per model**, synchronously, inside the request, and
the lanes run `LANGFLOW_WORKERS=1`. On an **idle** container:

| Operation | Cost |
|---|---|
| enable 1 model | 0.42–1.01 s |
| enable 30 models | **103 s** |
| **disable** the same 30 | **0.02 s** (no validation on that path) |

All 74 would cost ~250 s of blocked backend per sweep, twice per shard — the wedge the
lanes already carry a health gate for (#922/#927/#1045). The prototype confirmed it: the
sweep went 40 s → 120 s+, google's write was unanswered at 45 s, and the confirmation read
then timed out as well.

That per-model validation is also the mechanism behind the eight `1 write(s) started,
0 finished` give-ups #1672 taught the picker read to name instead of blaming
`MODEL_PICKER_DEFECT`.

## What this does

The sweep now only **reads** model names for `models.json`. `ensureTargetModelsEnabled`
writes the one model per **active** provider that the key axis settled on — all any spec
picks — then confirms it against the server. Measured **~2 s**, and the sweep is *faster*
than before (22–35 s against 40 s) because it no longer clicks 74 toggles for nothing. The
server ends at the five `MIN_DEFAULT_MODELS` defaults plus the target.

**The write outranks a negative read.** Two states leave a model reading "not enabled" and
only one is a defect: a 2xx write plus a model still off is real; a write that never
answered 2xx means the read describes the state *before* an enable that never happened. On
2026-09-01 the daily measured 19 outages and four `WORKER TIMEOUT` → SIGKILL cycles, so a
dropped write is the shape of a bad day — failing on it would redden `pr-validation.yml`'s
whole E2E job, where this pre-flight is a hard gate. A **refused** write is in that branch
too: `400 Cannot enable not supported model: o3` is definite and reachable whenever the key
axis settles on one of OpenAI's `not_supported` entries, but its cause is the candidate
choice, so it is `unknown` carrying the server's own words rather than "the enable did not
take effect".

`providers.json` records **four states**, not a boolean — `off` (listed, disabled) and
`absent` (not listed at all: a name/catalog mismatch, or a policy-hidden provider) send a
reader to different places, and collapsing them is the ambiguity this issue spent an
investigation resolving.

## The two decisions #1666 asked to be recorded

**Warn or fail → FAIL, scoped.** Three things keep it off the provider-health coupling
`Collect models` spent #915/#910/#911 learning to avoid, and off the #980 trade:

- an **inactive** provider has no settled model and never reaches the check, so a drained
  key still cannot redden it;
- `unknown` **warns** — it covers a wedged backend and a refused enable alike, and never
  reads as clean (#1012);
- it is **scoped** through `COLLECT_REQUIRED_PROVIDERS`, the mechanism the collector-stall
  step already uses, so an enable failure on a provider `pr-validation.yml`'s pinned run
  (#1169) will never target cannot kill its E2E job. Unset — the daily, `manual.yml`, local
  — still requires every env-keyed provider, and a non-required provider's cold state is
  still **reported**.

**The cold path is observable at run level.** The enablement state prints on **every** run,
green included, and is recorded per provider in `providers.json`, so the next daily's
triage reads it instead of inferring it from a warning's absence.

## Two hardening details worth the reviewer's eye

**Both data files are written BEFORE the new step**, and `providers.json` is patched after.
The step spends up to one write per provider plus a read at the very end of a minutes-long
sweep, so a `test.setTimeout` abort inside it used to discard the whole catalog —
`resolveTestTargets()` then resolves one `(fallback)` target and every parametrized spec
skips green (#570/#1012).

**The per-call ceiling is now counted explicitly** against the pre-flight timeout, because
a per-call constant can silently break the #1385 sizing invariant. It already had, at 60 s
(450 + 90 + 240 > 720), with that assertion passing.

`waitForToggleChecked` is deleted with its tests: it polled `aria-checked`, flipped
synchronously before any request leaves the browser, so it could only ever confirm the
optimistic client cache — and with no clicks left there is nothing to wait on.

## Known cost this change introduces (measured, not assumed)

Google was the last provider, so its ~30 models used to be left enabled by the escaping
batch and `setupGoogle` clicked nothing. It now clicks ~24 and spends the give-up budget.
The write **does** land just after the give-up, so it is paid **once per instance per
provider**, not per spec: two consecutive `agent-current-date-tool` runs measured 3.3 min
then **1.1 min**, server ending at openai 41 / google 35 enabled. Pointing those helpers at
the target model is #1651's surface and is tracked separately.

## Validation

- `tests/collect-models.spec.ts` — **4 clean `--retries=0` runs**, fresh container and
  already-configured, 22.0 / 22.6 / 28.6 / 35.2 s.
- **Forced failure, both modes.** Write suppressed while reporting 2xx: unscoped, both
  providers fail naming `off`; with `COLLECT_REQUIRED_PROVIDERS=openai`, openai fails and
  google warns *"Not fatal on this lane"*.
- `agent-current-date-tool.spec.ts` (the spec #1666 names) — **4 passed / 2 skipped, twice**
  at `--retries=0`. The 2 skips are anthropic, whose key reports `credit balance is too
  low`, so this PR could not exercise the third provider end to end.
- `npm run typecheck` clean · `npm run lint` 0 errors · `npm run test:units` **884/884** ·
  `npm run test:scripts` **901/901** · both QA-CHECKLIST guards ✓ · `watch-upstream-areas
  --mode=check-docs` reports no unresolved path in the changed doc (both new `src/…` tokens
  verified on `origin/main` **and** `release-1.12.0`).
- 18 new unit tests cover `ensureTargetModelsEnabled` and `targetEnablementVerdict` against
  a duck-typed `APIRequestContext` — one POST per provider (never one batch: the endpoint
  raises on the first rejected update *before* persisting any), the body shape, the typed
  map winning over the flat one the backend documents as OR-ing across model types, and
  every path that must report rather than throw.

**Nothing was quarantined for #1666**, so there is no `test.fixme` to remove and no
`@stable` to restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
