### PR TITLE
fix(knowledge,llm-agents): fold the remaining canvas bottom-overlay call sites onto the shared helper (#1675)

### DIFF
--- a/docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
+++ b/docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts`
 
-**Last validated:** Langflow 1.12.0.dev44
+**Last validated:** Langflow 1.13.x
 
 ---
 
@@ -217,6 +217,14 @@ provider recorded `inactive` in `providers.json` (`providerSkipGate("google")`, 
 3. Create the flow via `POST /api/v1/flows/` (`createFlow`, unique name), record
    its id, navigate to `/flow/{id}`, wait for a Knowledge node title, then adjust
    the canvas view so the target node run controls are rendered and clickable.
+4. Clear the canvas bottom-centre overlay slot once, up front
+   (`clearCanvasBottomOverlay(page, { allowAlreadyClear: true })`), so the
+   "Flow needs review" banner this fixture raises (6 outdated components on
+   1.13.0.dev0) can never overlay any of the node-output clicks that follow. It
+   runs after the node title is on screen, which is what makes an empty slot
+   readable as "no banner" rather than as "not mounted yet" — measured mount is
+   1-3 ms after that gate. `allowAlreadyClear` is set because a refreshed fixture
+   would legitimately raise no banner at all.
 
 **Test — full RAG pipeline:**
 1. Run Ingest: click `button_run_knowledge` scoped to `[data-id="Knowledge-ingest"]`;
@@ -257,6 +265,19 @@ provider recorded `inactive` in `providers.json` (`providerSkipGate("google")`, 
   `DELETE /api/v1/knowledge_bases/{name}` (scoped cleanup).
 - Flows API: `POST /api/v1/flows/` (fixture create), `DELETE /api/v1/flows/{id}`
   (scoped cleanup).
+- `tests/helpers/ui/clear-canvas-bottom-overlay.ts` — frees the canvas
+  bottom-centre overlay slot at flow open (`allowAlreadyClear: true`), which
+  Langflow shares between the build-status bar and the "Flow needs review / N
+  components need updates" banner (#1643/#1675). The banner is raised because this
+  fixture's nodes are behind the running image, it never leaves on its own, and a
+  click under it is refused for the full `locator.click` budget. It replaces a
+  private `dismissUpdateBannerIfPresent` that searched the whole page for the exact
+  label `"Dismiss All"` — a label the banner only renders while more than one
+  component is outdated.
+- `src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx` and
+  `src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx` — the
+  two components that share that slot. Declared so
+  `watch-upstream-areas.mjs --mode=check-docs` fails the PR that renames them.
 - Component/UI testids (scouted live on 1.11.0.dev38): node ids `Knowledge-ingest`,
   `Knowledge-retrieve`, `Parser-answer`, `Prompt-answer`, `LanguageModel-answer`,
   `ChatOutput-answer`; `button_run_knowledge`, `node_duration_knowledge` (scoped by

--- a/docs/core-functionality/knowledge-ingestion-management/split-text-chunking.md
+++ b/docs/core-functionality/knowledge-ingestion-management/split-text-chunking.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/split-text-chunking.spec.ts`
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.13.x
 
 ---
 
@@ -82,8 +82,16 @@ so the node run control is not occluded by the bottom react-flow toolbar panel.
 1. Run Split Text: click `button_run_split text`.
 2. Assert the successful build badge `node_duration_split text` is visible
    (Chat Input builds as its upstream dependency).
-3. Open the Chunks output inspector `output-inspection-chunks-splittext`.
-4. Assert the ag-Grid shows **exactly 5 rows** (`locator('[row-index]')` count
+3. Free the canvas bottom-centre overlay slot (`clearCanvasBottomOverlay`) before
+   reaching for the inspector. The fixture is `lf_version: 1.6.0`, so the running
+   image reports one of its components outdated and raises the "Flow needs review"
+   banner into that slot; the banner never leaves on its own and its top edge sits
+   **13.2 px** below the inspect button's bottom edge (measured on 1.13.0.dev0:
+   button y 555.2-572.8, slot y 586.0-656.0). The click is therefore not
+   intercepted *today*, and this step is what stops that from being the whole
+   defence — the same 5 px of node height decided #1643 in the other direction.
+4. Open the Chunks output inspector `output-inspection-chunks-splittext`.
+5. Assert the ag-Grid shows **exactly 5 rows** (`locator('[row-index]')` count
    === 5) and that **exactly one** row contains the sentinel phrase.
 
 ---
@@ -100,6 +108,16 @@ so the node run control is not occluded by the bottom react-flow toolbar panel.
 - Flows API: `POST /api/v1/flows/` (fixture create), `DELETE /api/v1/flows/{id}`
   (scoped cleanup).
 - No model provider credentials required (pure text split, no LLM/embeddings).
+- `tests/helpers/ui/clear-canvas-bottom-overlay.ts` — frees the canvas
+  bottom-centre overlay slot, which Langflow shares between the build-status bar
+  and the "Flow needs review / N components need updates" banner (#1643/#1675).
+  The banner is raised because this fixture's nodes are behind the running image,
+  it never leaves on its own, and a click under it is refused for the full
+  `locator.click` budget.
+- `src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx` and
+  `src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx` — the
+  two components that share that slot. Declared so
+  `watch-upstream-areas.mjs --mode=check-docs` fails the PR that renames them.
 
 ---
 

--- a/docs/core-functionality/knowledge-ingestion-management/vector-store-index-query.md
+++ b/docs/core-functionality/knowledge-ingestion-management/vector-store-index-query.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts`
 
-**Last validated:** Langflow 1.12.0.dev44
+**Last validated:** Langflow 1.13.x
 
 ---
 
@@ -176,6 +176,14 @@ local `providers.json`.
    record its id, navigate to `/flow/{id}`, wait for a Knowledge node title,
    then `adjustScreenView` so the node run controls are not occluded by the
    bottom react-flow toolbar panel.
+4. Clear the canvas bottom-centre overlay slot once, up front
+   (`clearCanvasBottomOverlay(page, { allowAlreadyClear: true })`), so the
+   "Flow needs review" banner this fixture raises (3 outdated components on
+   1.13.0.dev0) can never overlay any of the node-output clicks that follow. It
+   runs after the node title is on screen, which is what makes an empty slot
+   readable as "no banner" rather than as "not mounted yet" — measured mount is
+   1-3 ms after that gate. `allowAlreadyClear` is set because a refreshed fixture
+   would legitimately raise no banner at all.
 
 **Test 1 — Indexing in Vector Store:**
 1. Run Ingest: click `button_run_knowledge` scoped to the `Knowledge-ingest`
@@ -218,6 +226,19 @@ local `providers.json`.
   `DELETE /api/v1/knowledge_bases/{name}` (scoped cleanup).
 - Flows API: `POST /api/v1/flows/` (fixture create), `DELETE /api/v1/flows/{id}`
   (scoped cleanup).
+- `tests/helpers/ui/clear-canvas-bottom-overlay.ts` — frees the canvas
+  bottom-centre overlay slot at flow open (`allowAlreadyClear: true`), which
+  Langflow shares between the build-status bar and the "Flow needs review / N
+  components need updates" banner (#1643/#1675). The banner is raised because this
+  fixture's nodes are behind the running image, it never leaves on its own, and a
+  click under it is refused for the full `locator.click` budget. It replaces a
+  private `dismissUpdateBannerIfPresent` that searched the whole page for the exact
+  label `"Dismiss All"` — a label the banner only renders while more than one
+  component is outdated.
+- `src/frontend/src/pages/FlowPage/components/flowBuildingComponent/index.tsx` and
+  `src/frontend/src/pages/FlowPage/components/UpdateAllComponents/index.tsx` — the
+  two components that share that slot. Declared so
+  `watch-upstream-areas.mjs --mode=check-docs` fails the PR that renames them.
 - Component/UI testids (scouted live on 1.11.0.dev38): node ids `Knowledge-ingest`
   / `Knowledge-retrieve`; `button_run_knowledge`, `node_duration_knowledge`,
   `output-inspection-results-knowledge` (all scoped by node `data-id`); grid rows

--- a/tests/helpers/ui/clear-canvas-bottom-overlay.fake.ts
+++ b/tests/helpers/ui/clear-canvas-bottom-overlay.fake.ts
@@ -19,7 +19,12 @@
 //   - the update banner reads "Flow needs review / 1 component needs updates" and
 //     offers "Dismiss" + "Update All", and never leaves on its own — a click under
 //     it burns the full `locator.click` budget with "subtree intercepts pointer
-//     events".
+//     events";
+//   - that Dismiss is PLURAL-CONDITIONAL: one outdated component renders
+//     "Dismiss", several render "Dismiss All" (re-measured on 1.13.0.dev0 across
+//     three fixtures reporting 1, 3 and 6 — #1675). Both labels are modelled below
+//     because an exact-name matcher passes against one and no-ops against the
+//     other, which is the hole the two hand-rolled copies carried.
 import type { Page } from "@playwright/test";
 
 export interface Occupant {
@@ -32,6 +37,12 @@ export interface Occupant {
    * times out somewhere else.
    */
   ignoresDismiss?: boolean;
+  /**
+   * The button's visible label. Defaults to the singular "Dismiss"; the update
+   * banner renders "Dismiss All" as soon as more than one component is outdated,
+   * and the helper's matcher has to cover both (#1675).
+   */
+  dismissLabel?: string;
 }
 
 export const BUILD_BAR: Occupant = {
@@ -52,6 +63,17 @@ export const BUILD_FAILED_BAR: Occupant = {
 export const UPDATE_BANNER: Occupant = {
   text: "Flow needs review\n1 component needs updates\nDismiss\nUpdate All",
   dismissible: true,
+};
+
+/**
+ * The same banner with MORE than one outdated component, which is the shape every
+ * multi-node fixture raises — and the shape whose label an exact `"Dismiss All"`
+ * matcher gets right while missing `UPDATE_BANNER` entirely, and vice versa.
+ */
+export const UPDATE_BANNER_PLURAL: Occupant = {
+  text: "Flow needs review\n6 components need updates\nDismiss All\nUpdate All",
+  dismissible: true,
+  dismissLabel: "Dismiss All",
 };
 
 export interface FakeOptions {
@@ -114,7 +136,11 @@ export function fakeOverlay({
     // would let the helper find a Dismiss on the build bar, which is precisely
     // the distinction the helper's predicate rests on.
     getByRole: (role: string, options?: { name?: RegExp }) => {
-      if (role !== "button" || !options?.name?.test("Dismiss")) {
+      // Matched against the occupant's OWN label, so a matcher that only covers
+      // the singular "Dismiss" (or only the plural "Dismiss All") fails here
+      // instead of passing on a hardcoded string neither banner renders.
+      const label = current()?.dismissLabel ?? "Dismiss";
+      if (role !== "button" || !options?.name?.test(label)) {
         return { count: async () => 0, first: () => ({ click: async () => {} }) };
       }
       return dismissLocator();

--- a/tests/helpers/ui/clear-canvas-bottom-overlay.test.ts
+++ b/tests/helpers/ui/clear-canvas-bottom-overlay.test.ts
@@ -14,6 +14,7 @@ import {
   BUILD_BAR,
   BUILD_FAILED_BAR,
   UPDATE_BANNER,
+  UPDATE_BANNER_PLURAL,
   fakeOverlay,
 } from "./clear-canvas-bottom-overlay.fake";
 import {
@@ -58,6 +59,28 @@ test("the persistent update banner is dismissed", async () => {
   await clearCanvasBottomOverlay(overlay.page, { timeout: 5000 });
 
   assert.equal(overlay.dismissClicks, 1);
+});
+
+test("both the singular and the plural Dismiss labels are matched", async () => {
+  // The banner renders "Dismiss" for one outdated component and "Dismiss All" for
+  // several — measured on 1.13.0.dev0 across the three fixtures this helper serves
+  // (1, 3 and 6 components). The two private copies folded in by #1675 searched for
+  // the exact name "Dismiss All" and treated "not found" as "nothing to do", so
+  // they would have silently no-opped on any flow down to its last outdated
+  // component, leaving the banner to intercept the click they exist to protect.
+  for (const banner of [UPDATE_BANNER, UPDATE_BANNER_PLURAL]) {
+    const overlay = fakeOverlay({ timeline: [banner] });
+
+    await clearCanvasBottomOverlay(overlay.page, { timeout: 5000 });
+
+    assert.equal(
+      overlay.dismissClicks,
+      1,
+      `the banner labelled ${JSON.stringify(
+        banner.dismissLabel ?? "Dismiss",
+      )} was never dismissed — the matcher does not cover both labels`,
+    );
+  }
 });
 
 test("the bar to banner handover gap is not read as clear", async () => {

--- a/tests/helpers/ui/clear-canvas-bottom-overlay.ts
+++ b/tests/helpers/ui/clear-canvas-bottom-overlay.ts
@@ -52,6 +52,34 @@ import type { Page } from "@playwright/test";
  * harmless for one that asserts on the persisted graph, counts flow writes, or
  * cares about the `edited` flag. Check that before adding a call site.
  *
+ * **Two call-site shapes, and they differ in what an empty slot means.**
+ *
+ * - *Post-build* (#1643's own callers): called between the run and a click that
+ *   lands under the slot, right after `waitForSelector("text=built successfully")`.
+ *   The build bar is on screen by construction, so an empty slot is a LOST
+ *   SELECTOR and the default `allowAlreadyClear: false` is correct.
+ * - *At flow open* (`rag-pipeline`, `vector-store-index-query`): called once after
+ *   the flow's nodes render, to clear the update banner up front so it can never
+ *   overlay any of the several node-output clicks that follow. There is no build
+ *   bar yet and a refreshed fixture would legitimately raise no banner at all, so
+ *   these pass `allowAlreadyClear: true`. Measured on nightly 1.13.0.dev0, the
+ *   banner is in the slot within **1-3 ms** of the first node title becoming
+ *   visible — three fixtures, three reads — so the quiet window below (800 ms)
+ *   clears the mount by more than two orders of magnitude. That margin is what
+ *   makes `allowAlreadyClear` safe HERE, and it only holds if the caller gates on
+ *   a rendered node first; called before the canvas paints, the helper would read
+ *   an empty slot the banner has not reached yet.
+ *
+ * **The Dismiss button's label is plural-conditional, and matching it exactly is
+ * how a private copy of this silently stops working.** Measured on 1.13.0.dev0:
+ * one outdated component renders `"Dismiss"`, several render `"Dismiss All"`
+ * (`split-text-chunking`'s fixture reports 1, `vector-store-index-query`'s 3,
+ * `rag-pipeline`'s 6). The two hand-rolled copies this helper replaced searched
+ * the whole page for the exact name `"Dismiss All"`, so they would have no-opped
+ * on any flow down to its last outdated component — silently, since they treated
+ * "not found" as "nothing to do". The prefix match below covers both, and is
+ * pinned by a unit test rather than by this comment.
+ *
  * A single empty read is deliberately NOT enough (see `EMPTY_CONFIRMATIONS`), and
  * a slot that is empty for the helper's whole life is treated as a LOST SELECTOR
  * rather than as success — see `allowAlreadyClear`.
@@ -105,7 +133,7 @@ export interface ClearCanvasBottomOverlayOptions {
   /**
    * Accept a slot that was empty for this helper's entire life.
    *
-   * Defaults to FALSE, and that is a fail-closed choice. Every current caller
+   * Defaults to FALSE, and that is a fail-closed choice. A post-build caller
    * reaches this immediately after `waitForSelector("text=built successfully")`,
    * which proves the build bar is on screen — so "nothing ever matched" cannot mean
    * "the slot is free", it means the selector no longer matches the container
@@ -113,7 +141,9 @@ export interface ClearCanvasBottomOverlayOptions {
    * `bottom-20`). Returning success there would report the overlay handled while it
    * is fully present, and #1643 would come back as the unattributed 20 s
    * `locator.click` timeout — with a helper call in the trace implying otherwise.
-   * Set true only for a caller that genuinely may find the slot already free.
+   * Set true only for a caller that genuinely may find the slot already free —
+   * today, the at-flow-open callers described above, whose banner is raised by an
+   * outdated fixture and would simply not exist once that fixture is refreshed.
    */
   allowAlreadyClear?: boolean;
 }

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
@@ -12,6 +12,7 @@ import {
   getKnowledgeBase,
 } from "../../../../helpers/knowledge/knowledge-base";
 import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
+import { clearCanvasBottomOverlay } from "../../../../helpers/ui/clear-canvas-bottom-overlay";
 
 // §5.2.4 — the *complete RAG pipeline* end-to-end. Builds on #673 (Split Text
 // chunking) and #674 (vector-store index + query) and adds the final "answer"
@@ -211,28 +212,24 @@ async function openRagFlow(page: Page): Promise<void> {
       .getByTestId("button_run_chat output"),
   ).toBeVisible({ timeout: 30000 });
 
-  // Dismiss the outdated-update banner up front (present on load, persists once
-  // dismissed) so it never overlays a later node-output click.
-  await dismissUpdateBannerIfPresent(page);
-}
-
-// The fixture was captured on an older nightly, so on a newer build its
-// components resolve to outdated updates and a bottom-centered "N components need
-// updates" banner overlays the node output controls, intercepting the
-// output-inspection click. It is noise for this spec (outdated notifications are
-// covered by outdated-component-notification.spec.ts), so dismiss it before
-// reading a node's output.
-async function dismissUpdateBannerIfPresent(page: Page): Promise<void> {
-  // The outdated diff resolves asynchronously after the flow loads, so the banner
-  // can appear a beat late; wait briefly for it (the fixture is deliberately
-  // behind the nightly, so it always appears within this window) before
-  // dismissing. If a future fixture refresh removes the outdated state, this
-  // just times out and no-ops — the test still runs in full, never skips.
-  const dismissAll = page.getByRole("button", { name: "Dismiss All" });
-  if (await dismissAll.isVisible({ timeout: 6000 }).catch(() => false)) {
-    await dismissAll.click();
-    await expect(dismissAll).toBeHidden({ timeout: 5000 });
-  }
+  // Free the canvas bottom-centre overlay slot once, up front: this fixture is
+  // behind the running image, so Langflow raises the "Flow needs review" banner
+  // into the slot it shares with the build-status bar, the banner never leaves on
+  // its own, and a click under it is refused for the full `locator.click` budget
+  // (#1643). Clearing it here covers every node-output click that follows.
+  // `allowAlreadyClear` because a refreshed fixture would raise no banner at all —
+  // safe only because this runs AFTER a node title is on screen, the gate the
+  // banner mounts within 1-3 ms of (measured on 1.13.0.dev0, #1675). The cost is
+  // real and deliberate: it also opts this call site out of the helper's
+  // lost-selector guard, so an upstream Tailwind rename of the slot container is
+  // SILENT here (verified — mutating the selector leaves both tests green). The
+  // guard is not lost to the suite, it is held where the alternative is worse:
+  // `split-text-chunking` and the three #1643 specs call the helper post-build,
+  // where the build bar is on screen by construction and an empty slot can only
+  // mean a broken selector. Making this call site fail closed instead would tie
+  // two @stable specs to the fixture STAYING outdated, so the maintenance action
+  // that fixes the root cause would be the one that reddens them.
+  await clearCanvasBottomOverlay(page, { allowAlreadyClear: true });
 }
 
 /**

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/split-text-chunking.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/split-text-chunking.spec.ts
@@ -5,6 +5,7 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { clearCanvasBottomOverlay } from "../../../../helpers/ui/clear-canvas-bottom-overlay";
 
 // §5.2.1 — the *processing* step of RAG ingestion: a document (delivered by
 // Chat Input) is split into chunks by Split Text. Embedding the chunks requires
@@ -108,6 +109,18 @@ test(
     });
 
     await test.step("the Chunks output holds exactly the expected chunks", async () => {
+      // Free the canvas bottom-centre overlay slot before reaching for the
+      // inspector. Langflow shares that slot between the transient build-status
+      // bar and the "Flow needs review" banner, which this fixture raises
+      // (`lf_version: 1.6.0`, one component reported outdated) and which never
+      // leaves on its own — a click under it is refused for the full
+      // `locator.click` budget (#1643). Measured on 1.13.0.dev0 the click is NOT
+      // intercepted here: the banner's top edge (y 586.0) clears the button's
+      // bottom edge (y 572.8) by 13.2 px. That margin is node height, which is
+      // exactly what upstream moves — the context-id specs of #1643 had ~5 px and
+      // burned three attempts a run, `agent-n-messages-limit` had ~37 px and was
+      // hardened anyway. This call costs ~3 s and removes the dependence (#1675).
+      await clearCanvasBottomOverlay(page);
       await page.getByTestId("output-inspection-chunks-splittext").click();
       // The Chunks DataFrame renders as an ag-Grid; each chunk is one data row
       // (carrying a `row-index`) inside the grid's center-columns viewport.

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
@@ -12,6 +12,7 @@ import {
   getKnowledgeBase,
 } from "../../../../helpers/knowledge/knowledge-base";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { clearCanvasBottomOverlay } from "../../../../helpers/ui/clear-canvas-bottom-overlay";
 import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 // §5.2.2 + §5.2.3 — the *vectorization + retrieval* step of RAG ingestion. The
@@ -148,28 +149,24 @@ async function openVectorStoreFlow(page: Page): Promise<void> {
   // run-button click on nodes near the right edge otherwise).
   await adjustScreenView(page, { numberOfZoomOut: 2 });
 
-  // Dismiss the outdated-update banner up front (present on load, persists once
-  // dismissed) so it never overlays a later node-output click.
-  await dismissUpdateBannerIfPresent(page);
-}
-
-// The fixture flow was captured on an older nightly, so on a newer build its
-// components resolve to outdated updates and the canvas shows a bottom-centered
-// "N components need updates" banner. That banner overlays the node output
-// controls and intercepts the output-inspection click. It is pure noise for this
-// spec (outdated notifications are covered by outdated-component-notification.spec.ts),
-// so dismiss it before interacting with a node's output.
-async function dismissUpdateBannerIfPresent(page: Page): Promise<void> {
-  // The outdated diff resolves asynchronously after the flow loads, so the banner
-  // can appear a beat late; wait briefly for it (the fixture is deliberately
-  // behind the nightly, so it always appears within this window) before
-  // dismissing. If a future fixture refresh removes the outdated state, this
-  // just times out and no-ops — the test still runs in full, never skips.
-  const dismissAll = page.getByRole("button", { name: "Dismiss All" });
-  if (await dismissAll.isVisible({ timeout: 6000 }).catch(() => false)) {
-    await dismissAll.click();
-    await expect(dismissAll).toBeHidden({ timeout: 5000 });
-  }
+  // Free the canvas bottom-centre overlay slot once, up front: this fixture is
+  // behind the running image, so Langflow raises the "Flow needs review" banner
+  // into the slot it shares with the build-status bar, the banner never leaves on
+  // its own, and a click under it is refused for the full `locator.click` budget
+  // (#1643). Clearing it here covers every node-output click that follows.
+  // `allowAlreadyClear` because a refreshed fixture would raise no banner at all —
+  // safe only because this runs AFTER a node title is on screen, the gate the
+  // banner mounts within 1-3 ms of (measured on 1.13.0.dev0, #1675). The cost is
+  // real and deliberate: it also opts this call site out of the helper's
+  // lost-selector guard, so an upstream Tailwind rename of the slot container is
+  // SILENT here (verified — mutating the selector leaves both tests green). The
+  // guard is not lost to the suite, it is held where the alternative is worse:
+  // `split-text-chunking` and the three #1643 specs call the helper post-build,
+  // where the build bar is on screen by construction and an empty slot can only
+  // mean a broken selector. Making this call site fail closed instead would tie
+  // two @stable specs to the fixture STAYING outdated, so the maintenance action
+  // that fixes the root cause would be the one that reddens them.
+  await clearCanvasBottomOverlay(page, { allowAlreadyClear: true });
 }
 
 /**

--- a/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-1.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-1.spec.ts
@@ -7,6 +7,31 @@ import { initialGPTsetup } from "../../../../helpers/other/initialGPTsetup";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
+// Why this file does NOT call `clearCanvasBottomOverlay` (#1675, measured on
+// 1.13.0.dev0 rather than assumed).
+//
+// Both tests here click an `output-inspection-*` button shortly after a build,
+// which is the shape that cost #1643 two specs — but the occupant that made that
+// shape dangerous cannot arise here. `UpdateAllComponents` ("Flow needs review /
+// N components need updates") only mounts for a node the running image reports
+// outdated, and neither test loads a stored fixture: the first builds from the
+// live **Basic Prompting** template and the second drags **URL** + two **Chat
+// Output** components onto a blank flow, so every node is created by the image
+// under test and none can be behind it. Probed end to end on the second test's
+// flow, the slot is empty before the run, holds the transient build bar at the
+// spec's own +600 ms wait (y 598.0-656.0), and is empty again by +2.6 s and at
+// +6.6 s — the banner never appears.
+//
+// What remains is the build bar, which leaves on its own 2 s after "built
+// successfully", and it clears the inspect button's bottom edge (y 551.5) by
+// 46.5 px — an order of magnitude more than the ~5 px that decided #1643, and
+// nine times `agent-n-messages-limit`'s ~37 px. Calling the helper here would
+// also be wrong in one direction the other call sites are not: after the bar
+// auto-dismisses the slot stays EMPTY for good, so the default
+// `allowAlreadyClear: false` would report a lost selector on a healthy page.
+//
+// Revisit if either test starts seeding a stored flow fixture — that is the one
+// change that puts `UpdateAllComponents` back on this canvas.
 test(
   "user must be able to see output inspection",
   { tag: ["@release", "@components", "@agents"] },


### PR DESCRIPTION
**Closes #1675.**

Follow-up to #1643 / PR #1674, which found the mechanism and built the shared helper, fixing only its own three-file cluster. Four more specs touch the same overlay in a different shape and were deliberately left out of that fix.

## Problem

Langflow renders **two components into one fixed container** over the canvas — `absolute bottom-16 left-1/2 z-50 w-[530px] -translate-x-1/2`: the transient build-status bar (`flowBuildingComponent`) and the "Flow needs review / N components need updates" banner (`UpdateAllComponents`), which is hidden while the bar is up, retakes the slot when the bar's state is cleared, and then never leaves. A click under it is refused for the full `locator.click` budget. `tests/helpers/ui/clear-canvas-bottom-overlay.ts` is the shared answer.

Still on their own: two byte-identical private `dismissUpdateBannerIfPresent` copies, one spec with no clearing at all, and one bare `waitForTimeout(600)`.

**Each of the four was measured on nightly `1.13.0.dev0` before deciding**, because #1643 established that the outcome turns on a per-spec margin — node height — and not on the shape. This is not "four more broken specs".

| Spec | Banner on its flow? | Geometry | Verdict |
|---|---|---|---|
| `split-text-chunking` | **yes** — 1 component (fixture is `lf_version: 1.6.0`, the most outdated of the four) | banner y 586.0–656.0 · inspect button y 555.2–572.8 → **13.2 px** clear | **adopts** |
| `rag-pipeline` | **yes** — 6 components | cleared at flow open | **adopts** (replaces private copy) |
| `vector-store-index-query` | **yes** — 3 components | cleared at flow open | **adopts** (replaces private copy) |
| `chatInputOutputUser-shard-1` | **no, and cannot** | build bar y 598.0–656.0 · target y 537.4–551.5 → **46.5 px** clear | **records why not** |

### Two findings the measurement produced

**1. The banner's Dismiss label is plural-conditional.** One outdated component renders `"Dismiss"`; several render `"Dismiss All"` — measured across the three fixtures reporting 1, 3 and 6. Both private copies searched the **whole page** for the exact name `"Dismiss All"` and treated "not found" as "nothing to do", so they would have silently no-opped on any flow down to its last outdated component, leaving the banner free to intercept the click they exist to prevent. Latent today, not live. The helper's prefix matcher already covered both labels; nothing pinned it — now a unit test does, asserted in both directions.

**2. `chatInputOutputUser-shard-1` cannot raise the banner at all.** Neither test loads a stored fixture: the first builds from the live **Basic Prompting** template, the second drags **URL** + two **Chat Output** components onto a blank flow, so every node is created by the image under test and none can be behind it. Probed end to end on the second test's flow: the slot is empty before the run, holds the transient bar at the spec's own `+600 ms` wait, and is empty again at `+2.6 s` and `+6.6 s`.

## Fix

- **`rag-pipeline`, `vector-store-index-query`** — the private copies are gone; both call `clearCanvasBottomOverlay(page, { allowAlreadyClear: true })` at flow open, which is where they already cleared and where one call covers every node-output click that follows.
- **`split-text-chunking`** — adopts the helper post-build, before the inspector click. It is **not** intercepted today (13.2 px), but that margin is node height and node height is exactly what upstream moves: #1643's context-id specs had ~5 px and burned three attempts a run, `agent-n-messages-limit` had ~37 px and was hardened anyway. This one is thinner than the spec #1674 already hardened, and the call costs ~3 s.
- **`chatInputOutputUser-shard-1`** — no code change. A comment records the measurement and the reason, plus the one change that would invalidate it (starting to seed a stored fixture). Calling the helper there would also be wrong in a direction the other sites are not: after the bar auto-dismisses the slot stays empty for good, so the default `allowAlreadyClear: false` would report a lost selector on a healthy page.

### The `allowAlreadyClear` trade is stated where it is made

`allowAlreadyClear: true` also opts the at-open call sites **out of the helper's lost-selector guard** — verified: mutating the slot selector leaves both green (see FF-A2 below). This is not a regression (the private copies were equally silent), and the guard is not lost to the suite — it is held on the four post-build callers, where the build bar is on screen by construction and an empty slot can only mean a broken selector. Making the at-open sites fail closed instead would tie two `@stable` specs to their fixture **staying** outdated, so the maintenance action that fixes the root cause would be the one that reddens them.

It is safe there because the banner is in the slot **within 1–3 ms** of the first node title rendering (measured, three fixtures) — the helper's 800 ms quiet window clears that by two orders of magnitude — and only while the caller keeps gating on a rendered node first, which both do.

## Scope note

**No assertion changed anywhere.** Only the path to the output inspector is. All three knowledge specs stay `mode: "serial"`.

## Validation (nightly `1.13.0.dev0`, `--retries=0`, `--workers=1`)

The nightly cut over to the 1.13 cycle on 2026-09-02, and that is the image `daily-stable.yml` pulls, so these `@stable` specs were validated against it rather than against 1.12.

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `npm run test:units` ✅ (901 pass / 0 fail, incl. the new one) · `npm run test:scripts` ✅ (941 / 0) · `check-checklist-guard.mjs` ✅ · `npm run check:checklist-coverage` ✅ · `watch-upstream-areas --mode=check-docs` ✅ (no unresolved path in the changed docs)
- **3 clean runs** of all four files: `6 passed` (1.4 min, 1.3 min) plus the per-file round.
- `--trace=on` ✅ on `split-text-chunking` (9.8 s, trace produced — no hang; the Simple Agent family limitation of #490/#518 does not apply here).
- Zero `🚨 Backend Error`. Flow-orphan check: **36 flows before and after** — the starter templates only, zero leaked.
- Both declared upstream paths resolve on `origin/main` **and** `origin/release-1.12.0`.

### Force-fails — all EXECUTED and observed failing, then reverted (0 mutation markers left)

| # | Target | Mutation | Observed |
|---|---|---|---|
| FF-A | `split-text-chunking` | slot selector `w-[530px]` → `w-[560px]` | `matched NOTHING for 5 consecutive reads` ⇒ failed, attributed |
| FF-A2 | `vector-store-index-query` | same mutation | **passed** — records the `allowAlreadyClear` trade above as measured, not assumed |
| FF-B | `split-text-chunking` | `EXPECTED_CHUNKS` 5 → 6 | `Expected: 6, Received: 5` ⇒ failed |
| FF-C | `vector-store-index-query` #1 | KB chunk count 5 → 4 | `Expected: 4, Received: 5` ⇒ failed |
| FF-D | `vector-store-index-query` #2 | result rows 1 → 2 | `Expected: 2, Received: 1` ⇒ failed |
| FF-E | `rag-pipeline` | `ZEPHYR-42` → `KRYPTON-99` | `Expected pattern: /KRYPTON-99/, Received: "ZEPHYR-42"` ⇒ failed |
| FF-F2 | `chatInputOutputUser-shard-1` #1 | inspect icon `nth(2)` → `nth(9)` | `locator.click: Timeout 15000ms` ⇒ failed |
| FF-G | `chatInputOutputUser-shard-1` #2 | output-inspection testid → nonexistent | `locator.click: Timeout 20000ms` ⇒ failed |
| FF-H | helper, unit | matcher → `/^dismiss$/i` | only the new label test fails (9 pass / 1 fail) |
| FF-I | helper, unit | matcher → `/^dismiss all$/i` | 4 fail — both directions pinned |

### One thing this surfaced and did NOT fix

`FF-F1`: replacing the asserted text `"Sender"` with `"SenderXYZ"` in `chatInputOutputUser-shard-1` **passes**. Its text checks are `.isVisible()` calls with no `expect`, so they cannot fail — pre-existing, unrelated to this change, and out of this issue's scope. That file also has no spec doc, unlike its shard-0 and shard-2 siblings. Worth a follow-up; flagged here rather than silently left.

Related: #1643 (the mechanism and the helper), #1674 (the three-file cluster it fixed), #989 (the previous fix of the sibling cluster).
