### PR TITLE
Trace the way daily-stable.yml traces, so the VM lane can pass the traces specs

### DIFF
--- a/reports/README.md
+++ b/reports/README.md
@@ -23,12 +23,9 @@ carry. Four known blind spots (#1211), stated here rather than only in a PR body
 comment so a reader of a number finds its limits in the same place:
 
 - **A local instance records nothing, and developer spend is OUT OF SCOPE for this series
-  (#1300).** Both start scripts *default* `LANGFLOW_DEACTIVATE_TRACING` to `true`, so the poller
-  has no traces to read at all when developing against a local container. The value is a
-  parameter rather than a literal because the scheduled VM lane needs the opposite and is not a
-  local instance: `scripts/run-e2e.sh` runs it with tracing ON, the way `daily-stable.yml` does,
-  and on the same CI keys — so its spend belongs in this series exactly as the Actions lane's
-  does, and the attribution problem below is not reintroduced (#1714). That is a **decision**, not a
+  (#1300).** The Docker and pip start scripts set `LANGFLOW_DEACTIVATE_TRACING=true` as a
+  literal, and `start-langflow-source.sh` defaults it to `true`, so the poller has no traces to
+  read at all when developing locally. That is a **decision**, not a
   pending fix: flipping the flag locally would produce traces nobody can attribute, because the CI
   secret and a developer's `.env` draw on one account balance and #1183's key-separation
   recommendation (`ANTHROPIC_API_KEY_AGENT` / `ANTHROPIC_API_KEY_CI`) is still unimplemented — so a
@@ -36,6 +33,13 @@ comment so a reader of a number finds its limits in the same place:
   consequence to carry: **this file is CI spend, and must never be quoted as total account
   spend.** The gap between the two is whatever developers spent locally, which only the provider
   console can answer, and only once the keys are split.
+- **The scheduled VM lane traces, and still writes nothing here (#1714).** It is not a local
+  instance: `scripts/run-e2e.sh` overrides that default and runs with tracing ON, the way
+  `daily-stable.yml` does, because the traces specs assert against a traced instance. Its
+  summary call carries `TOKENS_SUPPRESS_HISTORY=1` all the same — while both dailies run, the
+  Actions one owns this series, and a second line a day for the same `@stable` sweep would
+  double-count the trend and halve the anomaly window. The VM lane's own series lives outside
+  that clone until the switch makes it the only writer.
 - **`Collect models` spend enters the totals with no spec name.** That pre-flight sweep drives the
   same Langflow instance the token poller watches, but it is not a spec run, so its traces land in
   `unattributed`, never in `by_spec`.

--- a/reports/README.md
+++ b/reports/README.md
@@ -23,8 +23,12 @@ carry. Four known blind spots (#1211), stated here rather than only in a PR body
 comment so a reader of a number finds its limits in the same place:
 
 - **A local instance records nothing, and developer spend is OUT OF SCOPE for this series
-  (#1300).** Both start scripts set `LANGFLOW_DEACTIVATE_TRACING=true`, so the poller has no
-  traces to read at all when developing against a local container. That is a **decision**, not a
+  (#1300).** Both start scripts *default* `LANGFLOW_DEACTIVATE_TRACING` to `true`, so the poller
+  has no traces to read at all when developing against a local container. The value is a
+  parameter rather than a literal because the scheduled VM lane needs the opposite and is not a
+  local instance: `scripts/run-e2e.sh` runs it with tracing ON, the way `daily-stable.yml` does,
+  and on the same CI keys — so its spend belongs in this series exactly as the Actions lane's
+  does, and the attribution problem below is not reintroduced (#1714). That is a **decision**, not a
   pending fix: flipping the flag locally would produce traces nobody can attribute, because the CI
   secret and a developer's `.env` draw on one account balance and #1183's key-separation
   recommendation (`ANTHROPIC_API_KEY_AGENT` / `ANTHROPIC_API_KEY_CI`) is still unimplemented — so a

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -194,6 +194,15 @@ export PATH="$HOME/.local/bin:$PATH"
 # globalSetup — see the migration's divergence list, entry 1.
 export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="${PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-ubuntu24.04-x64}"
 
+# Tracing ON, because daily-stable.yml runs with it on and the traces/observability
+# specs assert against a traced instance. Both starters default it OFF — right for a
+# developer's own instance, wrong for the lane that has to match CI — so the value
+# belongs here, in the file whose whole job is mirroring that workflow. Measured, not
+# assumed: on 2026-09-04 eight @stable specs failed on the VM while the same day's
+# Actions daily was green, for no reason other than this variable (#1714). Read the
+# workflow before changing it — run-e2e.test.mjs asserts the two agree.
+LANGFLOW_DEACTIVATE_TRACING="${LANGFLOW_DEACTIVATE_TRACING:-false}"
+
 # ---------------------------------------------------------------------------
 # UTILITIES
 # ---------------------------------------------------------------------------
@@ -659,7 +668,7 @@ start_backend_for_shard() {
   # clone, and its absence fails with the right message for the wrong reason.
   # shellcheck disable=SC2086
   ssh -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 $TARGET_SSH_OPTS "$TARGET_SSH" \
-    "PATH=\$HOME/.local/bin:\$PATH LANGFLOW_SRC_REPO=\${LANGFLOW_SRC_REPO:-\$HOME/langflow} LANGFLOW_REQUIRE_BUILD_STAMP=$STAMP_REQUIRED ${bind_env}LANGFLOW_PORT=$port bash -s; sleep 86400" \
+    "PATH=\$HOME/.local/bin:\$PATH LANGFLOW_SRC_REPO=\${LANGFLOW_SRC_REPO:-\$HOME/langflow} LANGFLOW_REQUIRE_BUILD_STAMP=$STAMP_REQUIRED LANGFLOW_DEACTIVATE_TRACING=$LANGFLOW_DEACTIVATE_TRACING ${bind_env}LANGFLOW_PORT=$port bash -s; sleep 86400" \
     < scripts/start-langflow-source.sh > "$holder_log" 2>&1 &
   HELD_SESSIONS+=("$!")
 

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -202,6 +202,14 @@ export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="${PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-u
 # Actions daily was green, for no reason other than this variable (#1714). Read the
 # workflow before changing it — run-e2e.test.mjs asserts the two agree.
 LANGFLOW_DEACTIVATE_TRACING="${LANGFLOW_DEACTIVATE_TRACING:-false}"
+# Checked because this is the first CALLER-supplied value to be interpolated into
+# the remote command bare, and because the flag reads anything that is not "true"
+# as false. `0`, `FALSE` or a value carrying a space would go in silently and land
+# the lane back in #1714 — tracing off, nothing said.
+case "$LANGFLOW_DEACTIVATE_TRACING" in
+  true | false) ;;
+  *) echo "LANGFLOW_DEACTIVATE_TRACING must be exactly 'true' or 'false', got: '$LANGFLOW_DEACTIVATE_TRACING'" >&2; exit 1 ;;
+esac
 
 # ---------------------------------------------------------------------------
 # UTILITIES
@@ -1030,7 +1038,16 @@ phase_publish() {
     fi
   fi
 
-  TOKENS_DIR="$RUN_DIR/all-tokens" node scripts/watch-tokens.mjs --summarize \
+  # TOKENS_SUPPRESS_HISTORY, because with tracing on this lane HAS spend to record and
+  # would otherwise append a line to reports/token-history.jsonl — a git-tracked file,
+  # inside the clone this run does not own. Two costs, both concrete: the line is an
+  # uncommitted modification that the next `git pull --ff-only` refuses (that refusal is
+  # the guarantee, so breaking it daily is not an option), and once committing is on
+  # there would be TWO lines a day for one scope — a double-counted trend and an
+  # anomaly window half as wide. The PR and manual lanes carry the same flag for the
+  # neighbouring reason, scope rather than duplication (#1183). This lane's own series
+  # belongs in the ledger outside the clone, which is a step of its own.
+  TOKENS_DIR="$RUN_DIR/all-tokens" TOKENS_SUPPRESS_HISTORY=1 node scripts/watch-tokens.mjs --summarize \
     > "$RUN_DIR/logs/token-summary.log" 2>&1 || warn "the token summary failed (not blocking)."
 
   if [ "$COMMIT_HISTORY" = "1" ] && [ "$EVENT_NAME" = "schedule" ]; then

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -28,6 +28,7 @@ import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { evaluateWorkflowValue } from "./lib/gh-expression.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..");
@@ -137,20 +138,73 @@ test("the publish switches are OFF by default, all four of them", () => {
   assert.equal(r.stdout.trim(), "0 0 0 0");
 });
 
+// Comment lines go before anything is matched, for the reason watch-tokens.test.mjs
+// already paid for at #1300: a `#` line merely SPELLING the old value could both mask
+// a real setting and fail a CORRECT workflow — and the failure message would then
+// invite the next reader to "fix" this lane by restoring the value that caused #1714.
+const stripComments = (text) =>
+  text
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+
 test("the lane runs tracing the way the workflow does, read out of the workflow", () => {
-  // What this pins cost eight @stable specs on 2026-09-04: the VM lane came back red
-  // while the same day's Actions daily was green, because both starters default tracing
-  // OFF and daily-stable.yml runs it ON. A literal here would drift the moment the
-  // workflow changed, so the expectation is READ from the workflow, never copied.
-  const wf = readFileSync(join(REPO_ROOT, ".github/workflows/daily-stable.yml"), "utf8");
-  const declared = wf.match(/LANGFLOW_DEACTIVATE_TRACING:\s*"?([A-Za-z]+)"?/)?.[1];
-  assert.ok(declared, "could not read LANGFLOW_DEACTIVATE_TRACING out of daily-stable.yml");
-  const r = sourced(`echo "$LANGFLOW_DEACTIVATE_TRACING"`);
+  // What this pins cost nine @stable tests on 2026-09-04: the VM lane came back red
+  // while the same day's Actions daily was green, because all three starters keep
+  // tracing OFF and daily-stable.yml runs it ON. A literal here would drift the moment
+  // the workflow changed, so the expectation is READ from the workflow, never copied.
+  const wf = stripComments(readFileSync(join(REPO_ROOT, ".github/workflows/daily-stable.yml"), "utf8"));
+
+  // EVERY occurrence, not the first: a second setting further down the file would
+  // otherwise pass unnoticed while this lane mirrored only one of them.
+  const settings = [...wf.matchAll(/LANGFLOW_DEACTIVATE_TRACING:\s*(.+)/g)].map((m) => m[1].trim());
+  assert.equal(
+    settings.length,
+    1,
+    `daily-stable.yml must set the tracing flag exactly once for this to be readable; found ${settings.length}`,
+  );
+
+  // Evaluated rather than string-compared, for the day the value becomes an
+  // expression — it already is one on pr-validation.yml. An expression this cannot
+  // evaluate fails here deliberately: a guard that cannot read the value is a guard
+  // that is not checking it.
+  let declared;
+  try {
+    declared = evaluateWorkflowValue(settings[0], {});
+  } catch (err) {
+    assert.fail(`cannot evaluate daily-stable.yml's tracing setting, so it is unverified — ${err.message}`);
+  }
+
+  // The environment is blanked, not inherited. `sourced()` forwards process.env, so an
+  // exported LANGFLOW_DEACTIVATE_TRACING — on the VM, or in the shell of whoever was
+  // debugging #1714 — would answer for the default and let this test pass with the
+  // line deleted. `:-` treats empty as unset, so this measures the default itself.
+  const r = sourced(`echo "$LANGFLOW_DEACTIVATE_TRACING"`, { LANGFLOW_DEACTIVATE_TRACING: "" });
   assert.equal(
     r.stdout.trim(),
     declared,
     `this lane has to trace the way daily-stable.yml does (${declared})`,
   );
+});
+
+test("a tracing value that is neither true nor false stops the run", () => {
+  // The flag reads anything that is not "true" as false, so `0` or `FALSE` would mean
+  // tracing OFF while looking deliberate — #1714's failure class, arriving through the
+  // caller instead of the file.
+  const r = sourced(`echo unreachable`, { LANGFLOW_DEACTIVATE_TRACING: "0" });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /must be exactly 'true' or 'false'/);
+});
+
+test("the lane does not append to the daily's token series", () => {
+  // With tracing ON this lane has spend to record, and the summarizer's default is to
+  // append one line to reports/token-history.jsonl — a git-tracked file, in a clone
+  // this run does not own, whose `git pull --ff-only` would then refuse every day.
+  const line = readFileSync(SCRIPT, "utf8")
+    .split("\n")
+    .find((l) => l.includes("watch-tokens.mjs --summarize"));
+  assert.ok(line, "could not find the token summary invocation");
+  assert.match(line, /TOKENS_SUPPRESS_HISTORY=1/);
 });
 
 test("the tracing value crosses the ssh boundary, which a default alone does not", () => {

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -137,6 +137,33 @@ test("the publish switches are OFF by default, all four of them", () => {
   assert.equal(r.stdout.trim(), "0 0 0 0");
 });
 
+test("the lane runs tracing the way the workflow does, read out of the workflow", () => {
+  // What this pins cost eight @stable specs on 2026-09-04: the VM lane came back red
+  // while the same day's Actions daily was green, because both starters default tracing
+  // OFF and daily-stable.yml runs it ON. A literal here would drift the moment the
+  // workflow changed, so the expectation is READ from the workflow, never copied.
+  const wf = readFileSync(join(REPO_ROOT, ".github/workflows/daily-stable.yml"), "utf8");
+  const declared = wf.match(/LANGFLOW_DEACTIVATE_TRACING:\s*"?([A-Za-z]+)"?/)?.[1];
+  assert.ok(declared, "could not read LANGFLOW_DEACTIVATE_TRACING out of daily-stable.yml");
+  const r = sourced(`echo "$LANGFLOW_DEACTIVATE_TRACING"`);
+  assert.equal(
+    r.stdout.trim(),
+    declared,
+    `this lane has to trace the way daily-stable.yml does (${declared})`,
+  );
+});
+
+test("the tracing value crosses the ssh boundary, which a default alone does not", () => {
+  // The failure mode this catches LOOKS fixed: the value is set here, the shell that
+  // runs the starter is on the other machine, and it inherits nothing from this one.
+  // A variable that never crosses is a variable that never applied.
+  const line = readFileSync(SCRIPT, "utf8")
+    .split("\n")
+    .find((l) => l.includes("bash -s; sleep 86400"));
+  assert.ok(line, "could not find the command that starts the backend on the target");
+  assert.match(line, /LANGFLOW_DEACTIVATE_TRACING=\$LANGFLOW_DEACTIVATE_TRACING/);
+});
+
 test("the version check is on by default, and so is enforcing it", () => {
   // Enforcement waited for two things, and both arrived on 2026-09-03: the run now
   // places the clone itself, so a mismatch is no longer somebody forgetting to move

--- a/scripts/start-langflow-source.sh
+++ b/scripts/start-langflow-source.sh
@@ -258,7 +258,15 @@ echo "Starting Langflow on ${BIND_HOST}:${PORT} (logs: ${LOG_FILE})..."
 # The flags below carry the same reasoning as scripts/start-langflow-pip.sh — read
 # that file's comments for the why of each. Repeated here rather than sourced because
 # a starter that hides its environment behind an include is a starter nobody audits.
-#   LANGFLOW_DEACTIVATE_TRACING  local spend is out of scope for token history (#1300, #1183)
+#   LANGFLOW_DEACTIVATE_TRACING  local spend is out of scope for token history (#1300, #1183).
+#                                Overridable, and the default deliberately STAYS `true`: this
+#                                block is asserted against start-langflow-pip.sh's, and a
+#                                different default here would let a spec tell which starter
+#                                brought its instance up. The scheduled lane needs the
+#                                opposite value — daily-stable.yml runs with tracing ON and
+#                                the traces specs assert against a traced instance — so
+#                                scripts/run-e2e.sh sets it, which is the file whose job is
+#                                to mirror that workflow (#1714).
 #   LANGFLOW_A2A_ENABLED         product default is OFF, and a disabled server passes every A2A spec while testing nothing (#1240, #1195)
 #   LANGFLOW_SSRF_ALLOWED_HOSTS  private ranges only, loopback deliberately OUT (security/ssrf-url-validation.spec.ts asserts the refusal)
 #   --workers 1                  Langflow defaults to (2*cpu)+1, each holding full in-memory state (#773) — and on this lane N shards multiply it
@@ -280,7 +288,7 @@ cd "${REPO}"
 LANGFLOW_AUTO_LOGIN=true \
 LANGFLOW_SUPERUSER="${LANGFLOW_SUPERUSER:-langflow}" \
 LANGFLOW_SUPERUSER_PASSWORD="${LANGFLOW_SUPERUSER_PASSWORD:-langflow123}" \
-LANGFLOW_DEACTIVATE_TRACING=true \
+LANGFLOW_DEACTIVATE_TRACING="${LANGFLOW_DEACTIVATE_TRACING:-true}" \
 LANGFLOW_A2A_ENABLED="${LANGFLOW_A2A_ENABLED:-true}" \
 LANGFLOW_SSRF_ALLOWED_HOSTS="${LANGFLOW_SSRF_ALLOWED_HOSTS:-172.16.0.0/12,10.0.0.0/8,192.168.0.0/16}" \
 LANGFLOW_CONFIG_DIR="${STATE_DIR}/data" \

--- a/scripts/start-langflow-source.test.mjs
+++ b/scripts/start-langflow-source.test.mjs
@@ -442,6 +442,21 @@ test("a process that ignores SIGTERM is escalated, not left as an orphan", () =>
   r.cleanup();
 });
 
+test("tracing is the caller's to set, and its default is not moved", () => {
+  // The scheduled lane needs tracing ON (daily-stable.yml runs it on, and the traces
+  // specs assert against a traced instance); a developer's own instance does not, which
+  // is what #1300/#1183 decided. So the value has to be a parameter — and the default
+  // has to STAY put, because the env-block parity test below is what keeps a spec from
+  // being able to tell which starter brought its instance up (#1714).
+  const off = runScript();
+  assert.match(off.langflowEnv, /^LANGFLOW_DEACTIVATE_TRACING=true$/m);
+  off.cleanup();
+
+  const on = runScript({ env: { LANGFLOW_DEACTIVATE_TRACING: "false" } });
+  assert.match(on.langflowEnv, /^LANGFLOW_DEACTIVATE_TRACING=false$/m);
+  on.cleanup();
+});
+
 test("the environment block matches the pip starter's, read from that file", () => {
   const r = runScript();
   assert.equal(r.status, 0);

--- a/scripts/start-langflow-source.test.mjs
+++ b/scripts/start-langflow-source.test.mjs
@@ -448,8 +448,18 @@ test("tracing is the caller's to set, and its default is not moved", () => {
   // is what #1300/#1183 decided. So the value has to be a parameter — and the default
   // has to STAY put, because the env-block parity test below is what keeps a spec from
   // being able to tell which starter brought its instance up (#1714).
+  // The pip starter's value is READ, not repeated: the claim being made is that the two
+  // agree, and a hardcoded `true` here would keep passing after pip changed. That is the
+  // same "read from that file" the env-block parity test below uses.
+  // Anchored to the start of a line, because the pip starter's own COMMENT spells the
+  // same assignment two lines above the real one — an unanchored match reads the prose
+  // and keeps passing after the setting changes. Found by mutation: flipping pip's real
+  // value left this test green.
+  const pipDefault = readFileSync(PIP_START, "utf8").match(/^LANGFLOW_DEACTIVATE_TRACING=(\w+)/m)?.[1];
+  assert.ok(pipDefault, "could not read the pip starter's tracing value");
+
   const off = runScript();
-  assert.match(off.langflowEnv, /^LANGFLOW_DEACTIVATE_TRACING=true$/m);
+  assert.match(off.langflowEnv, new RegExp(`^LANGFLOW_DEACTIVATE_TRACING=${pipDefault}$`, "m"));
   off.cleanup();
 
   const on = runScript({ env: { LANGFLOW_DEACTIVATE_TRACING: "false" } });


### PR DESCRIPTION
Closes #1714.

## What this fixes

The first full `@stable` run on the QA VMs came back **red** while the same day's
Actions daily came back **green**. **All nine failures** were the tracing family —
`api-monitor-traces.spec.ts` contributed two of them — and one named the cause in its own
assertion message:

> A 200 with no traces after a run is what `LANGFLOW_DEACTIVATE_TRACING=true` produces

The two lanes disagreed on one variable — `"false"` in `daily-stable.yml`, a hardcoded
`true` in `start-langflow-source.sh`. That is an environment difference, and the rule for
those is to fix the environment rather than the test.

## Where the fix lives, and why not in the starter

The starter only stops **pinning** the value; its default stays `true`, which is the right
answer for a developer's own instance (#1300, #1183). `scripts/run-e2e.sh` sets it,
because mirroring `daily-stable.yml` is that file's entire job — it already owns the
browser platform override and the `uv` PATH for the same reason.

To be precise about the justification, since the first version of this PR got it wrong:
the env-block parity test compares variable **names** (plus SSRF and `--workers`), so it
would *not* have caught a moved default. The property is real, the mechanism cited was
not — so the new starter test now **reads** pip's value, which pins the pair in both
directions and makes the claim true.

## Properties, each pinned by mutation

| Property | Mutation that must fail |
|---|---|
| The lane's value is **read out of** `daily-stable.yml`, never copied | default back to `true` → parity test fails |
| It is read **past comments**, and every occurrence must agree | a `#` line spelling the old value → guard stays **green** (no false positive) |
| The guard measures the **default**, not the ambient environment | delete the line *with the variable exported* → fails (it did not, before review) |
| The value **crosses the ssh boundary** | drop it from the remote command → boundary test fails |
| A value that is neither `true` nor `false` **stops the run** | remove the check → fails |
| The lane **does not append** to `reports/token-history.jsonl` | remove `TOKENS_SUPPRESS_HISTORY=1` → fails |
| The starter takes the value from its **caller**, matching pip's default | flip either starter's default → fails |

## What review changed, and why it mattered

- **The lane would have started writing the daily's token series.** With tracing on there
  is spend to record, and `--summarize` appends to a **git-tracked** file inside a clone
  this run does not own. The scheduled wrapper pulls with `--ff-only` precisely so local
  work fails the pull instead of being rewritten — so a line a day would have broken that
  guarantee daily, and once committing is on it would be two lines a day for one scope.
  `TOKENS_SUPPRESS_HISTORY=1` now, for the neighbouring reason the PR and manual lanes
  carry it (#1183).
- **The guard read the workflow as raw text** — no `stripComments()`, first match only.
  Both failures #1300's review already paid for, and the failure mode is the bad kind: it
  fails a *correct* workflow and invites restoring `true`.
- **The guard passed its own mutation** when the variable was exported, because
  `sourced()` forwards `process.env`.
- **A caller-supplied value went into the remote command bare.** `0` or `FALSE` means
  tracing off while looking deliberate — #1714's own failure class, through the caller.
- One of these was found by mutation rather than by review: the starter test's read of
  pip's default was unanchored, and the pip starter's **comment** spells the same
  assignment two lines above the real one, so it stayed green after the setting changed.

## Checks

- `npm run test:scripts` — **1096 passing**, 1 skipped, 0 failing, 7 new tests.
- Measured on the real machines: the divergence came out of a full run (570 passed /
  9 failed / 3 flaky / 18 skipped, report complete) with the same day's Actions daily
  green. Post-fix verification of the traces family on the VMs is running; result to
  follow in a comment, since no Actions lane exercises this path.

## Follow-ups, not in this PR

- **#1715** — `run-e2e.sh` aborts when `HOME` is unset, which is every scheduler that is
  not cron. Workaround in place on the machine.
- **The class this belongs to.** Review found three more of the daily's service variables
  that never reach the VM: `LANGFLOW_ALLOW_CUSTOM_COMPONENTS`, `LANGFLOW_SQLITE_PRAGMAS`
  and `LANGFLOW_WORKER_TIMEOUT`. Filed separately, with the severity measured rather than
  assumed.
