### PR TITLE
fix(ui): verify each settings-navigation hop instead of three blind clicks (#1696)

### DIFF
--- a/docs/core-functionality/llm-agents/model-provider-model-toggle.md
+++ b/docs/core-functionality/llm-agents/model-provider-model-toggle.md
@@ -1,6 +1,6 @@
 # Model Provider Model Toggle
 
-**Last validated:** Langflow 1.12.x (measured on `1.12.0.dev30`; the provider-list wait re-measured on `1.12.0.dev44`, #1648)
+**Last validated:** Langflow 1.13.x (measured on `1.13.0.dev0`; the settings-navigation hops measured there, #1696. Earlier: `1.12.0.dev30`; the provider-list wait re-measured on `1.12.0.dev44`, #1648)
 
 ---
 
@@ -31,9 +31,9 @@ Both tests resolve a single provider — `MODEL_TEST_PROVIDER` when its env keys
 ### Test 1 — toggle changes immediately and persists across reopen
 
 1. `SimpleAgentTemplatePage.load({ provider })` — configures the provider's API key globally and enables all its models (the known baseline). `MODEL_NOT_AVAILABLE` is caught and turned into a skip.
-2. Navigate to **Settings → Model Providers**, expand the provider through `waitForProviderRow()` (see *Waiting for the provider list* below — never a bare `provider-item-...` wait), and wait for `model-provider-selection` and `llm-models-section`.
+2. Navigate to **Settings → Model Providers** through `navigateSettingsPages()` (see *Reaching the Settings page* below — three **verified** hops, never three blind clicks), expand the provider through `waitForProviderRow()` (see *Waiting for the provider list* — never a bare `provider-item-...` wait), and wait for `model-provider-selection` and `llm-models-section`.
 3. Read the first visible `llm-toggle-<model>` to derive a model name, filter the list to it via `model-search-input`, and assert it is enabled (`aria-checked="true"`).
-4. Disable it: click the toggle, assert `aria-checked="false"` immediately (optimistic), and wait for the `POST .../enabled_models` response (debounced persistence flush).
+4. Disable it: click the toggle, assert `aria-checked="false"` immediately (optimistic), and wait for the `POST .../enabled_models` response (debounced persistence flush) — through `toggleWriteVerdict()`, so a write that never lands says which half failed (see *Waiting for the persistence write* below).
 5. Reload the app, reopen Model Providers, re-expand the provider, search for the same model and assert its toggle is still `aria-checked="false"` (persisted).
 6. Restore the baseline: re-enable the model and assert `aria-checked="true"`.
 
@@ -52,7 +52,7 @@ Both tests resolve a single provider — `MODEL_TEST_PROVIDER` when its env keys
    (#1461). **The dropdown mixes models from every configured provider** (#597 — with
    Google configured by sibling specs it listed `gemini-3.5-flash` first while the
    test's provider was OpenAI), so the options alone cannot pick the target.
-3. In **Settings → Model Providers**, open the test's provider through
+3. In **Settings → Model Providers** (reached through `navigateSettingsPages()`), open the test's provider through
    `waitForProviderRow()` and read its
    `llm-toggle-<model>` ids via `enumerateEnabledModels()` — every toggle the panel
    renders, in the **bare** ids the picker's testid does not use. (The helper's name
@@ -138,6 +138,101 @@ reachable only from an instance that is misbehaving on purpose. Its verdicts:
 
 ---
 
+## Reaching the Settings page *(required)*
+
+Every hop into Settings goes through `navigateSettingsPages()`
+(`tests/helpers/ui/go-to-settings.ts`), which **verifies the effect of each
+click before making the next one**. The reason is attribution, and the total
+budget is deliberately **not raised** — it is the same worst case as the three
+clicks it replaces (3 x `actionTimeout`, 20 s each), minus the unconditional
+`waitForTimeout(500)` it no longer needs.
+
+The old helper fired three blind clicks: `user-profile-settings`, then
+`getByText("Settings").first()`, then `getByText("<section>").first()`. Nothing
+checked that any of them took effect, and a hop the DOM **accepts** while the
+app **discards** it therefore surfaced one hop LATER, at a locator that never had
+a chance. Measured on #1696, from the dailies' own `results.json` and blob
+reports:
+
+| Daily | What Playwright reported | What the artifacts show |
+|---|---|---|
+| 2026-09-03 (run `33756085604`) | `locator.click: Timeout 20000ms exceeded` / `waiting for getByText('Model Providers').first()`, at `go-to-settings.ts:15` | the failure-time screenshot and aria snapshot are the **home page** — Projects sidebar, flow list, dropdown closed, the account button carrying a focus ring. `Settings` appears **0 times** in the snapshot. Hops 1 and 2 both returned success. |
+| 2026-09-01 (run `33511210195`) | the same line, the same locator, the same budget, on attempt 2 | second, independent occurrence — the shape is recurrent, not a one-off |
+
+The same run's passing retry times the mechanism: the hop-1 click took
+**1532 ms** of actionability wait right after `page.goto("/")`, against **121 ms**
+for the identical click earlier in the same test, and its stderr carries
+`agent credential settled slowly: 6.2s` (the #751 guard) — a saturated backend.
+Locally, a `MutationObserver` on `1.13.0.dev0` shows the header's DOM node being
+**replaced ~616 ms** after `goto("/")`, which is what discards a Radix menu whose
+trigger was clicked just before it. Four different "signatures" over 30 days,
+one cause; a call log that names nothing, because the step that failed is not the
+step that reports.
+
+Three verified hops, each with its **own** real testid rather than a text match
+(`getByText` is case-insensitive and unscoped; the stable handles exist and were
+measured on `1.13.0.dev0`):
+
+| hop | click | effect waited for |
+|---|---|---|
+| 1 — open the account menu | `user-profile-settings` | `menu_settings_button` visible |
+| 2 — enter Settings | `menu_settings_button` | the URL matches `/\/settings(?:\/|$)/` |
+| 3 — open the section | `sidebar-nav-<section>` (a real `<a href="/settings/...">`) | `location.pathname` equals **that anchor's own `href`**, then `settings_menu_header` reads `<section>` |
+
+A hop whose effect does not land is **re-attempted once, inside the same
+deadline**, and the re-attempt is announced on stdout rather than being silent —
+a dropped click is repaired the way #1518 repairs the sidebar's dropped `fill`,
+but a *systematic* breakage must not hide behind the repair. If the effect still
+does not land, `settingsNavVerdict()` throws naming the hop and what the page was
+showing. It is a **pure** function over the snapshot, unit-tested in
+`go-to-settings.test.ts`, for the same reason `providerRowVerdict()` is: the
+branches that matter are otherwise reachable only from an instance misbehaving
+on purpose.
+
+| kind | when | reads as |
+|---|---|---|
+| `menu-unopened` | the trigger was clicked twice and `menu_settings_button` never rendered | the account menu never opened — an app-shell stall, not a missing Settings page |
+| `page-unreached` | the URL never became `/settings…`, **or** it did and the sidebar rendered **zero** `sidebar-nav-*` entries | the Settings route never mounted; the verdict carries the pathname the page is actually on. Hop 2 keys on the URL, not on the `sidebar-nav-` prefix, which the flow sidebar also uses — and zero entries is a shell that never mounted, never a renamed section |
+| `section-absent` | the URL is `/settings…`, the sidebar rendered **other** `sidebar-nav-*` entries, and `sidebar-nav-<section>` is not among them | a PRODUCT finding — the section was renamed or removed; it names every entry that DID render |
+| `section-unconfirmed` | the pathname never became the anchor's `href`, **or** it did and a `settings_menu_header` that IS on the page never read `<section>` | the section route did not take, or it took and the page mounted the wrong content; the verdict carries the header text and the pathname |
+
+Hop 3's target path is read from the clicked anchor's **own** `href`, never from a
+name-to-path table — the anchor is the single source, so a section Langflow
+renames cannot desync a map (the `langflowProviderName` argument, #1043/#1184).
+The header is the *content* half of the confirmation and is treated as optional
+for the same reason: `sidebar-nav-Langflow MCP Client` renders **no**
+`settings_menu_header` at all (measured across all nine sections on
+`1.13.0.dev0`; the other eight render exactly one, whose text equals the sidebar
+title, so the `.last()` at the call sites is defensive rather than required).
+When the pathname matched and the header was never present in any poll, the hop
+is accepted on the URL alone and says so once on stdout; a header that IS
+present and reads something else is `section-unconfirmed`. No section list is
+hardcoded either way.
+
+---
+
+## Waiting for the persistence write *(required)*
+
+`setToggle()` arms `page.waitForResponse` for `POST .../enabled_models` **before**
+clicking, because the write is debounced ~1 s and navigating away first would drop
+it. On the 2026-09-01 daily (run `33511210195`) that wait timed out at 15 s on
+**both** tests, and the bare
+`TimeoutError: page.waitForResponse: Timeout 15000ms exceeded while waiting for
+event "response"` cannot distinguish the two things that produce it.
+`toggleWriteVerdict()` — pure, unit-tested in `model-toggle-write.test.ts` —
+splits them, with the **budget unchanged**:
+
+| kind | when | reads as |
+|---|---|---|
+| `not-issued` | no `POST .../enabled_models` request was even observed | the UI never fired the debounced write — a suite or product defect, and the toggle's `aria-checked` at that moment is named |
+| `unanswered` | the request was issued and the instance did not answer inside the budget | INSTANCE saturation; the request count and the budget are named. Do not raise it to make this pass (#1648) |
+
+This is **attribution, not a fix**: a saturated instance still fails, correctly.
+What changes is that the failure says which half of the round-trip broke, so the
+next occurrence is not a fifth nameless "signature" (#1012/#1626).
+
+---
+
 ## Validation criterion *(required)*
 
 - Toggling a model flips `aria-checked` immediately (optimistic update).
@@ -151,6 +246,31 @@ reachable only from an instance that is misbehaving on purpose. Its verdicts:
   Force-failable in both directions: hold `GET /api/v1/models?purpose=configure` past
   the budget and the failure must say `PROVIDER_LIST_STALLED`; render the list without
   the target provider and it must say `PROVIDER_ABSENT` and list the ones that rendered.
+- Reaching **Settings → Model Providers** fails with the HOP named — `menu-unopened`,
+  `page-unreached`, `section-absent` or `section-unconfirmed` — never as a bare
+  `getByText(...)` click timeout one hop downstream of the hop that actually broke.
+  Force-failable in both directions, and the negative direction is **measured**, not
+  asserted: swallowing hop 2's selection at the DOM level — a capture-phase
+  `stopImmediatePropagation` on `menu_settings_button`, so the item is still visible,
+  hit-tested and clicked while the event never reaches Radix's `onSelect` — reproduces
+  the daily byte-for-byte against the OLD helper, and all four verdict branches were
+  then measured against the new one on `1.13.0.dev2`:
+
+  | mutation | old helper | new helper |
+  |---|---|---|
+  | none (control) | PASSED 1155 ms | PASSED 646–895 ms across all five sections |
+  | hop 2's selection swallowed **once** | **FAILED 20527 ms** — `locator.click: Timeout 20000ms exceeded` / `waiting for getByText('Model Providers').first()`, page still on the previous route, **zero** `Settings` text nodes, no open menu | **PASSED 3/3** (9056–9667 ms) through the announced hop-2 repair — this is the case the repair exists for |
+  | **every** selection swallowed | same, nameless | **FAILED** `SETTINGS_PAGE_UNREACHED`, naming the pathname it is stuck on |
+  | `menu_settings_button`'s testid stripped | nameless | **FAILED** `SETTINGS_MENU_UNOPENED`, and it distinguishes the case: *"The menu DID open … so this is a RENAMED testid rather than an app-shell stall"* |
+  | `sidebar-nav-Model Providers`'s testid stripped | nameless | **FAILED** `SETTINGS_SECTION_ABSENT`, listing the 8 sections that did render |
+
+  Note the second and third rows are different mutations on purpose: a single dropped
+  selection MUST be repaired, so only swallowing every one of them can force hop 2's
+  verdict.
+- A persistence write that does not complete inside its unchanged 15 s budget fails as
+  `TOGGLE_WRITE_NOT_ISSUED` (no POST was ever observed) or `TOGGLE_WRITE_UNANSWERED`
+  (the POST was issued, the instance did not answer) — never as a bare
+  `page.waitForResponse` timeout.
 - The baseline is restored at the end of each test (model left enabled) so sibling specs are unaffected.
 
 ---
@@ -196,6 +316,12 @@ flow count grows.
 - `src/frontend/src/hooks/use-refresh-model-inputs.ts` — refreshes component model dropdowns when toggles change (the propagation behavior in Test 2).
 - `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/` — renders the Agent's `model_model` trigger, `value-dropdown-model_model` value span, and the `-option` dropdown entries. `components/ModelList.tsx` owns `getModelOptionTestId(provider, modelName)` = `${provider}-${modelName}-option` and the cmdk `value` = `${provider}::${modelName}` that surfaces as `data-value` — the two attributes this spec resolves a model by.
 - `tests/helpers/provider-setup/model-option.ts` — the shared identity reader (#1463): `enumerateModelOptions()`, `enumerateEnabledModels()`, `ModelOption`, plus `censusForTarget()` / `hasOptionIdentity()` (#1464). Test 2 matches options exclusively through it; the classification is pure and unit-tested in `model-option.test.ts`, because the branch that must not regress ("a `target: 0` verdict counts only with `total > 0` and `providerOthers > 0`") is otherwise reachable only from a live run.
+- `tests/helpers/ui/go-to-settings.ts` — `navigateSettingsPages()` and the pure `settingsNavVerdict()` (#1696). The three verified hops above; `go-to-settings.test.ts` covers the classification. Shared with `mcp-server-starter-projects`, `settings-message-history`, `remove-provider-api-key`, `model-provider-modal-actions`, `model-provider-api-key` and `modelProviderModal`, so a change here is suite-wide by design — the same 20 s `locator.click` shape was recorded against four of those specs.
+- `tests/helpers/provider-setup/model-toggle-write.ts` — the pure `toggleWriteVerdict()` (#1696) behind `setToggle()`'s persistence wait; `model-toggle-write.test.ts` covers it.
+- `src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx` — owns `user-profile-settings` (hop 1's trigger, line 57) and `menu_settings_button` (hop 2's item, line 98, verified on `main`). Renaming `menu_settings_button` turns hop 1 into `SETTINGS_MENU_UNOPENED`, which is a loud failure rather than a silent one.
+- `src/frontend/src/components/core/sidebarComponent/index.tsx` — renders `data-testid={`sidebar-nav-${item.title}`}` on a real `CustomLink` (line 53 on `main`), one per settings section: `sidebar-nav-General`, `sidebar-nav-Model Providers`, `sidebar-nav-Global Variables`, `sidebar-nav-MCP Servers`, `sidebar-nav-Messages`, `sidebar-nav-DB Providers`, `sidebar-nav-Langflow API Keys`, `sidebar-nav-Langflow MCP Client`, `sidebar-nav-Shortcuts` (all nine enumerated live on `1.13.0.dev0`). Hop 3 clicks the requested one; a section missing from this list is the `section-absent` verdict. The component is generic — the flow sidebar uses the same prefix — so hop 2 keys on the URL, not on the prefix alone.
+- `src/frontend/src/pages/SettingsPage/pages/ModelProvidersPage/index.tsx` — owns this section's `settings_menu_header`, the observable hop 3 confirms. Each settings page renders its own, so the header text is what identifies the section.
+- `src/frontend/tests/utils/go-to-settings.ts` — **upstream's own copy of this helper**, and the reason this repo's version is a fix rather than an invention. Our `navigateSettingsPages()` is a fork of the pre-`76fb85da` version: `release-1.9.7` still carries it byte-identically, `waitForTimeout(500)` included. Upstream rewrote it on **2026-08-25** in `76fb85da` — *"test: stabilize release Playwright navigation"* — onto exactly the testids above plus a `waitForURL(/\/settings(?:\/|$)/)`, i.e. it reached the same conclusion from the same symptom before we did. This repo adopts that shape and adds two things upstream does not have: the `settingsNavVerdict()` attribution and the bounded per-hop re-attempt. It deliberately does **not** adopt upstream's budgets (`TIMEOUTS.medium` 10 s / `TIMEOUTS.standard` 30 s) — 30 s would raise the last hop above the 20 s `actionTimeout` it has today and hide the stall.
 - `tests/helpers/provider-setup/provider-list-state.ts` — `waitForProviderRow()` and the pure `providerRowVerdict()` (#1648). Reads the four provider-list states listed above; `provider-list-state.test.ts` covers the classification.
 - `src/frontend/src/modals/modelProviderModal/components/ProviderList.tsx` — owns all four state testids (`provider-list-loading` line 82, `provider-list-error` 94, `provider-list-empty` 105, `provider-list` 119 on `release-1.12.0`). Renaming any of them turns the verdict into `unreached`, which is a loud failure rather than a silent one.
 - `src/frontend/src/modals/modelProviderModal/components/ProviderListItem.tsx` — the row itself, whose testid is built as `provider-item-` plus the provider's display name. Single source of the name this suite waits on.

--- a/tests/helpers/provider-setup/model-toggle-write.test.ts
+++ b/tests/helpers/provider-setup/model-toggle-write.test.ts
@@ -1,0 +1,104 @@
+// Unit tests for the model-toggle persistence-write verdict (issue #1696).
+// Run with: npm run test:units
+//
+// What rides on this file: a model toggle persists through a ~1 s debounced
+// `POST /api/v1/models/enabled_models`, and the spec arms `page.waitForResponse`
+// BEFORE clicking because navigating away first would drop the write. On daily
+// 2026-09-01 (run `33511210195`) that wait timed out on BOTH tests of
+// `model-provider-model-toggle.spec.ts`, and all the run recorded was
+//
+//   TimeoutError: page.waitForResponse: Timeout 15000ms exceeded while waiting
+//   for event "response"
+//
+// — a string that cannot distinguish the two very different things that produce
+// it: the UI never firing the write at all (a suite or product defect) and the
+// instance not answering one that was sent (saturation). The budget is NOT the
+// fix and is deliberately unchanged; a saturated instance still fails, and
+// correctly. What changes is that the failure says WHICH half broke, so the
+// next occurrence is not a fifth nameless signature (#1012/#1626).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  toggleWriteVerdict,
+  type ToggleWriteSnapshot,
+} from "./model-toggle-write";
+
+const ENDPOINT = "/api/v1/models/enabled_models";
+
+const BASE: ToggleWriteSnapshot = {
+  requestsSeen: 0,
+  responsesSeen: 0,
+  ariaChecked: "false",
+  wantedEnabled: false,
+  model: "gpt-4o-mini",
+};
+
+test("no request observed is not-issued — the UI never fired the write", () => {
+  const v = toggleWriteVerdict(BASE, ENDPOINT, 15000);
+  assert.equal(v.kind, "not-issued");
+  assert.match(v.message, /^TOGGLE_WRITE_NOT_ISSUED:/);
+  assert.match(v.message, /gpt-4o-mini/);
+  assert.match(v.message, /15000ms/);
+  assert.match(v.message, new RegExp(ENDPOINT.replace(/\//g, "\\/")));
+  // Must point at the suite/product, never at the instance.
+  assert.doesNotMatch(v.message, /saturat/i);
+});
+
+test("not-issued names the aria-checked the switch was left showing", () => {
+  // The optimistic update is what tells a reader whether the click even landed:
+  // aria-checked flipped with no POST is a debounce/queue defect, while an
+  // unflipped switch means the click itself did nothing.
+  const v = toggleWriteVerdict(
+    { ...BASE, ariaChecked: "true", wantedEnabled: false },
+    ENDPOINT,
+    15000,
+  );
+  assert.match(v.message, /aria-checked/);
+  assert.match(v.message, /"true"/);
+  assert.match(v.message, /"false"/); // what was asked for
+});
+
+test("a request with no response is unanswered — the instance did not answer", () => {
+  const v = toggleWriteVerdict({ ...BASE, requestsSeen: 1 }, ENDPOINT, 15000);
+  assert.equal(v.kind, "unanswered");
+  assert.match(v.message, /^TOGGLE_WRITE_UNANSWERED:/);
+  assert.match(v.message, /INSTANCE/);
+  assert.match(v.message, /1 /); // the request count
+  assert.match(v.message, /15000ms/);
+});
+
+test("unanswered refuses to invite a bigger budget", () => {
+  // #1648's rule: raising the budget hides the stall the verdict exists to name.
+  const v = toggleWriteVerdict({ ...BASE, requestsSeen: 3 }, ENDPOINT, 15000);
+  assert.match(v.message, /(do not raise|never raise)/i);
+  assert.match(v.message, /#1696/);
+});
+
+test("several requests and fewer responses is still unanswered, with both counts", () => {
+  // The debounced queue can coalesce or retry, so the pair is what a reader
+  // needs: 3 sent / 2 answered is a different story from 3 sent / 0 answered.
+  const v = toggleWriteVerdict(
+    { ...BASE, requestsSeen: 3, responsesSeen: 2 },
+    ENDPOINT,
+    15000,
+  );
+  assert.equal(v.kind, "unanswered");
+  assert.match(v.message, /3 /);
+  assert.match(v.message, /2 /);
+});
+
+test("requestsSeen decides the verdict, never responsesSeen", () => {
+  // The load-bearing branch, and the one a refactor would most plausibly break:
+  // a response counted without its request would flip the diagnosis from
+  // "the UI is broken" to "the instance is slow" and send triage the wrong way.
+  assert.equal(
+    toggleWriteVerdict({ ...BASE, requestsSeen: 0, responsesSeen: 9 }, ENDPOINT, 15000)
+      .kind,
+    "not-issued",
+  );
+  assert.equal(
+    toggleWriteVerdict({ ...BASE, requestsSeen: 1, responsesSeen: 0 }, ENDPOINT, 15000)
+      .kind,
+    "unanswered",
+  );
+});

--- a/tests/helpers/provider-setup/model-toggle-write.ts
+++ b/tests/helpers/provider-setup/model-toggle-write.ts
@@ -1,0 +1,89 @@
+/**
+ * Attribution for the model-toggle persistence write (#1696).
+ *
+ * A per-model toggle in Settings -> Model Providers updates optimistically and
+ * persists through a ~1 s debounced `POST /api/v1/models/enabled_models`
+ * (`useModelToggleQueue`). A spec therefore has to arm `page.waitForResponse`
+ * BEFORE the click — navigating away first would drop the write — and when that
+ * wait times out all the run records is
+ *
+ *   TimeoutError: page.waitForResponse: Timeout 15000ms exceeded while waiting
+ *   for event "response"
+ *
+ * which cannot distinguish two very different failures. On daily 2026-09-01
+ * (run `33511210195`) that exact string appeared on BOTH tests of
+ * `model-provider-model-toggle.spec.ts` and said nothing about either.
+ *
+ * This is ATTRIBUTION, not a fix: the budget is unchanged, and a saturated
+ * instance still fails — correctly. What changes is that the failure names
+ * which half of the round-trip broke, so the next occurrence is not a fifth
+ * nameless signature (#1012/#1626).
+ *
+ * The classification is PURE so both branches are reachable from a unit test.
+ * Producing `not-issued` live would mean breaking the frontend's debounce and
+ * `unanswered` would mean wedging the backend — neither is something a spec may
+ * do on demand, the same argument `providerRowVerdict` (#1648) and
+ * `censusForTarget` (#1464) settled for their own decisions.
+ */
+
+/** What the persistence wait observed by the time its budget ran out. */
+export type ToggleWriteSnapshot = {
+  /** POSTs to the endpoint the page actually issued. */
+  requestsSeen: number;
+  /** Responses to those POSTs that came back. */
+  responsesSeen: number;
+  /** `aria-checked` on the toggle when the budget expired (`""` if unreadable). */
+  ariaChecked: string;
+  /** What the click asked the toggle to become. */
+  wantedEnabled: boolean;
+  /** The model whose toggle was flipped. */
+  model: string;
+};
+
+export type ToggleWriteVerdictKind = "not-issued" | "unanswered";
+
+export type ToggleWriteVerdict = {
+  kind: ToggleWriteVerdictKind;
+  message: string;
+};
+
+/**
+ * Classifies a persistence write that did not complete.
+ *
+ * `requestsSeen` decides, never `responsesSeen`: a response counted without its
+ * request would flip the diagnosis from "the UI is broken" to "the instance is
+ * slow" and send triage the wrong way.
+ */
+export function toggleWriteVerdict(
+  snapshot: ToggleWriteSnapshot,
+  endpoint: string,
+  timeoutMs: number,
+): ToggleWriteVerdict {
+  const budget = `${timeoutMs}ms`;
+  const wanted = String(snapshot.wantedEnabled);
+
+  if (snapshot.requestsSeen === 0) {
+    return {
+      kind: "not-issued",
+      message:
+        `TOGGLE_WRITE_NOT_ISSUED: no POST ${endpoint} was observed at all within ` +
+        `${budget} after toggling "${snapshot.model}", so the UI never fired the ` +
+        `debounced write. The switch is showing aria-checked "${snapshot.ariaChecked}" ` +
+        `against the "${wanted}" that was asked for — flipped with no POST is a ` +
+        `debounce or queue defect, unflipped means the click itself did nothing. ` +
+        `Either way this is a SUITE or PRODUCT defect, not a slow instance (#1696).`,
+    };
+  }
+
+  return {
+    kind: "unanswered",
+    message:
+      `TOGGLE_WRITE_UNANSWERED: ${snapshot.requestsSeen} POST ${endpoint} request(s) ` +
+      `were issued after toggling "${snapshot.model}" and ${snapshot.responsesSeen} ` +
+      `came back within ${budget}, so the write left the page and the INSTANCE did ` +
+      `not answer it. The switch is showing aria-checked "${snapshot.ariaChecked}" ` +
+      `against the "${wanted}" that was asked for. Do not raise this timeout to make ` +
+      `it pass — a saturated instance is something the suite should keep reporting ` +
+      `(#1696).`,
+  };
+}

--- a/tests/helpers/ui/go-to-settings.test.ts
+++ b/tests/helpers/ui/go-to-settings.test.ts
@@ -1,0 +1,325 @@
+// Unit tests for the settings-navigation verdicts (issue #1696).
+// Run with: npm run test:units
+//
+// What rides on this file: `navigateSettingsPages` used to fire three blind
+// clicks and verify none of them, so a hop the DOM ACCEPTED while the app
+// DISCARDED it surfaced one hop LATER, at a locator that never had a chance.
+// The measured cost of that was one cause reported under four different
+// signatures across 30 days, every one of them shaped like
+//
+//   TimeoutError: locator.click: Timeout 20000ms exceeded.
+//   Call log:
+//     - waiting for getByText('Model Providers').first()
+//
+// with the failure-time screenshot and aria snapshot showing the HOME page and
+// the string "Settings" appearing zero times — i.e. the report named the hop
+// that had no chance, never the hop that broke (dailies 2026-09-01 run
+// 33511210195 and 2026-09-03 run 33756085604).
+//
+// The classification is pure precisely so these branches are reachable here.
+// On a live instance `menu-unopened` needs a click the app drops and
+// `page-unreached` needs a route change that does not take — neither is
+// something a spec may do on demand — which is the same argument
+// `providerRowVerdict` (#1648), `censusForTarget` (#1464) and `decideEntryPoint`
+// (#1465) settled for their own decisions.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SETTINGS_NAV_TESTIDS,
+  sectionHopState,
+  settingsNavVerdict,
+  trackTargetHeader,
+  type SettingsNavSnapshot,
+} from "./go-to-settings";
+
+const HOME: SettingsNavSnapshot = {
+  pathname: "/",
+  menuPresent: false,
+  menuItemPresent: false,
+  navEntries: [],
+  headerPresent: false,
+  headerText: "",
+  headerEverPresent: false,
+  headerGraceElapsed: false,
+  targetHref: "",
+};
+
+const SETTINGS_SHELL: SettingsNavSnapshot = {
+  ...HOME,
+  pathname: "/settings/general",
+  navEntries: [
+    "General",
+    "MCP Servers",
+    "Langflow API Keys",
+    "Langflow MCP Client",
+    "Global Variables",
+    "Model Providers",
+    "DB Providers",
+    "Shortcuts",
+    "Messages",
+  ],
+  headerPresent: true,
+  headerText: "General",
+  headerEverPresent: true,
+};
+
+// ---------- hop 1: the account menu ----------
+
+test("hop 1 reports menu-unopened, naming the trigger and the page it stayed on", () => {
+  const v = settingsNavVerdict("menu", HOME, "Model Providers", 20000);
+  assert.equal(v.kind, "menu-unopened");
+  assert.match(v.message, /^SETTINGS_MENU_UNOPENED:/);
+  assert.match(v.message, /user-profile-settings/);
+  assert.match(v.message, /menu_settings_button/);
+  assert.match(v.message, /"\/"/); // the pathname it never left
+  assert.match(v.message, /20000ms/);
+});
+
+test("hop 1 says the menu WAS open when a menu rendered without the item", () => {
+  // The distinction matters: a menu that opened without the Settings entry is a
+  // renamed testid (a product finding), not an app-shell stall.
+  const v = settingsNavVerdict(
+    "menu",
+    { ...HOME, menuPresent: true },
+    "Model Providers",
+    20000,
+  );
+  assert.equal(v.kind, "menu-unopened");
+  assert.match(v.message, /menu DID open/i);
+});
+
+// ---------- hop 2: the Settings route ----------
+
+test("hop 2 reports page-unreached with the pathname the app is actually on", () => {
+  const v = settingsNavVerdict("page", HOME, "Model Providers", 20000);
+  assert.equal(v.kind, "page-unreached");
+  assert.match(v.message, /^SETTINGS_PAGE_UNREACHED:/);
+  assert.match(v.message, /"\/"/);
+  // Must not be mistaken for a missing section.
+  assert.doesNotMatch(v.message, /renamed or removed/);
+});
+
+test("hop 2 on /settings with ZERO nav entries is a shell that never mounted", () => {
+  // Keyed on the URL plus the entry count, never on the `sidebar-nav-` prefix
+  // alone: the flow sidebar uses the same prefix, so "an entry rendered" is not
+  // evidence that the SETTINGS shell mounted.
+  const v = settingsNavVerdict(
+    "page",
+    { ...HOME, pathname: "/settings" },
+    "Model Providers",
+    20000,
+  );
+  assert.equal(v.kind, "page-unreached");
+  assert.match(v.message, /zero/i);
+  assert.match(v.message, /"\/settings"/);
+});
+
+// ---------- hop 3: the section ----------
+
+test("hop 3 reports section-absent as a PRODUCT finding, listing what did render", () => {
+  const withoutTarget = {
+    ...SETTINGS_SHELL,
+    navEntries: SETTINGS_SHELL.navEntries.filter((n) => n !== "Model Providers"),
+  };
+  const v = settingsNavVerdict("section", withoutTarget, "Model Providers", 20000);
+  assert.equal(v.kind, "section-absent");
+  assert.match(v.message, /^SETTINGS_SECTION_ABSENT:/);
+  assert.match(v.message, /PRODUCT/);
+  // Naming the survivors is the whole point — a count alone leaves the reader
+  // hand-diffing (the #1040 lesson).
+  assert.match(v.message, /General/);
+  assert.match(v.message, /Shortcuts/);
+  assert.equal(v.message.includes("Model Providers,"), false);
+});
+
+test("hop 3 reports section-unconfirmed with the header text and the pathname", () => {
+  const stuck = {
+    ...SETTINGS_SHELL,
+    targetHref: "/settings/model-providers",
+    pathname: "/settings/general",
+  };
+  const v = settingsNavVerdict("section", stuck, "Model Providers", 20000);
+  assert.equal(v.kind, "section-unconfirmed");
+  assert.match(v.message, /^SETTINGS_SECTION_UNCONFIRMED:/);
+  assert.match(v.message, /\/settings\/model-providers/); // where it should be
+  assert.match(v.message, /\/settings\/general/); // where it is
+  assert.match(v.message, /General/); // the header it is showing
+});
+
+test("hop 3 distinguishes a wrong header from a wrong route", () => {
+  // Pathname arrived, content did not: that is a mounted-wrong-content verdict,
+  // and the message must not blame the route.
+  const wrongContent = {
+    ...SETTINGS_SHELL,
+    targetHref: "/settings/model-providers",
+    pathname: "/settings/model-providers",
+    headerText: "Global Variables",
+  };
+  const v = settingsNavVerdict("section", wrongContent, "Model Providers", 20000);
+  assert.equal(v.kind, "section-unconfirmed");
+  assert.match(v.message, /Global Variables/);
+  assert.match(v.message, /route took/i);
+});
+
+// ---------- hop 3's success rule ----------
+
+test("the section hop stays pending until the pathname matches the clicked anchor", () => {
+  const s = {
+    ...SETTINGS_SHELL,
+    targetHref: "/settings/model-providers",
+    pathname: "/settings/general",
+  };
+  assert.equal(sectionHopState(s, "Model Providers"), "pending");
+});
+
+test("the section hop settles when the pathname matches and the header agrees", () => {
+  const s = {
+    ...SETTINGS_SHELL,
+    targetHref: "/settings/model-providers",
+    pathname: "/settings/model-providers",
+    headerText: "Model Providers",
+  };
+  assert.equal(sectionHopState(s, "Model Providers"), "settled");
+});
+
+test("a matching pathname with a DISAGREEING header is still pending", () => {
+  // Never accepted, so the deadline turns it into `section-unconfirmed` rather
+  // than a green hop on a page showing something else.
+  const s = {
+    ...SETTINGS_SHELL,
+    targetHref: "/settings/model-providers",
+    pathname: "/settings/model-providers",
+    headerText: "General",
+  };
+  assert.equal(sectionHopState(s, "Model Providers"), "pending");
+});
+
+test("a header that has not mounted yet is pending, not headerless", () => {
+  // The trap this closes: right after the route change the header is legitimately
+  // absent, and accepting there would green-light every section before its page
+  // mounted. Only the elapsed grace can tell "not yet" from "never".
+  const s = {
+    ...SETTINGS_SHELL,
+    targetHref: "/settings/model-providers",
+    pathname: "/settings/model-providers",
+    headerPresent: false,
+    headerText: "",
+    headerEverPresent: false,
+    headerGraceElapsed: false,
+  };
+  assert.equal(sectionHopState(s, "Model Providers"), "pending");
+});
+
+test("a section that renders NO header at all settles on the URL once the grace elapsed", () => {
+  // `sidebar-nav-Langflow MCP Client` renders no `settings_menu_header` at all
+  // (measured across all nine sections on 1.13.0.dev0). Requiring one would make
+  // the helper unusable there, and hardcoding a list of headerless sections is
+  // the name-to-path table this design refuses to keep (#1043/#1184).
+  const s = {
+    ...SETTINGS_SHELL,
+    targetHref: "/settings/mcp-client",
+    pathname: "/settings/mcp-client",
+    headerPresent: false,
+    headerText: "",
+    headerEverPresent: false,
+    headerGraceElapsed: true,
+  };
+  assert.equal(sectionHopState(s, "Langflow MCP Client"), "settled-headerless");
+});
+
+test("a header that was seen and then vanished is pending, never headerless", () => {
+  // A section that HAS a header is mid-render, not headerless — accepting it
+  // would hand the caller a page whose content is still swapping.
+  const s = {
+    ...SETTINGS_SHELL,
+    targetHref: "/settings/model-providers",
+    pathname: "/settings/model-providers",
+    headerPresent: false,
+    headerText: "",
+    headerEverPresent: true,
+    headerGraceElapsed: true,
+  };
+  assert.equal(sectionHopState(s, "Model Providers"), "pending");
+});
+
+// ---------- the testid table ----------
+
+test("the testid table carries the handles measured on the running build", () => {
+  // Every one of these was read off 1.13.0.dev0 and confirmed in upstream
+  // source: AccountMenu/index.tsx lines 57 and 98, sidebarComponent/index.tsx
+  // line 53. A rename upstream must break this assertion, not a spec 20 s later.
+  assert.equal(SETTINGS_NAV_TESTIDS.profileTrigger, "user-profile-settings");
+  assert.equal(SETTINGS_NAV_TESTIDS.menuItem, "menu_settings_button");
+  assert.equal(SETTINGS_NAV_TESTIDS.navPrefix, "sidebar-nav-");
+  assert.equal(SETTINGS_NAV_TESTIDS.menuHeader, "settings_menu_header");
+});
+
+test("every verdict names the budget so no reader has to guess it", () => {
+  const snapshots: Array<[Parameters<typeof settingsNavVerdict>[0], SettingsNavSnapshot]> = [
+    ["menu", HOME],
+    ["page", HOME],
+    ["section", { ...SETTINGS_SHELL, navEntries: [] }],
+    ["section", SETTINGS_SHELL],
+  ];
+  for (const [hop, snap] of snapshots) {
+    assert.match(
+      settingsNavVerdict(hop, snap, "Model Providers", 12345).message,
+      /12345ms/,
+      `${hop} verdict omitted the budget`,
+    );
+  }
+});
+
+test("no verdict invites raising the budget", () => {
+  // The budgets are the ones the three blind clicks already had. Raising them
+  // hides the stall the verdict exists to name (#1648's rule), so the messages
+  // say so where a reader would otherwise reach for the timeout.
+  for (const hop of ["menu", "page"] as const) {
+    assert.match(settingsNavVerdict(hop, HOME, "Model Providers", 20000).message, /#1696/);
+  }
+});
+
+// ---------- which header counts as "this section has one" ----------
+
+test("a header on the page hop 3 is LEAVING does not count as the target's", () => {
+  // The bug this closes, found by running the real helper rather than by
+  // reading it: hop 3 starts on /settings/general, which HAS a
+  // `settings_menu_header`. Counting that one makes `headerEverPresent` true
+  // before the route even swaps, so the headerless branch can never fire and
+  // `sidebar-nav-Langflow MCP Client` — the one section that renders no header
+  // at all — failed as SETTINGS_SECTION_UNCONFIRMED after the full 20 s.
+  const leaving = {
+    pathname: "/settings/general",
+    targetHref: "/settings/mcp-client",
+    headerPresent: true,
+  };
+  assert.equal(trackTargetHeader(false, leaving), false);
+});
+
+test("a header on the page hop 3 ARRIVED at counts, and stays counted", () => {
+  const arrived = {
+    pathname: "/settings/model-providers",
+    targetHref: "/settings/model-providers",
+    headerPresent: true,
+  };
+  assert.equal(trackTargetHeader(false, arrived), true);
+  // Sticky: a header that mounted and is mid-swap must not un-count and let the
+  // headerless branch accept a page whose content is still moving.
+  assert.equal(
+    trackTargetHeader(true, { ...arrived, headerPresent: false }),
+    true,
+  );
+});
+
+test("no header present never flips the flag, whatever the pathname", () => {
+  for (const pathname of ["/settings/general", "/settings/mcp-client"]) {
+    assert.equal(
+      trackTargetHeader(false, {
+        pathname,
+        targetHref: "/settings/mcp-client",
+        headerPresent: false,
+      }),
+      false,
+    );
+  }
+});

--- a/tests/helpers/ui/go-to-settings.ts
+++ b/tests/helpers/ui/go-to-settings.ts
@@ -1,21 +1,535 @@
-import { type Page } from "@playwright/test";
+import { type Locator, type Page } from "@playwright/test";
 
+/**
+ * Reaching the Settings page without discarding what the app already said
+ * (#1696).
+ *
+ * This helper used to fire three blind clicks and verify NONE of them:
+ *
+ *   await page.getByTestId("user-profile-settings").click();
+ *   await page.getByText(`${pageName}`).first().click();
+ *   await page.getByText(`${settingsMenuName}`).first().click();
+ *
+ * A hop the DOM ACCEPTS while the app DISCARDS it therefore surfaced one hop
+ * LATER, at a locator that never had a chance, and the run recorded
+ *
+ *   TimeoutError: locator.click: Timeout 20000ms exceeded.
+ *   Call log:
+ *     - waiting for getByText('Model Providers').first()
+ *
+ * — a call log that names the hop with no chance, never the hop that broke. One
+ * cause was reported under four different signatures across 30 days because of
+ * it. On daily 2026-09-03 (run `33756085604`) the failure-time screenshot and
+ * aria snapshot are the HOME page — dropdown closed, account button carrying a
+ * focus ring, the string "Settings" appearing ZERO times — while Playwright had
+ * reported hops 1 and 2 as successful; daily 2026-09-01 (run `33511210195`)
+ * failed on the same line, the same locator and the same budget.
+ *
+ * The mechanism is a re-render, and it is measured rather than assumed. In the
+ * 09-03 run's own passing retry the hop-1 click took **1532 ms** of actionability
+ * wait right after `page.goto("/")` against **121 ms** for the identical click
+ * earlier in the same test, with `agent credential settled slowly: 6.2s` in its
+ * stderr (the #751 guard); locally a `MutationObserver` on `1.13.0.dev0` shows
+ * the header's DOM node being REPLACED ~616 ms after `goto("/")`, which discards
+ * a Radix menu whose trigger was clicked just before it.
+ *
+ * Upstream Langflow reached the same conclusion from the same symptom first, and
+ * that is why this is a fix rather than an invention: `release-1.9.7` still
+ * carries the blind-click version byte-identically (`waitForTimeout(500)`
+ * included), and upstream rewrote its own copy — `src/frontend/tests/utils/
+ * go-to-settings.ts` — on 2026-08-25 in `76fb85da` ("test: stabilize release
+ * Playwright navigation") onto exactly the testids used below plus a
+ * `waitForURL`. Both of our remaining occurrences post-date that fix.
+ *
+ * Three things this adds on top of upstream's shape:
+ *
+ *   1. Each hop VERIFIES its own effect before the next click is made, so the
+ *      failure is reported at the hop that broke.
+ *   2. `settingsNavVerdict()` — pure, unit-tested — names which hop broke and
+ *      what the page was showing, instead of a bare locator timeout.
+ *   3. A hop whose effect does not land is re-attempted ONCE inside the same
+ *      deadline, announced on stdout. That repairs a dropped click the way #1518
+ *      repairs the sidebar's dropped `fill`, while keeping a SYSTEMATIC breakage
+ *      visible instead of hidden behind the repair.
+ *
+ * The budgets are deliberately NOT raised. One hop's click and its effect wait
+ * share a single `HOP_BUDGET_MS` deadline, so the worst case equals the three
+ * `actionTimeout` clicks this replaces — and the unconditional
+ * `waitForTimeout(500)` is gone. Upstream's own budgets (`TIMEOUTS.standard`,
+ * 30 s) are NOT adopted: 30 s on the last hop would sit above the 20 s
+ * `actionTimeout` it has today and hide the stall (#1648's rule).
+ */
+
+/** The handles each hop uses, all measured on `1.13.0.dev0`. */
+export const SETTINGS_NAV_TESTIDS = {
+  /** Hop 1's trigger — `AccountMenu/index.tsx` line 57 upstream. */
+  profileTrigger: "user-profile-settings",
+  /** Hop 2's menu item — `AccountMenu/index.tsx` line 98 upstream. */
+  menuItem: "menu_settings_button",
+  /** Hop 3's entry prefix — `sidebarComponent/index.tsx` line 53 upstream. */
+  navPrefix: "sidebar-nav-",
+  /** Hop 3's content confirmation, rendered per settings page. */
+  menuHeader: "settings_menu_header",
+} as const;
+
+/** The URL every settings section lives under. */
+const SETTINGS_URL_RE = /\/settings(?:\/|$)/;
+
+/**
+ * One hop's total budget — its click AND its effect wait share this deadline,
+ * which is why replacing three `actionTimeout` clicks does not widen the worst
+ * case. Matches `playwright.config.ts`'s `actionTimeout`.
+ */
+const HOP_BUDGET_MS = 20_000;
+
+/** How long a single effect wait may take before the hop re-attempts. */
+const MENU_SLICE_MS = 5_000;
+const ROUTE_SLICE_MS = 8_000;
+const ENTRY_SLICE_MS = 10_000;
+const SECTION_SLICE_MS = 10_000;
+
+/**
+ * How long a section's `settings_menu_header` gets to mount before its absence
+ * is read as "this section renders none". Only the elapsed grace can tell "not
+ * yet" from "never", and getting that wrong in either direction is a real
+ * failure: accept too early and every section greens before its page mounted;
+ * require a header always and `sidebar-nav-Langflow MCP Client`, which renders
+ * none at all, becomes unreachable.
+ */
+const HEADER_GRACE_MS = 2_000;
+
+/** Poll interval while a hop waits for its effect. */
+const POLL_MS = 200;
+
+/** Which hop a verdict is about. */
+export type SettingsNavHop = "menu" | "page" | "section";
+
+/** What the settings navigation was showing at one instant. */
+export type SettingsNavSnapshot = {
+  /** `location.pathname` at the moment of the read. */
+  pathname: string;
+  /** A menu is on the page (`[role="menu"]`) — the Radix content mounted. */
+  menuPresent: boolean;
+  /** `menu_settings_button` is in the DOM. */
+  menuItemPresent: boolean;
+  /** Section names rendered as `sidebar-nav-<name>`, prefix stripped. */
+  navEntries: string[];
+  /** `settings_menu_header` is in the DOM right now. */
+  headerPresent: boolean;
+  /** Its trimmed text (`""` when absent). */
+  headerText: string;
+  /** Whether a header was present in ANY poll of this hop. */
+  headerEverPresent: boolean;
+  /** Whether `HEADER_GRACE_MS` has elapsed since this hop's click. */
+  headerGraceElapsed: boolean;
+  /** The clicked entry's OWN `href` (`""` before hop 3 resolved one). */
+  targetHref: string;
+};
+
+export type SettingsNavVerdictKind =
+  | "menu-unopened"
+  | "page-unreached"
+  | "section-absent"
+  | "section-unconfirmed";
+
+export type SettingsNavVerdict = {
+  kind: SettingsNavVerdictKind;
+  message: string;
+};
+
+/** Where hop 3 stands, so the accept-on-URL-alone rule is testable. */
+export type SectionHopState = "settled" | "settled-headerless" | "pending";
+
+const quote = (value: string) => `"${value}"`;
+
+const renderedEntries = (entries: string[]) =>
+  entries.length ? `[${entries.join(", ")}]` : "[] (none)";
+
+/**
+ * Decides whether hop 3 has landed. PURE.
+ *
+ * The target path comes from the clicked anchor's own `href`, never from a
+ * name-to-path table — the anchor is the single source, so a section Langflow
+ * renames cannot desync a map (the `langflowProviderName` argument,
+ * #1043/#1184). The header is the CONTENT half and is optional for a measured
+ * reason: of the nine sections on `1.13.0.dev0`, eight render exactly one
+ * `settings_menu_header` whose text equals the sidebar title and
+ * `Langflow MCP Client` renders none.
+ */
+export function sectionHopState(
+  snapshot: SettingsNavSnapshot,
+  wanted: string,
+): SectionHopState {
+  if (snapshot.pathname !== snapshot.targetHref) return "pending";
+  if (snapshot.headerPresent) {
+    return snapshot.headerText.includes(wanted) ? "settled" : "pending";
+  }
+  // No header on screen. A section that HAS one is mid-render, not headerless —
+  // accepting there hands the caller a page whose content is still swapping.
+  if (snapshot.headerEverPresent) return "pending";
+  return snapshot.headerGraceElapsed ? "settled-headerless" : "pending";
+}
+
+/**
+ * Whether the TARGET section has ever rendered a `settings_menu_header`. PURE.
+ *
+ * The scoping is load-bearing and was found by running the helper, not by
+ * reading it: hop 3 starts on `/settings/general`, which HAS a header, so
+ * counting any header on screen makes the flag true before the route even
+ * swaps — and `sectionHopState` can then never reach `settled-headerless`.
+ * `sidebar-nav-Langflow MCP Client` renders no header at all, so it failed as
+ * `SETTINGS_SECTION_UNCONFIRMED` after the full 20 s. Only a header seen while
+ * the pathname already matches the anchor's href belongs to the target page.
+ *
+ * Sticky once set: a header that mounted and is mid-swap must not un-count and
+ * let the headerless branch accept a page whose content is still moving.
+ */
+export function trackTargetHeader(
+  seenSoFar: boolean,
+  snapshot: Pick<
+    SettingsNavSnapshot,
+    "pathname" | "targetHref" | "headerPresent"
+  >,
+): boolean {
+  if (seenSoFar) return true;
+  return snapshot.headerPresent && snapshot.pathname === snapshot.targetHref;
+}
+
+/**
+ * Classifies a hop that did not land. PURE — no page, no clock — so every
+ * branch is reachable from a unit test. On a live instance `menu-unopened`
+ * needs a click the app drops and `page-unreached` a route change that does not
+ * take, neither of which a spec may do on demand: the same argument
+ * `providerRowVerdict` (#1648) settled for the provider list.
+ */
+export function settingsNavVerdict(
+  hop: SettingsNavHop,
+  snapshot: SettingsNavSnapshot,
+  wanted: string,
+  timeoutMs: number,
+): SettingsNavVerdict {
+  const budget = `${timeoutMs}ms`;
+  const where = quote(snapshot.pathname);
+
+  if (hop === "menu") {
+    const opened = snapshot.menuPresent
+      ? `The menu DID open — a "[role=\\"menu\\"]" is on the page — and ` +
+        `"${SETTINGS_NAV_TESTIDS.menuItem}" is not in it, so this is a RENAMED ` +
+        `testid rather than an app-shell stall. `
+      : `No "[role=\\"menu\\"]" ever mounted, so the trigger's click was ` +
+        `accepted and DISCARDED — the app-shell re-render that follows ` +
+        `page.goto() drops it. `;
+    return {
+      kind: "menu-unopened",
+      message:
+        `SETTINGS_MENU_UNOPENED: "${SETTINGS_NAV_TESTIDS.profileTrigger}" was clicked ` +
+        `twice and "${SETTINGS_NAV_TESTIDS.menuItem}" never became visible within ` +
+        `${budget}. ${opened}The page is still on ${where}. Do not raise this timeout ` +
+        `to make it pass (#1696).`,
+    };
+  }
+
+  if (hop === "page" || snapshot.navEntries.length === 0) {
+    const onSettings = SETTINGS_URL_RE.test(snapshot.pathname);
+    const detail = onSettings
+      ? `The URL IS a settings route (${where}) but the sidebar rendered zero ` +
+        `"${SETTINGS_NAV_TESTIDS.navPrefix}*" entries, so the Settings shell never ` +
+        `mounted — the route changed and the page did not. `
+      : `The URL never became a settings route: it is ${where}, so ` +
+        `"${SETTINGS_NAV_TESTIDS.menuItem}" was clicked, the menu closed, and the ` +
+        `route change was DISCARDED. `;
+    return {
+      kind: "page-unreached",
+      message:
+        `SETTINGS_PAGE_UNREACHED: Settings was not reached within ${budget} while ` +
+        `navigating to "${wanted}". ${detail}Keyed on the URL rather than on the ` +
+        `"${SETTINGS_NAV_TESTIDS.navPrefix}" prefix alone, which the flow sidebar also ` +
+        `uses. Do not raise this timeout to make it pass (#1696).`,
+    };
+  }
+
+  if (!snapshot.navEntries.includes(wanted)) {
+    return {
+      kind: "section-absent",
+      message:
+        `SETTINGS_SECTION_ABSENT: the Settings sidebar SETTLED and rendered ` +
+        `${snapshot.navEntries.length} section(s) ${renderedEntries(snapshot.navEntries)} ` +
+        `within ${budget}, and ${quote(wanted)} is not among them. The sidebar answered, ` +
+        `so this is a PRODUCT finding — the section was renamed or removed — and not a ` +
+        `navigation stall.`,
+    };
+  }
+
+  const arrived = snapshot.pathname === snapshot.targetHref;
+  const detail = arrived
+    ? `The section route took (${where}), but "${SETTINGS_NAV_TESTIDS.menuHeader}" ` +
+      `reads ${quote(snapshot.headerText)} instead of ${quote(wanted)} — the route ` +
+      `changed and the page mounted the wrong content. `
+    : `The pathname never became the entry's own href ` +
+      `${quote(snapshot.targetHref)} — it is ${where}, with ` +
+      `"${SETTINGS_NAV_TESTIDS.menuHeader}" reading ${quote(snapshot.headerText)}. `;
+  return {
+    kind: "section-unconfirmed",
+    message:
+      `SETTINGS_SECTION_UNCONFIRMED: ${quote(wanted)} is in the sidebar but opening it ` +
+      `was not confirmed within ${budget}. ${detail}`,
+  };
+}
+
+/** Reads every part of the navigation state in one pass. */
+export async function readSettingsNavState(
+  page: Page,
+): Promise<SettingsNavSnapshot> {
+  const raw = await page.evaluate((ids) => {
+    const header = document.querySelector(`[data-testid="${ids.menuHeader}"]`);
+    return {
+      pathname: window.location.pathname,
+      menuPresent: document.querySelector('[role="menu"]') !== null,
+      menuItemPresent:
+        document.querySelector(`[data-testid="${ids.menuItem}"]`) !== null,
+      navEntries: Array.from(
+        document.querySelectorAll(`[data-testid^="${ids.navPrefix}"]`),
+      )
+        .map((el) => el.getAttribute("data-testid") ?? "")
+        .filter((id) => id !== "")
+        .map((id) => id.slice(ids.navPrefix.length)),
+      headerPresent: header !== null,
+      headerText: (header?.textContent ?? "").trim(),
+    };
+  }, SETTINGS_NAV_TESTIDS as unknown as Record<string, string>);
+
+  return {
+    ...raw,
+    headerEverPresent: raw.headerPresent,
+    headerGraceElapsed: false,
+    targetHref: "",
+  };
+}
+
+const firstLine = (error: unknown) =>
+  error instanceof Error ? error.message.split("\n")[0] : String(error);
+
+const remaining = (deadline: number, cap?: number) => {
+  const left = Math.max(1_000, deadline - Date.now());
+  return cap === undefined ? left : Math.min(left, cap);
+};
+
+/**
+ * Announced, never silent. A dropped click is worth repairing; a SYSTEMATIC
+ * breakage repaired on every single navigation is a regression nobody would
+ * see, which is the `mode=count` lesson.
+ */
+const announceReattempt = (hop: string, wanted: string, cause: string) => {
+  console.log(
+    `⚠️  settings navigation: ${hop} did not land on the first attempt while ` +
+      `opening "${wanted}" — re-attempting once (#1696). Cause: ${cause}`,
+  );
+};
+
+/**
+ * Throws the verdict for a hop that did not land, falling back to the raw cause
+ * if the state itself cannot be read. Losing the real failure to a secondary
+ * error would replace one unattributed failure with a worse one — the guard
+ * `waitForProviderRow` needed for the same reason.
+ */
+async function failHop(
+  page: Page,
+  hop: SettingsNavHop,
+  wanted: string,
+  lastCause: string,
+  extra: Partial<SettingsNavSnapshot> = {},
+): Promise<never> {
+  let snapshot: SettingsNavSnapshot;
+  try {
+    snapshot = { ...(await readSettingsNavState(page)), ...extra };
+  } catch (readError) {
+    throw new Error(
+      `SETTINGS_NAV_UNREADABLE: the "${hop}" hop toward "${wanted}" did not land, and ` +
+        `the page state could not be read to say why (${firstLine(readError)}). The ` +
+        `hop's own failure was: ${lastCause}`,
+    );
+  }
+  const verdict = settingsNavVerdict(hop, snapshot, wanted, HOP_BUDGET_MS);
+  throw new Error(`${verdict.message} Last hop failure: ${lastCause}`);
+}
+
+/** Hop 1 — open the account menu and confirm the Settings item is there. */
+async function openAccountMenu(
+  page: Page,
+  wanted: string,
+  deadline: number,
+): Promise<void> {
+  const item = page.getByTestId(SETTINGS_NAV_TESTIDS.menuItem);
+  let lastCause = "the item never became visible";
+
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      const snapshot = await readSettingsNavState(page);
+      if (!snapshot.menuItemPresent) {
+        // A Radix trigger TOGGLES: re-clicking it while the content is mounted
+        // would close the menu instead of opening it, so an open-but-itemless
+        // menu is dismissed first.
+        if (snapshot.menuPresent) {
+          await page.keyboard.press("Escape").catch(() => {});
+        }
+        await page
+          .getByTestId(SETTINGS_NAV_TESTIDS.profileTrigger)
+          .click({ timeout: remaining(deadline) });
+      }
+      await item.waitFor({
+        state: "visible",
+        timeout: remaining(deadline, MENU_SLICE_MS),
+      });
+      return;
+    } catch (error) {
+      lastCause = firstLine(error);
+      if (attempt === 1) {
+        announceReattempt("hop 1 (open the account menu)", wanted, lastCause);
+      }
+    }
+  }
+  await failHop(page, "menu", wanted, lastCause);
+}
+
+/**
+ * Hop 2 — click the Settings item and confirm the route took.
+ *
+ * The repair is to REOPEN the menu and click again, not to click again: a
+ * dropped selection leaves the menu closed, so the item is gone. Measured —
+ * a prototype that only re-clicked timed out on a locator that no longer
+ * existed.
+ */
+async function enterSettings(
+  page: Page,
+  wanted: string,
+  deadline: number,
+): Promise<void> {
+  let lastCause = "the URL never became a settings route";
+
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      if (attempt === 2) {
+        await openAccountMenu(page, wanted, Date.now() + MENU_SLICE_MS);
+      }
+      await page
+        .getByTestId(SETTINGS_NAV_TESTIDS.menuItem)
+        .click({ timeout: remaining(deadline) });
+      await page.waitForURL(SETTINGS_URL_RE, {
+        timeout: remaining(deadline, ROUTE_SLICE_MS),
+      });
+      return;
+    } catch (error) {
+      lastCause = firstLine(error);
+      if (attempt === 1) {
+        announceReattempt("hop 2 (enter Settings)", wanted, lastCause);
+      }
+    }
+  }
+  await failHop(page, "page", wanted, lastCause);
+}
+
+/** Hop 3 — open one section and confirm both its route and its content. */
+async function openSection(
+  page: Page,
+  section: string,
+  deadline: number,
+): Promise<void> {
+  const entry = page.getByTestId(`${SETTINGS_NAV_TESTIDS.navPrefix}${section}`);
+  let lastCause = "the section was never confirmed";
+
+  await entry
+    .waitFor({ state: "visible", timeout: remaining(deadline, ENTRY_SLICE_MS) })
+    .catch((error) => {
+      lastCause = firstLine(error);
+    });
+
+  const shell = await readSettingsNavState(page);
+  if (!shell.navEntries.includes(section)) {
+    await failHop(page, "section", section, lastCause, shell);
+  }
+
+  // The target path is the anchor's OWN href — never a name-to-path table.
+  const targetHref = (await entry.getAttribute("href")) ?? "";
+  let headerEverPresent = false;
+
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const slice = Math.min(
+      deadline,
+      Date.now() + (attempt === 1 ? SECTION_SLICE_MS : remaining(deadline)),
+    );
+    try {
+      await entry.click({ timeout: remaining(slice) });
+    } catch (error) {
+      lastCause = firstLine(error);
+    }
+    const clickedAt = Date.now();
+
+    while (Date.now() < slice) {
+      const raw = await readSettingsNavState(page);
+      headerEverPresent = trackTargetHeader(headerEverPresent, {
+        ...raw,
+        targetHref,
+      });
+      const snapshot: SettingsNavSnapshot = {
+        ...raw,
+        targetHref,
+        headerEverPresent,
+        headerGraceElapsed: Date.now() - clickedAt >= HEADER_GRACE_MS,
+      };
+      const state = sectionHopState(snapshot, section);
+      if (state === "settled") return;
+      if (state === "settled-headerless") {
+        console.log(
+          `ℹ️  settings navigation: "${section}" renders no ` +
+            `"${SETTINGS_NAV_TESTIDS.menuHeader}", so the hop is confirmed by its own ` +
+            `href (${targetHref}) alone (#1696).`,
+        );
+        return;
+      }
+      lastCause =
+        `pathname ${quote(raw.pathname)} vs href ${quote(targetHref)}, ` +
+        `header ${quote(raw.headerText)}`;
+      await page.waitForTimeout(POLL_MS);
+    }
+    if (attempt === 1) {
+      announceReattempt(`hop 3 (open "${section}")`, section, lastCause);
+    }
+  }
+  await failHop(page, "section", section, lastCause, {
+    targetHref,
+    headerEverPresent,
+    headerGraceElapsed: true,
+  });
+}
+
+/**
+ * Navigates to `Settings -> <settingsMenuName>` through three VERIFIED hops.
+ *
+ * The signature is unchanged from the blind-click version it replaces, so all
+ * of its call sites are untouched. `pageName` is kept for that reason and is
+ * only tested for emptiness — the Settings route is identified by URL, not by
+ * the label a menu happens to render.
+ */
 export const navigateSettingsPages = async (
   page: Page,
   pageName: string,
   settingsMenuName: string,
-) => {
+): Promise<void> => {
   if (!pageName) {
     return;
   }
-  await page.getByTestId("user-profile-settings").click();
-  await page.getByText(`${pageName}`).first().click();
+  const target = settingsMenuName || pageName;
+  await openAccountMenu(page, target, Date.now() + HOP_BUDGET_MS);
+  await enterSettings(page, target, Date.now() + HOP_BUDGET_MS);
 
   if (settingsMenuName) {
-    await page.getByText(`${settingsMenuName}`).first().click();
-    await page.waitForSelector('[data-testid="settings_menu_header"]', {
-      timeout: 5000,
-    });
-    await page.waitForTimeout(500);
+    await openSection(page, settingsMenuName, Date.now() + HOP_BUDGET_MS);
   }
 };
+
+/**
+ * The `sidebar-nav-<section>` locator, exported so a spec can assert on the
+ * entry itself without rebuilding the prefix.
+ */
+export const settingsNavEntry = (page: Page, section: string): Locator =>
+  page.getByTestId(`${SETTINGS_NAV_TESTIDS.navPrefix}${section}`);

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
@@ -1,6 +1,6 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import type { Locator, Page } from "@playwright/test";
+import type { Locator, Page, Request, Response } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage } from "../../../../pages";
 import { navigateSettingsPages } from "../../../../helpers/ui/go-to-settings";
@@ -13,6 +13,7 @@ import {
   type Provider,
 } from "../../../../helpers/provider-setup";
 import { waitForProviderRow } from "../../../../helpers/provider-setup/provider-list-state";
+import { toggleWriteVerdict } from "../../../../helpers/provider-setup/model-toggle-write";
 import {
   censusForTarget,
   enumerateEnabledModels,
@@ -64,6 +65,11 @@ const providerItemTestId = provider
 const providerLabel = provider ? langflowProviderName(provider) : "";
 
 const ENABLED_MODELS_ENDPOINT = "/api/v1/models/enabled_models";
+
+// The debounced persistence write's budget, UNCHANGED from the inline 15000 it
+// replaces (#1696). Named only so `toggleWriteVerdict` can quote the same number
+// it waited on — raising it would hide the saturation the verdict exists to name.
+const TOGGLE_WRITE_TIMEOUT_MS = 15000;
 
 // SimpleAgentTemplatePage.load() does NO cleanup (post-#553 contract) and the
 // canvas URL id is transient on 1.11 — track every flow the load actually
@@ -206,23 +212,80 @@ async function toggleForModel(page: Page, modelName: string): Promise<Locator> {
 
 // Flip a toggle and wait for the optimistic UI change plus the debounced POST
 // that persists it (useModelToggleQueue debounces the write by 1000ms).
+//
+// The wait is armed BEFORE the click because navigating away first would drop
+// the debounced write. When it times out, the bare
+// `page.waitForResponse: Timeout 15000ms exceeded while waiting for event
+// "response"` cannot distinguish the UI never firing the write from the
+// instance never answering one that was sent — it appeared on BOTH tests of
+// this file on daily 2026-09-01 (run 33511210195) and said neither. The
+// requests and responses are therefore counted and handed to the pure
+// `toggleWriteVerdict` (#1696). The budget is UNCHANGED: this is attribution,
+// and a saturated instance still fails, correctly.
 async function setToggle(
   page: Page,
   toggle: Locator,
   enabled: boolean,
+  modelName: string,
 ): Promise<void> {
   const current = (await toggle.getAttribute("aria-checked")) === "true";
   if (current === enabled) return;
-  const save = page.waitForResponse(
-    (resp) =>
-      resp.url().includes(ENABLED_MODELS_ENDPOINT) &&
-      resp.request().method() === "POST",
-    { timeout: 15000 },
-  );
-  await toggle.click();
-  // Optimistic update — the switch reflects the new state immediately.
-  await expect(toggle).toHaveAttribute("aria-checked", String(enabled));
-  await save;
+
+  const isWrite = (url: string, method: string) =>
+    url.includes(ENABLED_MODELS_ENDPOINT) && method === "POST";
+  let requestsSeen = 0;
+  let responsesSeen = 0;
+  const onRequest = (req: Request) => {
+    if (isWrite(req.url(), req.method())) requestsSeen += 1;
+  };
+  const onResponse = (resp: Response) => {
+    if (isWrite(resp.url(), resp.request().method())) responsesSeen += 1;
+  };
+  page.on("request", onRequest);
+  page.on("response", onResponse);
+
+  try {
+    const save = page.waitForResponse(
+      (resp) => isWrite(resp.url(), resp.request().method()),
+      { timeout: TOGGLE_WRITE_TIMEOUT_MS },
+    );
+    try {
+      await toggle.click();
+      // Optimistic update — the switch reflects the new state immediately.
+      await expect(toggle).toHaveAttribute("aria-checked", String(enabled));
+    } catch (error) {
+      // `save` is still armed. Discard its outcome so its later rejection is
+      // not an UNHANDLED one, which would replace this real failure with a
+      // worse, unattributed one — then report what actually broke. The discard
+      // lives here and never at arming time: a `.catch()` on `save` itself
+      // would make the `await` below resolve and silently disable the verdict.
+      void save.catch(() => {});
+      throw error;
+    }
+    try {
+      await save;
+    } catch (error) {
+      const ariaChecked = (await toggle.getAttribute("aria-checked")) ?? "";
+      const verdict = toggleWriteVerdict(
+        {
+          requestsSeen,
+          responsesSeen,
+          ariaChecked,
+          wantedEnabled: enabled,
+          model: modelName,
+        },
+        ENABLED_MODELS_ENDPOINT,
+        TOGGLE_WRITE_TIMEOUT_MS,
+      );
+      throw new Error(
+        `${verdict.message} Underlying wait failed with: ` +
+          `${error instanceof Error ? error.message.split("\n")[0] : String(error)}`,
+      );
+    }
+  } finally {
+    page.off("request", onRequest);
+    page.off("response", onResponse);
+  }
 }
 
 // Reads the OPEN model picker and counts what it establishes about the target.
@@ -253,19 +316,21 @@ async function readPickerCensus(
 test.describe.configure({ mode: "serial" });
 
 test.describe("Model Provider Model Toggle", () => {
-  // Quarantined at the triage of daily #1694 (run 33756085604, 2026-09-03).
-  // This test failed on 6 of the last 30 dailies under 4 distinct signatures,
-  // each stalling at a different step of the same short path (open Model
-  // Providers -> pick the provider -> toggle a model -> await the write). On
-  // 2026-09-03 it timed out on `getByText('Model Providers')` with only 1 of
-  // 21 liveness probes failing in its window, so it is not wedge collateral.
-  // Being `fixme` (a skip, not a failure) keeps the serial sibling below
-  // running. Lifting the quarantine (remove test.fixme + restore @stable) is
-  // a deliverable of #1696.
-  test.fixme(
+  // Quarantine LIFTED here (#1696) — `test.fixme` removed and `@stable`
+  // restored. It was quarantined at the triage of daily #1694 after failing 6
+  // of 30 dailies under 4 signatures, and reading each run's own artifacts
+  // resolved those into causes rather than one flake: two occurrences
+  // (2026-09-01, 2026-09-03) were `navigateSettingsPages` reporting a hop that
+  // never had a chance instead of the hop that broke, and that is what this
+  // issue fixes; one (2026-08-31) was the bare `provider-item-*` wait, already
+  // closed by #1648 after that daily; one (2026-09-01) was the persistence
+  // write, now attributed by `toggleWriteVerdict` rather than papered over; and
+  // three were page-entry-barrier wedge collateral belonging to #1589/#1549.
+  // The byte-identical signature carrying two different locators is #1626.
+  test(
     "model toggle changes immediately and persists across reopen",
     {
-      tag: ["@regression", "@components", "@model-provider"],
+      tag: ["@stable", "@regression", "@components", "@model-provider"],
     },
     async ({ page }) => {
       test.skip(!!skipReason, skipReason ?? "");
@@ -291,7 +356,7 @@ test.describe("Model Provider Model Toggle", () => {
       });
 
       await test.step("disable the model — change is immediate and persisted", async () => {
-        await setToggle(page, toggle, false);
+        await setToggle(page, toggle, false, modelName);
       });
 
       await test.step("reopen Model Providers — disabled state persisted", async () => {
@@ -301,7 +366,7 @@ test.describe("Model Provider Model Toggle", () => {
         await expect(reopened).toHaveAttribute("aria-checked", "false");
 
         // Restore the baseline so the model stays enabled for other specs.
-        await setToggle(page, reopened, true);
+        await setToggle(page, reopened, true, modelName);
         await expect(reopened).toHaveAttribute("aria-checked", "true");
       });
     },
@@ -452,7 +517,7 @@ test.describe("Model Provider Model Toggle", () => {
         ).toBeGreaterThan(0);
 
         const toggle = await toggleForModel(page, targetModel);
-        await setToggle(page, toggle, false);
+        await setToggle(page, toggle, false, targetModel);
         // Armed for the failure-path restore in afterEach; disarmed by the re-enable
         // step below when the test completes normally.
         disabledModel = targetModel;
@@ -512,7 +577,7 @@ test.describe("Model Provider Model Toggle", () => {
       await test.step("re-enabling the model brings it back to the dropdown", async () => {
         await openProviderModelList(page);
         const toggle = await toggleForModel(page, targetModel);
-        await setToggle(page, toggle, true);
+        await setToggle(page, toggle, true, targetModel);
         // Restored by the test itself — the afterEach net is no longer needed.
         disabledModel = null;
 


### PR DESCRIPTION
## Type

- [ ] `feat` — new test or new helper/page object
- [x] `fix` — fix for a broken or flaky test
- [ ] `chore` — CI, checklist, dependencies, internal refactoring
- [ ] `docs` — documentation update

---

## Roadmap linkage (required — do not delete)

- [ ] **Current wave** — a `roadmap`-labeled issue in the current wave's milestone: #___
- [x] **Exception** — off-wave work backed by an issue: a follow-up, a `daily-failure` triage issue, or a `community`-labeled regression. Issue #1696 (`daily-failure`, spun out of triage #1694)

---

## What this PR does

`tests/helpers/ui/go-to-settings.ts` fired three clicks — `user-profile-settings`, then `getByText("Settings").first()`, then `getByText("<section>").first()` — and verified **none** of them. A hop the DOM **accepts** while the app **discards** it therefore surfaced one hop *later*, at a locator that never had a chance, so one cause was reported under four different signatures across 30 days behind a call log that named nothing:

```
TimeoutError: locator.click: Timeout 20000ms exceeded.
Call log:
  - waiting for getByText('Model Providers').first()
```

Read out of the dailies' own artifacts, not theorized. On run [33756085604](https://github.com/oriontech-me/langflow-e2e/actions/runs/33756085604) the failing step is the **reopen** (21455 ms) while the *first* open of the same panel took 1534 ms; the failure-time screenshot and aria snapshot are the **home page** — dropdown closed, account button carrying a focus ring, the string `Settings` appearing **zero** times — yet Playwright reported hops 1 and 2 as successful. Run [33511210195](https://github.com/oriontech-me/langflow-e2e/actions/runs/33511210195) failed on the same line, locator and budget, so the shape is recurrent rather than a one-off.

The mechanism is measured: in the 09-03 run's own passing retry the hop-1 click took **1532 ms** of actionability against **121 ms** for the identical click earlier in the same test, with `agent credential settled slowly: 6.2s` in its stderr (the #751 guard), and a local `MutationObserver` on `1.13.0.dev0` shows the header's DOM node being **replaced ~616 ms** after `page.goto("/")` — which discards a Radix menu whose trigger was clicked just before it.

**Independent confirmation, and why this is a fix rather than an invention.** Upstream Langflow carries the same helper at `src/frontend/tests/utils/go-to-settings.ts`. `release-1.9.7` still holds our version **byte-identically** (`waitForTimeout(500)` included), and upstream rewrote its own copy on **2026-08-25** in `76fb85da` — *"test: stabilize release Playwright navigation"* — onto exactly the testids adopted here plus a `waitForURL`. Both of our remaining occurrences post-date that fix.

### Re-triage of the four signatures

The issue's table names one symptom row; reading each run's `results.json` resolves it into distinct causes, and only two of them belong here.

| Daily | Real stall point | Owner |
|---|---|---|
| 2026-09-01 (attempt 2), 2026-09-03 | `go-to-settings.ts:15` | **this PR** |
| 2026-09-01 (both tests) | `setToggle`'s 15 s `waitForResponse` on `POST /api/v1/models/enabled_models` | **this PR** (attribution only) |
| 2026-08-31 | `provider-item-OpenAI` in `setup-openai.ts:31` | **already closed by #1648**, which merged after that daily |
| 2026-08-05, 2026-08-26 | page-entry barrier, `[backend-unreachable]` | #1589 (wedge collateral) |
| 2026-08-21 | page-entry barrier with the backend answering HTTP 200 | #1549 |
| byte-identical signature carrying two different locators | the signature-collision gap itself | #1626 |

**Verdict: test defect, not a Langflow regression.** A real user simply clicks again, and the product exposes stable handles the helper was not using.

### The fix

Three **verified** hops, each on a real testid confirmed live on `1.13.0.dev0` and in upstream source (`AccountMenu/index.tsx:57,98`, `sidebarComponent/index.tsx:53`):

| hop | click | effect waited for |
|---|---|---|
| 1 — open the account menu | `user-profile-settings` | `menu_settings_button` visible |
| 2 — enter Settings | `menu_settings_button` | URL matches `/\/settings(?:\/\|$)/` |
| 3 — open the section | `sidebar-nav-<section>` (a real `<a href="/settings/…">`) | `location.pathname` equals **that anchor's own `href`**, then `settings_menu_header` reads the section |

Hop 3's target path comes from the anchor, never from a name-to-path table, so a section Langflow renames cannot desync a map. The header is the *content* half and is optional for a measured reason: of the nine sections, eight render exactly one `settings_menu_header` whose text equals the sidebar title and `Langflow MCP Client` renders **none** — requiring one would make it unreachable, and hardcoding a list of headerless sections is the table this design refuses to keep.

A hop whose effect does not land is **re-attempted once inside the same deadline** and announced on stdout, so a dropped click is repaired the way #1518 repairs the sidebar's dropped `fill` while a *systematic* breakage stays visible. The repair for hop 2 is to **reopen the menu** and click again, not to click again: a dropped selection leaves the menu closed, so the item is gone. Persisting, the pure `settingsNavVerdict()` names the hop — `menu-unopened`, `page-unreached`, `section-absent` (a PRODUCT finding listing the sections that *did* render) or `section-unconfirmed`.

**Budgets are not raised.** One hop's click and its effect wait share a single 20 s deadline, so the worst case equals the three `actionTimeout` clicks this replaces — and the unconditional `waitForTimeout(500)` is gone. Upstream's own `TIMEOUTS.standard` (30 s) is **deliberately not adopted**: 30 s on the last hop would sit above today's 20 s and hide the stall (#1648's rule).

The **fourth signature** is closed by attribution with the budget unchanged. `setToggle`'s 15 s `waitForResponse` timed out on both tests on 2026-09-01 and could not distinguish the UI never firing the debounced write from the instance never answering one that was sent. The pure `toggleWriteVerdict()` splits those into `not-issued` (no POST observed at all — a suite or product defect, naming the switch's `aria-checked` against what was asked for) and `unanswered` (issued, not answered — instance saturation, naming the request/response counts). This is attribution, **not** a fix: a saturated instance still fails, correctly.

**Quarantine lifted:** `test.fixme` removed and `@stable` restored on *"model toggle changes immediately and persists across reopen"*.

### Rejected alternatives

- **Raising the budget.** It is the thing the failure invites and the thing that would hide the stall; every verdict message says so explicitly.
- **Adopting upstream's shape verbatim.** It fails with a bare `expect(...).toBeVisible` timeout — better than today, still nameless — and its 30 s budget is a raise.
- **Fixing it in the spec instead of the helper.** The failure trace points at `go-to-settings.ts:15`, and the same 20 s `locator.click` shape is on record against four of the helper's other consumers (`modelProviderModal:48` on 09-01, `mcp-server-starter-projects:61` on 08-07, `remove-provider-api-key:17` on 07-27 and 08-03).

---

## Tests covered

| # | Test | What it validates |
|---|---|---|
| 1 | `model toggle changes immediately and persists across reopen` | A per-model toggle in Settings → Model Providers flips `aria-checked` **optimistically** and the change **survives leaving and reopening** the panel — i.e. the debounced `POST /api/v1/models/enabled_models` actually persisted it rather than the switch merely repainting. A regression in the optimistic update, in the debounce/queue, or in the read-back through `useGetEnabledModels` breaks it. Quarantine lifted here; `@stable` restored. |
| 2 | `disabling a model removes it from a component model dropdown` | Disabling a model in Settings **propagates** to an intelligent component's model picker on the canvas (`useRefreshModelInputs`), and re-enabling brings it back. Matched by option **identity** (`data-value` / `data-testid`), behind two guards that make the zero mean removal: the picker must still be populated and the provider's *other* models must still resolve. Re-checked against the same fix, as #1696 asks. |

---

## How the tests were built

Neither test's body changed. What changed is the shared navigation helper they and five other specs go through, plus one attribution wrapper inside this file:

- **`tests/helpers/ui/go-to-settings.ts`** — rewritten to three verified hops. The exported **signature is unchanged**, so all **11 call sites across 7 specs** are untouched. `settingsNavVerdict()`, `sectionHopState()` and `trackTargetHeader()` are **pure**, with a single guarded `page.evaluate` snapshot read feeding them — the shape `providerRowVerdict` (#1648) settled on, because these branches are otherwise reachable only from an instance misbehaving on purpose.
- **`tests/helpers/provider-setup/model-toggle-write.ts`** — the pure `toggleWriteVerdict()` behind `setToggle`'s unchanged 15 s persistence wait. `requestsSeen` decides the verdict, never `responsesSeen`: a response counted without its request would flip the diagnosis from "the UI is broken" to "the instance is slow" and send triage the wrong way.
- **Unit tests** — `go-to-settings.test.ts` (19) and `model-toggle-write.test.ts` (6). `trackTargetHeader` exists because of a bug found by *running* the helper, not reading it: hop 3 starts on `/settings/general`, which **has** a header, so counting any header on screen made the headerless branch unreachable and `Langflow MCP Client` failed after the full 20 s. Only a header seen while the pathname already matches the anchor's `href` belongs to the target page.
- `setToggle` now takes the model name so the verdict can name it; all four call sites updated.

---

## Dependencies

- **No new dependency.** No new POM, no new selector invented, no fixture change; `test` still comes from `tests/fixtures/fixtures.ts`.
- **Execution mode unchanged** — the file stays `test.describe.configure({ mode: "serial" })` and wants `--workers=1`: named template loads collide under parallelism and test 2 mutates **account-global** state.
- **Provider** — the spec needs one provider with its env keys set so models are listed. It makes **no LLM call**, so a drained key is sufficient. Locally, set `MODEL_TEST_PROVIDER` in the **shell** (Playwright and the pipeline read the shell, not `.env`).
- **`afterEach` cleanup, both pre-existing and re-verified here**: every `POST /api/v1/flows` → 201 id is deleted id-scoped, and a model left disabled is re-enabled over the API with 3 retries. Verified after every phase — the instance returned to its 26 seeded starter flows, and of 58 OpenAI models the 17 left disabled are all embeddings/audio/realtime/dated ids, i.e. exactly the ones `setup-openai` never enables.

---

## What this PR does not cover

Two out-of-scope findings surfaced while validating and are **filed separately, not fixed here**:

- Three `@stable` specs (`modelProviderModal`, `remove-provider-api-key`, `model-provider-modal-actions`) call `awaitBootstrapTest` with **zero** flow cleanup and leaked two flows (`New Flow` + `Basic Prompting`) per fresh-instance run. Purged from the test instance; the spec this PR touches leaks nothing. The fourth sibling, `model-provider-api-key`, already does it correctly.
- `mcp-server-starter-projects` logs `🚨 Backend Error: 409 Conflict` on every run — the 409 it deliberately asserts, with no `allowHttpErrors` / `expectKnownHttpError` hatch. **Proved pre-existing**: reverting the helper to HEAD produces the byte-identical line.

Also out of scope by attribution, per the re-triage table: the three page-entry-barrier occurrences (#1589 / #1549), the 08-31 provider-list wait (**already closed** by #1648), and the signature-collision gap itself (#1626 — the issue explicitly says not to fix it here).

---

## Known limitations

- **`toggleWriteVerdict` is attribution, not a fix.** A saturated instance still fails the persistence wait, correctly. What changes is that it says which half of the round-trip broke instead of becoming a fifth nameless signature.
- **The hop-2 repair is bounded to one re-attempt** and announced on stdout. That is deliberate: repairing silently, or repairing forever, would hide a systematic breakage — the `mode=count` lesson.
- **`--trace=on` was not used locally**: it hangs UI specs under Colima. Traces were read from the daily's own `blob-3` artifact instead, which is what produced the root-cause evidence above.
- **The pre-fix flake never reproduced locally** (0/10, plus 0/12 under two delay-injection strategies) — an unloaded box does not race the header remount. The mechanism was therefore proved deterministically; see the A/B table below.

---

## Related issue

Closes #1696

---

## Validation

Nightly `1.13.0.dev2` — `latest` at the time of the run — `--retries=0 --workers=1`.

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `npm run test:units` ✅ **1012/1012** (25 new)
- Target spec **3/3 clean** bursts: `expected=2 unexpected=0 flaky=0 skipped=0 backendErrors=false` (56.2 s / 50.7 s / 50.8 s)
- **Deterministic mechanism proof.** Injecting what the loaded backend does — a capture-phase `stopImmediatePropagation` on `menu_settings_button` that swallows hop 2's selection, followed by a Radix-native `Escape` close, with everything else about the click real:

| mutation | old helper | new helper |
|---|---|---|
| none (control) | PASSED 1155 ms | PASSED 646–895 ms across all five sections |
| hop 2's selection swallowed **once** | **FAILED 20527 ms** — the daily's exact error string, page still on the previous route, **zero** `Settings` text nodes, no open menu | **PASSED 3/3** (9056–9667 ms) via the announced hop-2 repair |
| **every** selection swallowed | same, nameless | **FAILED** `SETTINGS_PAGE_UNREACHED`, naming the pathname |
| `menu_settings_button`'s testid stripped | nameless | **FAILED** `SETTINGS_MENU_UNOPENED` — and it distinguishes the case: *"The menu DID open … so this is a RENAMED testid rather than an app-shell stall"* |
| `sidebar-nav-Model Providers`'s testid stripped | nameless | **FAILED** `SETTINGS_SECTION_ABSENT`, listing the 8 sections that did render |

  The middle two rows are different mutations on purpose: a single dropped selection **must** be repaired, so only swallowing every one of them can force hop 2's verdict.

- **Cross-spec safety**, since the helper is shared — **3/3 clean bursts each**: `modelProviderModal` (3 tests), `model-provider-modal-actions` (3), `model-provider-api-key` (3), `remove-provider-api-key` (2). `settings-message-history` skips honestly on `providerSkipGate("openai")` (drained key), so its `Messages` call site was covered by driving the real helper against it directly (PASSED 641–847 ms). `mcp-server-starter-projects` passes 2/2 with the pre-existing 409 noted above.
- [x] Ran the test in isolation and verified steps — traces read from the daily's `blob-3` artifact, not `--trace=on` (see Known limitations)
- [x] Forced a failure to confirm it is not a false positive — per test, then reverted with no `FF-MUTATION` marker left and a final green run (`expected=2 unexpected=0`):
  - *model toggle changes immediately and persists across reopen* — reopen asserting `aria-checked="true"` instead of `"false"` → failed
  - *disabling a model removes it from a component model dropdown* — removal poll asserting `.toBe(1)` instead of `.toBe(0)` → failed
- [x] Ran in `--debug` mode and walked through step by step
- [x] Confirmed there are no backend errors (`🚨 Backend Error:`) in the output — zero on the touched spec
- [ ] Updated `QA-CHECKLIST.md` — **intentionally not touched**: bullet 552 is already `[x]` and was silently false while the test was quarantined; restoring `@stable` makes it true again. Generated blocks regenerate on merge.
- [ ] Updated `QA-SCENARIOS-GUIDE.md` — not applicable: no new scenario, the behaviors were already documented.

### Reviewer note on the spec-doc dependency paths

The four new `src/frontend/…` paths were resolved through the GitHub API against **`main`, `release-1.12.0` and `release-1.9.7`** — the three refs `watch-upstream-areas.mjs --mode=check-docs` uses — with line numbers and testids read out of each file. A **local** run of that guard resolves against *our* HEAD and reports every `src/` path as missing; that output is noise.

```bash
PLAYWRIGHT_BASE_URL=http://localhost:7860 MODEL_TEST_PROVIDER=openai MODEL_TEST_ID= npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts --workers=1 --retries=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
