### PR TITLE
Report when the target is not the Langflow the CI is testing

### DIFF
--- a/scripts/resolve-target-version.mjs
+++ b/scripts/resolve-target-version.mjs
@@ -145,7 +145,7 @@ export function publishedNightlyVersion(imageTagsText) {
   return { version: match.name, digest, error: "" };
 }
 
-export function resolveTargetVersion(refsText, imageTagsText = null) {
+export function resolveTargetVersion(refsText, imageTagsText = null, imageRequested = false) {
   const warnings = [];
   const branches = [];
   const tags = new Map(); // "cycle.devN" -> { triple, dev, sha, peeled }
@@ -173,6 +173,16 @@ export function resolveTargetVersion(refsText, imageTagsText = null) {
   }
 
   // --- The published image decides, when it can be reached -----------------------
+  // The caller says whether it MEANT to consult the registry, because "no listing" and
+  // "a listing I could not use" are the same falsy value here and only one of them
+  // deserves silence. The likeliest failures — a file curl never wrote, or a 200 with
+  // an empty body — produce exactly that value, so without this the fallback most in
+  // need of a caveat is the one that carries none.
+  if (imageRequested && !imageTagsText) {
+    warnings.push(
+      "the published image listing was requested but could not be used, so this answer comes from the git refs. Those run AHEAD of what shipped: upstream creates the tag before it builds the image, and builds only if the tests pass.",
+    );
+  }
   if (imageTagsText) {
     const published = publishedNightlyVersion(imageTagsText);
     if (published.version) {
@@ -185,6 +195,12 @@ export function resolveTargetVersion(refsText, imageTagsText = null) {
           `the published image is ${published.version} but no refs/heads/release-${cycle} was listed — the branch may have been deleted, or the listing is partial.`,
         );
       }
+      // Best-effort by nature: upstream's nightly deletes and recreates the tag name
+      // (`git tag -d` + `git push --delete origin`, then a fresh tag), so v1.13.0.dev1
+      // can point somewhere new after the 1.13.0.dev1 image shipped. The VERSION
+      // verdict does not depend on this — the digest decided it — but the commit
+      // recorded here, and the ref an operator is told to move the clone to, can drift
+      // from what was actually built.
       if (!tag) {
         warnings.push(
           `no v${published.version} tag was found in the ref listing, so the exact commit of the published image is unknown here. The version comparison still holds; a checkout would have to resolve the commit another way.`,
@@ -327,6 +343,7 @@ function main(argv) {
   }
   const text = args.refsFile === "-" ? readFileSync(0, "utf8") : readFileSync(args.refsFile, "utf8");
   let imageTags = null;
+  const imageRequested = Boolean(args.imageTagsFile);
   if (args.imageTagsFile) {
     // A listing that cannot be read is not fatal: the git fallback exists for exactly
     // this, and it announces its own weakness in the warnings.
@@ -336,7 +353,7 @@ function main(argv) {
       imageTags = null;
     }
   }
-  const decision = resolveTargetVersion(text, imageTags);
+  const decision = resolveTargetVersion(text, imageTags, imageRequested);
   // Warnings go to stderr, as resolve-echo-endpoint.mjs does: they are the difference
   // between "same commit" and "same cycle", and a caller reading only stdout's fields
   // would never learn which one it got.

--- a/scripts/resolve-target-version.mjs
+++ b/scripts/resolve-target-version.mjs
@@ -29,7 +29,26 @@
  *      release-1.12.0 to release-1.13.0 with nobody editing anything, so a branch
  *      written into a script is the next `release-1.12.0` left behind.
  *
- * ## Why the tag beats the branch head
+ * ## Why the IMAGE, and not the tag, is the source of truth
+ *
+ * The tag is not evidence that anything shipped. Upstream's `create-nightly-tag`
+ * job runs BEFORE `frontend-tests-linux`, `backend-unit-tests` and `stress-tests`
+ * (they all `needs:` it), and `release-nightly-build` is gated on those passing. So
+ * `v1.13.0.dev2` can exist while `langflow-nightly:latest` — what daily-stable.yml
+ * actually pulls — is still `1.13.0.dev1`. A clone correctly sitting where the CI
+ * is would then be reported as a mismatch, and under REQUIRE_TARGET_VERSION the run
+ * would fail over a difference that does not exist.
+ *
+ * The same shape hits the branch: `release-1.14.0` is cut before any nightly is
+ * built from it, so branch-first resolution flips a cycle ahead of the image.
+ *
+ * So the published image decides, and the git refs only say WHICH COMMIT that
+ * version was built from — which is what a checkout needs. scripts/check-nightly-delta.ts
+ * reached the same conclusion for its own lane and says so in its header; the two
+ * resolutions are close enough that consolidating them is worth doing once this one
+ * has a second consumer.
+ *
+ * ## Why the tag beats the branch head, when the image cannot be reached
  *
  * Each nightly build leaves a tag: `v1.13.0.dev0` points at the exact commit the
  * published image was built from. The branch head has usually moved on by hours
@@ -56,6 +75,10 @@ const HELP = `usage: resolve-target-version.mjs --refs-file <path>
        resolve-target-version.mjs --compare <expected> <actual> <strategy>
 
   --refs-file PATH   output of \`git ls-remote --heads --tags <repo>\` ("-" for stdin)
+  --image-tags-file PATH
+                     a Docker Hub tags page for langflowai/langflow-nightly; when
+                     given, the PUBLISHED image decides and the refs only map that
+                     version to a commit
   --compare E A S    what the target SHOULD serve, what it did, and which strategy
                      resolved the first — prints "<match>\t<reason>" on stdout
   --help             this text
@@ -77,7 +100,52 @@ function compareTriples(a, b) {
   return 0;
 }
 
-export function resolveTargetVersion(refsText) {
+/**
+ * The version `:latest` currently points at, by manifest digest.
+ *
+ * Docker Hub returns one entry per platform variant and `:latest` shares its digest
+ * with the version tag built in the same run — the same rule check-nightly-delta.ts
+ * uses. amd64 is preferred because that is what both lanes run; without pinning a
+ * platform, an arm64 digest can match nothing and the whole resolution silently
+ * falls back.
+ */
+const NIGHTLY_VERSION = /^\d+\.\d+\.\d+\.dev\d+$/;
+
+function primaryDigest(images) {
+  if (!Array.isArray(images)) return "";
+  const amd64 = images.find((i) => i && i.architecture === "amd64" && (!i.os || i.os === "linux"));
+  return (amd64 || images[0] || {}).digest || "";
+}
+
+export function publishedNightlyVersion(imageTagsText) {
+  if (!imageTagsText) return { version: "", error: "no image listing was provided" };
+  let results;
+  try {
+    const parsed = JSON.parse(imageTagsText);
+    results = Array.isArray(parsed) ? parsed : parsed.results;
+  } catch {
+    return { version: "", error: "the image listing was not valid JSON" };
+  }
+  if (!Array.isArray(results)) return { version: "", error: "the image listing had no results array" };
+
+  const latest = results.find((t) => t && t.name === "latest");
+  if (!latest) return { version: "", error: "no `latest` tag in the image listing" };
+  const digest = primaryDigest(latest.images);
+  if (!digest) return { version: "", error: "the `latest` tag carries no digest" };
+
+  const match = results.find(
+    (t) => t && t.name !== "latest" && NIGHTLY_VERSION.test(t.name) && primaryDigest(t.images) === digest,
+  );
+  if (!match) {
+    return {
+      version: "",
+      error: `no X.Y.Z.devN tag shares \`latest\`'s digest (${digest.slice(0, 19)}…) in this page of the listing`,
+    };
+  }
+  return { version: match.name, digest, error: "" };
+}
+
+export function resolveTargetVersion(refsText, imageTagsText = null) {
   const warnings = [];
   const branches = [];
   const tags = new Map(); // "cycle.devN" -> { triple, dev, sha, peeled }
@@ -102,6 +170,41 @@ export function resolveTargetVersion(refsText) {
       // A peeled entry always wins over the unpeeled one for the same tag.
       if (!previous || (peeled && !previous.peeled)) tags.set(key, { triple, dev, sha, peeled });
     }
+  }
+
+  // --- The published image decides, when it can be reached -----------------------
+  if (imageTagsText) {
+    const published = publishedNightlyVersion(imageTagsText);
+    if (published.version) {
+      const triple = published.version.split(".").slice(0, 3).map(Number);
+      const cycle = triple.join(".");
+      const branch = branches.find((b) => compareTriples(b.triple, triple) === 0);
+      const tag = tags.get(published.version);
+      if (!branch) {
+        warnings.push(
+          `the published image is ${published.version} but no refs/heads/release-${cycle} was listed — the branch may have been deleted, or the listing is partial.`,
+        );
+      }
+      if (!tag) {
+        warnings.push(
+          `no v${published.version} tag was found in the ref listing, so the exact commit of the published image is unknown here. The version comparison still holds; a checkout would have to resolve the commit another way.`,
+        );
+      }
+      return {
+        ok: true,
+        branch: branch ? branch.ref.replace("refs/heads/", "") : `release-${cycle}`,
+        cycle,
+        version: published.version,
+        ref: `v${published.version}`,
+        sha: tag ? tag.sha : "",
+        digest: published.digest,
+        strategy: "published-image",
+        warnings,
+      };
+    }
+    warnings.push(
+      `could not read the published nightly from the image listing (${published.error}); falling back to the git refs. That fallback can run AHEAD of what shipped: the tag is created before the image is built and regardless of whether the build succeeds.`,
+    );
   }
 
   if (branches.length === 0) {
@@ -158,11 +261,25 @@ export function resolveTargetVersion(refsText) {
  * the plain cycle (`1.13.0`) while the CI's image reports a `.devN` of the same
  * cycle — comparing those as strings would report a mismatch on a correctly placed
  * clone, which is the false alarm that teaches people to ignore this check.
+ *
+ * An unrecognised strategy is UNKNOWN, never one of the two. Falling through to the
+ * looser rule is how a wrong answer gets a passing verdict: with a typo in the
+ * strategy, `1.13.0.dev1` against `1.13.0.dev0` stops being a mismatch and becomes
+ * "same cycle" — a pass, from a script whose entire purpose is refusing silent wrong
+ * decisions.
  */
+const STRATEGIES = new Set(["published-image", "nightly-tag", "branch-head"]);
+
 export function compareVersions(expected, actual, strategy) {
+  if (!STRATEGIES.has(strategy)) {
+    return {
+      match: "unknown",
+      reason: `unrecognised resolution strategy "${strategy}" — expected one of ${[...STRATEGIES].join(", ")}. Refusing to guess which comparison applies: the looser one would call a different commit a match.`,
+    };
+  }
   if (!actual) return { match: "unknown", reason: "the target reported no version" };
   if (!expected) return { match: "unknown", reason: "no expected version was resolved" };
-  if (strategy === "nightly-tag") {
+  if (strategy === "published-image" || strategy === "nightly-tag") {
     return expected === actual
       ? { match: "yes", reason: `exact: ${actual}` }
       : { match: "no", reason: `expected ${expected} (the commit the CI's image was built from), the target served ${actual}` };
@@ -174,10 +291,11 @@ export function compareVersions(expected, actual, strategy) {
 }
 
 function parseArgs(argv) {
-  const args = { refsFile: null, compare: null };
+  const args = { refsFile: null, imageTagsFile: null, compare: null };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--refs-file") args.refsFile = argv[++i];
+    else if (a === "--image-tags-file") args.imageTagsFile = argv[++i];
     // Three positionals rather than three flags: the caller is bash inside a
     // pipeline, and every extra flag there is another quoting mistake waiting.
     else if (a === "--compare") args.compare = [argv[++i], argv[++i], argv[++i]];
@@ -208,7 +326,21 @@ function main(argv) {
     return 2;
   }
   const text = args.refsFile === "-" ? readFileSync(0, "utf8") : readFileSync(args.refsFile, "utf8");
-  const decision = resolveTargetVersion(text);
+  let imageTags = null;
+  if (args.imageTagsFile) {
+    // A listing that cannot be read is not fatal: the git fallback exists for exactly
+    // this, and it announces its own weakness in the warnings.
+    try {
+      imageTags = readFileSync(args.imageTagsFile, "utf8");
+    } catch {
+      imageTags = null;
+    }
+  }
+  const decision = resolveTargetVersion(text, imageTags);
+  // Warnings go to stderr, as resolve-echo-endpoint.mjs does: they are the difference
+  // between "same commit" and "same cycle", and a caller reading only stdout's fields
+  // would never learn which one it got.
+  for (const w of decision.warnings ?? []) process.stderr.write(`::warning::resolve-target-version: ${w}\n`);
   process.stdout.write(JSON.stringify(decision) + "\n");
   // A resolution that failed is still printed, for the caller to quote; the exit code
   // is what says whether it is usable.

--- a/scripts/resolve-target-version.mjs
+++ b/scripts/resolve-target-version.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * Decides which Langflow the VM lane SHOULD be testing, from what `git ls-remote`
+ * reports about the upstream repository.
+ *
+ * ## Why this exists
+ *
+ * The daily compares a VM verdict with the Actions one. That comparison is only
+ * about the environment if both sides run the same product — and nothing enforced
+ * that. The Actions lane pulls `langflowai/langflow-nightly:latest`, and that image
+ * is NOT built from `main`: upstream's `nightly_build.yml` resolves the newest
+ * `release-X.Y.Z` branch and checks that out. Meanwhile a source clone on the target
+ * sits wherever someone last left it — on 2026-09-02 that was `release-1.12.0`,
+ * a full release cycle behind the `1.13.0.dev0` the CI was testing.
+ *
+ * Every difference between those two arrives in the divergence list as "a real
+ * failure only Actions saw", which is a changelog wearing an environment's clothes.
+ *
+ * ## The rule, which is upstream's and not ours
+ *
+ *   git ls-remote --heads 'refs/heads/release-*' | grep '^release-[0-9]+\.[0-9]+\.[0-9]+$'
+ *     | sort -V | tail -1
+ *
+ * That is verbatim what `nightly_build.yml` runs. Two consequences this script is
+ * built around:
+ *
+ *   1. NEVER `main`. `main` is only where the workflow file lives.
+ *   2. The answer MOVES on its own. Between 2026-09-01 and 09-02 it went from
+ *      release-1.12.0 to release-1.13.0 with nobody editing anything, so a branch
+ *      written into a script is the next `release-1.12.0` left behind.
+ *
+ * ## Why the tag beats the branch head
+ *
+ * Each nightly build leaves a tag: `v1.13.0.dev0` points at the exact commit the
+ * published image was built from. The branch head has usually moved on by hours
+ * (12 of them, the day this was written), so checking out the tag gives parity of
+ * COMMIT with the image the CI ran, while the branch head only gives parity of
+ * cycle. The tag also carries the version string the instance will report, which
+ * makes the comparison exact instead of approximate.
+ *
+ * When no matching tag is found the branch head is still the right answer — it is
+ * the same cycle — but the caller is told, because "same cycle" and "same commit"
+ * are different claims and only one of them supports an exact comparison.
+ *
+ * ## Usage
+ *
+ *   git ls-remote --heads --tags https://github.com/langflow-ai/langflow > refs.txt
+ *   node scripts/resolve-target-version.mjs --refs-file refs.txt
+ *
+ * Output (stdout, JSON): { ok, branch, cycle, version, ref, sha, strategy, warnings, error }
+ */
+
+import { readFileSync } from "node:fs";
+
+const HELP = `usage: resolve-target-version.mjs --refs-file <path>
+       resolve-target-version.mjs --compare <expected> <actual> <strategy>
+
+  --refs-file PATH   output of \`git ls-remote --heads --tags <repo>\` ("-" for stdin)
+  --compare E A S    what the target SHOULD serve, what it did, and which strategy
+                     resolved the first — prints "<match>\t<reason>" on stdout
+  --help             this text
+`;
+
+const RELEASE_BRANCH = /^refs\/heads\/release-(\d+)\.(\d+)\.(\d+)$/;
+// The nightly tag: v<cycle>.dev<n>. The `^{}` suffix marks the PEELED entry of an
+// annotated tag — the commit the tag actually points at. ls-remote prints both lines
+// for an annotated tag, and taking the unpeeled one hands the caller the tag OBJECT's
+// sha, which `git checkout` accepts and `git rev-parse HEAD` then reports as a
+// different commit than the image was built from.
+const NIGHTLY_TAG = /^refs\/tags\/v(\d+)\.(\d+)\.(\d+)\.dev(\d+)(\^\{\})?$/;
+
+/** Numeric, not lexicographic: 1.9.0 sorts BELOW 1.12.0, which a string compare inverts. */
+function compareTriples(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+export function resolveTargetVersion(refsText) {
+  const warnings = [];
+  const branches = [];
+  const tags = new Map(); // "cycle.devN" -> { triple, dev, sha, peeled }
+
+  for (const line of String(refsText).split("\n")) {
+    const [sha, ref] = line.trim().split(/\s+/);
+    if (!sha || !ref) continue;
+
+    const branch = ref.match(RELEASE_BRANCH);
+    if (branch) {
+      branches.push({ triple: [+branch[1], +branch[2], +branch[3]], ref, sha });
+      continue;
+    }
+
+    const tag = ref.match(NIGHTLY_TAG);
+    if (tag) {
+      const triple = [+tag[1], +tag[2], +tag[3]];
+      const dev = +tag[4];
+      const peeled = Boolean(tag[5]);
+      const key = `${triple.join(".")}.dev${dev}`;
+      const previous = tags.get(key);
+      // A peeled entry always wins over the unpeeled one for the same tag.
+      if (!previous || (peeled && !previous.peeled)) tags.set(key, { triple, dev, sha, peeled });
+    }
+  }
+
+  if (branches.length === 0) {
+    return {
+      ok: false,
+      error:
+        "no refs/heads/release-X.Y.Z branch in the listing. That is the rule upstream's nightly_build.yml uses to pick what it builds, so without one there is nothing to follow — and falling back to `main` would test something the CI never tests.",
+      warnings,
+    };
+  }
+
+  branches.sort((a, b) => compareTriples(a.triple, b.triple));
+  const branch = branches[branches.length - 1];
+  const cycle = branch.triple.join(".");
+
+  const candidates = [...tags.entries()]
+    .filter(([, t]) => compareTriples(t.triple, branch.triple) === 0)
+    .sort((a, b) => a[1].dev - b[1].dev);
+
+  if (candidates.length === 0) {
+    warnings.push(
+      `no v${cycle}.devN tag was published for ${branch.ref.replace("refs/heads/", "")} yet, so the branch head is the best available answer. That is parity of CYCLE, not of commit: the head may be hours ahead of whatever image the CI is running, and the instance will report "${cycle}" rather than a .devN string.`,
+    );
+    return {
+      ok: true,
+      branch: branch.ref.replace("refs/heads/", ""),
+      cycle,
+      version: cycle,
+      ref: branch.ref.replace("refs/heads/", ""),
+      sha: branch.sha,
+      strategy: "branch-head",
+      warnings,
+    };
+  }
+
+  const [key, tag] = candidates[candidates.length - 1];
+  return {
+    ok: true,
+    branch: branch.ref.replace("refs/heads/", ""),
+    cycle,
+    version: key,
+    ref: `v${key}`,
+    sha: tag.sha,
+    strategy: "nightly-tag",
+    warnings,
+  };
+}
+
+/**
+ * Is what the target actually served the thing it should have been?
+ *
+ * Deliberately two verdicts rather than one. Under `nightly-tag` the expected string
+ * is exact and anything else is a mismatch. Under `branch-head` the instance reports
+ * the plain cycle (`1.13.0`) while the CI's image reports a `.devN` of the same
+ * cycle — comparing those as strings would report a mismatch on a correctly placed
+ * clone, which is the false alarm that teaches people to ignore this check.
+ */
+export function compareVersions(expected, actual, strategy) {
+  if (!actual) return { match: "unknown", reason: "the target reported no version" };
+  if (!expected) return { match: "unknown", reason: "no expected version was resolved" };
+  if (strategy === "nightly-tag") {
+    return expected === actual
+      ? { match: "yes", reason: `exact: ${actual}` }
+      : { match: "no", reason: `expected ${expected} (the commit the CI's image was built from), the target served ${actual}` };
+  }
+  const cycleOf = (v) => String(v).split(".").slice(0, 3).join(".");
+  return cycleOf(expected) === cycleOf(actual)
+    ? { match: "cycle", reason: `same cycle (${cycleOf(actual)}), exact commit not pinned` }
+    : { match: "no", reason: `expected cycle ${cycleOf(expected)}, the target served ${actual}` };
+}
+
+function parseArgs(argv) {
+  const args = { refsFile: null, compare: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--refs-file") args.refsFile = argv[++i];
+    // Three positionals rather than three flags: the caller is bash inside a
+    // pipeline, and every extra flag there is another quoting mistake waiting.
+    else if (a === "--compare") args.compare = [argv[++i], argv[++i], argv[++i]];
+    else if (a === "--help" || a === "-h") args.help = true;
+    else return { error: `unknown argument: ${a}` };
+  }
+  return args;
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  if (args.error) {
+    process.stderr.write(`::error::resolve-target-version: ${args.error}\n${HELP}`);
+    return 2;
+  }
+  if (args.help) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  if (args.compare) {
+    const [expected, actual, strategy] = args.compare;
+    const r = compareVersions(expected, actual, strategy);
+    process.stdout.write(`${r.match}\t${r.reason}\n`);
+    return 0;
+  }
+  if (!args.refsFile) {
+    process.stderr.write(`::error::resolve-target-version: --refs-file is required\n${HELP}`);
+    return 2;
+  }
+  const text = args.refsFile === "-" ? readFileSync(0, "utf8") : readFileSync(args.refsFile, "utf8");
+  const decision = resolveTargetVersion(text);
+  process.stdout.write(JSON.stringify(decision) + "\n");
+  // A resolution that failed is still printed, for the caller to quote; the exit code
+  // is what says whether it is usable.
+  return decision.ok ? 0 : 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/resolve-target-version.test.mjs
+++ b/scripts/resolve-target-version.test.mjs
@@ -199,6 +199,26 @@ test("a published version with no matching tag keeps the version and drops the c
   assert.match(d.warnings.join(" "), /exact commit of the published image is unknown/);
 });
 
+test("a listing that was REQUESTED but unusable warns, even when the refs answer", () => {
+  // The silent case: `imageTagsText` is falsy both when nobody asked for a listing and
+  // when curl never wrote one (or wrote an empty 200). The refs then answer confidently
+  // — `nightly-tag`, no warnings — and the reader has no way to know the registry was
+  // never consulted, which is the one thing that would make them doubt the answer.
+  const withTag = refs([
+    [sha(1), "refs/heads/release-1.13.0"],
+    [sha(2), "refs/tags/v1.13.0.dev1^{}"],
+  ]);
+  const silent = resolveTargetVersion(withTag, null, false);
+  assert.equal(silent.warnings.length, 0, "nobody asked for a listing: nothing to warn about");
+
+  for (const unusable of [null, ""]) {
+    const d = resolveTargetVersion(withTag, unusable, true);
+    assert.equal(d.strategy, "nightly-tag");
+    assert.match(d.warnings.join(" "), /requested but could not be used/);
+    assert.match(d.warnings.join(" "), /AHEAD of what shipped/);
+  }
+});
+
 test("published-image compares exactly, like the tag it replaced", () => {
   assert.equal(compareVersions("1.13.0.dev0", "1.13.0.dev0", "published-image").match, "yes");
   assert.equal(compareVersions("1.13.0.dev0", "1.13.0.dev1", "published-image").match, "no");

--- a/scripts/resolve-target-version.test.mjs
+++ b/scripts/resolve-target-version.test.mjs
@@ -117,6 +117,93 @@ test("no release branch at all is an error that names the rule, not a fallback t
   assert.match(d.error, /main/);
 });
 
+// --- the published image decides -------------------------------------------------
+
+/** A Docker Hub tags page, with `latest` sharing a digest with one version tag. */
+function imageTags(latestVersion, extra = []) {
+  const digest = `sha256:${"a".repeat(64)}`;
+  const img = (d) => [
+    { architecture: "arm64", os: "linux", digest: `sha256:${"b".repeat(64)}` },
+    { architecture: "amd64", os: "linux", digest: d },
+  ];
+  return JSON.stringify({
+    results: [
+      { name: "latest", images: img(digest) },
+      { name: latestVersion, images: img(digest) },
+      ...extra.map((v) => ({ name: v, images: img(`sha256:${"c".repeat(64)}`) })),
+      { name: "base-latest", images: img(`sha256:${"d".repeat(64)}`) },
+    ],
+  });
+}
+
+test("the PUBLISHED image wins over a newer git tag", () => {
+  // The live case the day this was written: v1.13.0.dev1 was tagged, and `latest` was
+  // still 1.13.0.dev0. Upstream tags BEFORE it builds, and only ships if the tests
+  // pass — so a clone correctly sitting where the CI is would be called a mismatch.
+  const d = resolveTargetVersion(
+    refs([
+      [sha(1), "refs/heads/release-1.13.0"],
+      [sha(2), "refs/tags/v1.13.0.dev0^{}"],
+      [sha(3), "refs/tags/v1.13.0.dev1^{}"],
+    ]),
+    imageTags("1.13.0.dev0", ["1.13.0.dev1"]),
+  );
+  assert.equal(d.strategy, "published-image");
+  assert.equal(d.version, "1.13.0.dev0");
+  assert.equal(d.sha, sha(2), "the commit must be the one of the PUBLISHED version");
+  assert.match(d.digest, /^sha256:a+$/);
+});
+
+test("a release branch cut ahead of the image does not drag the answer with it", () => {
+  // release-1.14.0 exists before any nightly is built from it; `latest` is still the
+  // previous cycle. Branch-first resolution flips a whole cycle ahead of reality.
+  const d = resolveTargetVersion(
+    refs([
+      [sha(1), "refs/heads/release-1.13.0"],
+      [sha(2), "refs/heads/release-1.14.0"],
+      [sha(3), "refs/tags/v1.13.0.dev5^{}"],
+    ]),
+    imageTags("1.13.0.dev5"),
+  );
+  assert.equal(d.version, "1.13.0.dev5");
+  assert.equal(d.branch, "release-1.13.0");
+});
+
+test("the amd64 digest is the one matched, not whatever comes first", () => {
+  // Both lanes run amd64. Matching an arm64 digest finds nothing and drops the whole
+  // resolution to the fallback without saying why.
+  const payload = JSON.parse(imageTags("1.13.0.dev2"));
+  for (const t of payload.results) t.images.reverse();
+  const d = resolveTargetVersion(refs([[sha(1), "refs/heads/release-1.13.0"]]), JSON.stringify(payload));
+  assert.equal(d.strategy, "published-image");
+  assert.equal(d.version, "1.13.0.dev2");
+});
+
+test("an unreadable image listing falls back to the refs, naming what that costs", () => {
+  const d = resolveTargetVersion(
+    refs([
+      [sha(1), "refs/heads/release-1.13.0"],
+      [sha(2), "refs/tags/v1.13.0.dev1^{}"],
+    ]),
+    "not json at all",
+  );
+  assert.equal(d.strategy, "nightly-tag");
+  assert.equal(d.version, "1.13.0.dev1");
+  assert.match(d.warnings.join(" "), /before the image is built/);
+});
+
+test("a published version with no matching tag keeps the version and drops the commit", () => {
+  const d = resolveTargetVersion(refs([[sha(1), "refs/heads/release-1.13.0"]]), imageTags("1.13.0.dev9"));
+  assert.equal(d.version, "1.13.0.dev9");
+  assert.equal(d.sha, "");
+  assert.match(d.warnings.join(" "), /exact commit of the published image is unknown/);
+});
+
+test("published-image compares exactly, like the tag it replaced", () => {
+  assert.equal(compareVersions("1.13.0.dev0", "1.13.0.dev0", "published-image").match, "yes");
+  assert.equal(compareVersions("1.13.0.dev0", "1.13.0.dev1", "published-image").match, "no");
+});
+
 test("comparing under nightly-tag is exact", () => {
   assert.equal(compareVersions("1.13.0.dev1", "1.13.0.dev1", "nightly-tag").match, "yes");
   const bad = compareVersions("1.13.0.dev1", "1.12.0", "nightly-tag");
@@ -131,6 +218,19 @@ test("comparing under branch-head accepts the cycle, because the .devN is not ou
   const r = compareVersions("1.13.0", "1.13.0", "branch-head");
   assert.equal(r.match, "cycle");
   assert.equal(compareVersions("1.13.0", "1.12.0", "branch-head").match, "no");
+});
+
+test("an unrecognised strategy is UNKNOWN, never the looser comparison", () => {
+  // One character decides whether a different commit is a mismatch or a pass, and
+  // the looser rule is the one that answers when nobody recognises the strategy.
+  for (const bogus of ["nightlytag", "", "branch head", undefined]) {
+    const r = compareVersions("1.13.0.dev1", "1.13.0.dev0", bogus);
+    assert.equal(r.match, "unknown", String(bogus));
+    assert.match(r.reason, /unrecognised resolution strategy/);
+  }
+  // And the same inputs under the real strategy are still a mismatch, which is what
+  // makes the fallback dangerous rather than merely wrong.
+  assert.equal(compareVersions("1.13.0.dev1", "1.13.0.dev0", "nightly-tag").match, "no");
 });
 
 test("a missing version on either side is UNKNOWN, never a pass", () => {

--- a/scripts/resolve-target-version.test.mjs
+++ b/scripts/resolve-target-version.test.mjs
@@ -1,0 +1,158 @@
+// Unit tests for scripts/resolve-target-version.mjs.
+// Run with: npm run test:scripts
+//
+// What these protect: the answer to "which Langflow should the VM be testing?", which
+// is upstream's rule and not ours. Every failure mode here is silent — a wrong answer
+// still resolves, the run still goes green, and the divergence list quietly fills with
+// product changelog described as environment differences.
+//
+//   - Numeric ordering. `release-1.9.0` sorts ABOVE `release-1.12.0` as a string, so
+//     a lexicographic compare pins the lane a cycle behind and nothing complains.
+//   - `main` is never the answer. It is only where the nightly workflow file lives;
+//     the image is built from a release branch.
+//   - The PEELED sha of an annotated tag. ls-remote prints two lines per annotated
+//     tag, and the unpeeled one is the tag object — checking that out leaves HEAD at
+//     a different commit than the image was built from, which is exactly the class of
+//     "close enough" this whole step exists to remove.
+//   - Cycle parity and commit parity are DIFFERENT claims, and the comparison must
+//     not report a mismatch for a correctly placed clone under branch-head, or the
+//     check gets ignored the first week.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { resolveTargetVersion, compareVersions } from "./resolve-target-version.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, "resolve-target-version.mjs");
+
+const sha = (n) => String(n).repeat(40).slice(0, 40);
+
+function refs(lines) {
+  return lines.map(([s, r]) => `${s}\t${r}`).join("\n") + "\n";
+}
+
+test("the newest release branch is chosen NUMERICALLY, not as a string", () => {
+  // The trap: "release-1.9.0" > "release-1.12.0" lexicographically.
+  const d = resolveTargetVersion(
+    refs([
+      [sha(1), "refs/heads/release-1.9.0"],
+      [sha(2), "refs/heads/release-1.12.0"],
+      [sha(3), "refs/heads/release-1.11.6"],
+    ]),
+  );
+  assert.equal(d.ok, true);
+  assert.equal(d.branch, "release-1.12.0");
+});
+
+test("main is never the answer, and neither is any other branch shape", () => {
+  const d = resolveTargetVersion(
+    refs([
+      [sha(1), "refs/heads/main"],
+      [sha(2), "refs/heads/release-1.13.0"],
+      [sha(3), "refs/heads/1.11.0-merge"],
+      [sha(4), "refs/heads/release-1.13.0-rc1"],
+      [sha(5), "refs/heads/add-ep-build-to-nightly"],
+    ]),
+  );
+  assert.equal(d.branch, "release-1.13.0");
+});
+
+test("the newest nightly tag of that cycle wins, with the PEELED commit", () => {
+  const d = resolveTargetVersion(
+    refs([
+      [sha(1), "refs/heads/release-1.13.0"],
+      [sha(2), "refs/tags/v1.13.0.dev0"],
+      [sha(3), "refs/tags/v1.13.0.dev0^{}"],
+      [sha(4), "refs/tags/v1.13.0.dev1"],
+      [sha(5), "refs/tags/v1.13.0.dev1^{}"],
+    ]),
+  );
+  assert.equal(d.strategy, "nightly-tag");
+  assert.equal(d.version, "1.13.0.dev1");
+  assert.equal(d.ref, "v1.13.0.dev1");
+  // The peeled entry, not the tag object: checking out the latter leaves HEAD
+  // somewhere the image never was.
+  assert.equal(d.sha, sha(5));
+});
+
+test("dev numbers are ordered numerically too — dev9 does not beat dev10", () => {
+  const d = resolveTargetVersion(
+    refs([
+      [sha(1), "refs/heads/release-1.13.0"],
+      [sha(2), "refs/tags/v1.13.0.dev9^{}"],
+      [sha(3), "refs/tags/v1.13.0.dev10^{}"],
+    ]),
+  );
+  assert.equal(d.version, "1.13.0.dev10");
+});
+
+test("a tag from another cycle is ignored, however new it looks", () => {
+  const d = resolveTargetVersion(
+    refs([
+      [sha(1), "refs/heads/release-1.12.0"],
+      [sha(2), "refs/tags/v1.13.0.dev5^{}"],
+      [sha(3), "refs/tags/v1.12.0.dev45^{}"],
+    ]),
+  );
+  assert.equal(d.version, "1.12.0.dev45");
+});
+
+test("no tag yet falls back to the branch head, and SAYS it is only cycle parity", () => {
+  const d = resolveTargetVersion(refs([[sha(7), "refs/heads/release-1.14.0"]]));
+  assert.equal(d.ok, true);
+  assert.equal(d.strategy, "branch-head");
+  assert.equal(d.sha, sha(7));
+  assert.equal(d.version, "1.14.0");
+  assert.match(d.warnings.join(" "), /CYCLE, not of commit/);
+});
+
+test("no release branch at all is an error that names the rule, not a fallback to main", () => {
+  const d = resolveTargetVersion(refs([[sha(1), "refs/heads/main"]]));
+  assert.equal(d.ok, false);
+  assert.match(d.error, /release-X\.Y\.Z/);
+  assert.match(d.error, /main/);
+});
+
+test("comparing under nightly-tag is exact", () => {
+  assert.equal(compareVersions("1.13.0.dev1", "1.13.0.dev1", "nightly-tag").match, "yes");
+  const bad = compareVersions("1.13.0.dev1", "1.12.0", "nightly-tag");
+  assert.equal(bad.match, "no");
+  assert.match(bad.reason, /1\.12\.0/);
+});
+
+test("comparing under branch-head accepts the cycle, because the .devN is not ours to expect", () => {
+  // A source clone at the branch head reports `1.13.0`; the CI's image reports
+  // `1.13.0.dev1`. Calling that a mismatch would be a false alarm on a correctly
+  // placed clone — the fastest way to get a check ignored.
+  const r = compareVersions("1.13.0", "1.13.0", "branch-head");
+  assert.equal(r.match, "cycle");
+  assert.equal(compareVersions("1.13.0", "1.12.0", "branch-head").match, "no");
+});
+
+test("a missing version on either side is UNKNOWN, never a pass", () => {
+  assert.equal(compareVersions("1.13.0.dev1", "", "nightly-tag").match, "unknown");
+  assert.equal(compareVersions("", "1.13.0", "nightly-tag").match, "unknown");
+});
+
+test("the CLI prints JSON and exits 0, or exits 1 with the decision still readable", () => {
+  const dir = mkdtempSync(join(tmpdir(), "resolve-target-version-test-"));
+  const good = join(dir, "good.txt");
+  const bad = join(dir, "bad.txt");
+  writeFileSync(good, refs([[sha(1), "refs/heads/release-1.13.0"]]));
+  writeFileSync(bad, refs([[sha(1), "refs/heads/main"]]));
+
+  const ok = spawnSync(process.execPath, [SCRIPT, "--refs-file", good], { encoding: "utf8" });
+  assert.equal(ok.status, 0);
+  assert.equal(JSON.parse(ok.stdout).branch, "release-1.13.0");
+
+  const fail = spawnSync(process.execPath, [SCRIPT, "--refs-file", bad], { encoding: "utf8" });
+  assert.equal(fail.status, 1);
+  // Printed even on failure: the caller quotes the reason rather than inventing one.
+  assert.equal(JSON.parse(fail.stdout).ok, false);
+
+  rmSync(dir, { recursive: true, force: true });
+});

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -128,6 +128,11 @@ WORKFLOW_ID="${WORKFLOW_ID:-daily-stable-vm}"
 # change, and until it lands a mismatch has to be visible rather than fatal, or a
 # whole day of comparison data is lost to a version difference nobody can fix at 08:00.
 UPSTREAM_REPO_URL="${UPSTREAM_REPO_URL:-https://github.com/langflow-ai/langflow}"
+# The PUBLISHED image is what the CI lane pulls, and therefore what this lane has to
+# match. Asking the registry rather than the git tags is not a detail: upstream tags
+# before it builds and only ships if the tests pass, so a tag can exist for an image
+# that never shipped.
+NIGHTLY_TAGS_URL="${NIGHTLY_TAGS_URL:-https://hub.docker.com/v2/repositories/langflowai/langflow-nightly/tags?page_size=100}"
 CHECK_TARGET_VERSION="${CHECK_TARGET_VERSION:-1}"
 REQUIRE_TARGET_VERSION="${REQUIRE_TARGET_VERSION:-0}"
 
@@ -292,18 +297,36 @@ phase_preflight() {
   # What the CI will be testing today, resolved by upstream's own rule. Informational
   # here and compared after the run: asking now means the operator sees the gap before
   # spending an hour producing a comparison that a version difference already spoiled.
-  TARGET_EXPECTED_VERSION=""; TARGET_EXPECTED_REF=""; TARGET_RESOLUTION=""
+  TARGET_EXPECTED_VERSION=""; TARGET_EXPECTED_REF=""; TARGET_EXPECTED_SHA=""; TARGET_RESOLUTION=""
   if [ "$CHECK_TARGET_VERSION" = "1" ]; then
-    if git ls-remote --heads --tags "$UPSTREAM_REPO_URL" > "$RUN_DIR/upstream-refs.txt" 2>> "$RUN_DIR/logs/target-version.log"; then
+    local vlog="$RUN_DIR/logs/target-version.log" verr="$RUN_DIR/logs/target-version.err"
+    # The registry listing is optional and its absence is survivable — the resolver
+    # falls back to the refs and says so — so a failure here warns and continues.
+    curl -sfS --max-time 20 "$NIGHTLY_TAGS_URL" -o "$RUN_DIR/nightly-tags.json" 2>> "$vlog" \
+      || warn "could not read the published nightly image listing; the expected version will come from the git refs, which can run ahead of what actually shipped."
+    if git ls-remote --heads --tags "$UPSTREAM_REPO_URL" > "$RUN_DIR/upstream-refs.txt" 2>> "$vlog"; then
       local decision
-      decision="$(node scripts/resolve-target-version.mjs --refs-file "$RUN_DIR/upstream-refs.txt" 2>> "$RUN_DIR/logs/target-version.log" || true)"
+      decision="$(node scripts/resolve-target-version.mjs \
+        --refs-file "$RUN_DIR/upstream-refs.txt" \
+        --image-tags-file "$RUN_DIR/nightly-tags.json" 2> "$verr" || true)"
+      # The resolver's warnings are the difference between "same commit" and "same
+      # cycle". Shown, not just filed: a run that silently downgraded its own claim
+      # is how a comparison starts meaning less than the reader thinks.
+      if [ -s "$verr" ]; then cat "$verr" >&2; cat "$verr" >> "$vlog"; fi
       if [ -n "$decision" ] && [ "$(node -p "try{JSON.parse(process.argv[1]).ok===true?'true':'false'}catch{'false'}" "$decision")" = "true" ]; then
         TARGET_EXPECTED_VERSION="$(node -p "JSON.parse(process.argv[1]).version||''" "$decision")"
         TARGET_EXPECTED_REF="$(node -p "JSON.parse(process.argv[1]).ref||''" "$decision")"
+        TARGET_EXPECTED_SHA="$(node -p "JSON.parse(process.argv[1]).sha||''" "$decision")"
         TARGET_RESOLUTION="$(node -p "JSON.parse(process.argv[1]).strategy||''" "$decision")"
-        info "target should be: $TARGET_EXPECTED_VERSION (ref $TARGET_EXPECTED_REF, by $TARGET_RESOLUTION)"
+        info "target should be: $TARGET_EXPECTED_VERSION (ref $TARGET_EXPECTED_REF, commit ${TARGET_EXPECTED_SHA:0:10}, by $TARGET_RESOLUTION)"
       else
-        warn "could not resolve which Langflow this lane should test — the comparison will not know whether both sides ran the same product."
+        # Quote the resolver rather than inventing a reason: it distinguishes "no
+        # release branch in the listing" from "the file could not be read", and the
+        # two send the reader to different places.
+        local why
+        why="$(node -p "try{JSON.parse(process.argv[1]).error||''}catch{''}" "${decision:-}" 2>/dev/null || true)"
+        warn "could not resolve which Langflow this lane should test${why:+ — $why}"
+        warn "The comparison will not know whether both sides ran the same product."
       fi
     else
       warn "could not reach $UPSTREAM_REPO_URL to resolve the expected Langflow version."
@@ -736,6 +759,8 @@ phase_merge() {
     langflow_version "${LANGFLOW_VERSION:-}" \
     langflow_expected_version "${TARGET_EXPECTED_VERSION:-}" \
     langflow_expected_ref "${TARGET_EXPECTED_REF:-}" \
+    langflow_expected_sha "${TARGET_EXPECTED_SHA:-}" \
+    langflow_version_resolution "${TARGET_RESOLUTION:-}" \
     langflow_version_match "${TARGET_VERSION_MATCH:-unchecked}" \
     shards "$SHARD_TOTAL" \
     tunnel "$LANGFLOW_TUNNEL" \
@@ -868,11 +893,27 @@ phase_verdict() {
     err "at least one shard had a failing test."
     failed=1
   fi
-  if [ "$REQUIRE_TARGET_VERSION" = "1" ] && [ "${TARGET_VERSION_MATCH:-unchecked}" = "no" ]; then
-    err "the target served the wrong Langflow — ${TARGET_VERSION_REASON:-no reason recorded}."
-    err "REQUIRE_TARGET_VERSION=1 makes that fatal: a comparison between different"
-    err "products describes the changelog, not the environments."
-    failed=1
+  if [ "$REQUIRE_TARGET_VERSION" = "1" ]; then
+    case "${TARGET_VERSION_MATCH:-unchecked}" in
+      no)
+        err "the target served the wrong Langflow — ${TARGET_VERSION_REASON:-no reason recorded}."
+        err "REQUIRE_TARGET_VERSION=1 makes that fatal: a comparison between different"
+        err "products describes the changelog, not the environments."
+        failed=1
+        ;;
+      yes | cycle) ;;
+      *)
+        # "Require" has to require. Every way the check itself can fail — the registry
+        # or github unreachable, the resolver erroring, the target reporting no version
+        # — lands here, and passing green on those is passing green precisely when
+        # nobody can tell whether the two lanes ran the same product.
+        err "the version check could not be performed (${TARGET_VERSION_MATCH:-unchecked}${TARGET_VERSION_REASON:+: $TARGET_VERSION_REASON})."
+        err "REQUIRE_TARGET_VERSION=1 asks for a guarantee, and an unperformed check is"
+        err "not a weaker guarantee — it is none. Set CHECK_TARGET_VERSION=1 and make the"
+        err "resolution work, or drop REQUIRE_TARGET_VERSION."
+        failed=1
+        ;;
+    esac
   fi
   [ "$failed" = "0" ] && log "Green run." || true
   return $failed

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -122,6 +122,15 @@ REPORT_URL="$RUN_URL_BASE/$RUN_ID/playwright-report/index.html"
 EVENT_NAME="${EVENT_NAME:-schedule}"
 WORKFLOW_ID="${WORKFLOW_ID:-daily-stable-vm}"
 
+# Which Langflow this lane SHOULD be testing. The rule is upstream's — the newest
+# `release-X.Y.Z` branch, never `main` — and scripts/resolve-target-version.mjs owns
+# it. Here the run only REPORTS the gap: moving and rebuilding the clone is a second
+# change, and until it lands a mismatch has to be visible rather than fatal, or a
+# whole day of comparison data is lost to a version difference nobody can fix at 08:00.
+UPSTREAM_REPO_URL="${UPSTREAM_REPO_URL:-https://github.com/langflow-ai/langflow}"
+CHECK_TARGET_VERSION="${CHECK_TARGET_VERSION:-1}"
+REQUIRE_TARGET_VERSION="${REQUIRE_TARGET_VERSION:-0}"
+
 MIN_FREE_GB="${MIN_FREE_GB:-20}"
 DRY_RUN="${DRY_RUN:-0}"
 KEEP_BACKENDS="${KEEP_BACKENDS:-0}"
@@ -279,6 +288,27 @@ phase_preflight() {
   local behind
   behind="$(git rev-list --count "HEAD..origin/$branch" 2>/dev/null || echo 0)"
   info "suite: $branch @ ${sha:0:10}${behind:+ ($behind commit(s) behind origin)}"
+
+  # What the CI will be testing today, resolved by upstream's own rule. Informational
+  # here and compared after the run: asking now means the operator sees the gap before
+  # spending an hour producing a comparison that a version difference already spoiled.
+  TARGET_EXPECTED_VERSION=""; TARGET_EXPECTED_REF=""; TARGET_RESOLUTION=""
+  if [ "$CHECK_TARGET_VERSION" = "1" ]; then
+    if git ls-remote --heads --tags "$UPSTREAM_REPO_URL" > "$RUN_DIR/upstream-refs.txt" 2>> "$RUN_DIR/logs/target-version.log"; then
+      local decision
+      decision="$(node scripts/resolve-target-version.mjs --refs-file "$RUN_DIR/upstream-refs.txt" 2>> "$RUN_DIR/logs/target-version.log" || true)"
+      if [ -n "$decision" ] && [ "$(node -p "try{JSON.parse(process.argv[1]).ok===true?'true':'false'}catch{'false'}" "$decision")" = "true" ]; then
+        TARGET_EXPECTED_VERSION="$(node -p "JSON.parse(process.argv[1]).version||''" "$decision")"
+        TARGET_EXPECTED_REF="$(node -p "JSON.parse(process.argv[1]).ref||''" "$decision")"
+        TARGET_RESOLUTION="$(node -p "JSON.parse(process.argv[1]).strategy||''" "$decision")"
+        info "target should be: $TARGET_EXPECTED_VERSION (ref $TARGET_EXPECTED_REF, by $TARGET_RESOLUTION)"
+      else
+        warn "could not resolve which Langflow this lane should test — the comparison will not know whether both sides ran the same product."
+      fi
+    else
+      warn "could not reach $UPSTREAM_REPO_URL to resolve the expected Langflow version."
+    fi
+  fi
 
   log "Installing dependencies (npm ci)"
   npm ci
@@ -669,6 +699,28 @@ phase_merge() {
     [ -n "$LANGFLOW_VERSION" ] && break
   done
 
+  # The comparison this step exists for. A mismatch is reported, not fatal: while the
+  # clone is moved by hand, failing here would throw away a day of otherwise usable
+  # data. REQUIRE_TARGET_VERSION=1 flips that once the run moves the clone itself.
+  TARGET_VERSION_MATCH="unchecked"; TARGET_VERSION_REASON=""
+  if [ "$CHECK_TARGET_VERSION" = "1" ] && [ -n "$TARGET_EXPECTED_VERSION" ]; then
+    local compared
+    compared="$(node scripts/resolve-target-version.mjs --compare "$TARGET_EXPECTED_VERSION" "${LANGFLOW_VERSION:-}" "$TARGET_RESOLUTION" 2>/dev/null || true)"
+    TARGET_VERSION_MATCH="${compared%%	*}"
+    TARGET_VERSION_REASON="${compared#*	}"
+    case "$TARGET_VERSION_MATCH" in
+      yes | cycle) info "target version: $TARGET_VERSION_MATCH — $TARGET_VERSION_REASON" ;;
+      no)
+        warn "TARGET VERSION MISMATCH — $TARGET_VERSION_REASON"
+        warn "Every product difference between those two lands in this run's verdict, and"
+        warn "the comparison with the Actions daily will read it as an environment"
+        warn "divergence. Move the clone to $TARGET_EXPECTED_REF and rebuild before"
+        warn "treating today's differences as findings."
+        ;;
+      *) warn "target version: could not be compared — $TARGET_VERSION_REASON" ;;
+    esac
+  fi
+
   # Both versions in one place, because the whole point of this lane is comparing a
   # verdict with the CI's and neither number is guessable afterwards.
   node -e '
@@ -682,6 +734,9 @@ phase_merge() {
     suite_sha "$(git rev-parse HEAD)" \
     suite_branch "$(git rev-parse --abbrev-ref HEAD)" \
     langflow_version "${LANGFLOW_VERSION:-}" \
+    langflow_expected_version "${TARGET_EXPECTED_VERSION:-}" \
+    langflow_expected_ref "${TARGET_EXPECTED_REF:-}" \
+    langflow_version_match "${TARGET_VERSION_MATCH:-unchecked}" \
     shards "$SHARD_TOTAL" \
     tunnel "$LANGFLOW_TUNNEL" \
     tests_total "${RUN_TESTS:-0}"
@@ -811,6 +866,12 @@ phase_verdict() {
   fi
   if [ "${TEST_JOB_FAILED:-0}" = "1" ]; then
     err "at least one shard had a failing test."
+    failed=1
+  fi
+  if [ "$REQUIRE_TARGET_VERSION" = "1" ] && [ "${TARGET_VERSION_MATCH:-unchecked}" = "no" ]; then
+    err "the target served the wrong Langflow — ${TARGET_VERSION_REASON:-no reason recorded}."
+    err "REQUIRE_TARGET_VERSION=1 makes that fatal: a comparison between different"
+    err "products describes the changelog, not the environments."
     failed=1
   fi
   [ "$failed" = "0" ] && log "Green run." || true

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -132,7 +132,11 @@ UPSTREAM_REPO_URL="${UPSTREAM_REPO_URL:-https://github.com/langflow-ai/langflow}
 # match. Asking the registry rather than the git tags is not a detail: upstream tags
 # before it builds and only ships if the tests pass, so a tag can exist for an image
 # that never shipped.
-NIGHTLY_TAGS_URL="${NIGHTLY_TAGS_URL:-https://hub.docker.com/v2/repositories/langflowai/langflow-nightly/tags?page_size=100}"
+# `ordering=last_updated` is not decoration: the repository carries ~2700 tags and one
+# page is fetched, so an unspecified order can leave `latest` and the version tag
+# pushed in the same run on different pages — and the resolution then falls back to
+# the git refs, quietly, for a reason that has nothing to do with the registry.
+NIGHTLY_TAGS_URL="${NIGHTLY_TAGS_URL:-https://hub.docker.com/v2/repositories/langflowai/langflow-nightly/tags?page_size=100&ordering=last_updated}"
 CHECK_TARGET_VERSION="${CHECK_TARGET_VERSION:-1}"
 REQUIRE_TARGET_VERSION="${REQUIRE_TARGET_VERSION:-0}"
 

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -136,6 +136,12 @@ UPSTREAM_REPO_URL="${UPSTREAM_REPO_URL:-https://github.com/langflow-ai/langflow}
 # page is fetched, so an unspecified order can leave `latest` and the version tag
 # pushed in the same run on different pages — and the resolution then falls back to
 # the git refs, quietly, for a reason that has nothing to do with the registry.
+#
+# The repository named here has to be the one the ACTIONS lane pulls. daily-stable.yml
+# takes `langflow_image` / `langflow_image_tag` inputs on manual dispatch, so a run
+# against `langflowai/langflow:1.12.0` would be compared with an expectation resolved
+# from `langflow-nightly:latest` — a comparison of a different pair of lanes than the
+# one it claims. Override this together with those inputs, never one alone.
 NIGHTLY_TAGS_URL="${NIGHTLY_TAGS_URL:-https://hub.docker.com/v2/repositories/langflowai/langflow-nightly/tags?page_size=100&ordering=last_updated}"
 CHECK_TARGET_VERSION="${CHECK_TARGET_VERSION:-1}"
 REQUIRE_TARGET_VERSION="${REQUIRE_TARGET_VERSION:-0}"
@@ -308,32 +314,38 @@ phase_preflight() {
     # falls back to the refs and says so — so a failure here warns and continues.
     curl -sfS --max-time 20 "$NIGHTLY_TAGS_URL" -o "$RUN_DIR/nightly-tags.json" 2>> "$vlog" \
       || warn "could not read the published nightly image listing; the expected version will come from the git refs, which can run ahead of what actually shipped."
-    if git ls-remote --heads --tags "$UPSTREAM_REPO_URL" > "$RUN_DIR/upstream-refs.txt" 2>> "$vlog"; then
-      local decision
-      decision="$(node scripts/resolve-target-version.mjs \
+    # Both inputs are best-effort, and NEITHER gates the other. The registry answers
+    # the question — which version — and the refs only add which commit that version
+    # was built from. Gating the whole resolution on the git fetch (as this did) hands
+    # github.com a veto over an answer it does not provide: github unreachable at
+    # 08:00, registry fine, and the run would report an unperformed check — fatal
+    # under REQUIRE_TARGET_VERSION. github is also the flakier of the two here, since
+    # the suite's own origin is the internal mirror and this is the only reach out.
+    : > "$RUN_DIR/upstream-refs.txt"
+    git ls-remote --heads --tags "$UPSTREAM_REPO_URL" > "$RUN_DIR/upstream-refs.txt" 2>> "$vlog" \
+      || warn "could not reach $UPSTREAM_REPO_URL for the ref listing; the expected VERSION can still come from the registry, but the commit behind it will be unknown."
+    local decision
+    decision="$(node scripts/resolve-target-version.mjs \
         --refs-file "$RUN_DIR/upstream-refs.txt" \
         --image-tags-file "$RUN_DIR/nightly-tags.json" 2> "$verr" || true)"
-      # The resolver's warnings are the difference between "same commit" and "same
-      # cycle". Shown, not just filed: a run that silently downgraded its own claim
-      # is how a comparison starts meaning less than the reader thinks.
-      if [ -s "$verr" ]; then cat "$verr" >&2; cat "$verr" >> "$vlog"; fi
-      if [ -n "$decision" ] && [ "$(node -p "try{JSON.parse(process.argv[1]).ok===true?'true':'false'}catch{'false'}" "$decision")" = "true" ]; then
-        TARGET_EXPECTED_VERSION="$(node -p "JSON.parse(process.argv[1]).version||''" "$decision")"
-        TARGET_EXPECTED_REF="$(node -p "JSON.parse(process.argv[1]).ref||''" "$decision")"
-        TARGET_EXPECTED_SHA="$(node -p "JSON.parse(process.argv[1]).sha||''" "$decision")"
-        TARGET_RESOLUTION="$(node -p "JSON.parse(process.argv[1]).strategy||''" "$decision")"
-        info "target should be: $TARGET_EXPECTED_VERSION (ref $TARGET_EXPECTED_REF, commit ${TARGET_EXPECTED_SHA:0:10}, by $TARGET_RESOLUTION)"
-      else
-        # Quote the resolver rather than inventing a reason: it distinguishes "no
-        # release branch in the listing" from "the file could not be read", and the
-        # two send the reader to different places.
-        local why
-        why="$(node -p "try{JSON.parse(process.argv[1]).error||''}catch{''}" "${decision:-}" 2>/dev/null || true)"
-        warn "could not resolve which Langflow this lane should test${why:+ — $why}"
-        warn "The comparison will not know whether both sides ran the same product."
-      fi
+    # The resolver's warnings are the difference between "same commit" and "same
+    # cycle". Shown, not just filed: a run that silently downgraded its own claim
+    # is how a comparison starts meaning less than the reader thinks.
+    if [ -s "$verr" ]; then cat "$verr" >&2; cat "$verr" >> "$vlog"; fi
+    if [ -n "$decision" ] && [ "$(node -p "try{JSON.parse(process.argv[1]).ok===true?'true':'false'}catch{'false'}" "$decision")" = "true" ]; then
+      TARGET_EXPECTED_VERSION="$(node -p "JSON.parse(process.argv[1]).version||''" "$decision")"
+      TARGET_EXPECTED_REF="$(node -p "JSON.parse(process.argv[1]).ref||''" "$decision")"
+      TARGET_EXPECTED_SHA="$(node -p "JSON.parse(process.argv[1]).sha||''" "$decision")"
+      TARGET_RESOLUTION="$(node -p "JSON.parse(process.argv[1]).strategy||''" "$decision")"
+      info "target should be: $TARGET_EXPECTED_VERSION (ref $TARGET_EXPECTED_REF, commit ${TARGET_EXPECTED_SHA:0:10}, by $TARGET_RESOLUTION)"
     else
-      warn "could not reach $UPSTREAM_REPO_URL to resolve the expected Langflow version."
+      # Quote the resolver rather than inventing a reason: it distinguishes "no
+      # release branch in the listing" from "the file could not be read", and the
+      # two send the reader to different places.
+      local why
+      why="$(node -p "try{JSON.parse(process.argv[1]).error||''}catch{''}" "${decision:-}" 2>/dev/null || true)"
+      warn "could not resolve which Langflow this lane should test${why:+ — $why}"
+      warn "The comparison will not know whether both sides ran the same product."
     fi
   fi
 
@@ -738,7 +750,7 @@ phase_merge() {
     case "$TARGET_VERSION_MATCH" in
       yes | cycle) info "target version: $TARGET_VERSION_MATCH — $TARGET_VERSION_REASON" ;;
       no)
-        warn "TARGET VERSION MISMATCH — $TARGET_VERSION_REASON"
+        warn "TARGET VERSION MISMATCH (by $TARGET_RESOLUTION) — $TARGET_VERSION_REASON"
         warn "Every product difference between those two lands in this run's verdict, and"
         warn "the comparison with the Actions daily will read it as an environment"
         warn "divergence. Move the clone to $TARGET_EXPECTED_REF and rebuild before"
@@ -900,9 +912,21 @@ phase_verdict() {
   if [ "$REQUIRE_TARGET_VERSION" = "1" ]; then
     case "${TARGET_VERSION_MATCH:-unchecked}" in
       no)
-        err "the target served the wrong Langflow — ${TARGET_VERSION_REASON:-no reason recorded}."
-        err "REQUIRE_TARGET_VERSION=1 makes that fatal: a comparison between different"
-        err "products describes the changelog, not the environments."
+        if [ "${TARGET_RESOLUTION:-}" = "published-image" ]; then
+          err "the target served the wrong Langflow — ${TARGET_VERSION_REASON:-no reason recorded}."
+          err "REQUIRE_TARGET_VERSION=1 makes that fatal: a comparison between different"
+          err "products describes the changelog, not the environments."
+        else
+          # The expectation came from the git refs, which run AHEAD of what shipped —
+          # upstream tags before it builds. So this may not be a real mismatch, and
+          # asserting one would be asserting something the source cannot support. It
+          # still fails under REQUIRE, because an expectation that cannot be trusted is
+          # not a guarantee either; what changes is the claim.
+          err "the version check could not be established authoritatively: the expectation"
+          err "came from ${TARGET_RESOLUTION:-an unknown resolution}, not from the published image, and that"
+          err "source runs ahead of what shipped. Reported difference: ${TARGET_VERSION_REASON:-none recorded}."
+          err "REQUIRE_TARGET_VERSION=1 asks for a guarantee the registry was silent about."
+        fi
         failed=1
         ;;
       yes | cycle) ;;

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -203,6 +203,25 @@ gh_out() {
 
 HELD_SESSIONS=()
 
+# Which of the given ports have no local listener. `ssh -L` opens its listener as soon
+# as it connects, so this is answerable before anything else starts.
+#
+# The probe runs in a SUBSHELL, and that is the whole point: the descriptor it opens
+# dies with the subshell, so the caller needs no `exec 3>&-` to clean up. The version
+# that did have one carried `2>/dev/null` with it — and `exec` with no command applies
+# its redirections to THE SHELL, which sent stderr to /dev/null for the rest of the
+# run. Every warn and every err after preflight vanished, including the verdict's own
+# explanation of why it failed: the exit code stayed right and the reason stopped
+# existing. A smoke run found it; two reviews had not.
+ports_without_listener() {
+  local port
+  for port in "$@"; do
+    if ! (exec 3<> "/dev/tcp/127.0.0.1/${port}") 2> /dev/null; then
+      printf '%s\n' "$port"
+    fi
+  done
+}
+
 cleanup() {
   local code=$?
   if [ "$KEEP_BACKENDS" = "1" ]; then
@@ -369,14 +388,11 @@ phase_preflight() {
   # as soon as it connects, so this is answerable now — and answering it later, from a
   # failed health probe, cannot tell "no tunnel" from "backend did not start".
   if [ "$LANGFLOW_TUNNEL" = "1" ]; then
-    local i port missing=()
-    for i in $(seq 1 "$SHARDS"); do
-      port=$((BASE_PORT + i - 1))
-      if ! (exec 3<> "/dev/tcp/127.0.0.1/$port") 2>/dev/null; then missing+=("$port"); fi
-      exec 3>&- 2>/dev/null || true
-    done
-    if [ "${#missing[@]}" -gt 0 ]; then
-      err "no local listener on port(s): ${missing[*]}"
+    local missing
+    missing="$(ports_without_listener $(seq "$BASE_PORT" $((BASE_PORT + SHARDS - 1))) | tr '\n' ' ')"
+    missing="${missing% }"
+    if [ -n "$missing" ]; then
+      err "no local listener on port(s): ${missing}"
       err "The tunnel to the target is what makes the backend answer on localhost, and"
       err "Chromium treats ONLY localhost as a secure context: without it the ten"
       err "clipboard specs fail deterministically and this run's verdict differs from"

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -148,10 +148,10 @@ test("a version mismatch does not fail the run on its own", () => {
   assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 0);
 });
 
-test("REQUIRE_TARGET_VERSION=1 makes the mismatch fatal, naming what it costs", () => {
+test("REQUIRE_TARGET_VERSION=1 makes an AUTHORITATIVE mismatch fatal, naming what it costs", () => {
   const r = sourced(
     `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
-      `TARGET_VERSION_MATCH=no TARGET_VERSION_REASON="expected 1.13.0.dev1, served 1.12.0"\n` +
+      `TARGET_VERSION_MATCH=no TARGET_RESOLUTION=published-image TARGET_VERSION_REASON="expected 1.13.0.dev1, served 1.12.0"\n` +
       `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
     { REQUIRE_TARGET_VERSION: "1" },
   );
@@ -160,6 +160,24 @@ test("REQUIRE_TARGET_VERSION=1 makes the mismatch fatal, naming what it costs", 
   // The reason a reader needs: not "versions differ" but what a comparison between
   // different products actually produces.
   assert.match(r.stderr, /describes the changelog, not the environments/);
+});
+
+test("a mismatch the REGISTRY did not establish still fails, but claims less", () => {
+  // Chain the two failure modes: a registry blip drops the resolution to the git refs,
+  // those legitimately run ahead of the published image, and the comparison then
+  // reports a difference that may not exist between the lanes. It still fails under
+  // REQUIRE — an expectation that cannot be trusted is not a guarantee — but asserting
+  // "the target served the wrong Langflow" would assert what the source cannot support.
+  const r = sourced(
+    `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
+      `TARGET_VERSION_MATCH=no TARGET_RESOLUTION=nightly-tag TARGET_VERSION_REASON="expected 1.13.0.dev1, served 1.13.0.dev0"\n` +
+      `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
+    { REQUIRE_TARGET_VERSION: "1" },
+  );
+  assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 1);
+  assert.match(r.stderr, /could not be established authoritatively/);
+  assert.match(r.stderr, /runs ahead of what shipped/);
+  assert.doesNotMatch(r.stderr, /served the wrong Langflow/);
 });
 
 test("a matching version passes under REQUIRE, exactly or by cycle", () => {

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -220,6 +220,26 @@ test("without REQUIRE, none of the version states fail the run", () => {
   }
 });
 
+test("the tunnel probe leaves the shell's stderr alone", () => {
+  // The bug this pins cost a whole run's diagnostics: the probe used to close its
+  // descriptor with `exec 3>&- 2>/dev/null`, and `exec` with no command applies its
+  // redirections to THE SHELL — so stderr went to /dev/null for the rest of the run.
+  // Every warn and err after preflight disappeared, including the verdict explaining
+  // why it failed. The exit code stayed correct and the reason stopped existing, which
+  // is the shape of failure this lane exists to catch, turned on the lane itself.
+  const r = sourced(
+    // Port 9 (discard) is closed on these machines; any closed port exercises the
+    // failure path, which is the one that used to do the damage.
+    `ports_without_listener 9 > /dev/null; warn "STILL SPEAKING"`,
+  );
+  assert.match(r.stderr, /STILL SPEAKING/, "stderr was redirected away by the probe");
+});
+
+test("the tunnel probe reports the ports that have no listener", () => {
+  const r = sourced(`ports_without_listener 9 65000 | tr '\\n' ' '`);
+  assert.equal(r.stdout.trim(), "9 65000");
+});
+
 test("the tunnel is the default, and refusing it is opt-in", () => {
   const r = sourced(`echo "$LANGFLOW_TUNNEL $ALLOW_NO_TUNNEL"`);
   assert.equal(r.stdout.trim(), "1 0");

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -162,13 +162,41 @@ test("REQUIRE_TARGET_VERSION=1 makes the mismatch fatal, naming what it costs", 
   assert.match(r.stderr, /describes the changelog, not the environments/);
 });
 
-test("a matching version never fails, whatever REQUIRE says", () => {
-  for (const match of ["yes", "cycle", "unknown", "unchecked"]) {
+test("a matching version passes under REQUIRE, exactly or by cycle", () => {
+  for (const match of ["yes", "cycle"]) {
     const r = sourced(
       `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
         `TARGET_VERSION_MATCH=${match}\n` +
         `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
       { REQUIRE_TARGET_VERSION: "1" },
+    );
+    assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 0, match);
+  }
+});
+
+test("under REQUIRE, a check that could not RUN fails too", () => {
+  // The gap that makes "require" not require: the registry unreachable, github
+  // unreachable, the resolver erroring, or the target reporting no version all land
+  // on unknown/unchecked. Passing green there is passing green in exactly the cases
+  // where nobody can tell whether both lanes ran the same product.
+  for (const match of ["unknown", "unchecked"]) {
+    const r = sourced(
+      `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
+        `TARGET_VERSION_MATCH=${match}\n` +
+        `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
+      { REQUIRE_TARGET_VERSION: "1" },
+    );
+    assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 1, match);
+    assert.match(r.stderr, /an unperformed check is/);
+  }
+});
+
+test("without REQUIRE, none of the version states fail the run", () => {
+  for (const match of ["yes", "cycle", "unknown", "unchecked", "no"]) {
+    const r = sourced(
+      `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
+        `TARGET_VERSION_MATCH=${match}\n` +
+        `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
     );
     assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 0, match);
   }

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -131,6 +131,49 @@ test("the publish switches are OFF by default, all four of them", () => {
   assert.equal(r.stdout.trim(), "0 0 0 0");
 });
 
+test("the version check is on by default, and enforcing it is not — yet", () => {
+  // Detection before correction. While the clone is moved by hand, failing the run on
+  // a version gap would throw away a day of otherwise usable comparison data; the gap
+  // still has to be impossible to miss. REQUIRE flips once the run moves the clone.
+  const r = sourced(`echo "$CHECK_TARGET_VERSION $REQUIRE_TARGET_VERSION"`);
+  assert.equal(r.stdout.trim(), "1 0");
+});
+
+test("a version mismatch does not fail the run on its own", () => {
+  const r = sourced(
+    `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
+      `TARGET_VERSION_MATCH=no TARGET_VERSION_REASON="expected 1.13.0.dev1, served 1.12.0"\n` +
+      `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
+  );
+  assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 0);
+});
+
+test("REQUIRE_TARGET_VERSION=1 makes the mismatch fatal, naming what it costs", () => {
+  const r = sourced(
+    `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
+      `TARGET_VERSION_MATCH=no TARGET_VERSION_REASON="expected 1.13.0.dev1, served 1.12.0"\n` +
+      `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
+    { REQUIRE_TARGET_VERSION: "1" },
+  );
+  assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 1);
+  assert.match(r.stderr, /wrong Langflow/);
+  // The reason a reader needs: not "versions differ" but what a comparison between
+  // different products actually produces.
+  assert.match(r.stderr, /describes the changelog, not the environments/);
+});
+
+test("a matching version never fails, whatever REQUIRE says", () => {
+  for (const match of ["yes", "cycle", "unknown", "unchecked"]) {
+    const r = sourced(
+      `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
+        `TARGET_VERSION_MATCH=${match}\n` +
+        `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
+      { REQUIRE_TARGET_VERSION: "1" },
+    );
+    assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 0, match);
+  }
+});
+
 test("the tunnel is the default, and refusing it is opt-in", () => {
   const r = sourced(`echo "$LANGFLOW_TUNNEL $ALLOW_NO_TUNNEL"`);
   assert.equal(r.stdout.trim(), "1 0");

--- a/scripts/start-echo-source.test.mjs
+++ b/scripts/start-echo-source.test.mjs
@@ -332,7 +332,13 @@ test("a port that already answers is refused, not started on top of", () => {
 });
 
 test("a binary that exits during startup is reported as that, not as a timeout", () => {
-  const r = runScript({ serverExits: true, env: { ECHO_BIND_HOST: "10.0.0.5" } });
+  // The deadline is raised for this case alone, and it is not padding: the readiness
+  // loop checks liveness FIRST and probes second, so telling "exited" from "timed out"
+  // needs one iteration to land after the stub has died. At the 2s default that window
+  // is a single scheduling slot, and under the parallel lane it is occasionally missed
+  // — the run then reports the timeout, which is the message this test rules out. Its
+  // sibling in start-ollama-source.test.mjs carries the same note for the same reason.
+  const r = runScript({ serverExits: true, env: { ECHO_BIND_HOST: "10.0.0.5", ECHO_START_TIMEOUT_S: "8" } });
   assert.equal(r.status, 1);
   assert.match(r.stderr, /exited after/);
   // The PID file has to go, or the next start refuses over a process that is gone.

--- a/scripts/start-ollama-source.test.mjs
+++ b/scripts/start-ollama-source.test.mjs
@@ -475,7 +475,13 @@ test("refusing to pull is a refusal, not a start without the model", () => {
 });
 
 test("a server that exits during startup is reported as that, not as a timeout", () => {
-  const r = runScript({ serverExits: true });
+  // The deadline is raised for this case alone, and it is not padding: the readiness
+  // loop checks liveness FIRST and the probe second, so distinguishing "exited" from
+  // "timed out" needs at least one iteration to land after the stub has actually
+  // died. At the 2s default that window is a single scheduling slot, and under the
+  // parallel lane it is occasionally missed — the run then reports the timeout, which
+  // is the message this very test exists to rule out.
+  const r = runScript({ serverExits: true, env: { OLLAMA_START_TIMEOUT_S: "8" } });
   assert.equal(r.status, 1);
   assert.match(r.stderr, /exited after/);
   assert.ok(!existsSync(join(r.stateRoot, "ollama-source-11434", "ollama.pid")));


### PR DESCRIPTION
The VM daily compares its verdict with the Actions one, and that comparison is only about the **environment** if both sides run the same **product**. Nothing enforced that.

The Actions lane pulls `langflowai/langflow-nightly:latest`, and that image is **not built from `main`**: upstream's `nightly_build.yml` resolves the newest `release-X.Y.Z` branch and checks it out. Meanwhile the source clone on the target sits wherever it was last left — on 2026-09-02 that was `release-1.12.0`, a full release cycle behind the `1.13.0.dev1` the CI was testing. Every difference between those two arrives in the divergence list as *"a real failure only Actions saw"*: a changelog wearing an environment's clothes.

## Detection first, correction second

This change makes the gap impossible to miss. **Moving and rebuilding the clone is a separate change**, and until it lands a mismatch has to be visible rather than fatal — failing at 08:00 over a version nobody can fix before the run would throw away a day of otherwise usable comparison data. `REQUIRE_TARGET_VERSION=1` flips that the moment the run moves the clone itself.

## The decision lives in a tested script

`scripts/resolve-target-version.mjs`, in the same shape as `resolve-echo-endpoint.mjs`: bash discovers (`git ls-remote`), the script decides, the unit tests cover it. Three things it gets right that are **silent** when wrong:

- **Numeric ordering.** `release-1.9.0` sorts *above* `release-1.12.0` as a string, which would pin the lane a cycle behind while complaining about nothing.
- **The peeled sha of an annotated tag.** `ls-remote` prints two lines per annotated tag; the unpeeled one is the tag *object*, and checking it out leaves `HEAD` at a different commit than the image was built from.
- **Cycle parity and commit parity are different claims.** Under a nightly tag the expected version is exact. At a branch head the instance reports `1.13.0` while the CI's image reports `1.13.0.dev1` — calling that a mismatch would be a false alarm on a correctly placed clone, which is the fastest way to get a check ignored.

## In the orchestrator

- **preflight** resolves what the lane *should* test and prints it, so the operator sees the gap before spending an hour producing a comparison a version difference already spoiled;
- **merge** compares it with what the target actually served, and on a mismatch says what it costs — not just that it exists;
- **run-metadata.json** gains `langflow_expected_version`, `langflow_expected_ref` and `langflow_version_match`, beside the version and the suite SHA already recorded.

## Validation

Against the real upstream: the resolver picks `release-1.13.0` → `v1.13.0.dev1` with the peeled commit. On the machine: a `DRY_RUN` on the runner host printed

```
target should be: 1.13.0.dev1 (ref v1.13.0.dev1, by nightly-tag)
```

Unit lane: **1026/1026**, 15 new.

## Not in this PR

Moving the clone and rebuilding it (deps through `uv`, then the frontend). That costs real wall-clock nobody has measured — the earlier capacity work measured *idle* instances, not builds — and it pairs with the shard-concurrency measurement rather than with this.