### PR TITLE
fix(history): close the review findings on the liveness block (#1077)

### DIFF
--- a/reports/README.md
+++ b/reports/README.md
@@ -200,11 +200,14 @@ The series is **not continuous**. Document any missing weeks here rather than ba
         "totals": { "passed": 128, "failed": 0, "flaky": 4, "skipped": 2 }
       }
     ],
-    "unassigned": { "passed": 0, "failed": 2, "flaky": 0, "skipped": 0 }
+    "unassigned": { "passed": 0, "failed": 2, "flaky": 0, "skipped": 0 },
                                              // OPTIONAL: specs no shard claimed. Omitted when
                                              // empty — which is the normal case, and is why the
                                              // rest of this example is the real 2026-09-02 row
-                                             // while this one line is not.
+                                             // while these last two lines are not.
+    "double_claimed": ["a.spec.ts"]          // OPTIONAL: specs more than one shard listed.
+                                             // Omitted when empty; present means the partition
+                                             // is wrong.
   }
 }
 ```
@@ -227,7 +230,9 @@ The series is **not continuous**. Document any missing weeks here rather than ba
   - **Absent ≠ zero, and `shards_measured: 0` ≠ healthy.** The block is **omitted entirely** by a lane that never measured (the weekly, any local run, anything that does not set `LIVENESS_DIR`). A run whose shards *did* report but recorded no probes carries the block with `shards_measured: 0` — that is UNKNOWN, and must never be read as a backend that stayed up (#1012). `shards_reported` below `shard_total` is a shard whose job died before writing a summary; `shard_total: null` means the run declared no count, which is the one state that makes such a shard undetectable.
   - `blips_total` counts single-probe failures **below** the 2-probe window threshold, so they are excluded from `down_seconds_total`. A non-zero value means the down-share on that row is a **floor**, not a ceiling — the caveat that changed a triage conclusion on 2026-09-01 (#1665).
   - `span_seconds` is the **recorder's** observed span (first probe → last probe), not the shard job's duration: the recorder starts after the post-`collect-models` health gate and is killed in teardown. It is the window the down-share is computed against, and the only wall clock the artifacts can support.
-  - `attempts` / `failing` / `collateral` count test **attempts** (retries included — the cost of a wedge is precisely that each collateral test burns its whole retry budget), while `shards[].totals` counts **tests**, in the same vocabulary as the line's run-level `totals`. The per-shard totals **sum to that run-level `totals`**; when they cannot, the difference is named in `unassigned` rather than silently lost.
+  - `attempts` / `failing` / `collateral` count test **attempts** (retries included — the cost of a wedge is precisely that each collateral test burns its whole retry budget), while `shards[].totals` counts **tests**, in the same vocabulary as the line's run-level `totals`.
+  - **The per-shard totals plus `unassigned` sum to the line's run-level `totals`, always.** That is enforced, not hoped for: every spec file is counted exactly once across the whole run. A file no shard listed lands in `unassigned`; a file **two** shards listed is attributed to the first and named in `double_claimed` rather than counted twice — `unassigned` can only ever detect the under-count, so without that rule the sum would break in the one direction nothing checks. `double_claimed` is empty and omitted in practice, because `partition-shards.mjs` emits disjoint lists; its presence means the partition itself is wrong.
+  - A file under the liveness directory that is **not** a shard summary is ignored rather than counted as a shard, with the number ignored printed. Left in, it produces a phantom `{shard: "?"}` record that inflates `shards_reported` — filling exactly the gap against `shard_total` that a shard whose job died is supposed to show.
   - Absent from history written before #1077.
 - `param` (optional, additive to schema v1) is the parameterization label a model-parameterized spec carries on its `describe` title — e.g. `"google / gemini-2.5-flash"` or `"model:gpt-4o-mini"`. The triage dataset builder uses it to group failures by provider variant and surface **provider-wide** clusters (same provider failing across ≥2 spec files → likely an environment/package cause, not per-test rot; #899). Absent for non-parameterized specs and for history written before #899.
 

--- a/scripts/backfill-backend-history.mjs
+++ b/scripts/backfill-backend-history.mjs
@@ -23,7 +23,8 @@
 //   node scripts/backfill-backend-history.mjs \
 //     --history reports/daily-history.jsonl \
 //     --artifacts <dir> \
-//     [--shard-total 4] [--dry-run]
+//     --shard-total <n> \
+//     [--dry-run]
 //
 // `<dir>` holds one subdirectory per run id, laid out as the run's artifacts
 // download:  <dir>/<run_id>/liveness-N/backend-liveness.json
@@ -36,18 +37,45 @@ import path from "node:path";
 import { buildBackendBlock } from "./lib/backend-history.mjs";
 import { readSummaries } from "./report-backend-outages.mjs";
 
+// Accepts both `--flag value` and `--flag=value`. The `=` form used to fall
+// through to the fallback silently, which for `--shard-total=6` meant writing
+// the DEFAULT while the refusal below reported a number the caller never typed.
 function arg(name, fallback = null) {
-  const i = process.argv.indexOf(`--${name}`);
-  return i === -1 ? fallback : process.argv[i + 1];
+  const argv = process.argv;
+  const i = argv.indexOf(`--${name}`);
+  if (i !== -1 && i + 1 < argv.length && !argv[i + 1].startsWith("--")) return argv[i + 1];
+  const inline = argv.find((a) => a.startsWith(`--${name}=`));
+  if (inline) return inline.slice(name.length + 3);
+  return fallback;
 }
 
 const historyPath = arg("history", "reports/daily-history.jsonl");
 const artifactsDir = arg("artifacts");
-const shardTotal = Number(arg("shard-total", "4")) || null;
 const dryRun = process.argv.includes("--dry-run");
 
 if (!artifactsDir) {
   console.error("--artifacts <dir> is required.");
+  process.exit(2);
+}
+
+// REQUIRED, and parsed strictly. It used to default to 4 — a guess about runs
+// the caller may not have checked, and `shard_total` is the one field whose
+// entire purpose is making a shard that uploaded NOTHING visible. A 2-shard
+// repro backfilled under that default records `shards_reported: 2` against
+// `shard_total: 4`, which reads as "two shards died" forever, and the
+// `shards_reported > shard_total` refusal below cannot see it — it only catches
+// the excess. An unparseable value is refused for the sharper version of the
+// same reason: `Number("abc") || null` yielded `null`, which SHORT-CIRCUITS that
+// refusal and writes the state this file's own comments call the one that makes
+// a silent shard undetectable.
+const shardTotalRaw = arg("shard-total");
+if (shardTotalRaw === null) {
+  console.error("--shard-total <n> is required — the run's real shard count, not a guess.");
+  process.exit(2);
+}
+const shardTotal = Number(shardTotalRaw);
+if (!Number.isInteger(shardTotal) || shardTotal < 1) {
+  console.error(`--shard-total must be a positive integer; got "${shardTotalRaw}".`);
   process.exit(2);
 }
 
@@ -66,7 +94,12 @@ if (!runDirs.length) {
 const blocks = new Map();
 for (const runId of runDirs) {
   const dir = path.join(artifactsDir, runId);
-  const summaries = readSummaries(dir).filter((s) => s.shard !== undefined);
+  // Unfiltered on purpose: `buildBackendBlock` rejects non-summary JSON itself
+  // (and says how many it dropped), so the live appender and this script cannot
+  // disagree about what counts as a shard. This script used to carry its own
+  // copy of that filter while the appender carried none — the hardening was on
+  // the ad-hoc path and missing from the one that runs unattended forever.
+  const summaries = readSummaries(dir);
   const reportPath = path.join(dir, "results.json");
   const report = fs.existsSync(reportPath)
     ? JSON.parse(fs.readFileSync(reportPath, "utf8"))
@@ -99,6 +132,12 @@ for (const runId of runDirs) {
   blocks.set(runId, block);
 }
 
+if (!fs.existsSync(historyPath)) {
+  // A raw ENOENT stack here points at `node:fs` rather than at the typo in
+  // `--history`, and this script's whole job is not to damage that file.
+  console.error(`History file not found at ${historyPath}.`);
+  process.exit(2);
+}
 const lines = fs.readFileSync(historyPath, "utf8").split("\n");
 const seen = new Set();
 const out = lines.map((line) => {

--- a/scripts/backfill-backend-history.test.mjs
+++ b/scripts/backfill-backend-history.test.mjs
@@ -81,6 +81,16 @@ function setup(runs, lines) {
   return { artifacts, history };
 }
 
+/**
+ * A line NOT produced by `JSON.stringify` — extra spacing and a key order the
+ * writer would not emit. Without it, "untouched lines pass through as their
+ * original bytes" is unfalsifiable: a fixture written by `JSON.stringify` reads
+ * identically whether it was passed through or re-serialised.
+ */
+function nonCanonicalLine(runId) {
+  return `{ "run_id": "${runId}",  "version": 1, "totals": {"passed": 1, "failed": 0, "flaky": 0, "skipped": 0} }`;
+}
+
 function run({ artifacts, history }, extra = []) {
   try {
     const stdout = execFileSync(
@@ -98,7 +108,7 @@ const readRows = (history) =>
   readFileSync(history, "utf8").trim().split("\n").map((l) => JSON.parse(l));
 
 test("only the named run's line changes, and only by an appended block", () => {
-  const untouched = historyLine("999");
+  const untouched = nonCanonicalLine("999");
   const env = setup({ "111": { shards: [summary(1, ["a.spec.ts"])] } }, [untouched, historyLine("111")]);
   assert.equal(run(env, ["--shard-total", "1"]).code, 0);
   const [first, second] = readFileSync(env.history, "utf8").trim().split("\n");
@@ -174,4 +184,83 @@ test("an empty artifacts directory fails instead of reporting a successful no-op
   const out = run(env, ["--shard-total", "1"]);
   assert.equal(out.code, 2);
   assert.match(out.stderr, /No run directories/);
+});
+
+test("an untouched line keeps its original bytes, not a re-serialisation", () => {
+  // `CLAUDE.md` forbids hand-editing this file; the script's promise is that a
+  // rerun rewrites only what it was asked for. A fixture written by
+  // `JSON.stringify` cannot tell passthrough from re-serialisation, so this one
+  // deliberately is not.
+  const untouched = nonCanonicalLine("999");
+  const env = setup({ "111": { shards: [summary(1, ["a.spec.ts"])] } }, [untouched, historyLine("111")]);
+  assert.equal(run(env, ["--shard-total", "1"]).code, 0);
+  assert.equal(readFileSync(env.history, "utf8").split("\n")[0], untouched);
+});
+
+test("a run with liveness but no usable summary is refused, naming the artifact", () => {
+  // Without this branch the run falls through carrying a null block and dies
+  // later with "No history line for run(s)" — pointing the operator at the
+  // history file when the cause is a missing download.
+  const dir = mkdtempSync(join(tmpdir(), "backfill-"));
+  const artifacts = join(dir, "artifacts");
+  mkdirSync(join(artifacts, "111"), { recursive: true });
+  writeFileSync(join(artifacts, "111", "results.json"), JSON.stringify(report()));
+  const history = join(dir, "history.jsonl");
+  writeFileSync(history, historyLine("111") + "\n");
+  const out = run({ artifacts, history }, ["--shard-total", "1"]);
+  assert.equal(out.code, 1);
+  assert.match(out.stderr, /no liveness summary found/);
+});
+
+test("--artifacts is required", () => {
+  const env = setup({ "111": { shards: [summary(1, ["a.spec.ts"])] } }, [historyLine("111")]);
+  try {
+    execFileSync(process.execPath, [SCRIPT, "--history", env.history, "--shard-total", "1"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    assert.fail("must not run without an artifacts directory");
+  } catch (err) {
+    assert.equal(err.status, 2);
+    assert.match(String(err.stderr), /--artifacts <dir> is required/);
+  }
+});
+
+test("--shard-total is required, and a guess is not offered as a default", () => {
+  // It used to default to 4. A 2-shard repro backfilled under that default
+  // records `shard_total: 4` against 2 summaries, which reads as "two shards
+  // died" forever — and the shards_reported > shard_total refusal cannot see
+  // it, because it only catches the excess.
+  const env = setup({ "111": { shards: [summary(1, ["a.spec.ts"])] } }, [historyLine("111")]);
+  const out = run(env, []);
+  assert.equal(out.code, 2);
+  assert.match(out.stderr, /--shard-total <n> is required/);
+});
+
+for (const bad of ["abc", "4x", "0", "-1", "2.5"]) {
+  test(`--shard-total ${bad} is refused rather than read as unknown`, () => {
+    // `Number(x) || null` turned every one of these into `shard_total: null`,
+    // which short-circuits the refusal below AND records the one state the code
+    // calls undetectable.
+    const env = setup({ "111": { shards: [summary(1, ["a.spec.ts"])] } }, [historyLine("111")]);
+    const out = run(env, ["--shard-total", bad]);
+    assert.equal(out.code, 2);
+    assert.match(out.stderr, /must be a positive integer/);
+  });
+}
+
+test("--shard-total=N is honoured, not silently ignored", () => {
+  // The `=` form used to fall through to the default, so the refusal could name
+  // a number the caller never typed.
+  const env = setup({ "111": { shards: [summary(1, ["a.spec.ts"]), summary(2, [])] } }, [historyLine("111")]);
+  const out = run(env, ["--shard-total=1"]);
+  assert.equal(out.code, 1);
+  assert.match(out.stderr, /2 shard summaries but --shard-total 1/);
+});
+
+test("a --history path that does not exist is named, not a node:fs stack", () => {
+  const env = setup({ "111": { shards: [summary(1, ["a.spec.ts"])] } }, [historyLine("111")]);
+  const out = run({ artifacts: env.artifacts, history: join(env.history, "nope.jsonl") }, ["--shard-total", "1"]);
+  assert.equal(out.code, 2);
+  assert.match(out.stderr, /History file not found/);
 });

--- a/scripts/lib/backend-history.mjs
+++ b/scripts/lib/backend-history.mjs
@@ -86,9 +86,36 @@ export function buildBackendBlock(summaries, report, shardTotal) {
   // `shards_measured: 0`, which reads as UNKNOWN and never as a clean backend.
   if (!summaries.length) return null;
 
+  // `readSummaries` takes ANY `*.json` that parses to an object, and the merge
+  // job's download directory is not guaranteed to hold only liveness artifacts —
+  // a stray file there was measured producing a phantom `{shard: "?"}` record,
+  // inflating `shards_reported`. That is exactly the slot `shard_total` vs
+  // `shards_reported` exists to expose (a shard whose job died before writing a
+  // summary), so a phantom does not merely add noise: it FILLS the gap that the
+  // absence was supposed to show, in a file that is machine-read as a series.
+  //
+  // Filtered HERE, before `attribute()`, and never in the caller: the shard join
+  // below is positional over the array `attribute()` mapped, so a filter applied
+  // afterwards would desynchronise the indexes and trade a visible phantom for
+  // two shards silently swapping totals. `hasOwn` and not a type check — a real
+  // summary always declares `shard`, including as the empty string a lane that
+  // forgot WATCH_LABEL produces.
+  const usable = summaries.filter((s) => s && Object.hasOwn(s, "shard"));
+  const rejected = summaries.length - usable.length;
+  if (rejected > 0) {
+    // Named, never silent (#1012): dropping input quietly is the same class of
+    // error as counting it wrongly.
+    console.warn(
+      `⚠️  [liveness] ignored ${rejected} file(s) under the liveness directory that are not shard summaries.`,
+    );
+  }
+  if (!usable.length) return null;
+  summaries = usable;
+
   const agg = attribute(summaries, collectAttempts(report));
   const byFile = countByFile(report);
   const claimed = new Set();
+  const doubleClaimed = new Set();
 
   const shards = agg.shards.map((shard, index) => {
     // Positional, not by label. `attribute()` maps `summaries` to its own
@@ -100,12 +127,21 @@ export function buildBackendBlock(summaries, report, shardTotal) {
     // a new lane is one forgotten env var away from not doing so.
     const summary = summaries[index];
     const totals = emptyTotals();
-    // Deduplicated for the same reason `attribute()` deduplicates its own copy
-    // of this list: `a.spec.ts` and `./a.spec.ts` are both accepted spellings
-    // of one file, and counting a shard's file twice inflates that shard's
-    // totals. `unassigned` below can only ever detect the UNDER-count, so a
-    // duplicate would break the sum-to-run-totals invariant silently.
+    // Each file is counted ONCE, across the whole run. Deduplicating within the
+    // shard is the same thing `attribute()` does to its own copy of this list
+    // (`a.spec.ts` and `./a.spec.ts` are both accepted spellings of one file);
+    // the cross-shard half matters for the same reason and is not covered by it.
+    // `unassigned` below can only ever detect the UNDER-count, so without this
+    // an over-count would break the sum-to-run-totals invariant in the one
+    // direction nothing checks — and that invariant is what makes a row's shard
+    // breakdown reconcilable with its own `totals` instead of merely plausible.
+    // The duplicate is attributed to the first shard that claimed it and named
+    // in `double_claimed`, rather than dropped from both or counted in both.
     for (const norm of new Set((summary?.files || []).map(normalizeSpecPath))) {
+      if (claimed.has(norm)) {
+        doubleClaimed.add(norm);
+        continue;
+      }
       claimed.add(norm);
       addTotals(totals, byFile.get(norm) || {});
     }
@@ -150,6 +186,10 @@ export function buildBackendBlock(summaries, report, shardTotal) {
     collateral_attempts: agg.collateralAttempts,
     shards,
     ...(isZero(unassigned) ? {} : { unassigned }),
+    // A file two shards both listed. The partitioner emits disjoint lists, so
+    // this is empty in practice and omitted — its presence means the partition
+    // itself is wrong, which is worth seeing on the row that depends on it.
+    ...(doubleClaimed.size ? { double_claimed: [...doubleClaimed].sort() } : {}),
   };
 }
 

--- a/scripts/lib/backend-history.test.mjs
+++ b/scripts/lib/backend-history.test.mjs
@@ -357,6 +357,84 @@ test("a hostile LIVENESS_DIR loses the block, never the history line", () => {
     return { LIVENESS_DIR: live, SHARD_TOTAL: "4" };
   });
   assert.equal(entry.totals.passed, 1, "the run history is written regardless");
+  assert.equal("backend" in entry, false, "…and nothing was invented from garbage");
+});
+
+test("a stray JSON beside a real summary does not become a phantom shard", () => {
+  // The case the assertion above cannot reach: this file PARSES, is an object,
+  // and `readSummaries` therefore accepts it. Left in, it records a
+  // `{shard: "?"}` record and `shards_reported: 2` — filling the very gap
+  // between `shards_reported` and `shard_total` that a dead shard is supposed
+  // to show.
+  const entry = append((dir) => {
+    const live = join(dir, "all-liveness");
+    mkdirSync(join(live, "liveness-1"), { recursive: true });
+    writeFileSync(
+      join(live, "liveness-1", "backend-liveness.json"),
+      JSON.stringify(summary("1", ["a.spec.ts"])),
+    );
+    writeFileSync(join(live, "liveness-1", "manifest.json"), JSON.stringify({ note: "not a summary" }));
+    return { LIVENESS_DIR: live, SHARD_TOTAL: "4" };
+  });
+  assert.equal(entry.backend.shards_reported, 1, "one shard uploaded; three are missing and must stay missing");
+  assert.equal(entry.backend.shards.length, 1);
+  assert.deepEqual(entry.backend.shards[0].totals, { passed: 1, failed: 0, flaky: 0, skipped: 0 });
+});
+
+test("a file two shards both list is counted once and named", () => {
+  // `unassigned` catches only the UNDER-count. Without this the per-shard totals
+  // over-count against the line's own `totals`, in the direction nothing checks
+  // — while the schema documents the sum as an invariant.
+  const block = buildBackendBlock(
+    [summary(1, ["a.spec.ts"]), summary(2, ["a.spec.ts", "c.spec.ts"])],
+    report([
+      { file: "a.spec.ts", status: "expected" },
+      { file: "c.spec.ts", status: "expected" },
+    ]),
+    2,
+  );
+  const summed = block.shards.reduce((acc, s) => acc + s.totals.passed, 0);
+  assert.equal(summed, 2, "the run has 2 passing tests, and the shards may not report 3");
+  assert.deepEqual(block.double_claimed, ["a.spec.ts"], "the partition anomaly is named, not absorbed");
+  assert.equal(block.unassigned, undefined);
+});
+
+test("double_claimed is omitted on a healthy partition", () => {
+  const block = buildBackendBlock(
+    [summary(1, ["a.spec.ts"]), summary(2, ["c.spec.ts"])],
+    report([
+      { file: "a.spec.ts", status: "expected" },
+      { file: "c.spec.ts", status: "expected" },
+    ]),
+    2,
+  );
+  assert.equal("double_claimed" in block, false);
+});
+
+test("the block's per-shard totals reconcile with the line's own totals", () => {
+  // The claim the schema makes, asserted end to end through the appender rather
+  // than against hand-written per-shard expectations — which cannot notice the
+  // two halves drifting apart together.
+  const entry = append((dir) => {
+    const live = join(dir, "all-liveness");
+    for (const [shard, files] of [["1", ["a.spec.ts"]], ["2", []]]) {
+      mkdirSync(join(live, `liveness-${shard}`), { recursive: true });
+      writeFileSync(
+        join(live, `liveness-${shard}`, "backend-liveness.json"),
+        JSON.stringify(summary(shard, files)),
+      );
+    }
+    return { LIVENESS_DIR: live, SHARD_TOTAL: "2" };
+  });
+  const keys = ["passed", "failed", "flaky", "skipped"];
+  const summed = Object.fromEntries(
+    keys.map((k) => [
+      k,
+      entry.backend.shards.reduce((acc, s) => acc + s.totals[k], 0) +
+        (entry.backend.unassigned?.[k] ?? 0),
+    ]),
+  );
+  assert.deepEqual(summed, entry.totals);
 });
 
 // --- the one thing no behavioural test can reach -----------------------------
@@ -370,15 +448,28 @@ test("the appender does not statically import the liveness block builder", () =>
   // Measured before the import was made dynamic: a module-scope throw gave
   // exit=1 and no history file at all. No behavioural test can reach this
   // without poisoning the real module on disk.
-  const appender = readFileSync(APPENDER, "utf8");
-  assert.equal(
-    /^\s*import\s[^\n]*backend-history\.mjs/m.test(appender),
-    false,
-    "the block builder must be imported inside the try that guards it",
-  );
+  // Whitespace-normalised, and covering BOTH modules of the chain. The first
+  // version matched `/^\s*import\s[^\n]*backend-history\.mjs/m`, which passed
+  // against `import{x}from"./lib/backend-history.mjs"`, against a Prettier-shaped
+  // multi-line import, and — the realistic regression — against an unrelated
+  // static import of `report-backend-outages.mjs`, which `backend-history.mjs`
+  // pulls in and whose module body is just as fatal. Measured with that last
+  // one plus a module-scope throw: guard green, appender `exit=1`, no history
+  // file at all. #1226's lesson is that a guard pinning a spelling passes the
+  // mutation it exists to catch; this pins an absence over a normalised string.
+  const appender = readFileSync(APPENDER, "utf8").replace(/\s+/g, " ");
+  for (const module of ["backend-history.mjs", "report-backend-outages.mjs"]) {
+    assert.equal(
+      new RegExp(`(^|;|\\}) ?import ?[^;]*from ?["'][^"']*${module.replace(".", "\\.")}["']`).test(
+        ` ${appender}`,
+      ),
+      false,
+      `${module} must not be statically imported — its module body would run before any line is written`,
+    );
+  }
   assert.ok(
-    /await import\(["'\.\/]*lib\/backend-history\.mjs["']\)/.test(appender),
-    "…and it must still be imported at all",
+    /await import\( *["'][^"']*lib\/backend-history\.mjs["'] *\)/.test(appender),
+    "…and the block builder must still be imported at all",
   );
 });
 


### PR DESCRIPTION
Closes #1077.

## What this PR is now

**One commit: the review fixes.** The mechanism itself is already on `main`.

PR #1687 was branched off this branch — an accident of two agents sharing one working tree — and was **squash-merged**, so it carried this PR's first four commits into `main` under its own title. `b53e4eb1`'s body opens with `* feat(history): record the in-run backend liveness on each daily history line (#1077)`. `scripts/lib/backend-history.mjs`, `scripts/backfill-backend-history.mjs`, their tests, the `daily-stable.yml` wiring, the schema docs and the five backfilled history rows are therefore live already — **at the state before two review passes and Copilot were addressed**. Squashing changes the SHAs, so those commits are not ancestors of `main` and git saw the files as add/add; this branch has been rebased onto `main` and the four now drop as already-upstream.

Issue #1077 is still open, because the squash carried no `Closes`. This PR closes it.

## Why the issue existed

The mid-run worker wedge is measured by the in-run recorder into per-shard `liveness-N` artifacts uploaded with `retention-days: 7`. Measured 2026-09-02: the dailies of 08-24, 08-25 and 08-26 were already `expired=true`. Every measurement accumulated on #1077 since July is a table typed by hand into a comment, re-derived by a human inside a one-week window, and the four axes its benchmark compares on appeared on no committed record. The `backend` block puts them on the one file in this repo that is append-only and committed back to `main`.

The baseline it captured, now on `main`:

```
2026-08-27  outages=0   down=0s       shards=4/4  passed=545
2026-08-28  outages=10  down=838.2s   shards=4/4  passed=536
2026-08-31  outages=14  down=1004.2s  shards=4/4  passed=523
2026-09-01  outages=19  down=1524.1s  shards=4/4  passed=524
2026-09-02  outages=12  down=864s     shards=4/4  passed=534
```

Five consecutive scheduled dailies, every shard executing tests, `shards_measured == shard_total` on all four. **2026-08-27 is the near-control**: 0 outage windows on four shards at roughly half the summed span of the wedged days — the wedge is not a constant of the runner. Applying and measuring a lever against this is **#1686**, blocked on #1679.

## What the commit fixes

Two independent review passes with clean context (both against the real artifacts, never fixtures) plus Copilot. **Two findings overlap, and both land on one asymmetry: the ad-hoc backfill script was hardened against a state the appender — the path that runs unattended on every daily forever — was not.**

- **A stray `*.json` in the liveness directory invented a shard.** `readSummaries` takes any file that parses to an object. Measured: a `manifest.json` beside a real summary yields `shards_reported: 2` with a phantom `{shard: "?", measured: false}` while one shard uploaded — which *fills* the gap between `shards_reported` and `shard_total` that a shard whose job died is supposed to show. The filter lives in `buildBackendBlock`, **before** `attribute()`, never in a caller: the shard join is positional over the array `attribute()` mapped, so filtering afterwards would desynchronise the indexes and trade a visible phantom for two shards silently swapping totals. The backfill's own copy of the filter is deleted with it.
- **`--shard-total` is required and strictly parsed.** It defaulted to `4`. A 2-shard repro backfilled under that default records `shards_reported: 2` against `shard_total: 4` — "two shards died", permanently — and the `shards_reported > shard_total` refusal cannot see it, since it only catches the excess. Sharper still: `Number(x) || null` turned `abc`, `4x`, `0` and an omitted value into `shard_total: null`, which **short-circuits that refusal** and writes the state the code's own comment calls the one that makes a silent shard undetectable. `--shard-total=6` also fell through to the default.
- **The reconciliation invariant is enforced, not asserted.** `unassigned` only ever detected the under-count, so two shards listing the same file both counted it. Every file is now counted once per run; a duplicate is attributed to the first shard and named in `double_claimed` (empty in practice — `partition-shards.mjs` emits disjoint lists). A test asserts the sum **through the appender** against the line's own totals, rather than against per-shard expectations written by hand, which cannot notice the two halves drifting together.
- **Three refusals had no test and survived mutation**: the missing-summary branch (without it a run dies later with "No history line for run(s)", pointing the operator at the history file when the cause is a missing download), the missing `--artifacts`, and an unreadable `--history` path, which raised a raw `node:fs` stack at the one script whose whole job is not to damage that file.
- **The structural import guard was #1226's failure mode verbatim.** It passed against `import{x}from"…"`, against a multi-line import, and against a static import of `report-backend-outages.mjs` — equally fatal, since `backend-history.mjs` pulls it in. Measured with that plus a module-scope throw: guard green, appender `exit=1`, **no history file at all**, on every lane. It now matches either module of the chain over whitespace-normalised text.
- **"Untouched lines pass through as their original bytes" was unfalsifiable** — the fixture's untouched line was itself a `JSON.stringify`, so re-serialising read identically. It is deliberately non-canonical now.

## Validation

| check | result |
|---|---|
| `npm run test:scripts` | 1027 pass / 0 fail (42 new; 1 pre-existing skip) |
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors (1413 pre-existing warnings) |
| Re-derive the five rows **now on `main`** with the fixed code | byte-identical |
| Mutation pass: 18 on the block builder, 8 on the backfill refusals, 3 import spellings | all caught |

```bash
npm run test:scripts && npm run typecheck && npm run lint
node --test scripts/lib/backend-history.test.mjs scripts/backfill-backend-history.test.mjs
jq -r 'select(.backend) | "\(.date)  outages=\(.backend.outages_total)  down=\(.backend.down_seconds_total)s  passed=\(.totals.passed)"' reports/daily-history.jsonl
```

**Nothing about the recorded baseline moves.** The five rows on `main` were written by the pre-fix code and re-derive byte-identically under the fixed code.

## Known gap, recorded rather than fixed

History lines are written on `schedule` only, so a lever measured through a `workflow_dispatch` of `daily-stable.yml` produces no durable row. Either compare across ≥2 scheduled dailies — what #1686's last *Done when* asks for anyway — or extend the append step first. Noted in `failure-modes.md`, which is already on `main`.

The series also cannot be extended backwards: everything before 2026-08-27 is gone.

The `daily-stable.yml` wiring still has **no CI proof** and cannot get one — it is one `env:` block on a step that runs only on `schedule`, so the PR lane never reaches it and a dispatch skips it. First real proof is the next scheduled daily: the `Append daily history` step log ends with `outages=… down=…s shards_measured=N/4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
