### PR TITLE
fix(llm-agents): free the canvas bottom overlay before the memory inspect click (#1643)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-context-id-continuity.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-continuity.md
@@ -1,6 +1,6 @@
 # Agent context_id — continuity between session messages
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev45`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev39`)
 
 ---
 
@@ -53,6 +53,11 @@ tag or don't accumulate history — the agent memory layering contract dies.
 (1.11.0.dev36; issue #487's "Done when" includes `@stable`). `@regression` — guards
 the context tagging + scoped-retrieval wiring; `@agents` — Agent memory
 surface; `@components` — Message History node drives the retrieval assert.
+
+`@stable` was removed and `test.fixme` added at the 2026-08-31 triage (#1643, PR
+#1647) while the canvas bottom-overlay intercepted the retrieval click. Both are
+restored here: root cause named and fixed (see the overlay note under *Step by
+step*), re-validated with clean `--retries=0` runs on nightly `1.12.0.dev39`.
 
 ---
 
@@ -108,11 +113,40 @@ surface; `@components` — Message History node drives the retrieval assert.
    context back to empty for one extra run, sentinel `S-CTRL`).
 4. On the flow canvas, add a Message History node (Retrieve), expose and set
    `session_id` = the custom session, `context_id = CTX`, `n_messages=100`;
-   run the node (`button_run`), open the output inspector.
+   run the node (`button_run`), **free the canvas bottom-overlay slot** (see
+   the note below), open the output inspector.
 5. **Assert:** the rendered retrieval contains `S-1`, `S-2` AND `S-3`
    (continuity across all turns of the context) and does NOT contain
    `S-CTRL` (the retrieval is genuinely context-filtered — the negative that
    makes the positive falsifiable).
+
+
+> **Canvas bottom-overlay note (#1643).** Langflow renders two different
+> components into ONE fixed container over the canvas —
+> `absolute bottom-16 left-1/2 z-50 w-[530px] -translate-x-1/2`: the
+> build-status bar (`flowBuildingComponent`, transient — it auto-dismisses 2 s
+> after "Flow built successfully" plus a 500 ms exit) and the "Flow needs
+> review / N components need updates" banner (`UpdateAllComponents`), which is
+> **hidden while the bar is up and takes the slot back the moment it
+> dismisses**, then stays indefinitely. Measured on nightly `1.12.0.dev39` at
+> the default 1280x720 viewport, the Message History node's
+> `output-inspection-messages-memory` button sits at y 585.6-601.0 (centre
+> 593.3) while the bar's top edge is y 598 — the click clears it by ~5 px — and
+> the banner is 12 px taller, top edge y ~586, i.e. **above** the centre. So the
+> identical click passed or was refused purely on which component owned the
+> slot, and once the banner owned it no retry could help: on the 2026-08-31
+> daily both context-id specs burned the full 20 s `locator.click` budget on all
+> three attempts against `<div class="flex items-center justify-between gap-6
+> rounded-lg border bg-background px-4 py-3 text-sm shadow-md">`, the banner's
+> inner element. The banner is present because the seeded flow comes from
+> `tests/assets/flows/chat-io-ok-trace-fixture.json`, whose nodes carry
+> `lf_version: 1.7.0` and one of which the 1.12 nightly reports as outdated.
+> Refreshing that fixture would silence it only until the next upstream template
+> bump — and would leave the build bar's ~5 px margin untouched — so the step
+> above frees the slot (`clearCanvasBottomOverlay`, waits the transient occupant
+> out and dismisses the persistent one) instead of clicking into it. Both files
+> are `mode: "serial"`, so this failure also skipped each file's sibling; with
+> it fixed the siblings run again.
 
 ---
 

--- a/docs/core-functionality/llm-agents/agent-context-id-continuity.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-continuity.md
@@ -1,6 +1,6 @@
 # Agent context_id — continuity between session messages
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev39`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev0`)
 
 ---
 
@@ -57,7 +57,9 @@ surface; `@components` — Message History node drives the retrieval assert.
 `@stable` was removed and `test.fixme` added at the 2026-08-31 triage (#1643, PR
 #1647) while the canvas bottom-overlay intercepted the retrieval click. Both are
 restored here: root cause named and fixed (see the overlay note under *Step by
-step*), re-validated with clean `--retries=0` runs on nightly `1.12.0.dev39`.
+step*), re-validated with clean `--retries=0` runs on nightly `1.13.0.dev0` — the
+image `daily-stable.yml` pulls as `:latest` — as well as on `1.12.0.dev39`, where
+the geometry above was measured.
 
 ---
 
@@ -120,7 +122,6 @@ step*), re-validated with clean `--retries=0` runs on nightly `1.12.0.dev39`.
    `S-CTRL` (the retrieval is genuinely context-filtered — the negative that
    makes the positive falsifiable).
 
-
 > **Canvas bottom-overlay note (#1643).** Langflow renders two different
 > components into ONE fixed container over the canvas —
 > `absolute bottom-16 left-1/2 z-50 w-[530px] -translate-x-1/2`: the
@@ -146,7 +147,14 @@ step*), re-validated with clean `--retries=0` runs on nightly `1.12.0.dev39`.
 > above frees the slot (`clearCanvasBottomOverlay`, waits the transient occupant
 > out and dismisses the persistent one) instead of clicking into it. Both files
 > are `mode: "serial"`, so this failure also skipped each file's sibling; with
-> it fixed the siblings run again.
+> it fixed the siblings run again. The serial mode itself stays — it is the
+> agent-area rule for a file that loads the Simple Agent template — and the
+> coupling is already mitigated the way this file can mitigate it: the model-free
+> describe is declared BEFORE the parametrized loop on purpose, so a weak-model or
+> missing-provider failure there cannot skip the half that needs no provider. What
+> that ordering cannot protect against is a failure in the FIRST describe, which is
+> what happened here; the answer is to stop that failure, not to unpick the
+> execution mode.
 
 ---
 
@@ -229,3 +237,13 @@ string checks on persisted/rendered data — no model judgment anywhere.
     for why (a UI-driven first configure races across workers).
 - No external network for the "retrieval layer (model-free)" test (API passthrough +
   local retrieval), and no provider either — it is outside the parametrization.
+- **Upstream frontend sources the retrieval step now depends on (#1643).** The
+  slot-clearing step reads Langflow's own canvas bottom-centre overlay, so a rename
+  of either component is a silent break — the selector would match nothing and the
+  click would go back to being intercepted. Declared here so
+  `watch-upstream-areas.mjs --mode=check-docs` fails the PR that moves them:
+  `src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx` and
+  `src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx`. A
+  class-only edit (`w-[530px]`, `bottom-16`) is not caught by that guard, which is
+  why `clearCanvasBottomOverlay` additionally fails closed when its selector matches
+  nothing at all.

--- a/docs/core-functionality/llm-agents/agent-context-id-isolation.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-isolation.md
@@ -1,6 +1,6 @@
 # Agent context_id — switching isolates history between contexts
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev15`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev39`)
 
 ---
 
@@ -61,6 +61,12 @@ context tagging + scoped-retrieval isolation wiring; `@agents` — Agent memory
 surface; `@components` — Message History node drives the read-side assert;
 `@playground` — test 2 switches contexts across live playground turns.
 
+
+`@stable` was removed and `test.fixme` added at the 2026-08-31 triage (#1643, PR
+#1647) while the canvas bottom-overlay intercepted the retrieval click. Both are
+restored here: root cause named and fixed (see the overlay note under *Step by
+step*), re-validated with clean `--retries=0` runs on nightly `1.12.0.dev39`.
+
 ---
 
 ## Preconditions *(optional)*
@@ -87,10 +93,12 @@ surface; `@components` — Message History node drives the read-side assert;
    `B-1..B-3`; poll to the new exact total (12 stored messages).
 4. On the flow canvas, add a Message History node (Retrieve), expose and set
    `session_id` = the custom session, `context_id = CTX-A`, `n_messages=100`;
-   run the node, read the output inspector.
+   run the node, **free the canvas bottom-overlay slot** (see the note below),
+   read the output inspector.
 5. **Assert (A side):** retrieval contains `A-1`, `A-2`, `A-3` and does NOT
    contain any `B-*` sentinel.
-6. Update the node's `context_id` field to `CTX-B`, run again, read output.
+6. Update the node's `context_id` field to `CTX-B`, run again, free the
+   overlay slot again, read output.
 7. **Assert (B side):** retrieval contains `B-1`, `B-2`, `B-3` and does NOT
    contain any `A-*` sentinel.
 
@@ -124,6 +132,34 @@ surface; `@components` — Message History node drives the read-side assert;
 > once the server confirms the intended context on all three nodes. If the
 > editor wins three times in a row the test fails as an explicit **setup**
 > error naming the reverted write — never as a fake isolation defect.
+
+
+> **Canvas bottom-overlay note (#1643).** Langflow renders two different
+> components into ONE fixed container over the canvas —
+> `absolute bottom-16 left-1/2 z-50 w-[530px] -translate-x-1/2`: the
+> build-status bar (`flowBuildingComponent`, transient — it auto-dismisses 2 s
+> after "Flow built successfully" plus a 500 ms exit) and the "Flow needs
+> review / N components need updates" banner (`UpdateAllComponents`), which is
+> **hidden while the bar is up and takes the slot back the moment it
+> dismisses**, then stays indefinitely. Measured on nightly `1.12.0.dev39` at
+> the default 1280x720 viewport, the Message History node's
+> `output-inspection-messages-memory` button sits at y 585.6-601.0 (centre
+> 593.3) while the bar's top edge is y 598 — the click clears it by ~5 px — and
+> the banner is 12 px taller, top edge y ~586, i.e. **above** the centre. So the
+> identical click passed or was refused purely on which component owned the
+> slot, and once the banner owned it no retry could help: on the 2026-08-31
+> daily both context-id specs burned the full 20 s `locator.click` budget on all
+> three attempts against `<div class="flex items-center justify-between gap-6
+> rounded-lg border bg-background px-4 py-3 text-sm shadow-md">`, the banner's
+> inner element. The banner is present because the seeded flow comes from
+> `tests/assets/flows/chat-io-ok-trace-fixture.json`, whose nodes carry
+> `lf_version: 1.7.0` and one of which the 1.12 nightly reports as outdated.
+> Refreshing that fixture would silence it only until the next upstream template
+> bump — and would leave the build bar's ~5 px margin untouched — so the step
+> above frees the slot (`clearCanvasBottomOverlay`, waits the transient occupant
+> out and dismisses the persistent one) instead of clicking into it. Both files
+> are `mode: "serial"`, so this failure also skipped each file's sibling; with
+> it fixed the siblings run again.
 
 ---
 

--- a/docs/core-functionality/llm-agents/agent-context-id-isolation.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-isolation.md
@@ -1,6 +1,6 @@
 # Agent context_id — switching isolates history between contexts
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev39`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev0`)
 
 ---
 
@@ -61,11 +61,12 @@ context tagging + scoped-retrieval isolation wiring; `@agents` — Agent memory
 surface; `@components` — Message History node drives the read-side assert;
 `@playground` — test 2 switches contexts across live playground turns.
 
-
 `@stable` was removed and `test.fixme` added at the 2026-08-31 triage (#1643, PR
 #1647) while the canvas bottom-overlay intercepted the retrieval click. Both are
 restored here: root cause named and fixed (see the overlay note under *Step by
-step*), re-validated with clean `--retries=0` runs on nightly `1.12.0.dev39`.
+step*), re-validated with clean `--retries=0` runs on nightly `1.13.0.dev0` — the
+image `daily-stable.yml` pulls as `:latest` — as well as on `1.12.0.dev39`, where
+the geometry above was measured.
 
 ---
 
@@ -133,7 +134,6 @@ step*), re-validated with clean `--retries=0` runs on nightly `1.12.0.dev39`.
 > editor wins three times in a row the test fails as an explicit **setup**
 > error naming the reverted write — never as a fake isolation defect.
 
-
 > **Canvas bottom-overlay note (#1643).** Langflow renders two different
 > components into ONE fixed container over the canvas —
 > `absolute bottom-16 left-1/2 z-50 w-[530px] -translate-x-1/2`: the
@@ -159,7 +159,14 @@ step*), re-validated with clean `--retries=0` runs on nightly `1.12.0.dev39`.
 > above frees the slot (`clearCanvasBottomOverlay`, waits the transient occupant
 > out and dismisses the persistent one) instead of clicking into it. Both files
 > are `mode: "serial"`, so this failure also skipped each file's sibling; with
-> it fixed the siblings run again.
+> it fixed the siblings run again. The serial mode itself stays — it is the
+> agent-area rule for a file that loads the Simple Agent template — and the
+> coupling is already mitigated the way this file can mitigate it: the model-free
+> describe is declared BEFORE the parametrized loop on purpose, so a weak-model or
+> missing-provider failure there cannot skip the half that needs no provider. What
+> that ordering cannot protect against is a failure in the FIRST describe, which is
+> what happened here; the answer is to stop that failure, not to unpick the
+> execution mode.
 
 ---
 
@@ -248,3 +255,13 @@ persisted/rendered data — no model judgment anywhere.
 - `tests/helpers/provider-setup/data/models.json` + `providers.json`
   (collect-models) — test 2.
 - No external network for test 1 (API passthrough + local retrieval).
+- **Upstream frontend sources the retrieval step now depends on (#1643).** The
+  slot-clearing step reads Langflow's own canvas bottom-centre overlay, so a rename
+  of either component is a silent break — the selector would match nothing and the
+  click would go back to being intercepted. Declared here so
+  `watch-upstream-areas.mjs --mode=check-docs` fails the PR that moves them:
+  `src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx` and
+  `src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx`. A
+  class-only edit (`w-[530px]`, `bottom-16`) is not caught by that guard, which is
+  why `clearCanvasBottomOverlay` additionally fails closed when its selector matches
+  nothing at all.

--- a/docs/core-functionality/llm-agents/agent-n-messages-limit.md
+++ b/docs/core-functionality/llm-agents/agent-n-messages-limit.md
@@ -1,6 +1,6 @@
 # n_messages — limits the number of retained messages
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev7`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev0`)
 
 ---
 
@@ -95,10 +95,30 @@ Shared setup per test (all data is per-run unique):
    save to settle.
 7. Run the node (`button_run_message history`, mode tab *Retrieve* is the
    default), wait for **built successfully**.
-8. Open the output inspector (`output-inspection-messages-memory`) and read the
-   retrieved text from its `textarea`. The default template renders one line
-   per message (`{sender_name}: {text}`), so occurrences of the sentinel
-   prefix count the retrieved messages exactly.
+8. **Free the canvas bottom-overlay slot** (see the note below), then open the
+   output inspector (`output-inspection-messages-memory`) and read the retrieved
+   text from its `textarea`. The default template renders one line per message
+   (`{sender_name}: {text}`), so occurrences of the sentinel prefix count the
+   retrieved messages exactly.
+
+> **Canvas bottom-overlay note (#1643) — hardening, not a fix of a live defect
+> here.** Langflow renders two components into ONE fixed container over the canvas
+> (`absolute bottom-16 left-1/2 z-50 w-[530px] -translate-x-1/2`): the transient
+> build-status bar and the "Flow needs review" banner, which is hidden while the bar
+> is up, retakes the slot when the bar dismisses, and then stays. On the two
+> `agent-context-id-*` specs that combination refused the inspect click for the full
+> 20 s `locator.click` budget on the 2026-08-31 daily. This spec seeds from the same
+> `chat-io-ok-trace-fixture.json`, adds the same node the same way, and reaches the
+> same testid with the same five lines — and the banner IS present here too,
+> **measured** on nightly `1.13.0.dev0` at y 586-656. What differs is the margin:
+> this node exposes two advanced fields where the context-id specs expose three, so
+> it is ~14 px shorter and its inspect button sits at y 541.0-556.9 — **~37 px clear
+> of the banner**, against ~5 px there. Forcing the failing condition (dwelling 4 s
+> so the banner owns the slot) does NOT reproduce an interception here, which was
+> checked rather than assumed. The step is added anyway because ~37 px of clearance
+> is a coincidence of node height, and node height is precisely what upstream moves
+> — `dev46` already changed how these fields are exposed. It costs ~2 s per
+> retrieval and removes the dependence.
 
 ---
 
@@ -170,6 +190,11 @@ Shared setup per test (all data is per-run unique):
   and field inputs.
 - `src/frontend/src/modals/` — the component output inspector
   (`output-inspection-*`, `textarea`).
+- `src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx` and
+  `src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx` — the
+  two components that share the canvas bottom-centre overlay slot the retrieval
+  step now clears (#1643). Declared so `watch-upstream-areas.mjs --mode=check-docs`
+  fails the PR that renames them.
 
 ---
 

--- a/tests/helpers/ui/clear-canvas-bottom-overlay.fake.ts
+++ b/tests/helpers/ui/clear-canvas-bottom-overlay.fake.ts
@@ -1,0 +1,147 @@
+// A simulated canvas bottom-centre overlay slot, for the unit tests of
+// `clear-canvas-bottom-overlay`.
+//
+// NOT a test file — it defines no `test()`. `npm run test:units` collects
+// `*.test.ts` only and Playwright's `testMatch` is `*.spec.ts`, so this file is
+// imported by tests and never executed as one.
+//
+// Why simulate: the behaviour that matters is a HANDOVER between two components
+// that own the same fixed container — the build-status bar unmounts, and the
+// "Flow needs review" banner mounts into the slot it just left. A live spec cannot
+// dwell on the one render tick where the slot is empty, and cannot reproduce a
+// build that stops honouring Dismiss at all. The timeline below makes both states
+// addressable.
+//
+// The simulated contract was verified live against nightly 1.12.0.dev39 (#1643):
+//   - both components render into `absolute bottom-16 left-1/2 z-50 w-[530px]`;
+//   - the build bar auto-dismisses ~2.5 s after "Flow built successfully" and
+//     offers no Dismiss in that state;
+//   - the update banner reads "Flow needs review / 1 component needs updates" and
+//     offers "Dismiss" + "Update All", and never leaves on its own — a click under
+//     it burns the full `locator.click` budget with "subtree intercepts pointer
+//     events".
+import type { Page } from "@playwright/test";
+
+export interface Occupant {
+  text: string;
+  /** Renders a Dismiss button — i.e. it will not leave on its own. */
+  dismissible: boolean;
+  /**
+   * Set true to model a build whose Dismiss no longer clears the overlay. The
+   * helper must then fail attributed rather than loop until the caller's click
+   * times out somewhere else.
+   */
+  ignoresDismiss?: boolean;
+}
+
+export const BUILD_BAR: Occupant = {
+  text: "Flow built successfully\n0.2s",
+  dismissible: false,
+};
+
+export const UPDATE_BANNER: Occupant = {
+  text: "Flow needs review\n1 component needs updates\nDismiss\nUpdate All",
+  dismissible: true,
+};
+
+export interface FakeOptions {
+  /**
+   * What occupies the slot, one entry per poll tick; `null` is an empty slot.
+   * The last entry repeats forever, so `[null]` models an already-free slot and
+   * `[BUILD_BAR, null, UPDATE_BANNER]` models the real handover, empty tick and
+   * all.
+   */
+  timeline?: (Occupant | null)[];
+}
+
+export interface FakeOverlay {
+  page: Page;
+  readonly ticks: number;
+  readonly dismissClicks: number;
+  readonly countReads: number;
+}
+
+export function fakeOverlay({
+  timeline = [null],
+}: FakeOptions = {}): FakeOverlay {
+  const state = { ticks: 0, dismissClicks: 0, countReads: 0, dismissed: false };
+
+  const current = (): Occupant | null => {
+    const entry = timeline[Math.min(state.ticks, timeline.length - 1)];
+    if (!entry) return null;
+    // Dismissing models Langflow's `dismissedNodes`: the banner stays gone for
+    // the rest of the session, not just for one tick.
+    if (state.dismissed && entry.dismissible && !entry.ignoresDismiss) {
+      return null;
+    }
+    return entry;
+  };
+
+  const dismissLocator = () => ({
+    count: async () => {
+      const occupant = current();
+      return occupant?.dismissible ? 1 : 0;
+    },
+    first: () => ({
+      click: async () => {
+        const occupant = current();
+        if (!occupant?.dismissible) {
+          throw new Error("locator.click: Timeout 5000ms exceeded");
+        }
+        state.dismissClicks += 1;
+        state.dismissed = true;
+      },
+    }),
+  });
+
+  const occupantLocator = () => ({
+    innerText: async () => {
+      const occupant = current();
+      if (!occupant) throw new Error("locator.innerText: element is not attached");
+      return occupant.text;
+    },
+    // The name is CHECKED, not ignored: a fake that answered for any role/name
+    // would let the helper find a Dismiss on the build bar, which is precisely
+    // the distinction the helper's predicate rests on.
+    getByRole: (role: string, options?: { name?: RegExp }) => {
+      if (role !== "button" || !options?.name?.test("Dismiss")) {
+        return { count: async () => 0, first: () => ({ click: async () => {} }) };
+      }
+      return dismissLocator();
+    },
+  });
+
+  const page = {
+    waitForTimeout: async () => {
+      state.ticks += 1;
+    },
+    // The selector is CHECKED, not ignored — a typo in the slot selector would
+    // otherwise pass every test here while matching nothing in production, where
+    // the helper would return "clear" on an overlay that is fully present.
+    locator: (selector: string) => {
+      if (!selector.includes("bottom-16") || !selector.includes("w-[530px]")) {
+        throw new Error(`unexpected selector: ${selector}`);
+      }
+      return {
+        count: async () => {
+          state.countReads += 1;
+          return current() ? 1 : 0;
+        },
+        first: () => occupantLocator(),
+      };
+    },
+  } as unknown as Page;
+
+  return {
+    page,
+    get ticks() {
+      return state.ticks;
+    },
+    get dismissClicks() {
+      return state.dismissClicks;
+    },
+    get countReads() {
+      return state.countReads;
+    },
+  };
+}

--- a/tests/helpers/ui/clear-canvas-bottom-overlay.fake.ts
+++ b/tests/helpers/ui/clear-canvas-bottom-overlay.fake.ts
@@ -8,14 +8,14 @@
 // Why simulate: the behaviour that matters is a HANDOVER between two components
 // that own the same fixed container — the build-status bar unmounts, and the
 // "Flow needs review" banner mounts into the slot it just left. A live spec cannot
-// dwell on the one render tick where the slot is empty, and cannot reproduce a
-// build that stops honouring Dismiss at all. The timeline below makes both states
-// addressable.
+// dwell on the gap between the two (~89 ms measured, and upstream-controlled — see
+// `BANNER_UNHIDE_DELAY_MS`), and cannot reproduce a build that stops honouring
+// Dismiss at all. The timeline below makes both states addressable.
 //
 // The simulated contract was verified live against nightly 1.12.0.dev39 (#1643):
 //   - both components render into `absolute bottom-16 left-1/2 z-50 w-[530px]`;
-//   - the build bar auto-dismisses ~2.5 s after "Flow built successfully" and
-//     offers no Dismiss in that state;
+//   - the build bar auto-dismisses 2 s after "Flow built successfully" and offers
+//     no Dismiss in that state — only Stop, and Retry + Dismiss when it errored;
 //   - the update banner reads "Flow needs review / 1 component needs updates" and
 //     offers "Dismiss" + "Update All", and never leaves on its own — a click under
 //     it burns the full `locator.click` budget with "subtree intercepts pointer
@@ -37,6 +37,16 @@ export interface Occupant {
 export const BUILD_BAR: Occupant = {
   text: "Flow built successfully\n0.2s",
   dismissible: false,
+};
+
+/**
+ * The build bar's ERROR state: Retry + Dismiss, and no timer. It satisfies the
+ * helper's "offers a Dismiss" predicate, which is why the helper has to refuse it
+ * by name — dismissing it erases the only UI evidence of a failed run.
+ */
+export const BUILD_FAILED_BAR: Occupant = {
+  text: "Flow build failed\nRetry\nDismiss",
+  dismissible: true,
 };
 
 export const UPDATE_BANNER: Occupant = {

--- a/tests/helpers/ui/clear-canvas-bottom-overlay.test.ts
+++ b/tests/helpers/ui/clear-canvas-bottom-overlay.test.ts
@@ -3,8 +3,8 @@
 //
 // The helper's whole job is to survive a HANDOVER: Langflow's build-status bar and
 // its "Flow needs review" banner render into the same fixed container, the banner
-// is hidden while the bar is up, and it takes the slot back the moment the bar
-// auto-dismisses. A spec that waits for "built successfully" and clicks lands in
+// is hidden while the bar is up, and it takes the slot back the moment the bar's
+// state is cleared. A spec that waits for "built successfully" and clicks lands in
 // the gap — which is how #1643 burned the full 20 s `locator.click` budget on two
 // specs, three attempts each. The simulated slot and its live-verified contract are
 // documented in `./clear-canvas-bottom-overlay.fake`.
@@ -12,17 +12,31 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   BUILD_BAR,
+  BUILD_FAILED_BAR,
   UPDATE_BANNER,
   fakeOverlay,
 } from "./clear-canvas-bottom-overlay.fake";
-import { clearCanvasBottomOverlay } from "./clear-canvas-bottom-overlay";
+import {
+  BANNER_UNHIDE_DELAY_MS,
+  EMPTY_CONFIRMATIONS,
+  clearCanvasBottomOverlay,
+} from "./clear-canvas-bottom-overlay";
 
-test("an already-free slot returns without dismissing anything", async () => {
-  const overlay = fakeOverlay({ timeline: [null] });
+// The fake counts poll ticks and ignores their duration, so no behavioural test
+// here can see POLL_MS. That is exactly why the timing relationship is asserted on
+// the constants instead: it is upstream-controlled and load-bearing, and a
+// `POLL_MS = 0` survived every behavioural test in this file.
+test("the empty-slot quiet window outlasts the banner's un-hide delay", async () => {
+  const POLL_MS = 200; // private to the helper; mirrored here on purpose
+  const quietWindowMs = POLL_MS * (EMPTY_CONFIRMATIONS - 1);
 
-  await clearCanvasBottomOverlay(overlay.page, { timeout: 5000 });
-
-  assert.equal(overlay.dismissClicks, 0);
+  assert.ok(
+    quietWindowMs > BANNER_UNHIDE_DELAY_MS,
+    `the helper accepts an empty slot after ${quietWindowMs}ms of emptiness, but the ` +
+      `banner is un-hidden ${BANNER_UNHIDE_DELAY_MS}ms after the bar dismisses — the ` +
+      `whole window fits inside the handover gap, so the helper can return into the ` +
+      `banner's mount`,
+  );
 });
 
 test("the transient build bar is waited out, never dismissed", async () => {
@@ -46,11 +60,11 @@ test("the persistent update banner is dismissed", async () => {
   assert.equal(overlay.dismissClicks, 1);
 });
 
-test("the one empty tick of the bar to banner handover is not read as clear", async () => {
+test("the bar to banner handover gap is not read as clear", async () => {
   // THE load-bearing case. With a single-read "is it empty?" the helper returns
   // right here, and the caller's click meets the banner that mounts on the next
-  // tick — exactly the 2026-08-31 failure. Two consecutive empty reads are what
-  // make the difference, so the banner must still be seen and dismissed.
+  // tick — exactly the 2026-08-31 failure. The quiet window is what makes the
+  // difference, so the banner must still be seen and dismissed.
   const overlay = fakeOverlay({
     timeline: [BUILD_BAR, null, UPDATE_BANNER],
   });
@@ -61,6 +75,57 @@ test("the one empty tick of the bar to banner handover is not read as clear", as
     overlay.dismissClicks,
     1,
     "returned during the handover gap instead of waiting for the banner",
+  );
+});
+
+test("a slot that was NEVER occupied is a lost selector, not a free slot", async () => {
+  // Fail-closed (#1012). Callers reach this right after the build bar rendered, so
+  // "nothing ever matched" can only mean the selector stopped matching the
+  // container — an upstream Tailwind edit. Returning success there would report the
+  // overlay handled while it is fully present.
+  const overlay = fakeOverlay({ timeline: [null] });
+
+  await assert.rejects(
+    () => clearCanvasBottomOverlay(overlay.page, { timeout: 5000 }),
+    (error: Error) => {
+      assert.match(error.message, /matched\s+NOTHING/);
+      assert.match(error.message, /allowAlreadyClear/);
+      return true;
+    },
+  );
+  assert.equal(overlay.dismissClicks, 0);
+});
+
+test("allowAlreadyClear opts a caller out of the lost-selector guard", async () => {
+  const overlay = fakeOverlay({ timeline: [null] });
+
+  await clearCanvasBottomOverlay(overlay.page, {
+    timeout: 5000,
+    allowAlreadyClear: true,
+  });
+
+  assert.equal(overlay.dismissClicks, 0);
+});
+
+test("the FAILED-build bar is refused by name, never dismissed", async () => {
+  // It offers Retry + Dismiss and has no timer, so it satisfies the "will not leave
+  // on its own" predicate — but dismissing it erases the only UI evidence of a
+  // failed run, and the v2 run-stream flow-error verdict is advisory on 1.12.x, so
+  // the spec could go green on a build that failed.
+  const overlay = fakeOverlay({ timeline: [BUILD_FAILED_BAR] });
+
+  await assert.rejects(
+    () => clearCanvasBottomOverlay(overlay.page, { timeout: 5000 }),
+    (error: Error) => {
+      assert.match(error.message, /FAILED-BUILD bar/);
+      assert.match(error.message, /Flow build failed/);
+      return true;
+    },
+  );
+  assert.equal(
+    overlay.dismissClicks,
+    0,
+    "dismissed the failed-build bar — that erases the failure's only UI evidence",
   );
 });
 

--- a/tests/helpers/ui/clear-canvas-bottom-overlay.test.ts
+++ b/tests/helpers/ui/clear-canvas-bottom-overlay.test.ts
@@ -1,0 +1,96 @@
+// Unit tests for the canvas bottom-overlay clearing helper (issue #1643).
+// Run with: npm run test:units
+//
+// The helper's whole job is to survive a HANDOVER: Langflow's build-status bar and
+// its "Flow needs review" banner render into the same fixed container, the banner
+// is hidden while the bar is up, and it takes the slot back the moment the bar
+// auto-dismisses. A spec that waits for "built successfully" and clicks lands in
+// the gap — which is how #1643 burned the full 20 s `locator.click` budget on two
+// specs, three attempts each. The simulated slot and its live-verified contract are
+// documented in `./clear-canvas-bottom-overlay.fake`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  BUILD_BAR,
+  UPDATE_BANNER,
+  fakeOverlay,
+} from "./clear-canvas-bottom-overlay.fake";
+import { clearCanvasBottomOverlay } from "./clear-canvas-bottom-overlay";
+
+test("an already-free slot returns without dismissing anything", async () => {
+  const overlay = fakeOverlay({ timeline: [null] });
+
+  await clearCanvasBottomOverlay(overlay.page, { timeout: 5000 });
+
+  assert.equal(overlay.dismissClicks, 0);
+});
+
+test("the transient build bar is waited out, never dismissed", async () => {
+  // The success bar offers no Dismiss — the helper must poll it away, not go
+  // looking for a button that only its ERROR state renders.
+  const overlay = fakeOverlay({
+    timeline: [BUILD_BAR, BUILD_BAR, BUILD_BAR, null],
+  });
+
+  await clearCanvasBottomOverlay(overlay.page, { timeout: 5000 });
+
+  assert.equal(overlay.dismissClicks, 0);
+  assert.ok(overlay.ticks >= 3, `polled only ${overlay.ticks} times`);
+});
+
+test("the persistent update banner is dismissed", async () => {
+  const overlay = fakeOverlay({ timeline: [UPDATE_BANNER] });
+
+  await clearCanvasBottomOverlay(overlay.page, { timeout: 5000 });
+
+  assert.equal(overlay.dismissClicks, 1);
+});
+
+test("the one empty tick of the bar to banner handover is not read as clear", async () => {
+  // THE load-bearing case. With a single-read "is it empty?" the helper returns
+  // right here, and the caller's click meets the banner that mounts on the next
+  // tick — exactly the 2026-08-31 failure. Two consecutive empty reads are what
+  // make the difference, so the banner must still be seen and dismissed.
+  const overlay = fakeOverlay({
+    timeline: [BUILD_BAR, null, UPDATE_BANNER],
+  });
+
+  await clearCanvasBottomOverlay(overlay.page, { timeout: 5000 });
+
+  assert.equal(
+    overlay.dismissClicks,
+    1,
+    "returned during the handover gap instead of waiting for the banner",
+  );
+});
+
+test("an overlay that ignores its own Dismiss fails attributed, not silently", async () => {
+  const stuck = { ...UPDATE_BANNER, ignoresDismiss: true };
+  const overlay = fakeOverlay({ timeline: [stuck] });
+
+  await assert.rejects(
+    () => clearCanvasBottomOverlay(overlay.page, { timeout: 300 }),
+    (error: Error) => {
+      // The message has to name WHAT is stuck and that Dismiss was tried —
+      // without both, this reads as an unexplained click timeout at the call
+      // site, which is the misattribution #1643 cost a day of triage to.
+      assert.match(error.message, /Flow needs review/);
+      assert.match(error.message, /Dismiss clicked [1-9]/);
+      assert.match(error.message, /#1643/);
+      return true;
+    },
+  );
+});
+
+test("an occupant that offers no Dismiss and never leaves is reported as such", async () => {
+  const overlay = fakeOverlay({ timeline: [BUILD_BAR] });
+
+  await assert.rejects(
+    () => clearCanvasBottomOverlay(overlay.page, { timeout: 300 }),
+    (error: Error) => {
+      assert.match(error.message, /Flow built successfully/);
+      assert.match(error.message, /Dismiss clicked 0 time\(s\)/);
+      return true;
+    },
+  );
+});

--- a/tests/helpers/ui/clear-canvas-bottom-overlay.ts
+++ b/tests/helpers/ui/clear-canvas-bottom-overlay.ts
@@ -8,12 +8,13 @@ import type { Page } from "@playwright/test";
  * canvas, and they hand the slot to each other:
  *
  * - `flowBuildingComponent` — the build-status bar ("Flow built successfully", the
- *   building progress, "Build failed"). **Transient on success**: it auto-dismisses
- *   2 s after the run finishes, plus a 500 ms exit animation.
+ *   building progress, "Flow build failed"). **Transient on success only** (see
+ *   `BANNER_UNHIDE_DELAY_MS`); in its error state it never leaves on its own.
  * - `UpdateAllComponents` — the "Flow needs review / N components need updates"
  *   banner. Its `shouldHide` includes `isBuilding || buildInfo?.error ||
  *   buildInfo?.success`, so it is **hidden while the build bar is up and takes the
- *   slot back the moment the bar dismisses** — and then stays there indefinitely.
+ *   slot back the moment the bar's state is cleared** — and then stays there
+ *   indefinitely.
  *
  * That handover is what makes a plain wait insufficient, and it is the mechanism
  * behind #1643: `agent-context-id-{isolation,continuity}` waited for "built
@@ -36,62 +37,137 @@ import type { Page } from "@playwright/test";
  * an occupied slot at all, not to keep the slot lucky.
  *
  * **The predicate is "will this occupant leave on its own?", read off the DOM as
- * "does it offer a Dismiss button".** That is exactly right for both components: the
- * update banner always offers one until every component is dismissed, and the build
- * bar offers one only in its `buildInfo.error` state — the one state where it, too,
- * never leaves. Callers reach this helper after asserting the run succeeded, so the
- * error bar is not a state this can silence.
+ * "does it offer a Dismiss button".** That is exactly right for the update banner.
+ * It is ALSO true of the build bar's error state, which renders Retry + Dismiss and
+ * has no timer — and there, dismissing would delete the only UI evidence of a
+ * failed run. Since `flow-error-policy`'s v2 verdict is advisory on 1.12.x, that
+ * could green a genuinely failed build, so the error bar is refused by name rather
+ * than dismissed (`BUILD_FAILED_TEXT`).
  *
- * A single empty read is deliberately NOT enough (see `EMPTY_CONFIRMATIONS`): the
- * slot is genuinely empty for a tick between the bar unmounting and the banner
- * mounting, and returning there would hand the caller a click that races the banner.
+ * **THIS HELPER WRITES TO THE FLOW.** Dismissing the update banner runs
+ * `handleDismissAllComponents`, which does not only record the dismissal in the
+ * store: it calls `setNodes` marking each flagged node `edited: true`, and the
+ * editor persists that with a `PATCH /api/v1/flows/{id}` (observed on the wire).
+ * Harmless for a caller that seeds a throwaway flow and deletes it in teardown; NOT
+ * harmless for one that asserts on the persisted graph, counts flow writes, or
+ * cares about the `edited` flag. Check that before adding a call site.
  *
- * On timeout it throws naming what is still in the slot, so a future build that
- * makes the overlay non-dismissible fails attributed instead of as an unexplained
+ * A single empty read is deliberately NOT enough (see `EMPTY_CONFIRMATIONS`), and
+ * a slot that is empty for the helper's whole life is treated as a LOST SELECTOR
+ * rather than as success — see `allowAlreadyClear`.
+ *
+ * On timeout it throws naming what is still in the slot, so a build that makes the
+ * overlay non-dismissible fails attributed instead of as an unexplained
  * `locator.click` timeout at the call site (#997/#1012).
+ *
+ * Upstream sources this mirrors — declared in the dependent specs' docs so
+ * `watch-upstream-areas.mjs --mode=check-docs` fails the PR that renames them:
+ * `src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx`,
+ * `src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx`.
  */
 export const CANVAS_BOTTOM_OVERLAY_SLOT =
   'div[class*="bottom-16"][class*="z-50"][class*="w-[530px]"]';
 
-/** Covers the build bar's 2 s auto-dismiss + 500 ms exit with a wide margin. */
+/** `flowBuild.buildFailed` in `locales/en.json`. The one occupant never to dismiss. */
+export const BUILD_FAILED_TEXT = "Flow build failed";
+
 export const OVERLAY_CLEAR_TIMEOUT_MS = 20000;
 
 const POLL_MS = 200;
 
 /**
+ * How long after a successful build the update banner is un-hidden.
+ *
+ * NOT the exit animation, and the difference is what sizes `EMPTY_CONFIRMATIONS`.
+ * `handleDismiss` sets `dismissed = true` — the bar then leaves via a framer-motion
+ * exit (`duration: 0.2, delay: 0.2`, ~340 ms measured) — and SEPARATELY schedules
+ * `setBuildInfo(null)` at +500 ms, which is what clears `shouldHide` and lets the
+ * banner mount. The slot is therefore empty for `500 ms - exitAnimation`, measured
+ * at ~89 ms on nightly 1.12.0.dev39 with a 10 ms sampler. Shorten the exit upstream
+ * and that gap walks toward the full 500 ms, so the quiet window below is sized
+ * against THIS constant, not against what the gap happens to be today.
+ */
+export const BANNER_UNHIDE_DELAY_MS = 500;
+
+/**
  * Consecutive empty reads required before the slot counts as free.
  *
- * Two, because the bar → banner handover leaves the slot empty for one render
- * tick. One read would return exactly into the banner's mount.
+ * They span `POLL_MS * (EMPTY_CONFIRMATIONS - 1)` of observed emptiness, which must
+ * exceed `BANNER_UNHIDE_DELAY_MS` — otherwise the whole window can fit inside the
+ * handover gap and the helper returns into the banner's mount, which is the very
+ * failure it exists to prevent. The relationship is asserted in the unit tests,
+ * because it is the constants that are load-bearing here, not the loop.
  */
-export const EMPTY_CONFIRMATIONS = 2;
+export const EMPTY_CONFIRMATIONS = 5;
 
 export interface ClearCanvasBottomOverlayOptions {
   timeout?: number;
+  /**
+   * Accept a slot that was empty for this helper's entire life.
+   *
+   * Defaults to FALSE, and that is a fail-closed choice. Every current caller
+   * reaches this immediately after `waitForSelector("text=built successfully")`,
+   * which proves the build bar is on screen — so "nothing ever matched" cannot mean
+   * "the slot is free", it means the selector no longer matches the container
+   * (a Tailwind edit upstream: `w-[530px]` -> `w-[560px]`, `bottom-16` ->
+   * `bottom-20`). Returning success there would report the overlay handled while it
+   * is fully present, and #1643 would come back as the unattributed 20 s
+   * `locator.click` timeout — with a helper call in the trace implying otherwise.
+   * Set true only for a caller that genuinely may find the slot already free.
+   */
+  allowAlreadyClear?: boolean;
 }
 
 export async function clearCanvasBottomOverlay(
   page: Page,
-  { timeout = OVERLAY_CLEAR_TIMEOUT_MS }: ClearCanvasBottomOverlayOptions = {},
+  {
+    timeout = OVERLAY_CLEAR_TIMEOUT_MS,
+    allowAlreadyClear = false,
+  }: ClearCanvasBottomOverlayOptions = {},
 ): Promise<void> {
   const slot = page.locator(CANVAS_BOTTOM_OVERLAY_SLOT);
   const deadline = Date.now() + timeout;
   let consecutiveEmpties = 0;
+  let sawOccupant = false;
   let lastOccupant = "";
   let dismissClicks = 0;
 
   while (Date.now() < deadline) {
     if ((await slot.count()) === 0) {
-      if (++consecutiveEmpties >= EMPTY_CONFIRMATIONS) return;
+      if (++consecutiveEmpties >= EMPTY_CONFIRMATIONS) {
+        if (sawOccupant || allowAlreadyClear) return;
+        throw new Error(
+          `The canvas bottom overlay selector (${CANVAS_BOTTOM_OVERLAY_SLOT}) matched ` +
+            `NOTHING for ${EMPTY_CONFIRMATIONS} consecutive reads. Callers reach this ` +
+            `right after the build bar rendered, so an empty slot here means the ` +
+            `selector no longer matches the container, not that the overlay is gone ` +
+            `(#1643). Check the Tailwind classes on flowBuildingComponent / ` +
+            `UpdateAllComponents upstream, or pass { allowAlreadyClear: true } if this ` +
+            `call site can legitimately start with a free slot.`,
+        );
+      }
       await page.waitForTimeout(POLL_MS);
       continue;
     }
 
     consecutiveEmpties = 0;
+    sawOccupant = true;
     const occupant = slot.first();
     lastOccupant = ((await occupant.innerText().catch(() => "")) || "")
       .replace(/\s+/g, " ")
       .trim();
+
+    // Refused, never dismissed: this bar IS the failed run's only UI evidence.
+    if (lastOccupant.includes(BUILD_FAILED_TEXT)) {
+      throw new Error(
+        `The canvas bottom overlay is the FAILED-BUILD bar (${JSON.stringify(
+          lastOccupant,
+        )}), which this helper refuses to dismiss — doing so would erase the only ` +
+          `UI evidence of a failed node run, and the v2 run-stream flow-error verdict ` +
+          `is advisory on 1.12.x, so the spec could go green on a build that failed ` +
+          `(#1643). The caller ran a flow that did not build.`,
+      );
+    }
 
     // Scoped to the slot so this can never reach a Dismiss elsewhere on the page.
     const dismiss = occupant.getByRole("button", { name: /^dismiss/i });

--- a/tests/helpers/ui/clear-canvas-bottom-overlay.ts
+++ b/tests/helpers/ui/clear-canvas-bottom-overlay.ts
@@ -1,0 +1,119 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Frees the canvas' bottom-centre overlay slot before a click that lands under it.
+ *
+ * Langflow renders TWO different components into one fixed container —
+ * `absolute bottom-16 left-1/2 z-50 w-[530px] -translate-x-1/2` — sitting over the
+ * canvas, and they hand the slot to each other:
+ *
+ * - `flowBuildingComponent` — the build-status bar ("Flow built successfully", the
+ *   building progress, "Build failed"). **Transient on success**: it auto-dismisses
+ *   2 s after the run finishes, plus a 500 ms exit animation.
+ * - `UpdateAllComponents` — the "Flow needs review / N components need updates"
+ *   banner. Its `shouldHide` includes `isBuilding || buildInfo?.error ||
+ *   buildInfo?.success`, so it is **hidden while the build bar is up and takes the
+ *   slot back the moment the bar dismisses** — and then stays there indefinitely.
+ *
+ * That handover is what makes a plain wait insufficient, and it is the mechanism
+ * behind #1643: `agent-context-id-{isolation,continuity}` waited for "built
+ * successfully" and clicked the memory node's `output-inspection-*` button
+ * immediately. Measured on nightly 1.12.0.dev39 at the default 1280x720 viewport,
+ * that button's box is y 585.6-601.0 (centre 593.3) while the build bar's top edge
+ * is at y 598 — the click clears it by ~5 px — and the update banner is 12 px
+ * taller, top edge y ~586, which is ABOVE the centre. So the same click passes or
+ * is refused purely on which of the two owns the slot, and once the banner owns it
+ * no amount of retrying helps: on 2026-08-31 both specs burned the full 20 s
+ * `locator.click` budget against `<div class="flex items-center justify-between
+ * gap-6 rounded-lg border bg-background px-4 py-3 text-sm shadow-md">`, which is
+ * the banner's inner element.
+ *
+ * The banner is there because these specs seed their flow from
+ * `tests/assets/flows/chat-io-ok-trace-fixture.json`, whose nodes carry
+ * `lf_version: 1.7.0`; the 1.12 nightly reports one of them as outdated. Refreshing
+ * that fixture would silence it only until the next upstream template bump, and the
+ * build bar would still be a ~5 px coin flip — so the fix is to stop clicking into
+ * an occupied slot at all, not to keep the slot lucky.
+ *
+ * **The predicate is "will this occupant leave on its own?", read off the DOM as
+ * "does it offer a Dismiss button".** That is exactly right for both components: the
+ * update banner always offers one until every component is dismissed, and the build
+ * bar offers one only in its `buildInfo.error` state — the one state where it, too,
+ * never leaves. Callers reach this helper after asserting the run succeeded, so the
+ * error bar is not a state this can silence.
+ *
+ * A single empty read is deliberately NOT enough (see `EMPTY_CONFIRMATIONS`): the
+ * slot is genuinely empty for a tick between the bar unmounting and the banner
+ * mounting, and returning there would hand the caller a click that races the banner.
+ *
+ * On timeout it throws naming what is still in the slot, so a future build that
+ * makes the overlay non-dismissible fails attributed instead of as an unexplained
+ * `locator.click` timeout at the call site (#997/#1012).
+ */
+export const CANVAS_BOTTOM_OVERLAY_SLOT =
+  'div[class*="bottom-16"][class*="z-50"][class*="w-[530px]"]';
+
+/** Covers the build bar's 2 s auto-dismiss + 500 ms exit with a wide margin. */
+export const OVERLAY_CLEAR_TIMEOUT_MS = 20000;
+
+const POLL_MS = 200;
+
+/**
+ * Consecutive empty reads required before the slot counts as free.
+ *
+ * Two, because the bar → banner handover leaves the slot empty for one render
+ * tick. One read would return exactly into the banner's mount.
+ */
+export const EMPTY_CONFIRMATIONS = 2;
+
+export interface ClearCanvasBottomOverlayOptions {
+  timeout?: number;
+}
+
+export async function clearCanvasBottomOverlay(
+  page: Page,
+  { timeout = OVERLAY_CLEAR_TIMEOUT_MS }: ClearCanvasBottomOverlayOptions = {},
+): Promise<void> {
+  const slot = page.locator(CANVAS_BOTTOM_OVERLAY_SLOT);
+  const deadline = Date.now() + timeout;
+  let consecutiveEmpties = 0;
+  let lastOccupant = "";
+  let dismissClicks = 0;
+
+  while (Date.now() < deadline) {
+    if ((await slot.count()) === 0) {
+      if (++consecutiveEmpties >= EMPTY_CONFIRMATIONS) return;
+      await page.waitForTimeout(POLL_MS);
+      continue;
+    }
+
+    consecutiveEmpties = 0;
+    const occupant = slot.first();
+    lastOccupant = ((await occupant.innerText().catch(() => "")) || "")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    // Scoped to the slot so this can never reach a Dismiss elsewhere on the page.
+    const dismiss = occupant.getByRole("button", { name: /^dismiss/i });
+    if ((await dismiss.count()) > 0) {
+      dismissClicks++;
+      // A click that loses its target to the same handover this helper exists for
+      // is not a failure — the next poll re-reads the slot.
+      await dismiss
+        .first()
+        .click({ timeout: 5000 })
+        .catch(() => {});
+    }
+
+    await page.waitForTimeout(POLL_MS);
+  }
+
+  throw new Error(
+    `The canvas bottom overlay (${CANVAS_BOTTOM_OVERLAY_SLOT}) did not clear within ` +
+      `${timeout}ms, so a click under it would be refused with "subtree intercepts ` +
+      `pointer events" (#1643). Still in the slot: ${JSON.stringify(lastOccupant)}. ` +
+      `Dismiss clicked ${dismissClicks} time(s) — if that is > 0 the overlay stopped ` +
+      `honouring its own Dismiss; if it is 0 the occupant offers none and never ` +
+      `auto-dismisses. Either way this is an overlay change, not a slow test.`,
+  );
+}

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
@@ -380,11 +380,9 @@ test.describe.configure({ mode: "serial" });
 // one, which needs no provider at all. Ordering it first makes the model-free
 // coverage independent of whatever the routed target does.
 test.describe("Context ID continuity — retrieval layer (model-free)", () => {
-  // QUARANTINED for #1643 — an overlay at the canvas bottom intercepts the output-inspection-messages-memory click
-  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
-  test.fixme(
+  test(
     "context-scoped retrieval returns all turns of the context and not the untagged control",
-    { tag: ["@regression", "@agents", "@components"] },
+    { tag: ["@stable", "@regression", "@agents", "@components"] },
     async ({ page, request }) => {
       const seeded = await seedContextSession(request);
       try {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../helpers/ui/open-advanced-options";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
+import { clearCanvasBottomOverlay } from "../../../../helpers/ui/clear-canvas-bottom-overlay";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
@@ -324,6 +325,13 @@ async function retrieveViaMessageHistory(
 
   await page.getByTestId("button_run_message history").click();
   await page.waitForSelector("text=built successfully", { timeout: 30000 });
+
+  // The canvas' bottom-centre slot is shared by the build-status bar and the
+  // "Flow needs review" banner, and the banner takes the slot back the moment the
+  // bar auto-dismisses. This node's inspect button sits ~5 px from that slot, so
+  // the click is refused for as long as the taller banner owns it — #1643. Free
+  // the slot instead of retrying under it.
+  await clearCanvasBottomOverlay(page);
 
   const inspectButton = page.getByTestId("output-inspection-messages-memory");
   await expect(inspectButton).toBeEnabled({ timeout: 20000 });

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../helpers/ui/open-advanced-options";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
+import { clearCanvasBottomOverlay } from "../../../../helpers/ui/clear-canvas-bottom-overlay";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
@@ -468,6 +469,13 @@ async function runRetrievalScopedTo(page: Page, contextId: string): Promise<stri
   await page.waitForSelector("text=built successfully", { state: "hidden", timeout: 15000 });
   await page.getByTestId("button_run_message history").click();
   await page.waitForSelector("text=built successfully", { timeout: 30000 });
+
+  // The canvas' bottom-centre slot is shared by the build-status bar and the
+  // "Flow needs review" banner, and the banner takes the slot back the moment the
+  // bar auto-dismisses. This node's inspect button sits ~5 px from that slot, so
+  // the click is refused for as long as the taller banner owns it — #1643. Free
+  // the slot instead of retrying under it.
+  await clearCanvasBottomOverlay(page);
 
   const inspectButton = page.getByTestId("output-inspection-messages-memory");
   await expect(inspectButton).toBeEnabled({ timeout: 20000 });

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -517,11 +517,9 @@ const targets = resolveTestTargets({ tier: "any-completion" });
 test.describe.configure({ mode: "serial" });
 
 test.describe("Context ID isolation — retrieval layer (model-free)", () => {
-  // QUARANTINED for #1643 — an overlay at the canvas bottom intercepts the output-inspection-messages-memory click
-  // (daily 2026-08-31, run 33410643882; guard tripped, so the workflow removed nothing).
-  test.fixme(
+  test(
     "mirrored context-scoped retrievals return only their own context's messages",
-    { tag: ["@regression", "@agents", "@components"] },
+    { tag: ["@stable", "@regression", "@agents", "@components"] },
     async ({ page, request }) => {
       const seeded = await seedTwoContextSession(request);
       try {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-n-messages-limit.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-n-messages-limit.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
+import { clearCanvasBottomOverlay } from "../../../../helpers/ui/clear-canvas-bottom-overlay";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import {
@@ -152,6 +153,13 @@ async function retrieveViaMessageHistory(
 
   await page.getByTestId("button_run_message history").click();
   await page.waitForSelector("text=built successfully", { timeout: 30000 });
+
+  // The canvas' bottom-centre slot is shared by the build-status bar and the
+  // "Flow needs review" banner, and the banner takes the slot back the moment the
+  // bar auto-dismisses. This node's inspect button sits ~5 px from that slot, so
+  // the click is refused for as long as the taller banner owns it — #1643. Free
+  // the slot instead of retrying under it.
+  await clearCanvasBottomOverlay(page);
 
   // The inspector button stays disabled until the selected output has
   // non-empty data — it becoming enabled already signals a non-empty retrieval.


### PR DESCRIPTION
**Closes #1643.**

## Problem

Both context-id retrieval specs hard-failed all 3 attempts of the 2026-08-31 daily ([run 33410643882](https://github.com/oriontech-me/langflow-e2e/actions/runs/33410643882), triage #1642) on a 20 s `locator.click` timeout against `output-inspection-messages-memory` — the button *resolving* as `visible, enabled and stable` and every retry refused by `<div class="absolute bottom-16 left-1/2 z-50 w-[530px]">… subtree intercepts pointer events`. Quarantined by hand in #1647 because the mass-failure guard tripped and the workflow auto-removed nothing.

**Root cause (test defect — confirmed live, not a product regression).** Langflow renders **two different components into one fixed container** over the canvas, `absolute bottom-16 left-1/2 z-50 w-[530px] -translate-x-1/2`:

| Component | Behaviour in the slot |
|---|---|
| `flowBuildingComponent` — the build-status bar | **transient on success**: `handleDismiss` fires 2 s after "Flow built successfully" |
| `UpdateAllComponents` — the "Flow needs review / N components need updates" banner | its `shouldHide` includes `buildInfo?.success`, so it is **hidden while the bar is up, retakes the slot when the bar's state is cleared**, and then **never leaves** |

Measured at the default 1280×720 viewport, the inspect button's box is y 585.6–601.0, **centre 593.3**. The build bar's top edge is y **598** — the click clears it by ~5 px. The banner is 12 px taller, top edge y **~586** — *above* the centre. So the identical click passed or was refused purely on which component owned the slot, and once the banner owned it **no amount of retrying could help**, which is exactly what the call log shows: first interceptor the bar's inner `flex min-h-10 w-full items-center justify-between gap-2`, second the banner's `flex items-center justify-between gap-6 rounded-lg border bg-background px-4 py-3 text-sm shadow-md`.

The banner is present because these specs seed their flow from `tests/assets/flows/chat-io-ok-trace-fixture.json`, whose nodes carry `lf_version: 1.7.0`; the nightly reports one of them as outdated.

**Reproduced deterministically**: dwelling 4 s before the click hands the slot to the banner, and the failure returns with the interceptor byte-identical to the daily's. With the fix the same dwell passes — probe reads `Flow needs review …` → `EMPTY`.

The environmental hypothesis is ruled out as the issue asked: this reproduces on an idle local nightly with no wedge, and the daily's own liveness recorder had both specs' final attempt at 0–3 % of probes down.

## Fix

New shared helper `tests/helpers/ui/clear-canvas-bottom-overlay.ts`, called between the run and the inspect click. It frees the slot instead of clicking into it, and **fails closed in three directions** (the second and third came out of review):

- **Timeout** → throws naming what is still in the slot and whether Dismiss was tried, so a build that stops honouring its own Dismiss fails attributed rather than as an unexplained `locator.click` timeout at the call site.
- **Lost selector** → a slot that was *never* occupied is an error, not success. Callers reach this right after `waitForSelector("text=built successfully")`, which proves the bar is on screen, so "nothing ever matched" can only mean an upstream Tailwind edit (`w-[530px]` → `w-[560px]`). Reporting "clear" there would bring #1643 back as precisely the unattributed timeout the helper exists to prevent — with a helper call in the trace implying otherwise. `{ allowAlreadyClear: true }` opts out.
- **Failed-build bar** → refused by name, never dismissed. It renders Retry + Dismiss and has no timer, so it satisfies the "will not leave on its own" predicate — but dismissing it erases the only UI evidence of a failed run, and `flow-error-policy`'s v2 verdict is advisory on 1.12.x, so a caller could go green on a build that failed.

**The empty-slot window is sized against the real constant, not the observed gap.** `handleDismiss` sets `dismissed = true` (framer exit ~340 ms) and *separately* schedules `setBuildInfo(null)` at **+500 ms**, which is what un-hides the banner — so the gap is `500 ms − exit`, measured ~89 ms with a 10 ms sampler. Two 200 ms-spaced reads cleared that by ~2.2×, but drop the exit animation upstream and the window fits inside the gap. `EMPTY_CONFIRMATIONS = 5` (an 800 ms quiet window), and since the fake counts ticks and ignores durations (a `POLL_MS = 0` survived every behavioural test), the relationship `POLL_MS × (EMPTY_CONFIRMATIONS − 1) > BANNER_UNHIDE_DELAY_MS` is asserted on the constants.

Also documented, because it was not obvious: **the helper writes to the flow.** `handleDismissAllComponents` calls `setNodes` marking each flagged node `edited: true`, and the editor persists it with a `PATCH /api/v1/flows/{id}` (observed on the wire). Harmless for a caller that seeds a throwaway flow and deletes it in teardown; a trap for one that asserts on the persisted graph.

**Rejected alternatives:** refreshing `chat-io-ok-trace-fixture.json` (shared by many specs, silences this only until the next template bump, leaves the build bar's ~5 px margin as fragile); `click({ force: true })` (force skips the actionability check but the browser still dispatches at the point — the overlay swallows it and the test fails later, worse attributed); panning/zooming the node out of the slot (trades one geometric coincidence for another).

### Third file: `agent-n-messages-limit.spec.ts` — hardening, and the distinction is measured

Same fixture, same node, same five lines, both tests `@stable`; #989 treated the three sibling files together. **But it is not currently intercepted, and that was checked rather than assumed.** The banner *is* present on its flow (1.13.0.dev0, slot y 586–656) — what differs is the margin: this node exposes two advanced fields where the context-id specs expose three, so it is shorter and its inspect button sits at y 541.0–556.9, **~37 px clear** against ~5 px. Forcing the failing condition does **not** reproduce an interception there. Added anyway because 37 px is a coincidence of node height and node height is exactly what upstream moves (`dev46` already changed how these fields are exposed); it costs ~2 s and removes the dependence.

Four further specs share the exposure in a different shape (`split-text-chunking`, and byte-identical private `dismissUpdateBannerIfPresent` copies in `rag-pipeline` / `vector-store-index-query`, plus a bare `waitForTimeout(600)` in `chatInputOutputUser-shard-1`). Folding those into the helper is a dedup refactor, not this fix — follow-up issue.

## Scope note

**No assertion changed anywhere.** What each test proves is untouched; only the path to the output inspector is. The parametrized agent tests in these files are unchanged.

All three files stay `mode: "serial"` (the agent-area rule). With the retrieval tests passing, each file's sibling runs again — the 2 skips this cluster caused are gone, verified from the runner. The coupling itself is already mitigated the way these files can mitigate it: the model-free describe is declared *before* the parametrized loop, so a weak-model failure cannot skip the half that needs no provider. That ordering cannot help when the failure is in the *first* describe, which is what happened here.

## Validation

Run on **nightly `1.13.0.dev0`** — `langflowai/langflow-nightly:latest` cut over to the 1.13 cycle on 2026-09-02T03:54Z, and that is the image `daily-stable.yml` pulls, so restoring `@stable` on a 1.12-only validation would ship these into a lane running an image they were never run against. Root cause and geometry were measured on `1.12.0.dev39`.

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `npm run test:units` ✅ (893 pass / 0 fail, incl. 9 new) · `npm run check:checklist-coverage` ✅ · `check-checklist-guard.mjs` ✅ · `watch-upstream-areas --mode=check-docs` ✅ (no unresolved path in the changed docs)
- **2 clean full-file runs on 1.13.0.dev0** of both context-id specs: `6 passed, 2 skipped` (1.6–3.8 min). **2 clean runs** of `agent-n-messages-limit`: `2 passed` (~18 s).
- **3 further clean full-file runs on 1.12.0.dev39** plus 3 isolated `--retries=0` runs of the isolation retrieval test.
- The 2 skips are the **anthropic** parametrized targets — `providers.json` records the provider `inactive` ("Your credit balance is too low to access the Anthropic API"), a pre-existing key state unrelated to this issue. openai and google pass.
- **Adversarial**: the deterministic repro (4 s dwell, banner owning the slot) fails on `main` and passes with the fix.
- **The green run now proves the selector too** — with the fail-closed guard, a run that passes cannot have silently skipped a present overlay.
- Zero `🚨 Backend Error` on the final runs. (An earlier 1.12 run logged one `404` on `GET /api/v1/flows/{id}` — that is `resolveLiveFlowId` probing the collected transient ids on purpose, documented in the spec.)
- Flow-orphan check: the fresh 1.13 instance holds **26** flows after every run — the starter templates only, zero leaked. On the 1.12 instance, 27 before → 27 after.
- `--trace=on` **not run**: known limitation on the Simple Agent template family (#490/#518), where tracing hangs indefinitely. Covered by the `--retries=0` bursts, the force-fails and live scout probes instead.

### Force-fails — all EXECUTED and observed failing, then reverted (0 mutation markers left)

| # | Target | Mutation | Observed |
|---|---|---|---|
| FF-1 | `agent-context-id-isolation` retrieval | invert the cross-context negative | `Expected substring: "CTXISO-…-B-"` ⇒ failed |
| FF-2 | `agent-context-id-continuity` retrieval | invert the untagged-control negative | `Expected substring: "CTXCONT-…-CTRL"` ⇒ failed |
| FF-3 | `agent-context-id-isolation` parametrized | assert a context never set | `message(s) with wrong context_id: […]` ⇒ failed |
| FF-4 | `agent-context-id-continuity` parametrized | same on the session assertion | same shape ⇒ failed |
| FF-5 | helper, unit | `EMPTY_CONFIRMATIONS` 2 → 1 | only the handover test fails (5 pass / 1 fail) |
| FF-6 | helper, end-to-end | pre-fix code under the deterministic repro | fails with the daily's exact interceptor |
| FF-7 | `agent-n-messages-limit` truncation | expect 3 instead of 2 | `Expected: 3, Received: 2` ⇒ failed |
| FF-8 | `agent-n-messages-limit` causal control | expect `SEEDED_MESSAGES + 1` | `Expected: 11, Received: 10` ⇒ failed |

Related: #1642 (triage), #1647 (quarantine), #989 (the previous fix of this same three-file cluster).
