### PR TITLE
Send plain text to the transport that renders it as text

### DIFF
--- a/scripts/notify-slack.mjs
+++ b/scripts/notify-slack.mjs
@@ -171,144 +171,6 @@ if (nothingFailed && env.SLACK_FORCE !== "1") {
   process.exit(0);
 }
 
-const headline = {
-  empty: `⚠️ Daily @stable executed ZERO tests — ${date}`,
-  partial: `⚠️ Daily @stable was PARTIAL — a shard never ran — ${date}`,
-  // Never "failed — 0 test(s)". That sentence is read as "zero tests failed", i.e.
-  // as a clean day, on a run where nobody could tell — the same false verdict as
-  // announcing failures on an empty report, pointed the other way (#1012).
-  unknown: `⚠️ Daily @stable — verdict UNKNOWN, the run's report could not be read — ${date}`,
-  failures: `🔴 Daily @stable failed — ${totals.failed ?? failures.length} test(s) — ${date}`,
-}[shape];
-
-const diagnosis = {
-  empty: [
-    unreadable
-      ? "*The merged report was missing or unparseable* — the run produced no readable result at all."
-      : `*The merged report carries no test results at all* (${reportErrors} top-level report error(s)) — the shards aborted before the first test.`,
-    "No spec failed and no `@stable` tag was touched, so there is *no per-test evidence to triage*.",
-    "*Triage this as infrastructure*: find why nothing ran, not which test broke.",
-  ].join("\n"),
-  partial: [
-    `*${testsTotal} test result(s) but ${reportErrors} top-level report error(s).*`,
-    "A shard aborted before running the tests assigned to it, so the totals are *UNDER-COUNTED* — the dead shard's specs are neither passed nor failed, they never ran.",
-    "`@stable` auto-removal and the duration refresh were both skipped. *Triage the abort first* — a large drop against the last green run is the abort, not a fix.",
-  ].join("\n"),
-  unknown: [
-    payloadRead
-      ? `*The run payload carried no totals* (\`${truncate(payloadPath, 120)}\`) — it parsed, but the numbers this message reports are not in it.`
-      : `*The run payload was missing or unreadable* (\`${truncate(payloadPath, 120)}\`) — the numbers this message reports were never produced.`,
-    "The guards reported neither the empty nor the partial verdict, so *nothing can be said about what passed or failed* — this is not a clean day, it is an unread one.",
-    "*Start from the run directory and the merge step*: find out why the payload is not there, then re-read the verdict from the report itself.",
-  ].join("\n"),
-  failures: null,
-}[shape];
-
-// ---------------------------------------------------------------------------
-// The message, as text — computed ONCE and shared by both transports, so the
-// Workflow Builder message and the Block Kit message can never drift apart.
-// ---------------------------------------------------------------------------
-
-const wedged = env.LIVENESS_MEASURED === "true" && env.LIVENESS_WEDGED === "true";
-// The backend-outage verdict LEADS the per-test material when it fired: the cause
-// has to be read before the collateral, or triage starts from the wrong specs
-// (#1030). Gated on `measured` — `wedged` is also "false" when nothing was probed.
-const outageNote = wedged
-  ? `⚡ *The backend went down mid-run* — ${env.LIVENESS_OUTAGES || "?"} outage(s), ` +
-    `${env.LIVENESS_DOWN_SECONDS || "?"}s unreachable in total.\n` +
-    "Specs that failed inside those windows are *collateral, not per-test failures*. Read the outage first."
-  : "";
-
-const elisionNotice = (n) => `\n_… and ${n} more not listed here — see the report._`;
-
-/**
- * The failure list, built to FIT — `budget` is what Slack's section cap leaves
- * after everything that cannot be dropped has taken its share.
- *
- * NAME what was elided rather than silently cutting: a list that stops at 10 reads
- * as "10 failures" when it was 40. That was already true of the 10-item cap, but
- * not of the character cap underneath it: the notice is the LAST line, so a body
- * truncated at SECTION_MAX cut the notice off first and the message ended mid-entry
- * with an ellipsis — the same silent cut, one layer down. Measured before the fix:
- * 22 failures with realistic titles and signatures rendered a 2900-char body ending
- * inside the 9th entry, with no count. It had not fired yet — the worst day in
- * `reports/daily-history.jsonl` (2026-07-22, 22 failures) renders ~2140 — so this is
- * a floor under a margin of roughly three long entries, not a fix for a live defect.
- *
- * So the notice is BUDGETED, not appended: each entry is admitted only if it still
- * leaves room for the notice that stopping after it would require. At least one
- * entry is always kept — an empty list under a tight budget says even less than a
- * short one, and the final truncate() is still there as a backstop.
- */
-const failureList = (budget) => {
-  if (!failures.length) return "";
-  const rendered = failures.slice(0, MAX_FAILURES_LISTED).map((f) => {
-    const file = String(f.file || "").split("/").pop() || f.file || "?";
-    return `• \`${file}\` — ${truncate(f.test || "?", 120)}\n   _${truncate(f.error_signature || "unknown", SIGNATURE_MAX)}_`;
-  });
-
-  const kept = [];
-  let used = 0;
-  for (const entry of rendered) {
-    const cost = (kept.length ? 1 : 0) + entry.length; // 1 = the "\n" join
-    const leftIfStopHere = failures.length - (kept.length + 1);
-    const reserve = leftIfStopHere > 0 ? 1 + elisionNotice(leftIfStopHere).length : 0;
-    if (kept.length && used + cost + reserve > budget) break;
-    kept.push(entry);
-    used += cost;
-  }
-
-  const left = failures.length - kept.length;
-  return (left > 0 ? [...kept, elisionNotice(left)] : kept).join("\n");
-};
-
-const totalsLine =
-  shape === "failures"
-    ? `*${totals.failed ?? 0} failed* · ${totals.flaky ?? 0} flaky · ${totals.passed ?? 0} passed · ${totals.skipped ?? 0} skipped`
-    : "";
-
-// Truncate the quoted cause BEFORE it is fenced, not after. The body as a whole is
-// capped at SECTION_MAX, and a cut that lands inside the fence leaves it unclosed
-// and elides the diagnosis with nothing but an ellipsis to show for it — a silent
-// cap, which is the thing this file refuses to do for the failure list two blocks
-// up. check-run-integrity.mjs already caps `first_error` to a single line, so this
-// is a floor under an assumption about another script, not a fix for a live defect.
-const ERROR_MAX = 600;
-const errorBlock = firstError ? "```\n" + truncate(firstError, ERROR_MAX) + "\n```" : "";
-
-// Everything that cannot be dropped, in order. The failure list is the only part
-// that gets to shrink, so it is the only part that has to know what is left.
-const fixedText = [
-  `*Langflow* \`${truncate(version || image, 200)}\`  ·  *Run* \`${truncate(runId, 200)}\` on ${host}`,
-  totalsLine,
-  outageNote,
-  diagnosis || "",
-  diagnosis ? errorBlock : "",
-]
-  .filter(Boolean)
-  .join("\n\n");
-
-const tail = diagnosis ? "" : failureList(SECTION_MAX - fixedText.length - 2);
-
-const body = [fixedText, tail].filter(Boolean).join("\n\n");
-
-const links = [];
-if (env.ISSUE_URL) links.push(`<${env.ISSUE_URL}|Triage issue>`);
-if (env.REPORT_URL) {
-  // A `file://` report is not a link anyone can click from Slack — say where it
-  // is instead of rendering a link that silently does nothing.
-  links.push(
-    env.REPORT_URL.startsWith("file://")
-      ? `Report: \`${env.REPORT_URL.replace(/^file:\/\//, "")}\` on ${host}`
-      : `<${env.REPORT_URL}|Playwright report>`,
-  );
-}
-const linksText = links.join("  ·  ");
-
-// ---------------------------------------------------------------------------
-// Transport
-// ---------------------------------------------------------------------------
-
 // Keyed on the PATH segment, not on the host. `/triggers/` vs `/services/` is what
 // actually distinguishes the two, and requiring `hooks.slack.com` as well makes the
 // detection fail silently behind a proxy or a relay — falling back to Block Kit,
@@ -333,6 +195,168 @@ if (env.SLACK_MODE) {
     );
   }
 }
+
+// mrkdwn is a Block Kit feature. A Workflow Builder message step is a RICH-TEXT
+// editor, and whatever arrives through a variable is inserted as plain text: `*bold*`
+// renders as asterisks, `<url|label>` renders as itself. Verified against a real
+// trigger on 2026-09-03 — the POST returned 200 and the channel showed the markup,
+// which is the same class of silent wrongness the mode derivation above exists to
+// avoid, one layer further in.
+//
+// So the DECORATION is mode-aware while the WORDS stay a single construction — that
+// is what keeps the two transports from drifting apart. Generated plain rather than
+// stripped afterwards, because stripping cannot tell our markers from content: a
+// spec named `model_provider_base_url_ssrf` would lose half its name to a regex
+// hunting underscores, and the failure list is exactly where those names live.
+const rich = mode !== "workflow";
+const bold = (s) => (rich ? `*${s}*` : `${s}`);
+const code = (s) => (rich ? `\`${s}\`` : `${s}`);
+const italic = (s) => (rich ? `_${s}_` : `${s}`);
+const fence = (s) => (rich ? "```\n" + s + "\n```" : s);
+// A bare URL is auto-linked by Slack in both transports, so the plain form loses the
+// label's placement but never the destination.
+const linkTo = (url, label) => (rich ? `<${url}|${label}>` : `${label}: ${url}`);
+
+const headline = {
+  empty: `⚠️ Daily @stable executed ZERO tests — ${date}`,
+  partial: `⚠️ Daily @stable was PARTIAL — a shard never ran — ${date}`,
+  // Never "failed — 0 test(s)". That sentence is read as "zero tests failed", i.e.
+  // as a clean day, on a run where nobody could tell — the same false verdict as
+  // announcing failures on an empty report, pointed the other way (#1012).
+  unknown: `⚠️ Daily @stable — verdict UNKNOWN, the run's report could not be read — ${date}`,
+  failures: `🔴 Daily @stable failed — ${totals.failed ?? failures.length} test(s) — ${date}`,
+}[shape];
+
+const diagnosis = {
+  empty: [
+    unreadable
+      ? `${bold("The merged report was missing or unparseable")} — the run produced no readable result at all.`
+      : `${bold("The merged report carries no test results at all")} (${reportErrors} top-level report error(s)) — the shards aborted before the first test.`,
+    `No spec failed and no ${code("@stable")} tag was touched, so there is ${bold("no per-test evidence to triage")}.`,
+    `${bold("Triage this as infrastructure")}: find why nothing ran, not which test broke.`,
+  ].join("\n"),
+  partial: [
+    bold(`${testsTotal} test result(s) but ${reportErrors} top-level report error(s).`),
+    `A shard aborted before running the tests assigned to it, so the totals are ${bold("UNDER-COUNTED")} — the dead shard's specs are neither passed nor failed, they never ran.`,
+    `${code("@stable")} auto-removal and the duration refresh were both skipped. ${bold("Triage the abort first")} — a large drop against the last green run is the abort, not a fix.`,
+  ].join("\n"),
+  unknown: [
+    payloadRead
+      ? `${bold("The run payload carried no totals")} (${code(truncate(payloadPath, 120))}) — it parsed, but the numbers this message reports are not in it.`
+      : `${bold("The run payload was missing or unreadable")} (${code(truncate(payloadPath, 120))}) — the numbers this message reports were never produced.`,
+    `The guards reported neither the empty nor the partial verdict, so ${bold("nothing can be said about what passed or failed")} — this is not a clean day, it is an unread one.`,
+    `${bold("Start from the run directory and the merge step")}: find out why the payload is not there, then re-read the verdict from the report itself.`,
+  ].join("\n"),
+  failures: null,
+}[shape];
+
+// ---------------------------------------------------------------------------
+// The message, as text — computed ONCE and shared by both transports, so the
+// Workflow Builder message and the Block Kit message can never drift apart.
+// ---------------------------------------------------------------------------
+
+const wedged = env.LIVENESS_MEASURED === "true" && env.LIVENESS_WEDGED === "true";
+// The backend-outage verdict LEADS the per-test material when it fired: the cause
+// has to be read before the collateral, or triage starts from the wrong specs
+// (#1030). Gated on `measured` — `wedged` is also "false" when nothing was probed.
+const outageNote = wedged
+  ? `⚡ ${bold("The backend went down mid-run")} — ${env.LIVENESS_OUTAGES || "?"} outage(s), ` +
+    `${env.LIVENESS_DOWN_SECONDS || "?"}s unreachable in total.\n` +
+    `Specs that failed inside those windows are ${bold("collateral, not per-test failures")}. Read the outage first.`
+  : "";
+
+const elisionNotice = (n) => `\n${italic(`… and ${n} more not listed here — see the report.`)}`;
+
+/**
+ * The failure list, built to FIT — `budget` is what Slack's section cap leaves
+ * after everything that cannot be dropped has taken its share.
+ *
+ * NAME what was elided rather than silently cutting: a list that stops at 10 reads
+ * as "10 failures" when it was 40. That was already true of the 10-item cap, but
+ * not of the character cap underneath it: the notice is the LAST line, so a body
+ * truncated at SECTION_MAX cut the notice off first and the message ended mid-entry
+ * with an ellipsis — the same silent cut, one layer down. Measured before the fix:
+ * 22 failures with realistic titles and signatures rendered a 2900-char body ending
+ * inside the 9th entry, with no count. It had not fired yet — the worst day in
+ * `reports/daily-history.jsonl` (2026-07-22, 22 failures) renders ~2140 — so this is
+ * a floor under a margin of roughly three long entries, not a fix for a live defect.
+ *
+ * So the notice is BUDGETED, not appended: each entry is admitted only if it still
+ * leaves room for the notice that stopping after it would require. At least one
+ * entry is always kept — an empty list under a tight budget says even less than a
+ * short one, and the final truncate() is still there as a backstop.
+ */
+const failureList = (budget) => {
+  if (!failures.length) return "";
+  const rendered = failures.slice(0, MAX_FAILURES_LISTED).map((f) => {
+    const file = String(f.file || "").split("/").pop() || f.file || "?";
+    return `• ${code(file)} — ${truncate(f.test || "?", 120)}\n   ${italic(truncate(f.error_signature || "unknown", SIGNATURE_MAX))}`;
+  });
+
+  const kept = [];
+  let used = 0;
+  for (const entry of rendered) {
+    const cost = (kept.length ? 1 : 0) + entry.length; // 1 = the "\n" join
+    const leftIfStopHere = failures.length - (kept.length + 1);
+    const reserve = leftIfStopHere > 0 ? 1 + elisionNotice(leftIfStopHere).length : 0;
+    if (kept.length && used + cost + reserve > budget) break;
+    kept.push(entry);
+    used += cost;
+  }
+
+  const left = failures.length - kept.length;
+  return (left > 0 ? [...kept, elisionNotice(left)] : kept).join("\n");
+};
+
+const totalsLine =
+  shape === "failures"
+    ? `${bold(`${totals.failed ?? 0} failed`)} · ${totals.flaky ?? 0} flaky · ${totals.passed ?? 0} passed · ${totals.skipped ?? 0} skipped`
+    : "";
+
+// Truncate the quoted cause BEFORE it is fenced, not after. The body as a whole is
+// capped at SECTION_MAX, and a cut that lands inside the fence leaves it unclosed
+// and elides the diagnosis with nothing but an ellipsis to show for it — a silent
+// cap, which is the thing this file refuses to do for the failure list two blocks
+// up. check-run-integrity.mjs already caps `first_error` to a single line, so this
+// is a floor under an assumption about another script, not a fix for a live defect.
+const ERROR_MAX = 600;
+const errorBlock = firstError ? fence(truncate(firstError, ERROR_MAX)) : "";
+
+// Everything that cannot be dropped, in order. The failure list is the only part
+// that gets to shrink, so it is the only part that has to know what is left.
+const fixedText = [
+  `${bold("Langflow")} ${code(truncate(version || image, 200))}  ·  ${bold("Run")} ${code(truncate(runId, 200))} on ${host}`,
+  totalsLine,
+  outageNote,
+  diagnosis || "",
+  diagnosis ? errorBlock : "",
+]
+  .filter(Boolean)
+  .join("\n\n");
+
+const tail = diagnosis ? "" : failureList(SECTION_MAX - fixedText.length - 2);
+
+const body = [fixedText, tail].filter(Boolean).join("\n\n");
+
+const links = [];
+if (env.ISSUE_URL) links.push(linkTo(env.ISSUE_URL, "Triage issue"));
+if (env.REPORT_URL) {
+  // A `file://` report is not a link anyone can click from Slack — say where it
+  // is instead of rendering a link that silently does nothing.
+  links.push(
+    env.REPORT_URL.startsWith("file://")
+      ? `Report: ${code(env.REPORT_URL.replace(/^file:\/\//, ""))} on ${host}`
+      : linkTo(env.REPORT_URL, "Playwright report"),
+  );
+}
+const linksText = links.join("  ·  ");
+
+// ---------------------------------------------------------------------------
+// Transport
+// ---------------------------------------------------------------------------
+
+// The transport is resolved ABOVE, before the message text is built: what markup
+// that text may carry depends on which transport will carry it.
 
 const requestBody =
   mode === "workflow"

--- a/scripts/notify-slack.mjs
+++ b/scripts/notify-slack.mjs
@@ -86,6 +86,15 @@ if (!webhook && !dryRun) {
 // Slack's own limits, not guesses: a section's text caps at 3000 characters and a
 // header's at 150, and a payload that breaks either is rejected whole — so the
 // message would be lost precisely on the noisiest day.
+//
+// Those are BLOCK KIT's documented limits. A Workflow Builder trigger publishes no
+// per-variable limit, so the same cap is applied there — conservative rather than
+// derived, which is worth saying because a variable over the real limit would fail
+// the way everything fails on that transport: HTTP 200 and an empty channel.
+// Checked against a live trigger on 2026-09-03 with 40 failures: the budget listed
+// 9 and elided 31, the body rendered at 2718 characters, and the channel showed all
+// of it including the closing notice. So 2900 is safe on both at this order of
+// magnitude — measured, not assumed, and re-measure before raising it.
 const HEADER_MAX = 150;
 const SECTION_MAX = 2900;
 const MAX_FAILURES_LISTED = 10;

--- a/scripts/notify-slack.test.mjs
+++ b/scripts/notify-slack.test.mjs
@@ -79,6 +79,10 @@ function run(env = {}) {
   return { stdout: r.stdout || "", stderr: r.stderr || "", status: r.status };
 }
 
+/** The body text, whichever transport carried it. The two differ in DECORATION
+ *  only, so a property about length or budgeting is asserted through this. */
+const bodyText = (b) => (b.body !== undefined ? b.body : b.blocks[1].text.text);
+
 /** Dry-run and parse the rendered request body. */
 function render(env = {}) {
   const { stdout } = run({ SLACK_DRY_RUN: "1", ...env });
@@ -102,6 +106,82 @@ test("the transport is derived from the URL's path segment", () => {
 
   const forced = render({ SLACK_WEBHOOK_URL: "https://hooks.slack.com/triggers/E1/2/abc", SLACK_MODE: "blockkit" });
   assert.equal(forced.mode, "blockkit", "SLACK_MODE must override the derivation");
+});
+
+test("a Workflow Builder message carries no markup, because the step will not render it", () => {
+  // Verified against a real trigger on 2026-09-03: the POST returned 200 and the
+  // channel showed `*bold*` as asterisks, backticks as backticks and `<url|label>`
+  // as itself. That is the same class of silent wrongness the derivation above
+  // exists to prevent — accepted, 200, useless — one layer further in.
+  const { body } = render({
+    SLACK_WEBHOOK_URL: "https://hooks.slack.com/triggers/E1/2/abc",
+    ISSUE_URL: "https://example.invalid/issue/1",
+    REPORT_URL: "https://example.invalid/report",
+  });
+  const all = [body.headline, body.body, body.links].join("\n");
+  assert.doesNotMatch(all, /\*/, "no bold markers");
+  assert.doesNotMatch(all, /`/, "no code spans and no fences");
+  assert.doesNotMatch(all, /<https?:[^|>]*\|/, "no mrkdwn links");
+  // The destination survives — Slack auto-links a bare URL — and only the label's
+  // placement changes. A link whose text renders as `<url|label>` is worse than a
+  // bare URL: it looks broken and it is not clickable as the label.
+  assert.match(body.links, /Triage issue: https:\/\/example\.invalid\/issue\/1/);
+  assert.match(body.links, /Playwright report: https:\/\/example\.invalid\/report/);
+});
+
+test("Block Kit keeps the markup, so the transports differ in decoration and not in words", () => {
+  const { body } = render({
+    SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/T1/B2/xyz",
+    REPORT_URL: "https://example.invalid/report",
+  });
+  assert.match(bodyText(body), /\*Langflow\*/);
+  assert.match(bodyText(body), /\*3 failed\*/);
+  assert.match(JSON.stringify(body), /<https:\/\/example\.invalid\/report\|Playwright report>/);
+});
+
+test("the elision notice is plain in a Workflow Builder message too", () => {
+  // The one span the mode-aware pass missed, and the reason it needs its own test:
+  // the check above bans `*` and backticks, but it CANNOT ban underscores, because
+  // underscores are legitimate content here — the spec names carry them. So the
+  // notice's own shape is what has to be asserted.
+  const wf = render({ SLACK_WEBHOOK_URL: "https://hooks.slack.com/triggers/E1/2/abc" });
+  assert.match(wf.body.body, /… and \d+ more not listed here — see the report\./);
+  assert.doesNotMatch(wf.body.body, /_… and/, "no italic markers around the notice");
+
+  const bk = render({ SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/T1/B2/xyz" });
+  assert.match(bodyText(bk.body), /_… and \d+ more not listed here — see the report\._/);
+});
+
+test("a spec name carrying underscores survives both transports intact", () => {
+  // The property that rules out stripping the markup after the fact. These names are
+  // real — `model_provider_base_url_ssrf.spec.ts` is in the suite — and a regex
+  // hunting `_` to undo italics would eat half of them, in the one section where the
+  // reader needs the name exact enough to grep for it.
+  const underscored = join(dir, "payload-underscores.json");
+  const testName = "model_provider_base_url_ssrf › refuses a private address";
+  writeFileSync(
+    underscored,
+    JSON.stringify({
+      ...PAYLOAD,
+      totals: { passed: 10, failed: 1, flaky: 0, skipped: 0 },
+      failures: [
+        {
+          test: testName,
+          file: "tests/tests-automations/regression/security/model_provider_base_url_ssrf.spec.ts",
+          error_signature: "Error: expected _all_ resolved addresses to be named",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  for (const url of ["https://hooks.slack.com/triggers/E1/2/abc", "https://hooks.slack.com/services/T1/B2/xyz"]) {
+    const { body } = render({ SLACK_WEBHOOK_URL: url, PAYLOAD_JSON: underscored });
+    const text = bodyText(body);
+    assert.match(text, /model_provider_base_url_ssrf\.spec\.ts/, url);
+    assert.ok(text.includes(testName), `the test name survives intact — ${url}`);
+    assert.match(text, /expected _all_ resolved addresses to be named/, url);
+  }
 });
 
 test("a Workflow Builder post always carries all three declared variables", () => {
@@ -258,14 +338,22 @@ test("a long quoted cause is truncated inside its fence, not across it", () => {
   // fence leaves it unclosed and elides the diagnosis silently — the one thing this
   // script refuses to do for the failure list.
   const huge = "Error: worker process exited unexpectedly\n    at a stack frame that is long\n".repeat(60);
-  const { body } = render({
-    SLACK_WEBHOOK_URL: "https://hooks.slack.com/triggers/E1/2/abc",
-    RUN_PARTIAL: "true", RUN_TESTS: "180", RUN_ERRORS: "2", RUN_FIRST_ERROR: huge,
-  });
-  const fences = (body.body.match(/```/g) || []).length;
+  const bad = { RUN_PARTIAL: "true", RUN_TESTS: "180", RUN_ERRORS: "2", RUN_FIRST_ERROR: huge };
+
+  // Asserted on Block Kit, because a fence is Block Kit's: a Workflow Builder step
+  // inserts variables as plain text, so there the fence would be three literal
+  // backticks in the channel rather than a quoted block.
+  const bk = render({ SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/T1/B2/xyz", ...bad });
+  const fences = (bodyText(bk.body).match(/```/g) || []).length;
   assert.equal(fences % 2, 0, "the code fence must be closed");
   assert.equal(fences, 2);
-  assert.ok(body.body.length <= 2900, "and the body still fits Slack's section cap");
+  assert.ok(bodyText(bk.body).length <= 2900, "and the body still fits Slack's section cap");
+
+  // The cap is the transport-independent half, and the plain form must carry no
+  // fence at all — an unclosed fence cannot be the failure if there is no fence.
+  const wf = render({ SLACK_WEBHOOK_URL: "https://hooks.slack.com/triggers/E1/2/abc", ...bad });
+  assert.ok(bodyText(wf.body).length <= 2900);
+  assert.doesNotMatch(bodyText(wf.body), /```/);
 });
 
 test("the elision notice survives the section cap — the list is budgeted, not appended", () => {
@@ -294,7 +382,7 @@ test("the elision notice survives the section cap — the list is budgeted, not 
   const notice = /and (\d+) more not listed here/.exec(body.body);
   assert.ok(notice, "the count of what was elided must survive the cap, not be cut by it");
   // And it must be the TRUTH: shown + elided is every failure there was.
-  const shown = (body.body.match(/^• `/gm) || []).length;
+  const shown = (body.body.match(/^• /gm) || []).length;
   assert.equal(shown + Number(notice[1]), 22, "shown + elided must account for every failure");
 });
 


### PR DESCRIPTION
## Why

The Workflow Builder trigger for the VM daily went live today (step 08), and the
first real message arrived like this:

```
*Langflow* `unknown`  ·  *Run* `smoke-passo-08` on the QA VM
*2 failed* · 0 flaky · 217 passed · 0 skipped
• `chat-message-send.spec.ts` — chat › sends a message
   _expect(locator).toBeVisible() timed out_
<https://example.invalid/report|Playwright report>
```

A message step is a **rich-text editor**: whatever arrives through a variable is
inserted as plain text. So the mrkdwn this script builds for Block Kit survives into
the channel as decoration, and the report link renders as its own source.

This is the same class of silent wrongness the mode derivation already guards
against — accepted, HTTP 200, useless — one layer further in. The transport was
right; the markup inside it was not.

## What changes

The transport is resolved **before** the message text is built, and the decoration
became a function of it: `bold`, `code`, `italic`, `fence`, `linkTo`. The **words**
stay a single construction shared by both transports, which is the property the file
already set out to protect; only the decoration follows the mode.

**Generated plain, not stripped afterwards.** Stripping cannot tell our markers from
content: a spec named `model_provider_base_url_ssrf` would lose half its name to a
regex hunting underscores, and the failure list is exactly where those names live.
Pinned by a test that renders such a name in both transports and requires it intact.

A bare URL is auto-linked by Slack, so `Playwright report: https://…` loses the
label's placement and never the destination — better than a link that renders as
`<url|label>` and is clickable as neither.

## Two tests re-anchored, one added

Two existing tests measured truncation **through** the markup. The fenced-truncation
property is now asserted on Block Kit, where a fence exists, with the character cap
alone asserted on the plain form — an unclosed fence cannot be the failure where
there is no fence. The shown-item count no longer keys on a backtick.

The **elision notice** was the one span the sweep missed, and it earns its own test:
the check that bans `*` and backticks cannot ban underscores, because underscores are
legitimate content there.

## Verified against the live trigger, not in mock

| | |
|---|---|
| plain rendering | channel shows no stray markers; both URLs clickable |
| a name with underscores | `model_provider_base_url_ssrf` intact, `_all_` in the signature intact |
| 40 failures | budget listed 9, elided 31, body 2718 chars, whole message rendered including the closing notice |

That last row is why the second commit exists. 2900 comes from Block Kit's
documented 3000-character section limit; a Workflow Builder trigger publishes no
per-variable limit, so the same cap is applied there — conservative rather than
derived. Now measured, and the comment says so.

## Tests

4 new, `npm run test:scripts` at 1088 passing.
