### PR TITLE
Place the target on the commit the CI is testing, and gate on it

### DIFF
--- a/scripts/prepare-target-source.sh
+++ b/scripts/prepare-target-source.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# Put the target's source clone ON the commit the CI is testing, and make sure the
+# build in it belongs to that commit.
+#
+# ## Why this is a separate script
+#
+# scripts/start-langflow-source.sh promises, in its own header and in three places in
+# its code, NOT to touch the clone: a source checkout on a shared VM is also somebody's
+# working tree, and a lane that silently moves HEAD makes every later run
+# unattributable. It refuses to build the frontend for the same reason. Those refusals
+# are correct and this script does not weaken them — it is the one place allowed to
+# move the clone and to build in it, invoked deliberately, announcing what it did.
+#
+# So the division is: this script owns the clone's POSITION and its BUILD; the starter
+# owns the instance. The starter then only has to ask whether the build in front of it
+# belongs to HEAD, which is a question it can answer without touching anything.
+#
+# ## Why this exists at all
+#
+# The daily compares a VM verdict with the Actions one, and that comparison is only
+# about the ENVIRONMENT if both sides run the same product. Nothing enforced that:
+# Actions pulls `langflow-nightly:latest` on every run, while a source clone sits
+# wherever someone last left it. On 2026-09-03 that was `release-1.12.0` built on
+# 08-25, against a CI on 1.13.0.dev1 — a full release cycle and nine days. Every
+# difference between the two arrives in the divergence list as "a real failure only
+# Actions saw", which is a changelog wearing an environment's clothes.
+#
+# scripts/resolve-target-version.mjs answers WHICH commit (and why the published image
+# decides it, not the git tag). This script is the other half: obeying that answer.
+#
+# ## Why the commit, and never `main`
+#
+# TARGET_SHA is the preferred input because upstream's nightly DELETES AND RECREATES
+# its tag names, so `v1.13.0.dev1` can point somewhere new after the 1.13.0.dev1 image
+# shipped — the resolver says so in its own header. The sha it reports was matched by
+# image digest, and a sha cannot drift. TARGET_REF is carried for the log and used
+# only when no sha is available.
+#
+# `main` is refused outright. It is not what the nightly builds — upstream resolves
+# the newest `release-X.Y.Z` branch — so a clone on `main` tests something the CI
+# never tests, which is the exact failure this script exists to remove. A typo that
+# lands on `main` must not be indistinguishable from success.
+#
+# ## Why the build stamp
+#
+# `LANGFLOW_SRC_REF` in the starter left a debt the starter's own header describes: a
+# checkout moves the backend, and the PREVIOUS build's `index.html` stays where it is.
+# The backend then serves an old UI against a new backend and every spec passes or
+# fails for reasons nobody can attribute — a green run against the wrong build, which
+# is the worst outcome a scheduled lane has.
+#
+# The existence of assets is not evidence that they belong to HEAD. The stamp is: it
+# records the commit they were built from, next to the clone so it survives a reboot
+# (a stamp under /tmp would make every reboot look like a stale build). And it is
+# REMOVED BEFORE the build starts, never after it fails — an interrupted build must
+# leave "unknown", because a stamp that outlives the assets it describes is worse than
+# no stamp at all: it is a confident wrong answer.
+#
+# ## Why deps and frontend are timed apart
+#
+# Because the number decides where this script gets invoked from. If the frontend is
+# the whole cost, the rebuild becomes its own step, fired when the resolution changes;
+# if it is minutes, it fits at the head of every run. That is a measurement, not an
+# opinion, so the script reports the two halves separately every time it runs.
+#
+# ## Usage
+#
+#   TARGET_SHA=964a1eb1... TARGET_REF=v1.13.0.dev1 TARGET_BRANCH=release-1.13.0 \
+#     LANGFLOW_SRC_REPO=$HOME/langflow ./scripts/prepare-target-source.sh
+#
+#   PREPARE_SKIP_BUILD=1 ...    # move the clone, report what a build would do
+#   PREPARE_FORCE_REBUILD=1 ... # rebuild even when the stamp agrees with HEAD
+#   PREPARE_FETCH=0 ...         # offline: use what the clone already has
+#
+# Human progress goes to stderr; stdout carries ONLY `key=value` lines, so a caller
+# can capture the summary without parsing prose:
+#
+#   prepared_sha=<sha>  prepared_ref=<ref>  moved=yes|no
+#   rebuilt=yes|no  rebuild_reason=<why>  deps_s=<n>  frontend_s=<n>  total_s=<n>
+#
+# Environment (all optional except the target):
+#   LANGFLOW_SRC_REPO       the clone to prepare
+#   LANGFLOW_SRC_REMOTE     remote to fetch from (default: origin)
+#   TARGET_SHA/_REF/_BRANCH what to move to; SHA wins, BRANCH only aids the fetch
+#   LANGFLOW_SRC_FRONTEND_DIR  where the built UI is served from
+#   LANGFLOW_SRC_STAMP_FILE    where the build stamp lives
+#   PREPARE_FETCH, PREPARE_ALLOW_DIRTY, PREPARE_FORCE_REBUILD, PREPARE_SKIP_BUILD
+set -euo pipefail
+
+REPO="${LANGFLOW_SRC_REPO:-$HOME/langflow-project/langflow}"
+REMOTE="${LANGFLOW_SRC_REMOTE:-origin}"
+TARGET_SHA="${TARGET_SHA:-}"
+TARGET_REF="${TARGET_REF:-}"
+TARGET_BRANCH="${TARGET_BRANCH:-}"
+FRONTEND_DIR="${LANGFLOW_SRC_FRONTEND_DIR:-${REPO}/src/backend/base/langflow/frontend}"
+STAMP_FILE="${LANGFLOW_SRC_STAMP_FILE:-${REPO}/.langflow-e2e-build-stamp}"
+DO_FETCH="${PREPARE_FETCH:-1}"
+ALLOW_DIRTY="${PREPARE_ALLOW_DIRTY:-0}"
+FORCE_REBUILD="${PREPARE_FORCE_REBUILD:-0}"
+SKIP_BUILD="${PREPARE_SKIP_BUILD:-0}"
+
+# uv lives in ~/.local/bin and cron does not load it — the trap that the orchestrator
+# already exports a PATH for. Repeated here because this script is also invoked by
+# hand over `ssh <host> 'bash -s'`, where the same non-interactive shell applies.
+export PATH="${HOME}/.local/bin:${PATH}"
+
+say() { echo "$*" >&2; }
+emit() { echo "$*"; }
+die() { echo "ERROR: $*" >&2; exit 2; }
+
+# --- What we were asked to become ----------------------------------------------
+[ -n "${TARGET_SHA}" ] || [ -n "${TARGET_REF}" ] \
+  || die "neither TARGET_SHA nor TARGET_REF was given. This script does not pick a
+target: scripts/resolve-target-version.mjs does, from the published image, and being
+told is the whole point — a script that guesses is a script that can guess \`main\`."
+
+# Refused for all three inputs, not just the checkout target: TARGET_BRANCH steers the
+# fetch, and fetching `main` to then check out a commit "reachable from it" is the same
+# mistake wearing a different flag.
+for value in "${TARGET_SHA}" "${TARGET_REF}" "${TARGET_BRANCH}"; do
+  case "${value}" in
+    main | master | refs/heads/main | refs/heads/master)
+      die "refusing to prepare the target from '${value}'. Upstream's nightly builds the
+newest release-X.Y.Z branch, never ${value}, so a clone there tests something the CI
+never tests — and the divergence list would fill with product changelog."
+      ;;
+  esac
+done
+
+[ -d "${REPO}" ] || die "no clone at ${REPO}. Set LANGFLOW_SRC_REPO."
+git -C "${REPO}" rev-parse --git-dir > /dev/null 2>&1 || die "${REPO} is not a git clone."
+
+# --- Refuse to start work that cannot finish ------------------------------------
+# Checked BEFORE the checkout, not before the build. A missing npm discovered after
+# the move leaves the clone on the new commit with the old build and no stamp, which
+# is a state the starter has to refuse — so the machine ends up neither where it was
+# nor where it was going, over a tool that was never there.
+if [ "${SKIP_BUILD}" != "1" ]; then
+  command -v npm > /dev/null 2>&1 \
+    || die "npm is not on PATH, and the frontend build needs it. On a non-interactive
+shell (cron, \`ssh host 'bash -s'\`) a node installed through a version manager is
+often absent — check with \`ssh <host> 'command -v npm'\`, not from a login shell."
+  command -v uv > /dev/null 2>&1 \
+    || die "uv is not on PATH, and it is the only thing that builds this clone: the
+root dependencies resolve through [tool.uv.sources] workspace = true, which pip does
+not read. It usually lives in ~/.local/bin, which cron does not load."
+fi
+
+# --- A shared clone may hold somebody's work ------------------------------------
+DIRTY_COUNT="$(git -C "${REPO}" status --porcelain | grep -vcF "$(basename "${STAMP_FILE}")" || true)"
+if [ "${DIRTY_COUNT}" -gt 0 ] && [ "${ALLOW_DIRTY}" != "1" ]; then
+  say "$(git -C "${REPO}" status --short | head -20)"
+  die "${REPO} has ${DIRTY_COUNT} modified path(s). Moving HEAD would discard or
+strand them, and a lane that does that silently makes every later run unattributable.
+Clean the tree, or set PREPARE_ALLOW_DIRTY=1 if you know those changes are disposable."
+fi
+
+BEFORE_SHA="$(git -C "${REPO}" rev-parse HEAD)"
+BEFORE_REF="$(git -C "${REPO}" rev-parse --abbrev-ref HEAD)"
+# A clone this script has already prepared is DETACHED, and `rev-parse --abbrev-ref`
+# answers "HEAD" there — so the naive hint reads `checkout HEAD`, which reverts
+# nothing. Found by running it on the target, not by reading it: the second run is the
+# one that hits it, and the second run is every run after adoption. The commit is
+# always a usable answer; a branch name is only preferable when there is one.
+BEFORE_POS="${BEFORE_SHA}"
+[ "${BEFORE_REF}" != "HEAD" ] && BEFORE_POS="${BEFORE_REF}"
+say "before: ${BEFORE_REF} @ ${BEFORE_SHA:0:10}"
+say "revert with: git -C ${REPO} checkout ${BEFORE_POS}"
+
+# --- Fetch, then insist the target actually exists -------------------------------
+if [ "${DO_FETCH}" = "1" ]; then
+  say "fetching ${REMOTE} (tags included)..."
+  git -C "${REPO}" fetch --quiet --tags "${REMOTE}" \
+    || die "fetch from ${REMOTE} failed. Nothing has been moved."
+fi
+
+target_exists() {
+  git -C "${REPO}" cat-file -e "${1}^{commit}" 2> /dev/null
+}
+
+WANT="${TARGET_SHA:-${TARGET_REF}}"
+if ! target_exists "${WANT}"; then
+  # One retry, and only through the branch that was named. Upstream recreates nightly
+  # tags, so a tag fetch can legitimately miss a commit the branch still carries.
+  if [ -n "${TARGET_BRANCH}" ] && [ "${DO_FETCH}" = "1" ]; then
+    say "${WANT} is not in the clone; fetching ${TARGET_BRANCH}..."
+    git -C "${REPO}" fetch --quiet "${REMOTE}" \
+      "refs/heads/${TARGET_BRANCH}:refs/remotes/${REMOTE}/${TARGET_BRANCH}" \
+      || die "fetch of ${TARGET_BRANCH} failed. Nothing has been moved."
+  fi
+fi
+target_exists "${WANT}" \
+  || die "${WANT} does not exist in ${REPO}, even after fetching. Refusing to fall
+back to anything else: the point of being handed a commit is that no other commit is
+an acceptable substitute."
+
+WANT_SHA="$(git -C "${REPO}" rev-parse "${WANT}^{commit}")"
+
+# --- Move, and verify the move ---------------------------------------------------
+MOVED=no
+if [ "${WANT_SHA}" != "${BEFORE_SHA}" ]; then
+  say "checking out ${TARGET_REF:-${WANT_SHA:0:10}} (detached at ${WANT_SHA:0:10})..."
+  # Detached on purpose: a named local branch would suggest the clone tracks something
+  # and invites a later `git pull` to move it out from under a run.
+  git -C "${REPO}" checkout --quiet --detach "${WANT_SHA}" || die "checkout failed."
+  MOVED=yes
+else
+  say "already at ${WANT_SHA:0:10}; no checkout needed."
+fi
+ACTUAL_SHA="$(git -C "${REPO}" rev-parse HEAD)"
+[ "${ACTUAL_SHA}" = "${WANT_SHA}" ] \
+  || die "HEAD is ${ACTUAL_SHA} after checking out ${WANT_SHA}. Refusing to continue:
+building against a commit nobody asked for is how a green run against the wrong
+product happens."
+
+# --- Does the build in front of us belong to this commit? -------------------------
+stamped_sha() {
+  [ -f "${STAMP_FILE}" ] || return 1
+  # `cut` on the first `=` only: a value that contains one must not be truncated.
+  grep -m1 '^sha=' "${STAMP_FILE}" 2> /dev/null | sed 's/^sha=//' || return 1
+}
+
+REBUILD_REASON=""
+STAMPED="$(stamped_sha || true)"
+if [ "${FORCE_REBUILD}" = "1" ]; then
+  REBUILD_REASON="PREPARE_FORCE_REBUILD=1"
+elif [ ! -f "${FRONTEND_DIR}/index.html" ]; then
+  REBUILD_REASON="no frontend build at ${FRONTEND_DIR}"
+elif [ -z "${STAMPED}" ]; then
+  # The state every existing clone is in the first time this runs: assets exist and
+  # nothing says which commit they came from. Treated as stale, deliberately — the
+  # alternative is to trust assets of unknown origin, which is the debt itself.
+  REBUILD_REASON="the build carries no stamp, so its commit is unknown"
+elif [ "${STAMPED}" != "${ACTUAL_SHA}" ]; then
+  REBUILD_REASON="the build belongs to ${STAMPED:0:10}, HEAD is ${ACTUAL_SHA:0:10}"
+fi
+
+DEPS_S=0
+FRONTEND_S=0
+REBUILT=no
+START_S="$(date +%s)"
+
+if [ -n "${REBUILD_REASON}" ] && [ "${SKIP_BUILD}" = "1" ]; then
+  say "a rebuild is needed (${REBUILD_REASON}) but PREPARE_SKIP_BUILD=1 was set."
+  say "the clone has been moved and its build does NOT match HEAD; the starter will refuse."
+elif [ -n "${REBUILD_REASON}" ]; then
+  say "rebuilding: ${REBUILD_REASON}"
+  # The stamp dies FIRST. Every failure path below leaves the clone with no claim
+  # about its build, which is the honest state and the one the starter refuses.
+  rm -f "${STAMP_FILE}"
+
+  T="$(date +%s)"
+  if make -C "${REPO}" -n install_backend > /dev/null 2>&1; then
+    say "deps: make install_backend"
+    make -C "${REPO}" install_backend >&2 || die "install_backend failed."
+  else
+    say "deps: uv sync (no install_backend target in this Makefile)"
+    ( cd "${REPO}" && uv sync ) >&2 || die "uv sync failed."
+  fi
+  DEPS_S=$(( $(date +%s) - T ))
+  say "deps: ${DEPS_S}s"
+
+  T="$(date +%s)"
+  say "frontend: make install_frontend build_frontend"
+  make -C "${REPO}" install_frontend >&2 || die "install_frontend failed."
+  make -C "${REPO}" build_frontend >&2 || die "build_frontend failed."
+  FRONTEND_S=$(( $(date +%s) - T ))
+  say "frontend: ${FRONTEND_S}s"
+
+  # Verified before it is claimed. `make` exiting 0 is not the same as the served
+  # directory existing: build_frontend copies into a path that upstream can move.
+  [ -f "${FRONTEND_DIR}/index.html" ] \
+    || die "the build reported success but there is no ${FRONTEND_DIR}/index.html.
+No stamp has been written, so the starter will refuse rather than serve no UI."
+
+  printf 'sha=%s\nref=%s\nbuilt=deps+frontend\nfrontend_dir=%s\nat=%s\n' \
+    "${ACTUAL_SHA}" "${TARGET_REF:-${WANT_SHA}}" "${FRONTEND_DIR}" \
+    "$(date -u +%FT%TZ)" > "${STAMP_FILE}"
+  REBUILT=yes
+  say "stamped ${STAMP_FILE}"
+else
+  say "the build already belongs to ${ACTUAL_SHA:0:10}; nothing to rebuild."
+fi
+
+TOTAL_S=$(( $(date +%s) - START_S ))
+
+emit "prepared_sha=${ACTUAL_SHA}"
+emit "prepared_ref=${TARGET_REF:-${WANT_SHA}}"
+emit "moved=${MOVED}"
+emit "rebuilt=${REBUILT}"
+emit "rebuild_reason=${REBUILD_REASON:-none}"
+emit "deps_s=${DEPS_S}"
+emit "frontend_s=${FRONTEND_S}"
+emit "total_s=${TOTAL_S}"

--- a/scripts/prepare-target-source.sh
+++ b/scripts/prepare-target-source.sh
@@ -32,9 +32,20 @@
 #
 # TARGET_SHA is the preferred input because upstream's nightly DELETES AND RECREATES
 # its tag names, so `v1.13.0.dev1` can point somewhere new after the 1.13.0.dev1 image
-# shipped — the resolver says so in its own header. The sha it reports was matched by
-# image digest, and a sha cannot drift. TARGET_REF is carried for the log and used
-# only when no sha is available.
+# shipped — the resolver says so in its own header. TARGET_REF is carried for the log
+# and the stamp, and is used as a target only when no sha is available at all.
+#
+# What the registry digest does and does not settle, because the distinction decides
+# how much this placement is worth. The digest picks the VERSION STRING: the resolver
+# matches `latest`'s digest against the other published tags. The COMMIT is then looked
+# up by TAG NAME in the git ref listing — the very mapping that drifts. So a sha handed
+# to this script is commit parity only as far as that tag was trustworthy when it was
+# read, and when the tag cannot be found the resolver reports an EMPTY sha rather than
+# a wrong one. A caller must not turn that emptiness into a checkout of the tag name:
+# that asks for the ref the resolver has just said it could not find, and the refusal
+# below then costs a whole run. scripts/run-e2e.sh does not prepare without a sha for
+# exactly that reason (see target_preparation_plan there). Handed a ref by hand, this
+# script obeys it — the operator is the one making the claim then.
 #
 # `main` is refused outright. It is not what the nightly builds — upstream resolves
 # the newest `release-X.Y.Z` branch — so a clone on `main` tests something the CI

--- a/scripts/prepare-target-source.test.mjs
+++ b/scripts/prepare-target-source.test.mjs
@@ -1,0 +1,331 @@
+// Unit tests for scripts/prepare-target-source.sh.
+// Run with: npm run test:scripts
+//
+// What these protect: the properties that keep "the target is on the commit the CI
+// tests" from becoming a claim instead of a fact. Almost every one of them fails
+// GREEN if it breaks — a lane that runs against the wrong build still reports a
+// verdict, and the verdict looks like a product result.
+//
+//   - Being TOLD the target, never guessing it. No sha and no ref is a refusal, an
+//     absent commit is a refusal, and `main` is a refusal in all three inputs:
+//     upstream's nightly builds the newest release-X.Y.Z branch, so a clone on main
+//     tests something the CI never tests. A fallback here would put changelog into
+//     the divergence list, which is the failure the whole step exists to remove.
+//   - The tool check happens BEFORE the checkout. A missing npm found after the move
+//     leaves the clone on the new commit with the old build — neither where it was
+//     nor where it was going — and that state is one the starter has to refuse.
+//   - The stamp dies before the build and is written only after the served
+//     index.html exists. A stamp that outlives the assets it describes is a
+//     confident wrong answer: the starter would trust it and serve an old UI.
+//   - A rebuild is skipped only when the stamp AGREES with HEAD. Existence of assets
+//     is not provenance.
+//   - stdout carries only key=value, so the orchestrator can capture the summary
+//     without parsing prose.
+//
+// git is REAL here — the checkout, the verification and the dirty check are the
+// behaviour under test, and stubbing git would only test the stub. make, uv and npm
+// are stubbed through a PATH shim, so nothing is downloaded and nothing is built.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, chmodSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, "prepare-target-source.sh");
+const STAMP_NAME = ".langflow-e2e-build-stamp";
+
+function git(repo, ...args) {
+  return execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" }).trim();
+}
+
+/**
+ * A real two-commit clone, plus a PATH shim for the build tools.
+ *
+ * `frontendBuilt` writes the served index.html WITHOUT a stamp, which is the state
+ * every existing clone is in the first time the preparer runs on it.
+ */
+function setup({
+  frontendBuilt = true,
+  stampSha = null,
+  dirty = false,
+  stampOnlyDirt = false,
+  withNpm = true,
+  withUv = true,
+  makeMode = "ok", // ok | fail-deps | fail-frontend | ok-without-assets
+} = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "prepare-target-source-test-"));
+  const bin = join(dir, "bin");
+  const npmBin = join(dir, "npm-bin");
+  const uvBin = join(dir, "uv-bin");
+  const repo = join(dir, "clone");
+  for (const d of [bin, npmBin, uvBin, repo]) mkdirSync(d, { recursive: true });
+
+  execFileSync("git", ["init", "--quiet", "-b", "release-1.12.0", repo]);
+  git(repo, "config", "user.email", "t@example.com");
+  git(repo, "config", "user.name", "t");
+  // Upstream gitignores the served frontend directory, and the real clone on the
+  // target reports a clean tree WITH a build in it because of that. Without this the
+  // fixture's own build would read as somebody's uncommitted work.
+  writeFileSync(join(repo, ".gitignore"), "src/backend/base/langflow/frontend/\n");
+  writeFileSync(join(repo, "README"), "old\n");
+  git(repo, "add", "README", ".gitignore");
+  git(repo, "commit", "--quiet", "-m", "old");
+  const oldSha = git(repo, "rev-parse", "HEAD");
+  writeFileSync(join(repo, "README"), "new\n");
+  git(repo, "commit", "--quiet", "-am", "new");
+  const newSha = git(repo, "rev-parse", "HEAD");
+  // Back to the old commit: the interesting starting point is "behind", like the
+  // machine this step was written for.
+  git(repo, "checkout", "--quiet", oldSha);
+
+  const fe = join(repo, "src/backend/base/langflow/frontend");
+  if (frontendBuilt) {
+    mkdirSync(fe, { recursive: true });
+    writeFileSync(join(fe, "index.html"), "<!doctype html>");
+  }
+  if (stampSha) writeFileSync(join(repo, STAMP_NAME), `sha=${stampSha}\nref=whatever\n`);
+  // Untracked on purpose. A MODIFIED tracked file makes git itself refuse the
+  // checkout, so PREPARE_ALLOW_DIRTY would appear not to work when what actually
+  // happened is git protecting the edit — a different property, and git's, not ours.
+  if (dirty) writeFileSync(join(repo, "scratch-work.txt"), "someone's work in progress\n");
+  if (stampOnlyDirt) writeFileSync(join(repo, STAMP_NAME), `sha=${oldSha}\n`);
+
+  const makeLog = join(dir, "make.log");
+  const uvLog = join(dir, "uv.log");
+  // `-n install_backend` is how the script asks whether the target exists; answering
+  // 0 sends it down the Makefile path, which is what the target machine has.
+  writeFileSync(
+    join(bin, "make"),
+    `#!/usr/bin/env bash
+echo "$*" >> "${makeLog}"
+for a in "$@"; do
+  case "$a" in
+    -n) exit 0 ;;
+    install_backend) ${makeMode === "fail-deps" ? "exit 1" : "exit 0"} ;;
+    install_frontend) exit 0 ;;
+    build_frontend)
+      ${makeMode === "fail-frontend" ? "exit 1" : ""}
+      ${makeMode === "ok-without-assets" ? "exit 0" : `mkdir -p "${fe}" && echo built > "${fe}/index.html"`}
+      exit 0 ;;
+  esac
+done
+exit 0
+`,
+  );
+  writeFileSync(join(uvBin, "uv"), `#!/usr/bin/env bash\necho "$*" >> "${uvLog}"\nexit 0\n`);
+  writeFileSync(join(npmBin, "npm"), `#!/usr/bin/env bash\nexit 0\n`);
+  chmodSync(join(bin, "make"), 0o755);
+  chmodSync(join(uvBin, "uv"), 0o755);
+  chmodSync(join(npmBin, "npm"), 0o755);
+
+  return { dir, repo, bin, npmBin, uvBin, oldSha, newSha, makeLog, uvLog, fe, withNpm, withUv };
+}
+
+function run(ctx, env = {}) {
+  // The shim comes first, and the real PATH last so git and coreutils still resolve.
+  // Dropping npm or uv means dropping only its directory: with the caller's PATH in
+  // front, a real npm on the machine would answer `command -v` and the branch under
+  // test would never run.
+  const parts = [ctx.bin];
+  if (ctx.withUv) parts.push(ctx.uvBin);
+  if (ctx.withNpm) parts.push(ctx.npmBin);
+  const r = spawnSync("bash", [SCRIPT], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${parts.join(":")}:/usr/bin:/bin`,
+      HOME: ctx.dir,
+      LANGFLOW_SRC_REPO: ctx.repo,
+      PREPARE_FETCH: "0", // no remote in these clones; fetching is not what is under test
+      ...env,
+    },
+  });
+  const summary = {};
+  for (const line of (r.stdout || "").split("\n")) {
+    const m = line.match(/^([a-z_]+)=(.*)$/);
+    if (m) summary[m[1]] = m[2];
+  }
+  return { ...r, summary, stdoutLines: (r.stdout || "").split("\n").filter(Boolean) };
+}
+
+const madeCalls = (ctx) => (existsSync(ctx.makeLog) ? readFileSync(ctx.makeLog, "utf8") : "");
+const buildRan = (ctx) => /build_frontend/.test(madeCalls(ctx));
+const stampAt = (ctx) =>
+  existsSync(join(ctx.repo, STAMP_NAME)) ? readFileSync(join(ctx.repo, STAMP_NAME), "utf8") : null;
+
+test("refuses to run without a target, and does not move the clone", () => {
+  const ctx = setup();
+  const r = run(ctx);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /neither TARGET_SHA nor TARGET_REF/);
+  assert.equal(git(ctx.repo, "rev-parse", "HEAD"), ctx.oldSha);
+  assert.equal(buildRan(ctx), false);
+});
+
+for (const variable of ["TARGET_SHA", "TARGET_REF", "TARGET_BRANCH"]) {
+  test(`refuses main given as ${variable}`, () => {
+    const ctx = setup();
+    // TARGET_BRANCH alone is not a target, so it is paired with a real sha: the point
+    // is that a `main` anywhere in the inputs stops the run, not just in the checkout
+    // target. Fetching main to then take a commit "reachable from it" is the same
+    // mistake with a different flag.
+    const env = variable === "TARGET_BRANCH" ? { TARGET_SHA: ctx.newSha, TARGET_BRANCH: "main" } : { [variable]: "main" };
+    const r = run(ctx, env);
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /refusing to prepare the target from 'main'/);
+    assert.equal(git(ctx.repo, "rev-parse", "HEAD"), ctx.oldSha);
+  });
+}
+
+test("refuses a commit that is not in the clone, rather than substituting one", () => {
+  const ctx = setup();
+  const r = run(ctx, { TARGET_SHA: "0".repeat(40) });
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /does not exist in .*Refusing to fall\nback to anything else/s);
+  assert.equal(git(ctx.repo, "rev-parse", "HEAD"), ctx.oldSha);
+});
+
+test("refuses a dirty clone, and PREPARE_ALLOW_DIRTY is the only way past it", () => {
+  const dirtyCtx = setup({ dirty: true });
+  const refused = run(dirtyCtx, { TARGET_SHA: dirtyCtx.newSha });
+  assert.equal(refused.status, 2);
+  assert.match(refused.stderr, /modified path\(s\)/);
+  assert.match(refused.stderr, /scratch-work\.txt/);
+  assert.equal(git(dirtyCtx.repo, "rev-parse", "HEAD"), dirtyCtx.oldSha);
+
+  const allowed = setup({ dirty: true });
+  const ok = run(allowed, { TARGET_SHA: allowed.newSha, PREPARE_ALLOW_DIRTY: "1", PREPARE_SKIP_BUILD: "1" });
+  assert.equal(ok.status, 0);
+});
+
+test("the stamp file alone does not make the clone dirty", () => {
+  // The stamp is untracked and lives inside the clone on purpose (it must survive a
+  // reboot). If it counted as dirt, the second run would always refuse.
+  const ctx = setup({ stampOnlyDirt: true });
+  const r = run(ctx, { TARGET_SHA: ctx.newSha, PREPARE_SKIP_BUILD: "1" });
+  assert.equal(r.status, 0);
+  assert.equal(r.summary.moved, "yes");
+});
+
+for (const missing of ["npm", "uv"]) {
+  test(`refuses when ${missing} is missing, BEFORE moving the clone`, () => {
+    const ctx = setup(missing === "npm" ? { withNpm: false } : { withUv: false });
+    const r = run(ctx, { TARGET_SHA: ctx.newSha });
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, new RegExp(`${missing} is not on PATH`));
+    // The property, not the message: a build that cannot finish must not have already
+    // moved the clone. Otherwise the machine is left with a new backend and an old UI.
+    assert.equal(git(ctx.repo, "rev-parse", "HEAD"), ctx.oldSha);
+  });
+}
+
+test("the revert hint is usable on a clone this script already prepared", () => {
+  // A prepared clone is detached, where `rev-parse --abbrev-ref` answers "HEAD" — so
+  // the hint used to read `checkout HEAD` and revert nothing. The fixture is already
+  // detached, which is why this went unnoticed until the script ran on the machine:
+  // reading the code, "BEFORE_REF" looks like a branch name.
+  const ctx = setup();
+  const r = run(ctx, { TARGET_SHA: ctx.newSha, PREPARE_SKIP_BUILD: "1" });
+  assert.equal(r.status, 0);
+  assert.match(r.stderr, new RegExp(`revert with: git -C \\S+ checkout ${ctx.oldSha}`));
+  assert.doesNotMatch(r.stderr, /checkout HEAD$/m);
+});
+
+test("moves the clone, rebuilds, and stamps the commit it built", () => {
+  const ctx = setup({ frontendBuilt: false });
+  const r = run(ctx, { TARGET_SHA: ctx.newSha, TARGET_REF: "v1.13.0.dev1" });
+  assert.equal(r.status, 0);
+  assert.equal(git(ctx.repo, "rev-parse", "HEAD"), ctx.newSha);
+  assert.equal(r.summary.moved, "yes");
+  assert.equal(r.summary.rebuilt, "yes");
+  assert.equal(r.summary.prepared_sha, ctx.newSha);
+  assert.equal(r.summary.prepared_ref, "v1.13.0.dev1");
+  assert.match(madeCalls(ctx), /install_frontend/);
+  assert.match(madeCalls(ctx), /build_frontend/);
+  const stamp = stampAt(ctx);
+  assert.match(stamp, new RegExp(`^sha=${ctx.newSha}$`, "m"));
+});
+
+test("skips the rebuild only when the stamp agrees with HEAD", () => {
+  const ctx = setup({ stampSha: null });
+  // First bring it to the target and let it build, which writes the stamp.
+  run(ctx, { TARGET_SHA: ctx.newSha });
+  const again = run(ctx, { TARGET_SHA: ctx.newSha });
+  assert.equal(again.status, 0);
+  assert.equal(again.summary.moved, "no");
+  assert.equal(again.summary.rebuilt, "no");
+  assert.equal(again.summary.rebuild_reason, "none");
+});
+
+test("assets whose commit is unknown are treated as stale, not as good", () => {
+  // Every clone built by hand before this script existed is in exactly this state:
+  // an index.html and no stamp. Trusting it is the debt this step closes.
+  const ctx = setup({ frontendBuilt: true, stampSha: null });
+  const r = run(ctx, { TARGET_SHA: ctx.newSha });
+  assert.equal(r.status, 0);
+  assert.equal(r.summary.rebuilt, "yes");
+  assert.match(r.summary.rebuild_reason, /carries no stamp/);
+});
+
+test("a stamp from another commit forces a rebuild", () => {
+  const ctx = setup({ frontendBuilt: true, stampSha: "f".repeat(40) });
+  const r = run(ctx, { TARGET_SHA: ctx.newSha });
+  assert.equal(r.status, 0);
+  assert.equal(r.summary.rebuilt, "yes");
+  assert.match(r.summary.rebuild_reason, /the build belongs to fffffffff/);
+});
+
+for (const mode of ["fail-deps", "fail-frontend"]) {
+  test(`a failed build (${mode}) leaves NO stamp behind`, () => {
+    // The core fail-closed property. The stamp is removed before the build starts, so
+    // an interrupted or failed build leaves "unknown" rather than a stale claim that
+    // the starter would believe.
+    const ctx = setup({ frontendBuilt: true, stampSha: "f".repeat(40), makeMode: mode });
+    const r = run(ctx, { TARGET_SHA: ctx.newSha });
+    assert.notEqual(r.status, 0);
+    assert.equal(stampAt(ctx), null);
+  });
+}
+
+test("a build that reports success without producing index.html is a failure", () => {
+  const ctx = setup({ frontendBuilt: false, makeMode: "ok-without-assets" });
+  const r = run(ctx, { TARGET_SHA: ctx.newSha });
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /reported success but there is no/);
+  assert.equal(stampAt(ctx), null);
+});
+
+test("PREPARE_SKIP_BUILD moves the clone and says the build does not match", () => {
+  const ctx = setup({ frontendBuilt: true, stampSha: "f".repeat(40) });
+  const r = run(ctx, { TARGET_SHA: ctx.newSha, PREPARE_SKIP_BUILD: "1" });
+  assert.equal(r.status, 0);
+  assert.equal(git(ctx.repo, "rev-parse", "HEAD"), ctx.newSha);
+  assert.equal(r.summary.rebuilt, "no");
+  assert.notEqual(r.summary.rebuild_reason, "none");
+  assert.equal(buildRan(ctx), false);
+});
+
+test("stdout is only key=value, so a caller can capture it without parsing prose", () => {
+  const ctx = setup({ frontendBuilt: false });
+  const r = run(ctx, { TARGET_SHA: ctx.newSha });
+  assert.equal(r.status, 0);
+  for (const line of r.stdoutLines) {
+    assert.match(line, /^[a-z_]+=/, `prose on stdout: ${line}`);
+  }
+  // And the human narration still exists — on stderr, where it cannot corrupt the
+  // summary.
+  assert.match(r.stderr, /before: /);
+});
+
+test("reports deps and frontend timings separately", () => {
+  // The number that decides whether the rebuild fits at the head of a run or becomes
+  // its own step. One total would not answer that.
+  const ctx = setup({ frontendBuilt: false });
+  const r = run(ctx, { TARGET_SHA: ctx.newSha });
+  assert.match(r.summary.deps_s, /^\d+$/);
+  assert.match(r.summary.frontend_s, /^\d+$/);
+  assert.match(r.summary.total_s, /^\d+$/);
+});

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -164,9 +164,19 @@ PREPARE_TARGET="${PREPARE_TARGET:-1}"
 # measure what a rebuild would cost, and to move a clone whose build is being done
 # by hand elsewhere.
 PREPARE_TARGET_SKIP_BUILD="${PREPARE_TARGET_SKIP_BUILD:-0}"
+# Forwarded to the preparer, which refuses a clone carrying somebody's uncommitted
+# work. Exposed here because without it the only way past one stray file on a shared
+# VM is PREPARE_TARGET=0, which switches the whole placement off to get past it.
+PREPARE_TARGET_ALLOW_DIRTY="${PREPARE_TARGET_ALLOW_DIRTY:-0}"
 # The stamp is only demanded when this run is the thing that wrote it. A clone
 # prepared by hand carries no stamp, and refusing it there would break the one
 # workflow that has to keep working while this is being adopted.
+#
+# This is the INTENT. What is actually demanded is decided in phase_preflight from
+# what the preparation step really DID — see stamp_demand_for_plan(). The two differ
+# whenever the resolution could not name a commit: demanding the stamp there fails
+# the start with "no build stamp" over a cause that belonged to the resolver, which
+# sends the operator to the wrong machine.
 STAMP_REQUIRED="$([ "${PREPARE_TARGET}" = "1" ] && [ "${PREPARE_TARGET_SKIP_BUILD}" != "1" ] && echo 1 || echo 0)"
 
 MIN_FREE_GB="${MIN_FREE_GB:-20}"
@@ -196,6 +206,55 @@ die()  { err "$*"; exit 1; }
 
 # shellcheck disable=SC2086
 target_ssh() { ssh -o BatchMode=yes -o ConnectTimeout=15 $TARGET_SSH_OPTS "$TARGET_SSH" "$@"; }
+
+# Should this run place the target's clone, and if not, why not?
+#
+# Split out of phase_preflight so the decision is testable without ssh — the phase
+# around it fetches, curls and runs `npm ci`, so the only reachable alternative was a
+# regex over this file, and a guard that pins a spelling does not pin a behaviour.
+#
+# The answer turns on a resolved COMMIT and never on the ref, which is the whole point.
+# scripts/resolve-target-version.mjs returns `ok: true` with an EMPTY sha in two states
+# it can neither help nor hide: the github ref listing unreachable or partial (the
+# registry alone answers the version, not the commit), and the nightly tag deleted and
+# not yet recreated — which upstream does routinely. In both it still reports a ref,
+# `v1.13.0.dev1`. Handing that name to the preparer as a checkout target asks it for a
+# tag the resolver has just said it could not find, so it refuses and the run dies at
+# preflight — before phase_publish, so with no report at all. That is strictly worse
+# than the red-with-a-report the version gate produces on its own, and it hands
+# github.com the veto the resolution deliberately took away from it.
+target_preparation_plan() {
+  if [ "${PREPARE_TARGET:-1}" != "1" ]; then
+    echo "off"
+  elif [ "${CHECK_TARGET_VERSION:-1}" != "1" ]; then
+    # Placement obeys a resolution, so switching the resolution off switches placement
+    # off with it. Distinguished from "unresolved" so the operator who asked for this
+    # is not warned about a failure that is their own configuration.
+    echo "off"
+  elif [ -n "${TARGET_EXPECTED_SHA:-}" ]; then
+    echo "prepare"
+  elif [ -n "${TARGET_EXPECTED_VERSION:-}" ]; then
+    # The version is known and authoritative; only its commit is not. Distinguished
+    # from the unresolved case because it sends the reader somewhere else entirely.
+    echo "skip-no-commit"
+  else
+    echo "skip-unresolved"
+  fi
+  return 0
+}
+
+# Whether the starter must REFUSE an unstamped build, given what preparation actually
+# did. Only a run that placed and rebuilt the clone wrote a stamp, so only that run is
+# entitled to demand one; anywhere else the demand fails the start over a missing file
+# this run never undertook to create.
+stamp_demand_for_plan() {
+  if [ "${1:-}" = "prepare" ] && [ "${PREPARE_TARGET_SKIP_BUILD:-0}" != "1" ]; then
+    echo 1
+  else
+    echo 0
+  fi
+  return 0
+}
 
 # Reads one key out of a $GITHUB_OUTPUT-formatted file, including the heredoc form
 # (`key<<DELIM ... DELIM`) that report-backend-outages.mjs uses for multi-line values.
@@ -396,28 +455,46 @@ phase_preflight() {
   fi
 
   # --- Obey the resolution: put the target ON that commit -------------------------
-  # Failing here is the point. A run against the clone's old position still produces
-  # a verdict, and that verdict goes into the divergence list as "a real failure only
-  # Actions saw" — product changelog wearing an environment's clothes. A lane whose
-  # output would be misleading is worth less than no output.
+  # Failing an ATTEMPTED placement is the point. A run against the clone's old position
+  # still produces a verdict, and that verdict goes into the divergence list as "a real
+  # failure only Actions saw" — product changelog wearing an environment's clothes. A
+  # lane whose output would be misleading is worth less than no output.
+  #
+  # Not placing at all is a different case and must not share that fate. When the
+  # resolution names no commit, dying here costs the whole run — this is upstream of
+  # phase_publish, so there is no report either — where the version gate at the end
+  # produces the same red WITH the evidence. target_preparation_plan() draws that line.
   TARGET_PREPARED_SHA=""; TARGET_REBUILT=""; TARGET_REBUILD_REASON=""; TARGET_PREPARE_S=""
-  if [ "$PREPARE_TARGET" = "1" ] && [ -n "${TARGET_EXPECTED_SHA}${TARGET_EXPECTED_REF}" ]; then
+  local plan; plan="$(target_preparation_plan)"
+  # What is demanded of the starter follows what preparation DID, not what was asked
+  # for. The configured value above is the intent; this is the outcome.
+  STAMP_REQUIRED="$(stamp_demand_for_plan "$plan")"
+  if [ "$plan" = "prepare" ]; then
     log "Preparing the target's clone"
-    local prep_out prep_log="$RUN_DIR/logs/prepare-target.log"
+    local prep_out prep_rc=0 prep_log="$RUN_DIR/logs/prepare-target.log"
     # stderr is streamed AND filed: a rebuild is the longest thing this run does, and
     # a phase that prints nothing for half an hour is indistinguishable from a hang.
-    if ! prep_out="$(target_ssh \
+    #
+    # The status is captured rather than branched on directly, so the summary is filed
+    # on BOTH paths. On a failure the preparer has usually printed nothing to stdout —
+    # it emits its key=value block only after everything succeeded, and every refusal
+    # goes to stderr, which is tee'd — so this is insurance against a partial or
+    # polluted capture, not a lost summary. A log the operator is pointed at should
+    # not have a path on which it is silently short.
+    prep_out="$(target_ssh \
         "TARGET_SHA=${TARGET_EXPECTED_SHA} TARGET_REF=${TARGET_EXPECTED_REF} TARGET_BRANCH=${TARGET_EXPECTED_BRANCH} \
          LANGFLOW_SRC_REPO=\${LANGFLOW_SRC_REPO:-\$HOME/langflow} \
+         PREPARE_ALLOW_DIRTY=${PREPARE_TARGET_ALLOW_DIRTY} \
          PREPARE_SKIP_BUILD=${PREPARE_TARGET_SKIP_BUILD} bash -s" \
-        < scripts/prepare-target-source.sh 2> >(tee -a "$prep_log" >&2))"; then
+        < scripts/prepare-target-source.sh 2> >(tee -a "$prep_log" >&2))" || prep_rc=$?
+    printf '%s\n' "$prep_out" >> "$prep_log"
+    if [ "$prep_rc" != "0" ]; then
       err "could not put the target on ${TARGET_EXPECTED_REF:-${TARGET_EXPECTED_SHA}}."
       err "Refusing to run. The comparison this lane exists to produce is only about"
       err "the environment if both sides run the same product; against the clone's old"
       err "position it describes the product's changelog instead. See $prep_log."
       die "target preparation failed"
     fi
-    printf '%s\n' "$prep_out" >> "$prep_log"
     TARGET_PREPARED_SHA="$(printf '%s\n' "$prep_out" | sed -n 's/^prepared_sha=//p')"
     TARGET_REBUILT="$(printf '%s\n' "$prep_out" | sed -n 's/^rebuilt=//p')"
     TARGET_REBUILD_REASON="$(printf '%s\n' "$prep_out" | sed -n 's/^rebuild_reason=//p')"
@@ -430,9 +507,24 @@ phase_preflight() {
     fi
     info "target clone: ${TARGET_PREPARED_SHA:0:10} (rebuilt=${TARGET_REBUILT:-?}${TARGET_PREPARE_S:+, ${TARGET_PREPARE_S}s})"
     [ "${TARGET_REBUILT}" = "yes" ] && info "  rebuilt because: ${TARGET_REBUILD_REASON}"
-  elif [ "$PREPARE_TARGET" = "1" ]; then
-    warn "no target commit was resolved, so the clone was left where it is. The version"
-    warn "check below still runs, but nothing has been placed — treat a match as luck."
+  elif [ "$plan" = "skip-no-commit" ]; then
+    # The version is authoritative and the commit is not known — the registry decided
+    # the version string by digest, while the commit is looked up by TAG NAME in the
+    # git ref listing, and that lookup came back empty. Placing the clone on the tag
+    # name anyway would ask for the tag the resolver just failed to find; placing it on
+    # the branch head would build something nobody resolved and then fail the
+    # exact-match gate below for a difference this run invented. So: do less, say more.
+    warn "resolved ${TARGET_EXPECTED_VERSION} but not the commit behind it, so the clone was"
+    warn "left where it is. The registry names the version; the commit comes from the git"
+    warn "tag listing, which was empty for ${TARGET_EXPECTED_REF:-that version} — github"
+    warn "unreachable, or the nightly tag deleted and not yet recreated."
+    warn "The version check below still runs and will report the gap. To place it by hand:"
+    warn "  git -C <clone> checkout ${TARGET_EXPECTED_BRANCH:-release-<cycle>}  # cycle parity, not the commit"
+    warn "The build stamp is NOT demanded of the starter, because this run did not write one."
+  elif [ "$plan" = "skip-unresolved" ]; then
+    warn "no target version was resolved at all, so the clone was left where it is. The"
+    warn "version check below cannot run either — treat a green run as unverified, not as"
+    warn "evidence that both lanes tested the same product."
   fi
 
   log "Installing dependencies (npm ci)"

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -145,6 +145,23 @@ UPSTREAM_REPO_URL="${UPSTREAM_REPO_URL:-https://github.com/langflow-ai/langflow}
 NIGHTLY_TAGS_URL="${NIGHTLY_TAGS_URL:-https://hub.docker.com/v2/repositories/langflowai/langflow-nightly/tags?page_size=100&ordering=last_updated}"
 CHECK_TARGET_VERSION="${CHECK_TARGET_VERSION:-1}"
 REQUIRE_TARGET_VERSION="${REQUIRE_TARGET_VERSION:-0}"
+# Whether the run OBEYS the resolution instead of only reporting it. Reporting was
+# step 16's first half and was deliberately not fatal: failing at 08:00 over a clone
+# somebody had to move by hand threw away a day of data. This is the second half —
+# the run moves the clone itself, through scripts/prepare-target-source.sh, before
+# anything starts. That script is a no-op when the clone is already on the commit and
+# its build is stamped with it, so the cost lands only on the days the resolution
+# moves; with a nightly image, that is most days.
+PREPARE_TARGET="${PREPARE_TARGET:-1}"
+# Move the clone but do not build. Not a normal setting: the starter refuses a build
+# that does not belong to HEAD, so this ends the run early ON PURPOSE. It exists to
+# measure what a rebuild would cost, and to move a clone whose build is being done
+# by hand elsewhere.
+PREPARE_TARGET_SKIP_BUILD="${PREPARE_TARGET_SKIP_BUILD:-0}"
+# The stamp is only demanded when this run is the thing that wrote it. A clone
+# prepared by hand carries no stamp, and refusing it there would break the one
+# workflow that has to keep working while this is being adopted.
+STAMP_REQUIRED="$([ "${PREPARE_TARGET}" = "1" ] && [ "${PREPARE_TARGET_SKIP_BUILD}" != "1" ] && echo 1 || echo 0)"
 
 MIN_FREE_GB="${MIN_FREE_GB:-20}"
 DRY_RUN="${DRY_RUN:-0}"
@@ -327,6 +344,7 @@ phase_preflight() {
   # here and compared after the run: asking now means the operator sees the gap before
   # spending an hour producing a comparison that a version difference already spoiled.
   TARGET_EXPECTED_VERSION=""; TARGET_EXPECTED_REF=""; TARGET_EXPECTED_SHA=""; TARGET_RESOLUTION=""
+  TARGET_EXPECTED_BRANCH=""
   if [ "$CHECK_TARGET_VERSION" = "1" ]; then
     local vlog="$RUN_DIR/logs/target-version.log" verr="$RUN_DIR/logs/target-version.err"
     # The registry listing is optional and its absence is survivable — the resolver
@@ -356,6 +374,9 @@ phase_preflight() {
       TARGET_EXPECTED_REF="$(node -p "JSON.parse(process.argv[1]).ref||''" "$decision")"
       TARGET_EXPECTED_SHA="$(node -p "JSON.parse(process.argv[1]).sha||''" "$decision")"
       TARGET_RESOLUTION="$(node -p "JSON.parse(process.argv[1]).strategy||''" "$decision")"
+      # Carried for the preparer, not for the report: when the nightly tag has been
+      # recreated, the commit is only reachable through the branch it lives on.
+      TARGET_EXPECTED_BRANCH="$(node -p "JSON.parse(process.argv[1]).branch||''" "$decision")"
       info "target should be: $TARGET_EXPECTED_VERSION (ref $TARGET_EXPECTED_REF, commit ${TARGET_EXPECTED_SHA:0:10}, by $TARGET_RESOLUTION)"
     else
       # Quote the resolver rather than inventing a reason: it distinguishes "no
@@ -366,6 +387,46 @@ phase_preflight() {
       warn "could not resolve which Langflow this lane should test${why:+ — $why}"
       warn "The comparison will not know whether both sides ran the same product."
     fi
+  fi
+
+  # --- Obey the resolution: put the target ON that commit -------------------------
+  # Failing here is the point. A run against the clone's old position still produces
+  # a verdict, and that verdict goes into the divergence list as "a real failure only
+  # Actions saw" — product changelog wearing an environment's clothes. A lane whose
+  # output would be misleading is worth less than no output.
+  TARGET_PREPARED_SHA=""; TARGET_REBUILT=""; TARGET_REBUILD_REASON=""; TARGET_PREPARE_S=""
+  if [ "$PREPARE_TARGET" = "1" ] && [ -n "${TARGET_EXPECTED_SHA}${TARGET_EXPECTED_REF}" ]; then
+    log "Preparing the target's clone"
+    local prep_out prep_log="$RUN_DIR/logs/prepare-target.log"
+    # stderr is streamed AND filed: a rebuild is the longest thing this run does, and
+    # a phase that prints nothing for half an hour is indistinguishable from a hang.
+    if ! prep_out="$(target_ssh \
+        "TARGET_SHA=${TARGET_EXPECTED_SHA} TARGET_REF=${TARGET_EXPECTED_REF} TARGET_BRANCH=${TARGET_EXPECTED_BRANCH} \
+         LANGFLOW_SRC_REPO=\${LANGFLOW_SRC_REPO:-\$HOME/langflow} \
+         PREPARE_SKIP_BUILD=${PREPARE_TARGET_SKIP_BUILD} bash -s" \
+        < scripts/prepare-target-source.sh 2> >(tee -a "$prep_log" >&2))"; then
+      err "could not put the target on ${TARGET_EXPECTED_REF:-${TARGET_EXPECTED_SHA}}."
+      err "Refusing to run. The comparison this lane exists to produce is only about"
+      err "the environment if both sides run the same product; against the clone's old"
+      err "position it describes the product's changelog instead. See $prep_log."
+      die "target preparation failed"
+    fi
+    printf '%s\n' "$prep_out" >> "$prep_log"
+    TARGET_PREPARED_SHA="$(printf '%s\n' "$prep_out" | sed -n 's/^prepared_sha=//p')"
+    TARGET_REBUILT="$(printf '%s\n' "$prep_out" | sed -n 's/^rebuilt=//p')"
+    TARGET_REBUILD_REASON="$(printf '%s\n' "$prep_out" | sed -n 's/^rebuild_reason=//p')"
+    TARGET_PREPARE_S="$(printf '%s\n' "$prep_out" | sed -n 's/^total_s=//p')"
+    # The preparer verifies its own checkout; this checks that the machine it verified
+    # is the one this run resolved. They differ if TARGET_SSH points somewhere else.
+    if [ -n "${TARGET_EXPECTED_SHA}" ] && [ "${TARGET_PREPARED_SHA}" != "${TARGET_EXPECTED_SHA}" ]; then
+      err "the target reports ${TARGET_PREPARED_SHA:-nothing} after being asked for ${TARGET_EXPECTED_SHA}."
+      die "the prepared commit is not the resolved one"
+    fi
+    info "target clone: ${TARGET_PREPARED_SHA:0:10} (rebuilt=${TARGET_REBUILT:-?}${TARGET_PREPARE_S:+, ${TARGET_PREPARE_S}s})"
+    [ "${TARGET_REBUILT}" = "yes" ] && info "  rebuilt because: ${TARGET_REBUILD_REASON}"
+  elif [ "$PREPARE_TARGET" = "1" ]; then
+    warn "no target commit was resolved, so the clone was left where it is. The version"
+    warn "check below still runs, but nothing has been placed — treat a match as luck."
   fi
 
   log "Installing dependencies (npm ci)"
@@ -500,7 +561,7 @@ start_backend_for_shard() {
   # clone, and its absence fails with the right message for the wrong reason.
   # shellcheck disable=SC2086
   ssh -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 $TARGET_SSH_OPTS "$TARGET_SSH" \
-    "PATH=\$HOME/.local/bin:\$PATH LANGFLOW_SRC_REPO=\${LANGFLOW_SRC_REPO:-\$HOME/langflow} ${bind_env}LANGFLOW_PORT=$port bash -s; sleep 86400" \
+    "PATH=\$HOME/.local/bin:\$PATH LANGFLOW_SRC_REPO=\${LANGFLOW_SRC_REPO:-\$HOME/langflow} LANGFLOW_REQUIRE_BUILD_STAMP=$STAMP_REQUIRED ${bind_env}LANGFLOW_PORT=$port bash -s; sleep 86400" \
     < scripts/start-langflow-source.sh > "$holder_log" 2>&1 &
   HELD_SESSIONS+=("$!")
 
@@ -794,6 +855,10 @@ phase_merge() {
     langflow_expected_sha "${TARGET_EXPECTED_SHA:-}" \
     langflow_version_resolution "${TARGET_RESOLUTION:-}" \
     langflow_version_match "${TARGET_VERSION_MATCH:-unchecked}" \
+    langflow_prepared_sha "${TARGET_PREPARED_SHA:-}" \
+    langflow_prepared_rebuilt "${TARGET_REBUILT:-no}" \
+    langflow_prepared_reason "${TARGET_REBUILD_REASON:-}" \
+    langflow_prepare_seconds "${TARGET_PREPARE_S:-}" \
     shards "$SHARD_TOTAL" \
     tunnel "$LANGFLOW_TUNNEL" \
     tests_total "${RUN_TESTS:-0}"

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -144,7 +144,13 @@ UPSTREAM_REPO_URL="${UPSTREAM_REPO_URL:-https://github.com/langflow-ai/langflow}
 # one it claims. Override this together with those inputs, never one alone.
 NIGHTLY_TAGS_URL="${NIGHTLY_TAGS_URL:-https://hub.docker.com/v2/repositories/langflowai/langflow-nightly/tags?page_size=100&ordering=last_updated}"
 CHECK_TARGET_VERSION="${CHECK_TARGET_VERSION:-1}"
-REQUIRE_TARGET_VERSION="${REQUIRE_TARGET_VERSION:-0}"
+# Enforced by default since 2026-09-03, because the two conditions it was waiting for
+# both hold: this run PLACES the clone (see PREPARE_TARGET below), so a mismatch is no
+# longer somebody forgetting to move it by hand; and a source instance at v1.13.0.dev1
+# was smoked and reports `1.13.0.dev1` — the exact string the published-image strategy
+# expects, so enforcement cannot fail a correctly placed clone over a formatting
+# difference. Set to 0 to diagnose against a deliberately mismatched target.
+REQUIRE_TARGET_VERSION="${REQUIRE_TARGET_VERSION:-1}"
 # Whether the run OBEYS the resolution instead of only reporting it. Reporting was
 # step 16's first half and was deliberately not fatal: failing at 08:00 over a clone
 # somebody had to move by hand threw away a day of data. This is the second half —
@@ -815,9 +821,12 @@ phase_merge() {
     [ -n "$LANGFLOW_VERSION" ] && break
   done
 
-  # The comparison this step exists for. A mismatch is reported, not fatal: while the
-  # clone is moved by hand, failing here would throw away a day of otherwise usable
-  # data. REQUIRE_TARGET_VERSION=1 flips that once the run moves the clone itself.
+  # The comparison this step exists for. A mismatch is now FATAL by default: the run
+  # placed the clone itself a few phases ago, so the two sides disagreeing means
+  # something actually went wrong — the placement did not take, or the target answered
+  # for an instance this run did not start. Producing a comparison anyway would file
+  # product changelog as an environment difference, which is the failure this whole
+  # step exists to remove. REQUIRE_TARGET_VERSION=0 goes back to reporting only.
   TARGET_VERSION_MATCH="unchecked"; TARGET_VERSION_REASON=""
   if [ "$CHECK_TARGET_VERSION" = "1" ] && [ -n "$TARGET_EXPECTED_VERSION" ]; then
     local compared

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -139,6 +139,42 @@ test("the version check is on by default, and enforcing it is not — yet", () =
   assert.equal(r.stdout.trim(), "1 0");
 });
 
+test("the run moves the clone by default, and demands the stamp because of it", () => {
+  // The second half of step 16. Detection alone left the operator to move the clone,
+  // and a lane that depends on someone remembering is a lane that reports changelog
+  // as environment difference on the day they forget.
+  const r = sourced(`echo "$PREPARE_TARGET $PREPARE_TARGET_SKIP_BUILD $STAMP_REQUIRED"`);
+  assert.equal(r.stdout.trim(), "1 0 1");
+});
+
+test("the stamp is demanded only when this run is what wrote it", () => {
+  // Both exceptions are deliberate. With preparation off, or with the build skipped,
+  // no stamp exists and refusing over its absence would break the hand-driven path
+  // that has to keep working while this is adopted.
+  assert.equal(sourced(`echo "$STAMP_REQUIRED"`, { PREPARE_TARGET: "0" }).stdout.trim(), "0");
+  assert.equal(sourced(`echo "$STAMP_REQUIRED"`, { PREPARE_TARGET_SKIP_BUILD: "1" }).stdout.trim(), "0");
+});
+
+test("preparation is driven by the resolved COMMIT, and its failure stops the run", () => {
+  const text = readFileSync(SCRIPT, "utf8");
+  // The commit, not the branch or the tag name: upstream recreates nightly tag names,
+  // so only the sha the registry digest matched cannot drift.
+  assert.match(text, /TARGET_SHA=\$\{TARGET_EXPECTED_SHA\}/);
+  assert.match(text, /prepare-target-source\.sh/);
+  assert.match(text, /LANGFLOW_REQUIRE_BUILD_STAMP=\$STAMP_REQUIRED/);
+
+  const block = text.match(/# --- Obey the resolution[\s\S]*?\n  log "Installing dependencies/)?.[0];
+  assert.ok(block, "the preparation block is not where this test expects it");
+  // A run that could not be placed must not continue: its verdict would be about a
+  // different product, and that is worth less than no verdict.
+  assert.match(block, /die "target preparation failed"/);
+  assert.doesNotMatch(block, /\|\| true/, "the preparation must not be allowed to fail silently");
+
+  // And what it did is recorded, because nobody recovers it afterwards.
+  assert.match(text, /langflow_prepared_sha/);
+  assert.match(text, /langflow_prepare_seconds/);
+});
+
 test("a version mismatch does not fail the run on its own", () => {
   const r = sourced(
     `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -172,19 +172,71 @@ test("the stamp is demanded only when this run is what wrote it", () => {
   assert.equal(sourced(`echo "$STAMP_REQUIRED"`, { PREPARE_TARGET_SKIP_BUILD: "1" }).stdout.trim(), "0");
 });
 
+// The decision that says whether this run places the clone. Behavioural rather than a
+// regex over the file: phase_preflight around it fetches, curls and runs `npm ci`, so
+// a spelling guard was the only reachable alternative and #1226 established that such
+// a guard passes the mutations it exists to catch.
+const plan = (env) => sourced(`echo "$(target_preparation_plan)"`, env).stdout.trim();
+
+test("a resolved commit is what makes this run place the clone", () => {
+  assert.equal(plan({ TARGET_EXPECTED_SHA: "a".repeat(40), TARGET_EXPECTED_VERSION: "1.13.0.dev1" }), "prepare");
+  assert.equal(plan({ PREPARE_TARGET: "0", TARGET_EXPECTED_SHA: "a".repeat(40) }), "off");
+  // Placement obeys a resolution. Turning the resolution off turns placement off with
+  // it, and says so as configuration rather than warning about an absent answer nobody
+  // asked for.
+  assert.equal(plan({ CHECK_TARGET_VERSION: "0" }), "off");
+});
+
+test("a resolved VERSION with no commit does not place the clone, and does not kill the run", () => {
+  // The regression this guards. resolve-target-version.mjs returns ok:true with an
+  // EMPTY sha in two routine states — the github ref listing unreachable or partial,
+  // and the nightly tag deleted and not yet recreated, which upstream does routinely —
+  // while still reporting `ref: v1.13.0.dev1`. Gating on `sha || ref` passed on the
+  // ref, handed the preparer a tag name the resolver had just failed to find, and the
+  // preparer correctly refused: `die "target preparation failed"` in phase_preflight,
+  // upstream of phase_publish, so zero tests AND no report. The version gate at the end
+  // produces the same red with the evidence attached, which is why this must skip.
+  assert.equal(plan({ TARGET_EXPECTED_VERSION: "1.13.0.dev1", TARGET_EXPECTED_REF: "v1.13.0.dev1", TARGET_EXPECTED_SHA: "" }), "skip-no-commit");
+  // And "nothing resolved at all" stays a distinct answer: it sends the reader to the
+  // resolver rather than to the ref listing.
+  assert.equal(plan({}), "skip-unresolved");
+});
+
+test("the stamp is demanded only by a run that actually wrote one", () => {
+  // Derived from what preparation DID, not from the configuration. The two diverge on
+  // the skip paths, and demanding the stamp there fails the START with "no build stamp"
+  // over a cause that belonged to the resolver — sending the operator to the wrong
+  // machine, on a day the run could still have produced its comparison.
+  const demand = (arg, env = {}) => sourced(`stamp_demand_for_plan ${arg}`, env).stdout.trim();
+  assert.equal(demand("prepare"), "1");
+  assert.equal(demand("prepare", { PREPARE_TARGET_SKIP_BUILD: "1" }), "0");
+  for (const p of ["skip-no-commit", "skip-unresolved", "off"]) assert.equal(demand(p), "0", p);
+});
+
 test("preparation is driven by the resolved COMMIT, and its failure stops the run", () => {
   const text = readFileSync(SCRIPT, "utf8");
   // The commit, not the branch or the tag name: upstream recreates nightly tag names,
-  // so only the sha the registry digest matched cannot drift.
+  // so the tag-name lookup that produces the sha can point somewhere new — and when it
+  // finds nothing the resolver reports an empty sha rather than a wrong one.
   assert.match(text, /TARGET_SHA=\$\{TARGET_EXPECTED_SHA\}/);
   assert.match(text, /prepare-target-source\.sh/);
   assert.match(text, /LANGFLOW_REQUIRE_BUILD_STAMP=\$STAMP_REQUIRED/);
+  // A stray untracked file on a shared VM must not cost the placement its only escape
+  // hatch being PREPARE_TARGET=0, which switches the whole thing off.
+  assert.match(text, /PREPARE_ALLOW_DIRTY=\$\{PREPARE_TARGET_ALLOW_DIRTY\}/);
 
   const block = text.match(/# --- Obey the resolution[\s\S]*?\n  log "Installing dependencies/)?.[0];
   assert.ok(block, "the preparation block is not where this test expects it");
-  // A run that could not be placed must not continue: its verdict would be about a
-  // different product, and that is worth less than no verdict.
+  // A placement that was ATTEMPTED and failed must not continue: its verdict would be
+  // about a different product, and that is worth less than no verdict.
   assert.match(block, /die "target preparation failed"/);
+  // The preparer's own summary is filed before that die, so the log the operator is
+  // pointed at has no path on which it is silently short (Copilot, PR #1701).
+  const failurePath = block.indexOf('die "target preparation failed"');
+  assert.ok(
+    block.lastIndexOf('>> "$prep_log"', failurePath) > block.indexOf("prep_out=\"$(target_ssh"),
+    "prep_out must be appended to the log before the failure path exits",
+  );
   assert.doesNotMatch(block, /\|\| true/, "the preparation must not be allowed to fail silently");
 
   // And what it did is recorded, because nobody recovers it afterwards.

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -49,6 +49,12 @@ function verdict({ empty = "false", partial = "false", complete = "true", failed
     [
       `RUN_EMPTY=${empty} RUN_PARTIAL=${partial} SHARD_COMPLETE=${complete} TEST_JOB_FAILED=${failed}`,
       `RUN_TESTS=7 RUN_ERRORS=2 RUN_FIRST_ERROR="a top-level error" RUN_DIR=/tmp/does-not-matter`,
+      // The version dimension is neutralised on purpose. With enforcement on by
+      // default, leaving this unset makes it "unchecked" — fatal — so every case
+      // below would fail for the version reason instead of its own, and the ones
+      // that EXPECT a failure would pass for the wrong reason. The version states
+      // have their own tests.
+      `TARGET_VERSION_MATCH=yes`,
       // `set +e` because sourcing brought `set -e` with it, and a phase that returns
       // non-zero would abort this harness before it could report the code — which is
       // the very thing under test.
@@ -131,12 +137,23 @@ test("the publish switches are OFF by default, all four of them", () => {
   assert.equal(r.stdout.trim(), "0 0 0 0");
 });
 
-test("the version check is on by default, and enforcing it is not — yet", () => {
-  // Detection before correction. While the clone is moved by hand, failing the run on
-  // a version gap would throw away a day of otherwise usable comparison data; the gap
-  // still has to be impossible to miss. REQUIRE flips once the run moves the clone.
+test("the version check is on by default, and so is enforcing it", () => {
+  // Enforcement waited for two things, and both arrived on 2026-09-03: the run now
+  // places the clone itself, so a mismatch is no longer somebody forgetting to move
+  // it; and a smoked source instance at v1.13.0.dev1 reports `1.13.0.dev1`, the exact
+  // string the published-image strategy expects — so the gate cannot fail a correctly
+  // placed clone over a formatting difference.
   const r = sourced(`echo "$CHECK_TARGET_VERSION $REQUIRE_TARGET_VERSION"`);
-  assert.equal(r.stdout.trim(), "1 0");
+  assert.equal(r.stdout.trim(), "1 1");
+});
+
+test("by default, a version mismatch now fails the run", () => {
+  const r = sourced(
+    `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
+      `TARGET_VERSION_MATCH=no TARGET_VERSION_REASON="expected 1.13.0.dev1, served 1.12.0"\n` +
+      `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
+  );
+  assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 1);
 });
 
 test("the run moves the clone by default, and demands the stamp because of it", () => {
@@ -175,11 +192,14 @@ test("preparation is driven by the resolved COMMIT, and its failure stops the ru
   assert.match(text, /langflow_prepare_seconds/);
 });
 
-test("a version mismatch does not fail the run on its own", () => {
+test("with enforcement off, a version mismatch does not fail the run on its own", () => {
+  // The diagnosing path: pointed at a deliberately mismatched target, the run still
+  // produces its verdict and says what differed.
   const r = sourced(
     `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
       `TARGET_VERSION_MATCH=no TARGET_VERSION_REASON="expected 1.13.0.dev1, served 1.12.0"\n` +
       `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
+    { REQUIRE_TARGET_VERSION: "0" },
   );
   assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 0);
 });
@@ -245,12 +265,13 @@ test("under REQUIRE, a check that could not RUN fails too", () => {
   }
 });
 
-test("without REQUIRE, none of the version states fail the run", () => {
+test("with REQUIRE explicitly off, none of the version states fail the run", () => {
   for (const match of ["yes", "cycle", "unknown", "unchecked", "no"]) {
     const r = sourced(
       `RUN_EMPTY=false RUN_PARTIAL=false SHARD_COMPLETE=true TEST_JOB_FAILED=0\n` +
         `TARGET_VERSION_MATCH=${match}\n` +
         `set +e; phase_verdict; code=$?; set -e; echo "EXIT=$code"`,
+      { REQUIRE_TARGET_VERSION: "0" },
     );
     assert.equal(Number(r.stdout.match(/EXIT=(\d+)/)?.[1]), 0, match);
   }

--- a/scripts/start-langflow-source.sh
+++ b/scripts/start-langflow-source.sh
@@ -45,6 +45,12 @@
 #        - the frontend assets must exist. They are gitignored upstream, so a fresh
 #          clone has none, and the backend still answers /health_check 200 while
 #          serving no UI at all — every Playwright spec then dies at page load.
+#        - the frontend assets must belong to THIS commit. Existence is not
+#          provenance: a checkout moves the backend and leaves the previous build's
+#          index.html in place, so the lane exercises an old UI against a new
+#          backend and passes or fails for reasons nobody can attribute. The build
+#          stamp written by scripts/prepare-target-source.sh is what makes that
+#          answerable here without this script touching anything.
 #
 # Usage:
 #   ./scripts/start-langflow-source.sh                      # clone at $LANGFLOW_SRC_REPO, port 7860
@@ -76,6 +82,15 @@ LOG_FILE="${STATE_DIR}/langflow.log"
 # an upstream path is a gate that goes stale — but stale here means a loud refusal
 # on a good clone, never a silent pass on a broken one.
 FRONTEND_DIR="${LANGFLOW_SRC_FRONTEND_DIR:-${REPO}/src/backend/base/langflow/frontend}"
+# Written by scripts/prepare-target-source.sh, next to the clone rather than under
+# /tmp so that a reboot does not read as a stale build. Its only job here is to name
+# the commit the served assets were built from.
+BUILD_STAMP_FILE="${LANGFLOW_SRC_STAMP_FILE:-${REPO}/.langflow-e2e-build-stamp}"
+# A MISSING stamp is a warning by default and fatal on demand. Both are needed: a
+# clone prepared by hand has no stamp and must stay usable, while the scheduled lane
+# always runs the preparer first, so there "no stamp" means the preparer did not run
+# and the assets' origin is unknown — which is exactly what the lane cannot afford.
+REQUIRE_BUILD_STAMP="${LANGFLOW_REQUIRE_BUILD_STAMP:-0}"
 # Source starts are far slower than pip's 120 s: the first dependency sync on a cold
 # cache compiles wheels. A deadline shorter than that reads as "Langflow is broken"
 # when the truth is "the machine is still building".
@@ -131,9 +146,11 @@ fi
 if [ -n "${LANGFLOW_SRC_REF:-}" ]; then
   echo "Checking out ${LANGFLOW_SRC_REF} in ${REPO}..."
   git -C "${REPO}" checkout --quiet "${LANGFLOW_SRC_REF}"
-  echo "NOTE: the frontend assets are NOT rebuilt by this script. If ${LANGFLOW_SRC_REF}"
-  echo "      changes the UI, rebuild them (see the frontend check below) or the run"
-  echo "      exercises the previous build's interface against the new backend."
+  echo "NOTE: the frontend assets are NOT rebuilt by this script — see the header's"
+  echo "      second promise. If ${LANGFLOW_SRC_REF} changes the UI, the build stamp"
+  echo "      check below will REFUSE the start rather than serve the previous build's"
+  echo "      interface against the new backend. Use scripts/prepare-target-source.sh"
+  echo "      to move the clone and rebuild in one step; it writes the stamp."
 fi
 
 SRC_SHA="$(git -C "${REPO}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
@@ -205,6 +222,36 @@ if [ ! -f "${FRONTEND_DIR}/index.html" ]; then
   echo "  make -C ${REPO} install_frontend build_frontend" >&2
   echo "(Override the location with LANGFLOW_SRC_FRONTEND_DIR if upstream moves it.)" >&2
   exit 2
+fi
+
+# --- ...and the UI has to be the one THIS commit builds -------------------------
+# The check the LANGFLOW_SRC_REF note used to only warn about. A stale build fails
+# GREEN in the cases that matter: an old UI against a new backend passes the specs
+# that did not change and fails the ones that did, and the report blames the product.
+HEAD_SHA_FULL="$(git -C "${REPO}" rev-parse HEAD 2>/dev/null || echo unknown)"
+STAMPED_SHA=""
+if [ -f "${BUILD_STAMP_FILE}" ]; then
+  STAMPED_SHA="$(grep -m1 '^sha=' "${BUILD_STAMP_FILE}" 2>/dev/null | sed 's/^sha=//' || true)"
+fi
+if [ -n "${STAMPED_SHA}" ] && [ "${STAMPED_SHA}" != "${HEAD_SHA_FULL}" ]; then
+  echo "ERROR: the frontend build at ${FRONTEND_DIR} was built from ${STAMPED_SHA:0:10}," >&2
+  echo "but the clone is at ${HEAD_SHA_FULL:0:10}. Starting would serve that older UI" >&2
+  echo "against this backend, and the run would attribute the difference to the product." >&2
+  echo "Rebuild and re-stamp:" >&2
+  echo "  TARGET_SHA=${HEAD_SHA_FULL} LANGFLOW_SRC_REPO=${REPO} ./scripts/prepare-target-source.sh" >&2
+  exit 2
+fi
+if [ -z "${STAMPED_SHA}" ]; then
+  if [ "${REQUIRE_BUILD_STAMP}" = "1" ]; then
+    echo "ERROR: no build stamp at ${BUILD_STAMP_FILE}, so the commit those assets were" >&2
+    echo "built from is unknown, and LANGFLOW_REQUIRE_BUILD_STAMP=1 asks for a guarantee." >&2
+    echo "An unperformed check is not a weaker guarantee, it is none. Run the preparer:" >&2
+    echo "  TARGET_SHA=${HEAD_SHA_FULL} LANGFLOW_SRC_REPO=${REPO} ./scripts/prepare-target-source.sh" >&2
+    exit 2
+  fi
+  echo "NOTE: no build stamp at ${BUILD_STAMP_FILE} — the assets exist but nothing says"
+  echo "      which commit they came from. Fine for a clone you build by hand; the"
+  echo "      scheduled lane sets LANGFLOW_REQUIRE_BUILD_STAMP=1 to make this fatal."
 fi
 
 echo "Starting Langflow on ${BIND_HOST}:${PORT} (logs: ${LOG_FILE})..."

--- a/scripts/start-langflow-source.test.mjs
+++ b/scripts/start-langflow-source.test.mjs
@@ -88,6 +88,7 @@ function runScript({
   serverExits = false,
   ignoresTerm = false,
   withUv = true,
+  stamp = null,
 } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "start-langflow-source-test-"));
   const bin = join(dir, "bin");
@@ -105,6 +106,10 @@ function runScript({
     mkdirSync(fe, { recursive: true });
     writeFileSync(join(fe, "index.html"), "<!doctype html>");
   }
+  // The build stamp scripts/prepare-target-source.sh writes. The git stub below
+  // answers every rev-parse with "abc1234", so that is the sha a MATCHING stamp
+  // carries and anything else is the stale case.
+  if (repoExists && stamp) writeFileSync(join(repo, ".langflow-e2e-build-stamp"), `sha=${stamp}\n`);
 
   const uvLog = join(dir, "uv.log");
   const gitLog = join(dir, "git.log");
@@ -361,6 +366,41 @@ test("a still-running instance from a previous start is refused, naming the stop
   assert.match(second.stdout, /stop-langflow-source\.sh/);
   first.cleanup();
   second.cleanup();
+});
+
+test("a frontend build that belongs to another commit is refused", () => {
+  // What the LANGFLOW_SRC_REF note used to only warn about. A checkout moves the
+  // backend and leaves the previous build's index.html in place: the specs that did
+  // not change pass, the ones that did fail, and the report blames the product.
+  const r = runScript({ stamp: "deadbeefdeadbeef" });
+  assert.equal(r.status, 2);
+  assert.match(r.stdout, /was built from deadbeefde/);
+  assert.match(r.stdout, /prepare-target-source\.sh/);
+  assert.equal(r.pidFileExists, false);
+  r.cleanup();
+});
+
+test("an unstamped build warns by default and is fatal when the lane demands it", () => {
+  // Both halves are load-bearing. A clone built by hand has no stamp and has to stay
+  // usable; the scheduled lane runs the preparer first, so there "no stamp" means the
+  // preparer did not run and the assets' origin is unknown.
+  const lenient = runScript();
+  assert.equal(lenient.status, 0);
+  assert.match(lenient.stdout, /no build stamp at/);
+  lenient.cleanup();
+
+  const strict = runScript({ env: { LANGFLOW_REQUIRE_BUILD_STAMP: "1" } });
+  assert.equal(strict.status, 2);
+  assert.match(strict.stdout, /asks for a guarantee/);
+  assert.equal(strict.pidFileExists, false);
+  strict.cleanup();
+});
+
+test("a stamp that agrees with HEAD starts with nothing to say about provenance", () => {
+  const r = runScript({ stamp: "abc1234" });
+  assert.equal(r.status, 0);
+  assert.doesNotMatch(r.stdout, /build stamp/);
+  r.cleanup();
 });
 
 test("a clone with no frontend build is refused, naming the build command", () => {


### PR DESCRIPTION
## Why

The VM daily's comparison with the Actions one is only about the **environment** if
both sides run the same **product**. Nothing enforced that. Actions pulls
`langflow-nightly:latest` every run; the source clone on the target sits wherever it
was last left — on 2026-09-03 that was `release-1.12.0`, built on 08-25, against a CI
on `1.13.0.dev1`. A full release cycle and nine days.

Every difference between those two arrives in the divergence list as "a real failure
only Actions saw", which is product changelog wearing an environment's clothes. #1688
made that visible; this makes it impossible.

## What changes

**`scripts/prepare-target-source.sh` (new)** owns the clone's position and its build.
`start-langflow-source.sh` promises not to touch the clone and refuses to build the
frontend — both refusals are correct, so this is a separate script rather than a
weakening of them. It moves to the **commit** (never the tag name: upstream deletes
and recreates its nightly tags), refuses `main` in all three inputs, and checks for
`npm`/`uv` **before** the checkout, because a missing tool found afterwards leaves the
machine with a new backend and an old UI.

**The build stamp closes the `LANGFLOW_SRC_REF` debt.** A checkout moves the backend
and leaves the previous build's `index.html` in place; the lane then serves an old UI
against a new backend and passes or fails for reasons nobody can attribute. Existence
of assets is not provenance. The stamp names the commit they came from, dies **before**
a build starts, and is written only after the served `index.html` exists — so an
interrupted build leaves "unknown", never a confident wrong answer. A stamp that
disagrees with HEAD is now a refusal; a missing one stays a warning unless
`LANGFLOW_REQUIRE_BUILD_STAMP=1`, which the lane sets.

**The run obeys the resolution** in prep, and dies if it cannot place the target. A
verdict about a different product is worth less than no verdict. The preparer is a
no-op when the clone is already there and stamped, so the cost lands only on the days
the resolution moves.

**`REQUIRE_TARGET_VERSION` is now on by default**, which is the gate #1688 left
prepared and switched off.

## Evidence

Measured and smoked on the target, not in mock:

| | |
|---|---|
| rebuild, warm | **107s** — fetch 7, deps 1, `install_frontend` 4, `build_frontend` 94 |
| preparer against a prepared clone | `moved=no rebuilt=no rebuild_reason=none` |
| starter with the stamp demanded | healthy, and stopped clean |
| version reported by a source instance at `v1.13.0.dev1` | `1.13.0.dev1` — the exact string the `published-image` strategy expects, and the field the run already reads |

The 107s is what justifies running this at the head of every run rather than as a
separate scheduled step. It is the **warm** cost: `deps` in 1s means `uv` found the
environment satisfied and `install_frontend` in 4s that `node_modules` was warm, both
from the 08-25 build. A cold rebuild is another number and is not measured yet.

The version evidence is what justifies enforcing the gate: without it, enforcement
could have failed a correctly placed clone over `1.13.0` vs `1.13.0.dev1`.

## Two defects only execution found

- The revert hint printed `checkout HEAD` on a clone this script had already prepared,
  because `rev-parse --abbrev-ref` answers `HEAD` when detached — and the second run is
  every run after adoption. Reading the code, `BEFORE_REF` looks like a branch name.
- Turning the gate on left the tests' `verdict()` helper with the version state
  "unchecked", which is fatal under enforcement: every case would have failed for the
  version reason instead of its own, and the ones that expect a failure would have
  passed for the wrong reason.

Both are pinned by test.

## Escape hatches

`PREPARE_TARGET=0` goes back to resolve-and-report. `REQUIRE_TARGET_VERSION=0` reports
the mismatch without failing. `PREPARE_TARGET_SKIP_BUILD=1` moves the clone without
building, which ends the run at the starter's stamp check, on purpose.

## Tests

26 new, `npm run test:scripts` at 1081 passing. git is real in the preparer's tests —
the checkout, the verification and the dirty check are the behaviour under test; `make`,
`uv` and `npm` are stubbed through a PATH shim.
