### PR TITLE
test(promotion): promote the two 1.12 specs whose only blocker was a validation cycle (#1680)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -138,10 +138,10 @@
 
 > Langflow 1.12's serving-plane end-user identity (`langflow-ai/langflow` #14443, #14550) scopes per-user chat memory behind a **trusted gateway** header, `X-End-User-Id`. It is **off by default** and turned on only by instance-global environment variables, so this subsection asserts the *off* half — the configuration every deployment is in today. The *on* half needs a different container and lives under § 23. Spec doc: `docs/api/flows/serving-end-user-identity-default.md`.
 
-- [-] Premise guard: the instance under test genuinely has no identity header configured, probed by running the flow because `GET /api/v1/config` exposes no serving setting at all (35 keys, none matching `serving`/`end_user`/`trust`) — it **fails** rather than skipping, since a skip here would read green on all four configurations → `api/flows/serving-end-user-identity-default.spec.ts`
-- [-] `POST /api/v2/workflows` twice on one `session_id` as `alice` then `bob`: both report the session **verbatim** and all 4 messages land in it, with `alice::<S>` and `bob::<S>` holding 0 — the scoped counts are the load-bearing half, since an instance could report the plain session while persisting to the scoped one → `api/flows/serving-end-user-identity-default.spec.ts`
-- [-] `POST /api/v1/run/{id}` behaves identically (4 / 0 / 0) — asserted because #14550's phase 1 extends the v2-only scoping to *all* serving APIs, making v1 the surface a partial rollout would honour first, and the one deployed integrations actually call → `api/flows/serving-end-user-identity-default.spec.ts`
-- [-] Non-vacuity control: one identity-less run on a **different** `session_id` persists its 2 messages there. Without it, "the header did nothing" and "chat memory is broken outright" give identical readings — both leave the scoped sessions empty → `api/flows/serving-end-user-identity-default.spec.ts`
+- [x] Premise guard: the instance under test genuinely has no identity header configured, probed by running the flow because `GET /api/v1/config` exposes no serving setting at all (35 keys, none matching `serving`/`end_user`/`trust`) — it **fails** rather than skipping, since a skip here would read green on all four configurations → `api/flows/serving-end-user-identity-default.spec.ts`
+- [x] `POST /api/v2/workflows` twice on one `session_id` as `alice` then `bob`: both report the session **verbatim** and all 4 messages land in it, with `alice::<S>` and `bob::<S>` holding 0 — the scoped counts are the load-bearing half, since an instance could report the plain session while persisting to the scoped one → `api/flows/serving-end-user-identity-default.spec.ts`
+- [x] `POST /api/v1/run/{id}` behaves identically (4 / 0 / 0) — asserted because #14550's phase 1 extends the v2-only scoping to *all* serving APIs, making v1 the surface a partial rollout would honour first, and the one deployed integrations actually call → `api/flows/serving-end-user-identity-default.spec.ts`
+- [x] Non-vacuity control: one identity-less run on a **different** `session_id` persists its 2 messages there. Without it, "the header did nothing" and "chat memory is broken outright" give identical readings — both leave the scoped sessions empty → `api/flows/serving-end-user-identity-default.spec.ts`
 
 ---
 
@@ -893,17 +893,17 @@
 
 #### 17.2 Code Execution Endpoints
 
-- [-] `POST /api/v1/validate/code` rejects a payload crafted to execute on validation
+- [x] `POST /api/v1/validate/code` rejects a payload crafted to execute on validation
       (**recurring upstream defect — reported in 2023 as #696 and again in 2026 as #13336,
       three years apart on the same endpoint**, which is the strongest recurrence signal in
       the whole bug corpus). "Rejects" means *refuses to execute*: a fixed instance answers
       `200` with empty error lists, so the assertion is the absence of the side effect, never
       a status code → security/code-execution-endpoints.spec.ts
-- [-] The custom-component endpoint rejects the same class of payload
+- [x] The custom-component endpoint rejects the same class of payload
       (`langflow-ai/langflow#7900` — the boundary restored there is authentication; the
       authenticated build still executes posted code by design)
       → security/code-execution-endpoints.spec.ts
-- [-] A rejected payload leaves no partial component created
+- [x] A rejected payload leaves no partial component created
       → security/code-execution-endpoints.spec.ts
 
 #### 17.3 Secret Exposure

--- a/docs/api/flows/serving-end-user-identity-default.md
+++ b/docs/api/flows/serving-end-user-identity-default.md
@@ -2,7 +2,7 @@
 
 **File:** `tests/tests-automations/regression/api/flows/serving-end-user-identity-default.spec.ts`
 
-**Last validated:** Langflow 1.12.0.dev38 (`langflowai/langflow-nightly:latest`, `package: "Langflow Nightly"`)
+**Last validated:** Langflow 1.13.0.dev0 (`langflowai/langflow-nightly:latest`, `package: "Langflow Nightly"`)
 
 ---
 
@@ -65,9 +65,10 @@ because it pins an upstream security property rather than exploring a feature.
 opt-in lane and it would then never run on the default instance — which is the only instance
 it has anything to say about. The inert half belongs on the stock lane by construction.
 
-**No `@stable` yet**, per the repo rule that the tag is added only after team validation.
-It is a genuine candidate — keyless, no model, no external network, ~4 s — and promoting it
-is a one-line follow-up once the team has run it.
+**`@stable` since the validation cycle.** It shipped without the tag, per the repo rule that
+the tag is added only after team validation; the run that satisfied that rule is recorded under
+*Validation criterion* below. It was always the easy candidate — keyless, no model, no external
+network, ~2.5 s — so nothing about the spec changed to earn the tag.
 
 ---
 
@@ -118,6 +119,22 @@ unconfigured.
 must redden exactly one test. The behavioural mutation that matters is the one that mimics
 the vector — asserting `alice::S` holds 2 instead of 0 — because that is the reading a
 trusting instance produces.
+
+**Promotion run** (2 Sep 2026). Recorded here because `@stable` is what puts this file in front of
+`daily-stable.yml` every weekday, and the tag is only worth the alarm it raises if the run behind
+it is stated rather than remembered.
+
+| | |
+|---|---|
+| Instance | `1.12.0.dev45` · `package: "Langflow Nightly"` · `LANGFLOW_WORKERS=1` |
+| Repeats | 4 consecutive runs, `--workers=1 --retries=0` |
+| Result | 16 of 16 `expected`, 0 unexpected, 0 flaky, 0 skipped |
+| Duration | 2–3 s per run |
+| Backend errors | 0 occurrences of `🚨 Backend Error` across every run |
+| Re-measured | `nightly:latest` moved to `1.13.0.dev0` mid-promotion, and that is the line `daily-stable.yml` now runs — so the burst was repeated there on a **freshly created container**: 21 of 21 `expected` over 3 runs of the two promoted files together, 21–23 s for both files together, 0 backend errors |
+| Flow cleanup | `GET /api/v1/flows/?remove_example_flows=true&header_flows=true` reads **0 before and 0 after** the three 1.13 runs — the file leaks nothing |
+| Force-fail | `expect(countMessages(…, `session_id=${BOB}::${session}`)).toBe(0)` → `toBe(99)` reddens exactly one test (3 expected / 1 unexpected); reverted |
+
 
 ---
 

--- a/docs/security/code-execution-endpoints.md
+++ b/docs/security/code-execution-endpoints.md
@@ -1,6 +1,6 @@
 # Code Execution Endpoints — crafted payloads are validated, never executed
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.13.0.dev0
 
 ---
 
@@ -117,6 +117,12 @@ before being watched by `daily-stable.yml`; the checklist bullets ship as `[-]` 
 validation) and the promotion is a follow-up, not a spec-doc change. It is **not** `@destructive`:
 every test creates its own flow via the API and deletes it id-scoped in `afterEach`.
 
+**That validation cycle has since run and the tag is now present** — recorded under *Validation
+criterion* below. The flake risk the paragraph above names did not materialise: measured on
+`1.12.0.dev45` the file is 19–21 s, not the ~90 s the first delivery budgeted for, and the two
+sidebar adds landed in 4 consecutive runs out of 4. The reasoning is kept rather than deleted
+because it is what a future reader needs if the spec starts dropping clicks again.
+
 ---
 
 ## Step by step *(required)*
@@ -214,6 +220,22 @@ go through the page, so they are outside the fixture's HTTP monitor and need no
 - Teardown leaves no flow behind:
   `GET /api/v1/flows/?remove_example_flows=true&header_flows=true` returns the same count before
   and after the file runs.
+
+**Promotion run** (2 Sep 2026). Recorded here because `@stable` is what puts this file in front of
+`daily-stable.yml` every weekday, and the tag is only worth the alarm it raises if the run behind
+it is stated rather than remembered.
+
+| | |
+|---|---|
+| Instance | `1.12.0.dev45` · `package: "Langflow Nightly"` · `LANGFLOW_WORKERS=1` |
+| Repeats | 4 consecutive runs, `--workers=1 --retries=0` |
+| Result | 12 of 12 `expected`, 0 unexpected, 0 flaky, 0 skipped |
+| Duration | 19–21 s per run, against the ~90 s the first delivery budgeted |
+| Backend errors | 0 occurrences of `🚨 Backend Error` across every run |
+| Re-measured | `nightly:latest` moved to `1.13.0.dev0` mid-promotion, and that is the line `daily-stable.yml` now runs — so the burst was repeated there on a **freshly created container**: 21 of 21 `expected` over 3 runs of the two promoted files together, 21–23 s for both files together, 0 backend errors |
+| Flow cleanup | `GET /api/v1/flows/?remove_example_flows=true&header_flows=true` reads **0 before and 0 after** the three 1.13 runs — the file leaks nothing |
+| Force-fail | Test 2's `expect(buildStatus).toBe(400)` → `toBe(418)` reddens exactly one test (2 expected / 1 unexpected); reverted |
+
 
 ---
 

--- a/tests/tests-automations/regression/api/flows/serving-end-user-identity-default.spec.ts
+++ b/tests/tests-automations/regression/api/flows/serving-end-user-identity-default.spec.ts
@@ -86,7 +86,7 @@ test.describe("Serving end-user identity is inert on a default instance", () => 
 
   test(
     "the instance under test has no serving identity header configured",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       // The premise, asserted rather than assumed. A serving-configured instance
       // must not pass this file silently: every assertion below would then be
@@ -100,7 +100,7 @@ test.describe("Serving end-user identity is inert on a default instance", () => 
 
   test(
     "two identities on one session share it on POST /api/v2/workflows",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       const session = uniqueSession("v2");
 
@@ -143,7 +143,7 @@ test.describe("Serving end-user identity is inert on a default instance", () => 
 
   test(
     "two identities on one session share it on POST /api/v1/run/{id}",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       // Both surfaces, because #14550's phase 1 extends the v2-only scoping to
       // all serving APIs — v1 is where a partial rollout would first honour the
@@ -180,7 +180,7 @@ test.describe("Serving end-user identity is inert on a default instance", () => 
 
   test(
     "a different session persists separately, so the counts above are not vacuous",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       // Without this, "the header did nothing" and "chat memory does not work at
       // all" produce identical readings — both leave the scoped sessions empty.

--- a/tests/tests-automations/regression/security/code-execution-endpoints.spec.ts
+++ b/tests/tests-automations/regression/security/code-execution-endpoints.spec.ts
@@ -201,7 +201,7 @@ async function openBlankFlow(
 test.describe("Code execution endpoints", () => {
   test(
     "validating a crafted default-argument payload does not execute it",
-    { tag: ["@api", "@regression", "@components"] },
+    { tag: ["@stable", "@api", "@regression", "@components"] },
     async ({ page, request }) => {
       const bearer = await getAuthToken(request);
       const sentinel = uniqueSentinel();
@@ -294,7 +294,7 @@ test.describe("Code execution endpoints", () => {
 
   test(
     "the build endpoint refuses the same payload and leaves no partial component",
-    { tag: ["@api", "@regression", "@components"] },
+    { tag: ["@stable", "@api", "@regression", "@components"] },
     async ({ page, request }) => {
       // The build POST is driven into a 400 on purpose — declare it so the
       // fixture's advisory HTTP log stays trustworthy for every other spec
@@ -400,7 +400,7 @@ test.describe("Code execution endpoints", () => {
 
   test(
     "both endpoints refuse an unauthenticated caller before executing anything",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       // Pure API through the `request` fixture: these calls never go through the
       // page, so they are outside the fixture's HTTP monitor and need no


### PR DESCRIPTION
Closes #1680.

Two specs merged during the 1.12 cycle shipped without `@stable` for the same stated reason — the repo rule that the tag follows team validation — and both spec docs named the promotion as a follow-up. This is that follow-up: 7 `test()` calls gain the tag, and nothing else about either spec changes.

## 1. Promoted tests

| # | Spec · test | What it validates |
|---|---|---|
| 1 | `serving-end-user-identity-default` · *the instance under test has no serving identity header configured* | Premise guard. Probes by **running the flow**, because `GET /api/v1/config` exposes no serving setting at all. Fails rather than skipping — a skip here reads green on all four serving configurations. |
| 2 | ↳ *two identities on one session share it on `POST /api/v2/workflows`* | Runs as `alice` then `bob` on one `session_id`: both report the session **verbatim**, all 4 messages land in it, and `alice::<S>` / `bob::<S>` hold **0**. The scoped counts are the load-bearing half — an instance could report the plain session while persisting to the scoped one. |
| 3 | ↳ *two identities on one session share it on `POST /api/v1/run/{id}`* | Identical 4 / 0 / 0. Asserted because #14550's phase 1 extends the v2-only scoping to *all* serving APIs, making v1 the surface a partial rollout honours first. |
| 4 | ↳ *a different session persists separately, so the counts above are not vacuous* | One identity-less run on a **different** `session_id` persists its 2 messages there. Without it, "the header did nothing" and "chat memory is broken outright" give identical readings. |
| 5 | `code-execution-endpoints` · *validating a crafted default-argument payload does not execute it* | `POST /api/v1/validate/code` answers `200` with `imports.errors == []` and `function.errors == []` in under 4 s, the editor modal closes, and the sentinel is readable in the saved flow's `template.function_code.value`. |
| 6 | ↳ *the build endpoint refuses the same payload and leaves no partial component* | `POST /api/v1/custom_component` answers `400` naming `ZeroDivisionError`, the modal stays open, the canvas holds exactly one `Custom Component` node, and the stored `template.code.value` is byte-identical to the pre-attempt scaffold with the sentinel absent. |
| 7 | ↳ *both endpoints refuse an unauthenticated caller before executing anything* | Both unauthenticated calls answer `401`/`403` with a credentials-related detail in under 4 s each, while the authenticated scaffold build answers `200`. |

## 2. What changed

- `@stable` added to the 7 `test()` calls — no assertion, selector, timeout or scope touched.
- Each spec doc records the promotion run under **Validation criterion**, and `Last validated` moves to `1.13.0.dev0`. The original "why no `@stable`" reasoning is **kept, not deleted** — it is what a future reader needs if either spec starts misbehaving.
- 7 manual Part II bullets in `QA-CHECKLIST.md` flip `[-]` → `[x]`. The generated blocks are untouched (#741) — `npm run coverage:summary` was **not** run.

Daily lane: **533 → 540** `@stable` tests.

## 3. Validation

Measured twice, because `nightly:latest` moved lines mid-promotion.

**`1.12.0.dev45`** — 4 consecutive runs per file, `--workers=1 --retries=0`:

| File | Result | Duration |
|---|---|---|
| `serving-end-user-identity-default.spec.ts` | **16 / 16 `expected`**, 0 unexpected, 0 flaky, 0 skipped | 2–3 s per run |
| `code-execution-endpoints.spec.ts` | **12 / 12 `expected`**, 0 unexpected, 0 flaky, 0 skipped | 19–21 s per run, against the ~90 s its doc budgeted |

**`1.13.0.dev0`** — `nightly:latest` moved to the 1.13 line, which is what `daily-stable.yml` actually runs, so promoting on the 1.12 evidence alone would have put these tests into a lane running a different minor. Repeated on a **freshly created container**: **21 / 21 `expected`** over 3 runs of both files together, 21–23 s per run.

Across every run above: **0** occurrences of `🚨 Backend Error`.

**Force-fail**, one mutation per file, each reverted and the tree left clean:

| File | Mutation | Result |
|---|---|---|
| `serving-end-user-identity-default.spec.ts` | scoped-session count `toBe(0)` → `toBe(99)` | 3 expected / **1 unexpected** |
| `code-execution-endpoints.spec.ts` | build status `toBe(400)` → `toBe(418)` | 2 expected / **1 unexpected** |

**Flow cleanup:** `GET /api/v1/flows/?remove_example_flows=true&header_flows=true` reads **0 before and 0 after** the three 1.13 runs — neither file leaks a flow.

**Gates:** `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `check-checklist-coverage` ✅ (207 spec files / 540 `test()` calls) · `check-checklist-guard` ✅ (no generated block edited) · `watch-upstream-areas --mode=check-docs` ✅ (*"No unresolved dependency path in the changed docs"*).

## 4. Deliberately out of scope — `api/flows/workflows-v2-job-lifecycle.spec.ts`

Its spec doc disqualifies the file, and the same measurement pass confirms the reason rather than restating it. Test 4 is `test.fail()` against the `GET`-status race (`completed` with `outputs={}`), and across those 4 runs it **passed once**. On the daily that reports *"expected to fail but passed"* roughly one weekday in four, opening a `daily-failure` issue at 05:00 for a defect nobody regressed — exactly the alarm its doc argues belongs on a PR instead.

Promoting the file's other four tests is defensible on the evidence (16 of 16 `expected` across the same runs), but it needs a rewrite of a file-level "**No `@stable`**" statement in the spec doc. Separate decision, separate issue.

## 5. Dependencies

None — no provider key, no model, no external network. `serving-end-user-identity-default` is pure `request` fixture; `code-execution-endpoints` is UI-driven but creates its flows through the API and deletes them id-scoped in `afterEach`. Both are parallel-safe; the runs above used `--workers=1` only to keep the measurement attributable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
