### PR TITLE
fix(coverage): count the declared suite as OSS only, not OSS + Enterprise

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -928,8 +928,11 @@ jobs:
         id: cov
         continue-on-error: true
         run: |
+          # `total` is the OSS suite only: @enterprise is a lane no nightly can
+          # run (#1010), so counting it put ~88 unreachable tests in the
+          # denominator of the dashboard's coverage band.
           echo "stable=$(npx ts-node scripts/stable-tests.ts --count)" >> "$GITHUB_OUTPUT"
-          echo "total=$(grep -rE '^\s*test\s*\(' tests/tests-automations/regression --include='*.spec.ts' | wc -l | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          echo "total=$(npx ts-node scripts/stable-tests.ts --count-oss)" >> "$GITHUB_OUTPUT"
 
       - name: Build run payload
         if: always()

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -178,8 +178,11 @@ jobs:
         id: cov
         continue-on-error: true
         run: |
+          # `total` is the OSS suite only: @enterprise is a lane no nightly can
+          # run (#1010), so counting it put ~88 unreachable tests in the
+          # denominator of the dashboard's coverage band.
           echo "stable=$(npx ts-node scripts/stable-tests.ts --count)" >> "$GITHUB_OUTPUT"
-          echo "total=$(grep -rE '^\s*test\s*\(' tests/tests-automations/regression --include='*.spec.ts' | wc -l | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          echo "total=$(npx ts-node scripts/stable-tests.ts --count-oss)" >> "$GITHUB_OUTPUT"
 
       - name: Build run payload
         if: always()

--- a/scripts/lib/stable-tests.test.ts
+++ b/scripts/lib/stable-tests.test.ts
@@ -17,6 +17,7 @@ import * as path from "path";
 import {
   REGRESSION_ROOT,
   collectStableTests,
+  parseDeclaredCounts,
   parseStableTests,
 } from "./stable-tests";
 
@@ -182,4 +183,88 @@ test("the real suite walk finds @stable tests", () => {
   // and make this lane's verdict depend on the state of the whole suite.
   const { tests } = collectStableTests();
   assert.ok(tests.length > 0, "no @stable tests found under regression/");
+});
+
+// ─── Declared suite size, OSS only ───────────────────────────────────────────
+//
+// This counter is the denominator of the dashboard's coverage band, so the two
+// ways it can lie are the mirror of the ones above: counting an @enterprise
+// test as OSS inflates the denominator with tests no nightly can execute, and
+// counting an OSS test as Enterprise hides real declared surface.
+
+test("an untagged test() counts as OSS", () => {
+  const c = parseDeclaredCounts(`
+    test("does a thing", { tag: ["@components"] }, async ({ page }) => {});
+    test("does another", async ({ page }) => {});
+  `);
+  assert.deepEqual(c, { total: 2, enterprise: 0, oss: 2 });
+});
+
+test("an @enterprise test() is counted out of OSS", () => {
+  const c = parseDeclaredCounts(`
+    test("rbac baseline", { tag: ["@enterprise", "@authz"] }, async ({ page }) => {});
+    test("plain one", { tag: ["@api"] }, async ({ page }) => {});
+  `);
+  assert.deepEqual(c, { total: 2, enterprise: 1, oss: 1 });
+});
+
+test("@enterprise on a test.describe is inherited by the tests inside", () => {
+  // Playwright applies a suite tag to every test in it, so the lane grep-invert
+  // removes them all. Counting them as OSS would put unreachable tests back in
+  // the denominator — the exact bug this counter exists to fix.
+  const c = parseDeclaredCounts(`
+    test.describe("admin console", { tag: ["@enterprise"] }, () => {
+      test("lists users", async ({ page }) => {});
+      test("exports the audit log", { tag: ["@api"] }, async ({ page }) => {});
+    });
+  `);
+  assert.deepEqual(c, { total: 2, enterprise: 2, oss: 0 });
+});
+
+test("an @enterprise describe does not leak into a sibling test after it", () => {
+  // Guards the inheritance against being implemented as a latch: once the flag
+  // is set by a describe, it must fall back off when the walk leaves that
+  // subtree. A latch passes the test above and silently zeroes OSS from the
+  // first Enterprise suite in the file onward.
+  const c = parseDeclaredCounts(`
+    test.describe("admin console", { tag: ["@enterprise"] }, () => {
+      test("lists users", async ({ page }) => {});
+    });
+    test("an OSS test declared afterwards", { tag: ["@api"] }, async ({ page }) => {});
+  `);
+  assert.deepEqual(c, { total: 2, enterprise: 1, oss: 1 });
+});
+
+test("a nested describe inside an @enterprise one stays Enterprise", () => {
+  const c = parseDeclaredCounts(`
+    test.describe("enterprise surface", { tag: ["@enterprise"] }, () => {
+      test.describe("nested", { tag: ["@authz"] }, () => {
+        test("deep test", async ({ page }) => {});
+      });
+    });
+  `);
+  assert.deepEqual(c, { total: 1, enterprise: 1, oss: 0 });
+});
+
+test("@enterprise in prose or a commented-out tag is not counted", () => {
+  // The textual `grep` this replaced could not tell these apart.
+  const c = parseDeclaredCounts(`
+    /**
+     * Was promoted out of @enterprise when the surface shipped to OSS.
+     */
+    test("an OSS test", { tag: ["@api"] }, async ({ page }) => {});
+    // test("retired", { tag: ["@enterprise"] }, async ({ page }) => {});
+    const note = "@enterprise";
+  `);
+  assert.deepEqual(c, { total: 1, enterprise: 0, oss: 1 });
+});
+
+test("test.describe and test.skip are not counted as declared tests", () => {
+  const c = parseDeclaredCounts(`
+    test.describe("a suite", { tag: ["@api"] }, () => {
+      test.skip("skipped", async ({ page }) => {});
+      test("the only real one", async ({ page }) => {});
+    });
+  `);
+  assert.deepEqual(c, { total: 1, enterprise: 0, oss: 1 });
 });

--- a/scripts/lib/stable-tests.ts
+++ b/scripts/lib/stable-tests.ts
@@ -244,3 +244,82 @@ export function collectStableTests(): CollectResult {
   });
   return { tests: all, warnings };
 }
+
+// ─── Declared suite size, OSS only ───────────────────────────────────────────
+
+/**
+ * `@enterprise` is a LANE selector, not a severity: `tests/fixtures/lane.ts`
+ * grep-inverts it out of every run that does not set `PW_ENTERPRISE`, and the
+ * tag is deliberately never combined with `@stable` because no scheduled
+ * Enterprise lane exists (#1010). So an `@enterprise` test cannot be reached by
+ * the nightly, by construction.
+ */
+export const ENTERPRISE_TAG = "@enterprise";
+
+export interface DeclaredCounts {
+  /** Every plain `test()` call under `regression/`, whatever it is tagged. */
+  total: number;
+  /** Those carrying `@enterprise`, directly or inherited from a `test.describe`. */
+  enterprise: number;
+  /** `total - enterprise` — the OSS suite a nightly can actually reach. */
+  oss: number;
+}
+
+/**
+ * Count the declared tests in one spec's SOURCE TEXT, split OSS / Enterprise.
+ * The unit-testable seam under `collectDeclaredCounts()`.
+ *
+ * Unlike the `@stable` parser above, a `test.describe` tag is INHERITED rather
+ * than warned about. The two want different things from the same situation:
+ * Phase 0 lists individual tests, so a tag it cannot attribute to a `test()` is
+ * a defect to report; a count only needs the total, and Playwright really does
+ * apply a suite tag to every test inside it. Ignoring that here would count an
+ * Enterprise suite as OSS and re-inflate the very number this exists to fix.
+ */
+export function parseDeclaredCounts(text: string): DeclaredCounts {
+  const source = ts.createSourceFile(
+    "declared.spec.ts",
+    text,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+
+  let total = 0;
+  let enterprise = 0;
+
+  function visit(node: ts.Node, inheritedEnterprise: boolean): void {
+    let childrenInherit = inheritedEnterprise;
+
+    if (ts.isCallExpression(node)) {
+      if (isDescribeCall(node) && node.arguments.length >= 2) {
+        const { tags } = readTagsArray(node.arguments[1]);
+        if (tags?.includes(ENTERPRISE_TAG)) childrenInherit = true;
+      } else if (isPlainTestCall(node)) {
+        total++;
+        let isEnterprise = inheritedEnterprise;
+        if (!isEnterprise && node.arguments.length >= 2) {
+          const { tags } = readTagsArray(node.arguments[1]);
+          if (tags?.includes(ENTERPRISE_TAG)) isEnterprise = true;
+        }
+        if (isEnterprise) enterprise++;
+      }
+    }
+
+    ts.forEachChild(node, (child) => visit(child, childrenInherit));
+  }
+
+  visit(source, false);
+  return { total, enterprise, oss: total - enterprise };
+}
+
+/** The same split across every spec under `regression/`. */
+export function collectDeclaredCounts(): DeclaredCounts {
+  const acc: DeclaredCounts = { total: 0, enterprise: 0, oss: 0 };
+  for (const file of walkSpecs(REGRESSION_ROOT)) {
+    const c = parseDeclaredCounts(fs.readFileSync(file, "utf-8"));
+    acc.total += c.total;
+    acc.enterprise += c.enterprise;
+    acc.oss += c.oss;
+  }
+  return acc;
+}

--- a/scripts/stable-tests.ts
+++ b/scripts/stable-tests.ts
@@ -24,6 +24,7 @@ import * as path from "path";
 import {
   REPO_ROOT,
   type StableTest,
+  collectDeclaredCounts,
   collectStableTests,
 } from "./lib/stable-tests";
 
@@ -165,6 +166,21 @@ function main(): void {
   // count always matches the Phase 0 regeneration.
   if (process.argv.includes("--count")) {
     console.log(collectStableTests().tests.length);
+    process.exit(0);
+  }
+
+  // `--count-oss` mode: the size of the DECLARED suite the nightly can reach —
+  // every `test()` under regression/ minus the `@enterprise` ones. Feeds
+  // TOTAL_COUNT in daily-stable.yml / weekly-stable.yml, which is the
+  // denominator of the dashboard's coverage band.
+  //
+  // This used to be `grep -rE '^\s*test\s*\('` in the workflow. Two problems:
+  // it counted the Enterprise lane, which no nightly can execute (#1010), and
+  // it made the coverage band read one number off a regex while the numerator
+  // beside it came from the AST parser above — the "sources that are supposed
+  // to agree but don't" split #985 merged away for `@stable`.
+  if (process.argv.includes("--count-oss")) {
+    console.log(collectDeclaredCounts().oss);
     process.exit(0);
   }
 


### PR DESCRIPTION
## What changed

`TOTAL_COUNT` — the denominator of the coverage band on the QA Platform dashboard — is now the **OSS** suite only, and is computed by the AST parser that already produces `STABLE_COUNT` rather than by a regex.

- `scripts/lib/stable-tests.ts` — new `parseDeclaredCounts()` / `collectDeclaredCounts()`, returning `{ total, enterprise, oss }`.
- `scripts/stable-tests.ts` — new `--count-oss` flag, sitting next to the existing `--count`.
- `daily-stable.yml`, `weekly-stable.yml` — the `total=` line now calls that flag instead of `grep -rE '^\s*test\s*\('`.

**`stable` is unchanged at 533. `total` goes 757 → 669.**

## Why

The dashboard read `549 / 757 (73%)`. The 757 was every `test()` under `regression/`, which includes the 88 tagged `@enterprise`.

Those 88 can never be in the numerator. `@enterprise` is a lane selector, not a severity: `tests/fixtures/lane.ts` grep-inverts it out of every run that does not set `PW_ENTERPRISE`, and per #1010 the tag is deliberately never combined with `@stable` because no scheduled Enterprise lane exists. The nightly was being scored against tests it is structurally incapable of reaching, understating real OSS coverage by nine points — `549 / 669` is 82%.

Switching from regex to AST also closes the split #985 flagged for `@stable`: the two numbers printed side by side in one band were coming from two different notions of what a tagged test is, one textual and one syntactic.

## Notes for reviewers

**The describe-inheritance asymmetry is deliberate.** The `@stable` parser *warns* when it finds a tag on a `test.describe`; this counter *inherits* it. The two want different things from the same situation — Phase 0 lists individual tests, so a tag it cannot attribute to a `test()` is a defect worth reporting; a count only needs the total, and Playwright genuinely applies a suite tag to every test inside. Warning here would leave an Enterprise suite counted as OSS, which is the bug this PR fixes. There are no such blocks today (the parser reports zero), so this is a guard against a future one, not a current correction.

**Directory vs tag.** Every `@enterprise` test currently lives under `regression/enterprise/`, and the two criteria agree exactly at 88 today. The tag is what the lane actually selects on, so that is what is counted — a tagged spec landing outside that tree stays correctly excluded.

## Verification

| Check | Result |
|---|---|
| `--count-oss` against the current suite | `669`, matching `757 - 88` computed independently |
| `--count` (existing consumer) | still `533` — unperturbed |
| `npm run typecheck` | clean (confirmed via `--listFiles` that it really reads the edited files) |
| `check:checklist-coverage` | passes, `@stable` still 533 |
| `test:units` | 11 → 18 green |
| Mutation | dropping describe inheritance kills 3 tests; implementing it as a never-resetting latch kills the sibling-leak test |

`npm run lint:ci` only covers `tests/`; nothing under it was touched.

**Not verified:** neither workflow was run, so the counts are proven from the CLI, not from a live `steps.cov` output.

## Follow-up, outside this repo

Rows already in `nightly_runs` keep their inflated `total_count`, so the Trend coverage chart will step at the merge date until they are backfilled. That is a separate change on the QA Platform side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
