### PR TITLE
test(llm-agents): quarantine the model-toggle persistence test (#1694)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
@@ -253,10 +253,19 @@ async function readPickerCensus(
 test.describe.configure({ mode: "serial" });
 
 test.describe("Model Provider Model Toggle", () => {
-  test(
+  // Quarantined at the triage of daily #1694 (run 33756085604, 2026-09-03).
+  // This test failed on 6 of the last 30 dailies under 4 distinct signatures,
+  // each stalling at a different step of the same short path (open Model
+  // Providers -> pick the provider -> toggle a model -> await the write). On
+  // 2026-09-03 it timed out on `getByText('Model Providers')` with only 1 of
+  // 21 liveness probes failing in its window, so it is not wedge collateral.
+  // Being `fixme` (a skip, not a failure) keeps the serial sibling below
+  // running. Lifting the quarantine (remove test.fixme + restore @stable) is
+  // a deliverable of #1696.
+  test.fixme(
     "model toggle changes immediately and persists across reopen",
     {
-      tag: ["@stable", "@regression", "@components", "@model-provider"],
+      tag: ["@regression", "@components", "@model-provider"],
     },
     async ({ page }) => {
       test.skip(!!skipReason, skipReason ?? "");


### PR DESCRIPTION
Quarantines `model toggle changes immediately and persists across reopen` as prevention, from the triage of daily-failure umbrella #1694 (run [33756085604](https://github.com/oriontech-me/langflow-e2e/actions/runs/33756085604), 2026-09-03).

Tracked by #1696 — this PR does **not** fix the test, and #1696 stays open until it does.

## Why

The test failed on **6 of the last 30 dailies** under **4 distinct signatures**, each stalling at a different step of the same short path (open Model Providers → pick the provider → toggle a model → await the write):

| Daily | Signature (head) | Stalls at |
|---|---|---|
| 2026-08-05 | `[backend-unreachable] page-entry barrier …` | page entry, backend confirmed down |
| 2026-08-21 | `page-entry barrier … the backend answered … HTTP 200 …` | page entry, healthy-probe verdict (#1549) |
| 2026-08-26 | `[backend-unreachable] page-entry barrier …` | page entry, backend confirmed down |
| 2026-08-31 | `TimeoutError: locator.click: Timeout 20000ms exceeded.` | `getByTestId('provider-item-OpenAI')` |
| 2026-09-01 | `TimeoutError: page.waitForResponse: Timeout 15000ms exceeded` | the enable write |
| 2026-09-03 | `TimeoutError: locator.click: Timeout 20000ms exceeded.` | `getByText('Model Providers').first()` |

**Not wedge collateral, and that is measured.** 2026-09-03 was a wedge day — all four shards lost the backend mid-run (13 outages, 10.8 min down). This test ran on shard 3, the healthiest (3.7% down), and its failing attempt (12:50:40→12:51:21 UTC) overlapped **1 failed liveness probe out of 21**. Compare the collateral on the same run: `locale-resilience` 19/32 probes failed in its window, `modelInputComponent` 9/9.

**The formal criterion fired for the wrong reason, and this PR does not rest on it.** The daily's `actionable` flag came from a 2× same-signature match between 2026-08-31 and 2026-09-03, but that match is a signature collision — the two runs' call logs show different locators behind byte-identical signatures. That gap belongs to #1626 (enriched with this case). The quarantine here rests on the 6-hit history instead.

## What changed

`test(` → `test.fixme(` and `@stable` dropped from the tag array, at `model-provider-model-toggle.spec.ts:256`.

Both edits, not just the tag: removing `@stable` alone stops the daily, but the PR impacted-specs gate selects by **file diff**, not by tag, so the test would keep going red there. And `fixme` is a skip rather than a failure, which matters in this file — it is `mode: "serial"`, so a failing test would suppress its sibling at line 301. That sibling failed on the same path on 2026-08-31 and 2026-09-01 and is a re-check deliverable of #1696.

## Checks

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run check:checklist-coverage` — passes (the file keeps `@stable` on line 301, and the Part II bullet still resolves)
- `node scripts/check-checklist-guard.mjs` — no generated block touched

No spec doc or `QA-CHECKLIST.md` change: a quarantine is temporary and tracked by its issue, per `CONTRIBUTING.md`.
