### PR TITLE
test(llm-agents): scope the context-id specs' serial mode (#1690)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-context-id-continuity.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-continuity.md
@@ -63,17 +63,21 @@ the geometry above was measured.
 
 ---
 
-> **The parametrized test is `test.fail()` while #1689 is open.** The Agent's own
-> persisted message carries `context_id: null`, so the write half cannot pass:
-> `agent.py` threads `context_id` through the read path (`get_memory_data`) but
-> `_construct_agent_message` builds the stored Message without it, and
-> `lfx/base/agents/events.py` never mentions it. Reproduced 6/6 on `1.12.0.dev45`
-> and `1.13.0.dev1`, and **downstream** of the #1060 confirmed-write gate — which
-> passes, excluding a reverted write; the `User` message of the same session
-> carries the context correctly. The annotation keeps the test RUNNING so the
-> upstream fix reports "expected to fail, but passed"; it also absorbs any *other*
-> failure of this test, which is why lifting it is a deliverable of #1689 rather
-> than something to leave standing.
+> **The parametrized test currently fails on some providers (#1689).** On
+> `anthropic / claude-haiku-4-5` the message the Agent persists for its own turn
+> carries `context_id: null` while every other message of the same session
+> carries the configured one — 6 failures out of 6 across `1.12.0.dev45` and
+> `1.13.0.dev1`, and **downstream** of the #1060 confirmed-write gate, which
+> passes and so excludes a reverted write. On `openai / gpt-4o-mini`, against
+> the **same** build `1.13.0.dev1`, the same test passes (3 attempts, twice over
+> — measured on CI, which pins openai per #1169). The image is therefore held
+> constant and the provider is the axis; what the two paths do differently is
+> open in #1689. The related source fact — `agent.py` threads `context_id`
+> through the read path (`get_memory_data`) while `_construct_agent_message`
+> builds the stored Message without it and `lfx/base/agents/events.py` never
+> mentions it — is true but cannot be the whole cause, since it would fail both
+> providers. **No annotation is applied:** the test reports the truth per
+> provider, red where the defect reproduces and green where it does not.
 
 ## Preconditions *(optional)*
 

--- a/docs/core-functionality/llm-agents/agent-context-id-continuity.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-continuity.md
@@ -1,6 +1,6 @@
 # Agent context_id — continuity between session messages
 
-**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev0`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev1`)
 
 ---
 
@@ -62,6 +62,18 @@ image `daily-stable.yml` pulls as `:latest` — as well as on `1.12.0.dev39`, wh
 the geometry above was measured.
 
 ---
+
+> **The parametrized test is `test.fail()` while #1689 is open.** The Agent's own
+> persisted message carries `context_id: null`, so the write half cannot pass:
+> `agent.py` threads `context_id` through the read path (`get_memory_data`) but
+> `_construct_agent_message` builds the stored Message without it, and
+> `lfx/base/agents/events.py` never mentions it. Reproduced 6/6 on `1.12.0.dev45`
+> and `1.13.0.dev1`, and **downstream** of the #1060 confirmed-write gate — which
+> passes, excluding a reverted write; the `User` message of the same session
+> carries the context correctly. The annotation keeps the test RUNNING so the
+> upstream fix reports "expected to fail, but passed"; it also absorbs any *other*
+> failure of this test, which is why lifting it is a deliverable of #1689 rather
+> than something to leave standing.
 
 ## Preconditions *(optional)*
 

--- a/docs/core-functionality/llm-agents/agent-context-id-isolation.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-isolation.md
@@ -70,17 +70,21 @@ the geometry above was measured.
 
 ---
 
-> **The parametrized test is `test.fail()` while #1689 is open.** The Agent's own
-> persisted message carries `context_id: null`, so the write half cannot pass:
-> `agent.py` threads `context_id` through the read path (`get_memory_data`) but
-> `_construct_agent_message` builds the stored Message without it, and
-> `lfx/base/agents/events.py` never mentions it. Reproduced 6/6 on `1.12.0.dev45`
-> and `1.13.0.dev1`, and **downstream** of the #1060 confirmed-write gate — which
-> passes, excluding a reverted write; the `User` message of the same session
-> carries the context correctly. The annotation keeps the test RUNNING so the
-> upstream fix reports "expected to fail, but passed"; it also absorbs any *other*
-> failure of this test, which is why lifting it is a deliverable of #1689 rather
-> than something to leave standing.
+> **The parametrized test currently fails on some providers (#1689).** On
+> `anthropic / claude-haiku-4-5` the message the Agent persists for its own turn
+> carries `context_id: null` while every other message of the same session
+> carries the configured one — 6 failures out of 6 across `1.12.0.dev45` and
+> `1.13.0.dev1`, and **downstream** of the #1060 confirmed-write gate, which
+> passes and so excludes a reverted write. On `openai / gpt-4o-mini`, against
+> the **same** build `1.13.0.dev1`, the same test passes (3 attempts, twice over
+> — measured on CI, which pins openai per #1169). The image is therefore held
+> constant and the provider is the axis; what the two paths do differently is
+> open in #1689. The related source fact — `agent.py` threads `context_id`
+> through the read path (`get_memory_data`) while `_construct_agent_message`
+> builds the stored Message without it and `lfx/base/agents/events.py` never
+> mentions it — is true but cannot be the whole cause, since it would fail both
+> providers. **No annotation is applied:** the test reports the truth per
+> provider, red where the defect reproduces and green where it does not.
 
 ## Preconditions *(optional)*
 

--- a/docs/core-functionality/llm-agents/agent-context-id-isolation.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-isolation.md
@@ -1,6 +1,6 @@
 # Agent context_id — switching isolates history between contexts
 
-**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev0`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev1`)
 
 ---
 
@@ -69,6 +69,18 @@ image `daily-stable.yml` pulls as `:latest` — as well as on `1.12.0.dev39`, wh
 the geometry above was measured.
 
 ---
+
+> **The parametrized test is `test.fail()` while #1689 is open.** The Agent's own
+> persisted message carries `context_id: null`, so the write half cannot pass:
+> `agent.py` threads `context_id` through the read path (`get_memory_data`) but
+> `_construct_agent_message` builds the stored Message without it, and
+> `lfx/base/agents/events.py` never mentions it. Reproduced 6/6 on `1.12.0.dev45`
+> and `1.13.0.dev1`, and **downstream** of the #1060 confirmed-write gate — which
+> passes, excluding a reverted write; the `User` message of the same session
+> carries the context correctly. The annotation keeps the test RUNNING so the
+> upstream fix reports "expected to fail, but passed"; it also absorbs any *other*
+> failure of this test, which is why lifting it is a deliverable of #1689 rather
+> than something to leave standing.
 
 ## Preconditions *(optional)*
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
@@ -374,8 +374,9 @@ const targets = resolveTestTargets({ tier: "any-completion" });
 // agent-area rule (`llm-agents/CLAUDE.md`), so serial is declared on THAT
 // describe rather than on the file (#1690). File-level `mode: "serial"` makes a
 // failure skip every LATER test in the file. Measured on 1.13.0.dev1 — with the
-// parametrized test failing, every run reported `skipped=0`. Cleanup is
-// id-scoped; nothing here wipes flows.
+// parametrized test failing (it does on `anthropic / claude-haiku-4-5`, see
+// #1689), every run reported `skipped=0`. Cleanup is id-scoped; nothing here
+// wipes flows.
 
 // Declared BEFORE the parametrized loop deliberately (#1187) — kept, though the
 // scoped serial above now makes the two describes independent of each other

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
@@ -422,22 +422,6 @@ for (const { label, options, skipReason } of targets) {
           `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
         );
 
-        // #1689 — CONFIRMED product defect, not a mute. The message the Agent
-        // persists for its own turn carries `context_id: null` while every other
-        // message of the same session carries the configured one: `agent.py`
-        // threads `context_id` through the READ path (`get_memory_data`) but
-        // `_construct_agent_message` builds the stored Message without it, and
-        // `lfx/base/agents/events.py` never mentions it. Reproduced 6/6 on
-        // 1.12.0.dev45 and 1.13.0.dev1, and DOWNSTREAM of the #1060
-        // confirmed-write gate, which passes — so a reverted write is excluded.
-        //
-        // `test.fail()` rather than `test.fixme`: the test keeps RUNNING, so the
-        // day the upstream fix lands it reports "expected to fail, but passed"
-        // and points back at #1689 — a quarantine would stay silent. The cost,
-        // stated because it is real: this absorbs ANY failure of this test, so an
-        // unrelated regression here is invisible until the annotation is lifted.
-        // Lift it (and re-validate `@stable`) as #1689's deliverable.
-        test.fail();
 
         const nonce = `probe-${Date.now()}`;
         const contextId = `ctx-${nonce}`;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
@@ -371,14 +371,16 @@ async function retrieveViaMessageHistory(
 const targets = resolveTestTargets({ tier: "any-completion" });
 
 // Test 1 loads the Simple Agent template — serial + --workers=1 per the
-// agent-area rule. Cleanup is id-scoped; nothing here wipes flows.
-test.describe.configure({ mode: "serial" });
+// agent-area rule (`llm-agents/CLAUDE.md`), so serial is declared on THAT
+// describe rather than on the file (#1690). File-level `mode: "serial"` makes a
+// failure skip every LATER test in the file. Measured on 1.13.0.dev1 — with the
+// parametrized test failing, every run reported `skipped=0`. Cleanup is
+// id-scoped; nothing here wipes flows.
 
-// Declared BEFORE the parametrized loop deliberately (#1187). This file is
-// `mode: "serial"`, and in serial mode a failure SKIPS every later test in the
-// file — so with the routed test first, a weak-model failure there would skip this
-// one, which needs no provider at all. Ordering it first makes the model-free
-// coverage independent of whatever the routed target does.
+// Declared BEFORE the parametrized loop deliberately (#1187) — kept, though the
+// scoped serial above now makes the two describes independent of each other
+// rather than merely ordered, so this is belt-and-braces and no longer the thing
+// protecting the model-free coverage from a weak-model failure.
 test.describe("Context ID continuity — retrieval layer (model-free)", () => {
   test(
     "context-scoped retrieval returns all turns of the context and not the untagged control",
@@ -409,7 +411,7 @@ test.describe("Context ID continuity — retrieval layer (model-free)", () => {
 for (const { label, options, skipReason } of targets) {
   const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
 
-  test.describe(`Agent Context ID Continuity [${label}]`, () => {
+  test.describe.serial(`Agent Context ID Continuity [${label}]`, () => {
     test(
       "agent run persists every session message tagged with the custom context_id",
       { tag: ["@stable", "@regression", "@agents", "@components"] },
@@ -419,6 +421,23 @@ for (const { label, options, skipReason } of targets) {
           !hasProviderEnvKeys(provider),
           `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
         );
+
+        // #1689 — CONFIRMED product defect, not a mute. The message the Agent
+        // persists for its own turn carries `context_id: null` while every other
+        // message of the same session carries the configured one: `agent.py`
+        // threads `context_id` through the READ path (`get_memory_data`) but
+        // `_construct_agent_message` builds the stored Message without it, and
+        // `lfx/base/agents/events.py` never mentions it. Reproduced 6/6 on
+        // 1.12.0.dev45 and 1.13.0.dev1, and DOWNSTREAM of the #1060
+        // confirmed-write gate, which passes — so a reverted write is excluded.
+        //
+        // `test.fail()` rather than `test.fixme`: the test keeps RUNNING, so the
+        // day the upstream fix lands it reports "expected to fail, but passed"
+        // and points back at #1689 — a quarantine would stay silent. The cost,
+        // stated because it is real: this absorbs ANY failure of this test, so an
+        // unrelated regression here is invisible until the annotation is lifted.
+        // Lift it (and re-validate `@stable`) as #1689's deliverable.
+        test.fail();
 
         const nonce = `probe-${Date.now()}`;
         const contextId = `ctx-${nonce}`;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -513,8 +513,13 @@ async function runRetrievalScopedTo(page: Page, contextId: string): Promise<stri
 const targets = resolveTestTargets({ tier: "any-completion" });
 
 // Test 2 loads the Simple Agent template — serial + --workers=1 per the
-// agent-area rule. Cleanup is id-scoped; nothing here wipes flows.
-test.describe.configure({ mode: "serial" });
+// agent-area rule (`llm-agents/CLAUDE.md`), so serial is declared on THAT
+// describe rather than on the file (#1690). File-level `mode: "serial"` makes a
+// failure skip every LATER test in the file, and the two describes here share
+// nothing: the retrieval describe resolves no provider at all. Measured on
+// 1.13.0.dev1 — with the parametrized test failing, every run reported
+// `skipped=0` and the model-free coverage still reported its own verdict.
+// Cleanup is id-scoped; nothing here wipes flows.
 
 test.describe("Context ID isolation — retrieval layer (model-free)", () => {
   test(
@@ -561,7 +566,7 @@ test.describe("Context ID isolation — retrieval layer (model-free)", () => {
 for (const { label, options, skipReason } of targets) {
   const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
 
-  test.describe(`Agent Context ID Isolation [${label}]`, () => {
+  test.describe.serial(`Agent Context ID Isolation [${label}]`, () => {
     test(
       "switching the agent's context_id re-tags new turns without touching previous ones",
       { tag: ["@stable", "@regression", "@agents", "@playground"] },
@@ -571,6 +576,23 @@ for (const { label, options, skipReason } of targets) {
           !hasProviderEnvKeys(provider),
           `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
         );
+
+        // #1689 — CONFIRMED product defect, not a mute. The message the Agent
+        // persists for its own turn carries `context_id: null` while every other
+        // message of the same session carries the configured one: `agent.py`
+        // threads `context_id` through the READ path (`get_memory_data`) but
+        // `_construct_agent_message` builds the stored Message without it, and
+        // `lfx/base/agents/events.py` never mentions it. Reproduced 6/6 on
+        // 1.12.0.dev45 and 1.13.0.dev1, and DOWNSTREAM of the #1060
+        // confirmed-write gate, which passes — so a reverted write is excluded.
+        //
+        // `test.fail()` rather than `test.fixme`: the test keeps RUNNING, so the
+        // day the upstream fix lands it reports "expected to fail, but passed"
+        // and points back at #1689 — a quarantine would stay silent. The cost,
+        // stated because it is real: this absorbs ANY failure of this test, so an
+        // unrelated regression here is invisible until the annotation is lifted.
+        // Lift it (and re-validate `@stable`) as #1689's deliverable.
+        test.fail();
 
         const nonce1 = `probe-A-${Date.now()}`;
         const nonce2 = `probe-B-${Date.now()}`;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -517,8 +517,9 @@ const targets = resolveTestTargets({ tier: "any-completion" });
 // describe rather than on the file (#1690). File-level `mode: "serial"` makes a
 // failure skip every LATER test in the file, and the two describes here share
 // nothing: the retrieval describe resolves no provider at all. Measured on
-// 1.13.0.dev1 — with the parametrized test failing, every run reported
-// `skipped=0` and the model-free coverage still reported its own verdict.
+// 1.13.0.dev1 — with the parametrized test failing (it does on
+// `anthropic / claude-haiku-4-5`, see #1689), every run reported `skipped=0`
+// and the model-free coverage still reported its own verdict.
 // Cleanup is id-scoped; nothing here wipes flows.
 
 test.describe("Context ID isolation — retrieval layer (model-free)", () => {
@@ -577,22 +578,6 @@ for (const { label, options, skipReason } of targets) {
           `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
         );
 
-        // #1689 — CONFIRMED product defect, not a mute. The message the Agent
-        // persists for its own turn carries `context_id: null` while every other
-        // message of the same session carries the configured one: `agent.py`
-        // threads `context_id` through the READ path (`get_memory_data`) but
-        // `_construct_agent_message` builds the stored Message without it, and
-        // `lfx/base/agents/events.py` never mentions it. Reproduced 6/6 on
-        // 1.12.0.dev45 and 1.13.0.dev1, and DOWNSTREAM of the #1060
-        // confirmed-write gate, which passes — so a reverted write is excluded.
-        //
-        // `test.fail()` rather than `test.fixme`: the test keeps RUNNING, so the
-        // day the upstream fix lands it reports "expected to fail, but passed"
-        // and points back at #1689 — a quarantine would stay silent. The cost,
-        // stated because it is real: this absorbs ANY failure of this test, so an
-        // unrelated regression here is invisible until the annotation is lifted.
-        // Lift it (and re-validate `@stable`) as #1689's deliverable.
-        test.fail();
 
         const nonce1 = `probe-A-${Date.now()}`;
         const nonce2 = `probe-B-${Date.now()}`;


### PR DESCRIPTION
## Type

- [ ] `feat` — new test or new helper/page object
- [x] `fix` — fix for a broken or flaky test
- [ ] `chore` — CI, checklist, dependencies, internal refactoring
- [ ] `docs` — documentation update

---

## Roadmap linkage (required — do not delete)

- [ ] **Current wave** — a `roadmap`-labeled issue in the current wave's milestone: #___
- [x] **Exception** — off-wave work backed by an issue: a follow-up, a `daily-failure` triage issue, or a `community`-labeled regression. Issue **#1690** (follow-up) and **#1689** (follow-up)

---

## What this PR does

Two changes to the two `agent-context-id-*` specs. Both were found while working the overlay half of #1643, and neither is on `main` — that issue's merged work (`8b3a9073`, `a29f2303`) fixed the overlay only.

**1 — Scope the serial mode (#1690).** Both files declared `test.describe.configure({ mode: "serial" })` at *file* level. In serial mode a failure skips every **later** test in the file, and the two describes here share nothing: the retrieval describe resolves no provider at all. So a failure of the parametrized test removed the model-free coverage, and vice versa — which is how the 2026-08-31 daily's two hard failures also produced two skips, and how #1665 recorded `agent-current-date-tool.spec.ts:291` as a 3-attempt hard failure that spent one (`worker=-1` on both retries).

The agent-area rule (`llm-agents/CLAUDE.md`) is `test.describe.serial(...)` **per describe**, which is what serial is actually for here: the describe that loads the Simple Agent template. `continuity`'s deliberate ordering (#1187) is kept, but it is now belt-and-braces rather than the only thing protecting the model-free coverage.

This is 2 of the 5 files #1690 lists, so it does **not** close that issue.

**2 — Nothing else.** An earlier revision of this PR annotated both parametrized tests with `test.fail()` for #1689. **CI refuted the premise and the annotations are gone** — see *Known limitations*. The parametrized tests are otherwise untouched.

---

## Tests covered

| # | Test | What it validates |
|---|---|---|
| 1 | `agent-context-id-isolation.spec.ts` › "mirrored context-scoped retrievals return only their own context's messages" | Two `context_id` values over one session are mutually blind: the `CTX-A` retrieval returns every `A-*` sentinel and **no** `B-*`, and the `CTX-B` retrieval mirrors it exactly. Symmetric negatives, so a leak in either direction fails. Unchanged by this PR except that it can no longer be skipped by its sibling |
| 2 | `agent-context-id-isolation.spec.ts` › "switching the agent's context_id re-tags new turns without touching previous ones" | Switching the Agent's `context_id` between two turns of one session re-tags the write path with no cross-tagging: turn-1 messages carry exactly `CTX-A`, turn-2 exactly `CTX-B`. Unchanged by this PR except for the skip decoupling |
| 3 | `agent-context-id-continuity.spec.ts` › "context-scoped retrieval returns all turns of the context and not the untagged control" | A context-scoped retrieval over a session seeded with 3 tagged turns plus one untagged control returns **all three** sentinels and **not** the control. Unchanged except for the skip decoupling |
| 4 | `agent-context-id-continuity.spec.ts` › "agent run persists every session message tagged with the custom context_id" | Every message an agent run persists under a custom `context_id` carries exactly that tag. Unchanged except for the skip decoupling |

---

## How the tests were built

No new mechanism. The only structural change is `test.describe.configure({ mode: "serial" })` → `test.describe.serial(...)` on the describe that loads the Simple Agent template. No assertion, selector, timeout or wait is touched anywhere in either file.

---

## Dependencies

- The parametrized tests need a provider from `models.json` / `providers.json`; validated against `anthropic / claude-haiku-4-5`.
- `--workers=1` (agent-area rule; the parametrized tests load the Simple Agent template).
- Cleanup is unchanged and id-scoped: `afterEach` deletes every flow created via the template by id, and the model-free tests delete their API-created flow and API key in a `finally`. Nothing wipes flows. Orphan count on the validation instance after the full run: **0**.

---

## What this PR does not cover

- The **overlay** half of #1643 — already merged (`clearCanvasBottomOverlay`).
- The other three files on file-level serial (`agent-current-date-tool.spec.ts:254`, `agent-system-prompt.spec.ts:207`, `rag-pipeline.spec.ts:69`) — they stay on **#1690**, which needs the same judgement made per file rather than inherited.
- Fixing #1689 itself, which is upstream (`lfx/components/models_and_agents/agent.py`, `lfx/base/agents/events.py`).

---

## Known limitations

**The two parametrized tests fail on `anthropic`, and this PR does not hide that.** An earlier revision annotated them `test.fail()` for #1689 on the strength of 6 failures out of 6. CI then reported *"Expected to fail, but passed"* on all three attempts of both — because it pins `openai / gpt-4o-mini` (#1169) while the local runs used `anthropic / claude-haiku-4-5`. Both ran against the **same** build, `Langflow Nightly 1.13.0.dev1`, so the image is held constant and the **provider is the axis**: my 6/6 was 6/6 on one provider, reported as a general defect.

The annotations are removed rather than made conditional on the provider: two providers measured is not enough to claim the boundary is "anthropic", and a conditional scoped to the wrong axis would mute a real failure on a third. So the tests report the truth per provider — green here on openai, red on a daily whose rotation lands on anthropic, which is the signal #1689 should be triaged from rather than something to suppress. #1689 is corrected accordingly and now asks for a third provider on one build plus a monitor-API dump naming the untagged row.

---

## Related issue

Refs #1690 (2 of its 5 files), Refs #1689 (context, not fixed or annotated here).

---

## Validation

Resolved Langflow version: **`1.13.0.dev1`** (`langflowai/langflow-nightly:latest`, `package: "Langflow Nightly"`), a container started for this run — not the shared runner.

- 3 clean runs of both files on `anthropic / claude-haiku-4-5`, `--workers=1 --retries=0`, read from the JSON reporter's stats rather than the line reporter: `expected=4 unexpected=0 flaky=0 skipped=0` at 141 s / 131 s / 137 s. Those runs were taken with the `test.fail()` revision in place; what they establish and this PR still relies on is **`skipped=0` with a failing sibling in each file**, which is the observable the serial change exists for. On this PR's shipped diff the same two parametrized tests fail on anthropic, so a local run there reports 2 passed / 2 failed rather than 4 passed — see *Known limitations*.
- Final green after every mutation was reverted: `expected=4 unexpected=0 flaky=0 skipped=0`, 132 s.
- [x] Forced a failure to confirm it is not a false positive — all four tests, each mutation carrying a marker verified present before the run. Two of the four were performed against the `test.fail()` revision (the tripwire mutation: return early so the test passes, which is the red state for an expected-failure test) and are recorded for completeness; the two that gate the assertions in the shipped diff are:
  - `mirrored context-scoped retrievals…` — inverted the symmetric negative (assert a `B-*` sentinel **is** present in the `CTX-A` retrieval) ⇒ `unexpected=1`.
  - `context-scoped retrieval returns all turns…` — inverted the control negative (assert `-CTRL` **is** returned) ⇒ `unexpected=1`.

  The two parametrized tests carry no assertion change in the shipped diff — only the describe they live in changed — and their genuine red on `anthropic` plus green on `openai` is itself the evidence they are not stuck-green.
- [x] Confirmed there are no backend errors (`🚨 Backend Error:`) — 0 matching lines across all runs, greping `2>&1` (the fixture logs them to stdout).
- [x] `npm run typecheck` clean; `npm run lint` 0 errors; `npm run check:checklist-coverage` green.
- [ ] `--trace=on` — deliberately not used: it hangs UI specs on this local Docker setup. `--trace=retain-on-failure` is the working alternative.
- [ ] `QA-CHECKLIST.md` — no change needed; both specs already have their Part II bullets and neither gains or loses `@stable`.
- [ ] `QA-SCENARIOS-GUIDE.md` — no new scenario.

### Note for the reviewer

Both spec docs are updated: the #1689 note, and `Last validated` bumped `1.13.0.dev0` → `1.13.0.dev1`.

One thing worth a second opinion, **not** changed here because it was measured against a different implementation: `clearCanvasBottomOverlay` reads `slot.first()`. While building a (now discarded) duplicate of that helper, two elements matching the container selector at once were measured on `1.12.0.dev45` — an empty container mid exit-animation plus the review banner beside it — and reading only `.first()` polled the empty one for the whole budget, failing with `still holds an overlay after 20000ms: ""`. If that shape is reachable on `main`'s helper, its signature would be a timeout whose `Still in the slot:` quotes an empty string. Worth a look, but it is a hypothesis about `main`'s code, not a measurement of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
