### PR TITLE
Pin the VM lane's environment against daily-stable.yml's, and carry the three variables it never had

### DIFF
--- a/scripts/check-vm-env-parity.mjs
+++ b/scripts/check-vm-env-parity.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Does the VM lane account for every environment variable daily-stable.yml sets on the
+// Langflow service it tests?
+//
+//   node scripts/check-vm-env-parity.mjs --mode=check   # fail-closed verdict, exit 1 on a gap
+//   node scripts/check-vm-env-parity.mjs --mode=list    # the table, always exit 0
+//
+// The reasoning lives in scripts/lib/vm-env-parity.mjs. This file is the entry point,
+// so the question can be asked from a terminal on the QA VM — where the person holding
+// an odd verdict is — and not only from the unit lane.
+//
+// `--mode=check` is also what scripts/check-vm-env-parity.test.mjs drives, so the lane
+// and the human get the same answer from the same code.
+
+import { checkVmEnvParity, CLASSIFICATION, WORKFLOW_PATH } from "./lib/vm-env-parity.mjs";
+
+const mode = (process.argv.find((a) => a.startsWith("--mode=")) || "--mode=check").slice("--mode=".length);
+
+if (!["check", "list"].includes(mode)) {
+  console.error(`unknown mode: ${mode} (expected check or list)`);
+  process.exit(2);
+}
+
+const result = checkVmEnvParity();
+
+if (mode === "list") {
+  console.log(`${WORKFLOW_PATH} → the VM lane\n`);
+  for (const { name, carrier, reason, sameValue } of result.carried) {
+    const where = carrier === null ? "out of scope" : carrier;
+    console.log(`  ${name}`);
+    console.log(`    carried by : ${where}${sameValue === false ? " (different value, on purpose)" : ""}`);
+    console.log(`    because    : ${reason}`);
+  }
+  for (const f of result.findings) console.log(`  ${f.name ?? "-"}: ${f.message}`);
+  process.exit(0);
+}
+
+if (result.ok) {
+  const scoped = result.carried.filter((c) => c.carrier !== null).length;
+  const out = result.carried.length - scoped;
+  console.log(
+    `VM env parity OK — ${result.carried.length} LANGFLOW_* on the daily's service: ` +
+      `${scoped} carried to the target, ${out} recorded out of scope.`,
+  );
+  process.exit(0);
+}
+
+// Every finding, not the first: an enumeration guard that stops at one gap makes the
+// reader run it once per variable.
+for (const f of result.findings) console.error(`::error:: ${f.message}`);
+console.error("");
+console.error("Why this is fail-closed rather than a warning: half of this class produces");
+console.error("AGREEMENT, not failure. A variable the daily sets and the VM lane does not");
+console.error("carry can make the VM pass a spec the Actions daily would fail — and the");
+console.error("migration's whole product is the comparison between those two verdicts, so");
+console.error("no run can find it by going red. See #1717, and CLASSIFICATION in");
+console.error("scripts/lib/vm-env-parity.mjs for where to record the decision.");
+console.error(`(${Object.keys(CLASSIFICATION).length} variables classified today.)`);
+process.exit(1);

--- a/scripts/check-vm-env-parity.mjs
+++ b/scripts/check-vm-env-parity.mjs
@@ -39,7 +39,7 @@ if (result.ok) {
   const scoped = result.carried.filter((c) => c.carrier !== null).length;
   const out = result.carried.length - scoped;
   console.log(
-    `VM env parity OK — ${result.carried.length} LANGFLOW_* on the daily's service: ` +
+    `VM env parity OK — ${result.carried.length} variables on the daily's service: ` +
       `${scoped} carried to the target, ${out} recorded out of scope.`,
   );
   process.exit(0);

--- a/scripts/check-vm-env-parity.test.mjs
+++ b/scripts/check-vm-env-parity.test.mjs
@@ -4,23 +4,34 @@
 // What these protect. The guard's job is to fail when daily-stable.yml gains a service
 // variable the VM lane neither carries nor classifies — and the reason it has to be a
 // guard rather than a hand audit is that half of what it catches produces AGREEMENT
-// rather than failure, so no run can find it (#1717). A guard for an invisible class
-// is worth exactly what its own tests are worth, hence the shape below: every
-// assertion is driven by a MUTATED workflow, never by the wording of a line.
+// rather than failure, so no run can find it (#1717). A guard for an invisible class is
+// worth exactly what its own tests are worth, hence the shape below: every assertion is
+// driven by a MUTATED source, never by the wording of a line.
 //
-// The two failures this file is written against, both learned in #1716's review:
+// The failures this file is written against:
 //   - a comment merely SPELLING a variable must not answer for a real setting, in
 //     either direction — it must not mask one, and it must not fail a correct workflow
+//     (#1300, and #1716's first draft reintroduced it)
 //   - the read is scoped to the SERVICE block, because daily-stable.yml also sets
-//     LANGFLOW_IMAGE and LANGFLOW_VERSION as step env in later jobs, where they name
-//     the image to report rather than configure the instance under test
+//     LANGFLOW_IMAGE and LANGFLOW_VERSION as step env in later jobs
+//   - SHADOWING. The first version of this guard checked that the carrier file NAMED
+//     the variable, and that let the starter overwrite a mirrored value with a literal
+//     while every check stayed green. Found in review, reproduced here: it is the
+//     silent half of #1717 one layer down
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readServiceEnv, checkVmEnvParity, CLASSIFICATION, WORKFLOW_PATH } from "./lib/vm-env-parity.mjs";
+import {
+  readServiceEnv,
+  readStarterLaunchEnv,
+  readMirroredNames,
+  checkVmEnvParity,
+  CLASSIFICATION,
+  WORKFLOW_PATH,
+} from "./lib/vm-env-parity.mjs";
 import { evaluateWorkflowValue } from "./lib/gh-expression.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -45,23 +56,46 @@ const workflowWith = (envLines, tail = "") =>
     tail,
   ].join("\n");
 
-const MINIMAL = ["LANGFLOW_AUTO_LOGIN: \"true\"", "LANGFLOW_DEACTIVATE_TRACING: \"false\""];
+/** run-e2e.sh's composer, in the shape the reader expects. */
+const orchestratorWith = (names, extra = "") =>
+  [
+    extra,
+    "mirrored_target_env() {",
+    "  printf '%s' \\",
+    ...names.map((n) => `    "${n}=$(shq "$${n}") " \\`),
+    "}",
+  ].join("\n");
+
+/** start-langflow-source.sh's launch block, ending at the command as the real one does. */
+const starterWith = (assignments) =>
+  [
+    'cd "${REPO}"',
+    ...assignments.map((a) => `${a} \\`),
+    '  ${RUN_CMD} --host "${BIND_HOST}" --port "${PORT}" --no-open-browser \\',
+    '  --workers "${LANGFLOW_WORKERS:-1}" < /dev/null &',
+  ].join("\n");
+
+const MINIMAL = ['LANGFLOW_AUTO_LOGIN: "true"', 'LANGFLOW_DEACTIVATE_TRACING: "false"'];
 const CLASSES = {
-  LANGFLOW_AUTO_LOGIN: { carrier: "starter", reason: "auto-login" },
-  LANGFLOW_DEACTIVATE_TRACING: { carrier: "orchestrator", reason: "tracing" },
+  LANGFLOW_AUTO_LOGIN: { carrier: "starter", reason: "auto-login, and every starter does it" },
+  LANGFLOW_DEACTIVATE_TRACING: { carrier: "orchestrator", reason: "chosen for this lane, not for a dev box" },
 };
+const STARTER_OK = starterWith([
+  "LANGFLOW_AUTO_LOGIN=true",
+  'LANGFLOW_DEACTIVATE_TRACING="${LANGFLOW_DEACTIVATE_TRACING:-true}"',
+]);
 const check = (workflow, over = {}) =>
   checkVmEnvParity({
     workflow,
-    orchestrator: "LANGFLOW_DEACTIVATE_TRACING=x",
-    starter: "LANGFLOW_AUTO_LOGIN=true",
+    orchestrator: orchestratorWith(["LANGFLOW_DEACTIVATE_TRACING"]),
+    starter: STARTER_OK,
     classification: CLASSES,
     ...over,
   });
 
 test("the repository as it stands passes, and the CLI agrees", () => {
   // Not a tautology: it is the assertion that keeps the three variables #1717 named
-  // present. Delete one from run-e2e.sh and this fails.
+  // present. Delete one from mirrored_target_env() and this fails.
   const result = checkVmEnvParity();
   assert.ok(result.ok, result.findings.map((f) => f.message).join("\n"));
 
@@ -76,22 +110,117 @@ test("a variable the workflow gains and nobody classified fails the guard", () =
   const result = check(workflowWith([...MINIMAL, 'LANGFLOW_BRAND_NEW_KNOB: "1"']));
   assert.equal(result.ok, false);
   const found = result.findings.find((f) => f.name === "LANGFLOW_BRAND_NEW_KNOB");
-  assert.ok(found, `expected a finding for the new variable, got: ${JSON.stringify(result.findings)}`);
-  assert.equal(found.kind, "unclassified");
-  // The message has to say what to DO, because the reader meeting it is mid-edit on
-  // the workflow and has no reason to know this file exists.
+  assert.equal(found?.kind, "unclassified");
+  // The message has to say what to DO: the reader meeting it is mid-edit on the
+  // workflow and has no reason to know this file exists.
   assert.match(found.message, /run-e2e\.sh/);
   assert.match(found.message, /out of scope with a reason/);
 });
 
-test("a comment naming a variable is not a setting", () => {
-  // #1300's failure, and #1716's first draft reintroduced it: a `#` line spelling a
-  // variable both masks a real setting and FAILS A CORRECT WORKFLOW. Here it would
-  // invent an unclassified variable out of prose.
-  const result = check(
-    workflowWith([...MINIMAL, "# LANGFLOW_BRAND_NEW_KNOB is deliberately not set here", "# LANGFLOW_ALSO_NOT_SET: yes"]),
-  );
+test("the enumeration is not limited to the LANGFLOW_ namespace", () => {
+  // The first version filtered `startsWith("LANGFLOW_")` with no comment, so a
+  // DO_NOT_TRACK or a LANGSMITH_* configuring the instance under test read as clean —
+  // and a fail-closed promise is what makes the next reader stop looking.
+  const result = check(workflowWith([...MINIMAL, 'DO_NOT_TRACK: "1"']));
+  assert.equal(result.ok, false);
+  assert.equal(result.findings.find((f) => f.name === "DO_NOT_TRACK")?.kind, "unclassified");
+});
+
+test("a mirrored variable the starter overwrites with a literal fails", () => {
+  // The gap found in review, reproduced. One line in the starter's launch block, in
+  // the same shape LANGFLOW_AUTO_LOGIN=true is written two lines above it, and the
+  // orchestrator's value never reaches the server: a prefix assignment on `uv run`
+  // REPLACES the inherited value for that name rather than adding to it.
+  const result = check(workflowWith(MINIMAL), {
+    starter: starterWith(["LANGFLOW_AUTO_LOGIN=true", "LANGFLOW_DEACTIVATE_TRACING=true"]),
+  });
+  assert.equal(result.ok, false);
+  const found = result.findings.find((f) => f.name === "LANGFLOW_DEACTIVATE_TRACING");
+  assert.equal(found?.kind, "shadowed");
+  // It has to name the fix, because the line looks correct to anyone reading the
+  // starter alone — the whole point is that nothing else goes red.
+  assert.match(found.message, /\$\{LANGFLOW_DEACTIVATE_TRACING:-…\}/);
+});
+
+test("the overridable shape is not shadowing, because the caller's value wins", () => {
+  // `${NAME:-default}` is how the starter already carries tracing, and it must keep
+  // passing: a guard that forbade it would push the value out of the starter and break
+  // the parity with start-langflow-pip.sh that #1716 exists to protect.
+  const result = check(workflowWith(MINIMAL));
   assert.ok(result.ok, result.findings.map((f) => f.message).join("\n"));
+});
+
+test("naming a mirrored variable outside the composer does not count as carrying it", () => {
+  // "The file names it somewhere" was the first version's test and it is not the
+  // property: a mention in a string, or one left behind in a stale branch, would
+  // satisfy it while nothing reached the target.
+  const result = check(workflowWith(MINIMAL), {
+    orchestrator: orchestratorWith([], 'echo "LANGFLOW_DEACTIVATE_TRACING is handled below"'),
+  });
+  assert.equal(result.ok, false);
+  const found = result.findings.find((f) => f.name === "LANGFLOW_DEACTIVATE_TRACING");
+  assert.equal(found?.kind, "not-carried");
+  assert.match(found.message, /mirrored_target_env\(\)/);
+});
+
+test("a starter-carried variable its launch block does not set fails", () => {
+  const result = check(workflowWith(MINIMAL), {
+    starter: starterWith(['LANGFLOW_DEACTIVATE_TRACING="${LANGFLOW_DEACTIVATE_TRACING:-true}"']),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.findings.find((f) => f.name === "LANGFLOW_AUTO_LOGIN")?.kind, "not-carried");
+});
+
+test("a variable spent on a flag counts as carried, and its default is compared", () => {
+  // LANGFLOW_WORKERS is set as env by the workflow and spent as `--workers` by the
+  // starter. A name-only check would call it missing; a value check has to read the
+  // flag's default, because the assignment it would otherwise look for does not exist.
+  const classification = {
+    ...CLASSES,
+    LANGFLOW_WORKERS: { carrier: "starter", reason: "carried as the --workers flag, which is how langflow run takes it" },
+  };
+  assert.ok(check(workflowWith([...MINIMAL, 'LANGFLOW_WORKERS: "1"']), { classification }).ok);
+
+  const drift = check(workflowWith([...MINIMAL, 'LANGFLOW_WORKERS: "4"']), { classification });
+  assert.equal(drift.ok, false);
+  const found = drift.findings.find((f) => f.name === "LANGFLOW_WORKERS");
+  assert.equal(found?.kind, "value-drift");
+  assert.match(found.message, /"4"[\s\S]*"1"/);
+});
+
+test("a starter default that drifts from the workflow's value fails", () => {
+  // The residual the first version left open: change LANGFLOW_SUPERUSER_PASSWORD in
+  // the workflow and the two lanes authenticate differently with the guard green.
+  const result = check(workflowWith(['LANGFLOW_AUTO_LOGIN: "false"', 'LANGFLOW_DEACTIVATE_TRACING: "false"']));
+  assert.equal(result.ok, false);
+  const found = result.findings.find((f) => f.name === "LANGFLOW_AUTO_LOGIN");
+  assert.equal(found?.kind, "value-drift");
+  assert.match(found.message, /sameValue: false/);
+});
+
+test("sameValue: false records a deliberate difference instead of failing on it", () => {
+  const result = check(workflowWith(['LANGFLOW_AUTO_LOGIN: "false"', 'LANGFLOW_DEACTIVATE_TRACING: "false"']), {
+    classification: {
+      ...CLASSES,
+      LANGFLOW_AUTO_LOGIN: { carrier: "starter", sameValue: false, reason: "different on purpose, and here is the why" },
+    },
+  });
+  assert.ok(result.ok, result.findings.map((f) => f.message).join("\n"));
+});
+
+test("a comment naming a variable is not a setting, on either side", () => {
+  // #1300's failure: a `#` line spelling a variable both masks a real setting and
+  // FAILS A CORRECT WORKFLOW. In the workflow it would invent an unclassified
+  // variable out of prose; in the starter it would report shadowing that is not there.
+  assert.ok(
+    check(
+      workflowWith([...MINIMAL, "# LANGFLOW_BRAND_NEW_KNOB is deliberately not set here", "# LANGFLOW_ALSO_NOT: yes"]),
+    ).ok,
+  );
+  const commented = check(workflowWith(MINIMAL), {
+    starter: STARTER_OK.replace('cd "${REPO}"', '# LANGFLOW_DEACTIVATE_TRACING=true was removed in #1716\ncd "${REPO}"'),
+  });
+  assert.ok(commented.ok, commented.findings.map((f) => f.message).join("\n"));
 });
 
 test("a variable set outside the service block is not the service's", () => {
@@ -103,27 +232,6 @@ test("a variable set outside the service block is not the service's", () => {
   );
   assert.ok(result.ok, result.findings.map((f) => f.message).join("\n"));
   assert.equal(result.declared.has("LANGFLOW_IMAGE"), false);
-});
-
-test("a variable classified as carried, that its carrier never names, fails", () => {
-  // The half a classification table cannot promise on its own: an entry saying
-  // run-e2e.sh carries a value is a claim about another file, and claims rot.
-  const result = check(workflowWith(MINIMAL), { orchestrator: "# the tracing line was deleted here" });
-  assert.equal(result.ok, false);
-  const found = result.findings.find((f) => f.name === "LANGFLOW_DEACTIVATE_TRACING");
-  assert.equal(found?.kind, "not-carried");
-  assert.match(found.message, /scripts\/run-e2e\.sh/);
-});
-
-test("a carrier's own comments do not count as carrying", () => {
-  // Same asymmetry as the workflow side. A script that only MENTIONS a variable in a
-  // comment — "we deliberately do not set LANGFLOW_X" — has not carried it, and the
-  // most likely way this guard would be defeated is by satisfying it with prose.
-  const result = check(workflowWith(MINIMAL), {
-    orchestrator: "# LANGFLOW_DEACTIVATE_TRACING is handled elsewhere\necho hi",
-  });
-  assert.equal(result.ok, false);
-  assert.equal(result.findings.find((f) => f.name === "LANGFLOW_DEACTIVATE_TRACING")?.kind, "not-carried");
 });
 
 test("out of scope without a reason is not out of scope", () => {
@@ -138,7 +246,7 @@ test("out of scope without a reason is not out of scope", () => {
 
 test("out of scope WITH a reason passes, and is reported as out of scope", () => {
   const result = check(workflowWith(MINIMAL), {
-    classification: { ...CLASSES, LANGFLOW_AUTO_LOGIN: { carrier: null, reason: "a container-only concept" } },
+    classification: { ...CLASSES, LANGFLOW_AUTO_LOGIN: { carrier: null, reason: "a container-only concept here" } },
   });
   assert.ok(result.ok, result.findings.map((f) => f.message).join("\n"));
   assert.equal(result.carried.find((c) => c.name === "LANGFLOW_AUTO_LOGIN").carrier, null);
@@ -148,7 +256,7 @@ test("a classification for a variable the workflow dropped fails as stale", () =
   // A reason that outlives its variable is worse than no reason: a future reader will
   // trust it about a decision that no longer exists.
   const result = check(workflowWith(MINIMAL), {
-    classification: { ...CLASSES, LANGFLOW_LONG_GONE: { carrier: "starter", reason: "was a thing once" } },
+    classification: { ...CLASSES, LANGFLOW_LONG_GONE: { carrier: "starter", reason: "was a thing once, long ago" } },
   });
   assert.equal(result.ok, false);
   assert.equal(result.findings.find((f) => f.name === "LANGFLOW_LONG_GONE")?.kind, "stale");
@@ -161,13 +269,21 @@ test("every finding is reported, not just the first", () => {
   assert.equal(result.findings.filter((f) => f.kind === "unclassified").length, 2);
 });
 
-test("a workflow this cannot read fails instead of reading as clean", () => {
-  // #1012's rule: unevaluated is not clean. A shape the reader does not understand
-  // must never come back as "no gaps found" — that is a green verdict nobody produced.
-  for (const broken of ["name: no services here", workflowWith([]).replace("        env:", "        # env:")]) {
-    const result = check(broken);
-    assert.equal(result.ok, false, `expected a refusal for: ${broken.slice(0, 40)}`);
-    assert.equal(result.findings[0].kind, "unreadable");
+test("a source this cannot read fails instead of reading as clean", () => {
+  // #1012's rule: unevaluated is not clean. A shape the reader does not understand must
+  // never come back as "no gaps found" — that is a green verdict nobody produced. All
+  // three inputs, because each is a separate reader and each can go stale on its own.
+  const cases = [
+    { workflow: "name: no services here" },
+    { workflow: workflowWith(MINIMAL).replace("        env:", "        # env:") },
+    { starter: "echo there is no launch line here" },
+    { starter: '  ${RUN_CMD} --host x\n' },
+    { orchestrator: "echo there is no composer here" },
+  ];
+  for (const over of cases) {
+    const result = check(over.workflow ?? workflowWith(MINIMAL), over);
+    assert.equal(result.ok, false, `expected a refusal for: ${JSON.stringify(over).slice(0, 60)}`);
+    assert.equal(result.findings[0].kind, "unreadable", `wrong kind for: ${JSON.stringify(over).slice(0, 60)}`);
   }
 });
 
@@ -178,23 +294,30 @@ test("the same variable set twice in the service env is refused, not silently ha
   assert.match(result.findings[0].message, /set twice/);
 });
 
-test("the CLI exits 1 on a gap and names it, so the lane and a terminal agree", () => {
-  // The person holding an odd verdict is on the QA VM, not in the unit lane. Same code
-  // has to answer both, or the two answers can disagree.
-  const r = spawnSync(process.execPath, ["--input-type=module", "-e", `
-    import { checkVmEnvParity } from ${JSON.stringify(join(HERE, "lib/vm-env-parity.mjs"))};
-    const r = checkVmEnvParity({
-      workflow: ${JSON.stringify(workflowWith([...MINIMAL, 'LANGFLOW_SURPRISE: "1"']))},
-      orchestrator: "LANGFLOW_DEACTIVATE_TRACING", starter: "LANGFLOW_AUTO_LOGIN",
-      classification: ${JSON.stringify(CLASSES)},
-    });
-    process.stdout.write(JSON.stringify(r.findings.map((f) => f.name)));
-  `], { encoding: "utf8" });
-  assert.equal(r.status, 0, r.stderr);
-  assert.deepEqual(JSON.parse(r.stdout), ["LANGFLOW_SURPRISE"]);
+test("the readers agree with the real files they were written for", () => {
+  // The fixtures above are shapes; these are the files. A reader tested only against
+  // its own fixtures is a reader that has not been tested.
+  const launch = readStarterLaunchEnv(readFileSync(join(REPO_ROOT, "scripts/start-langflow-source.sh"), "utf8"));
+  assert.equal(launch.assignments.get("LANGFLOW_AUTO_LOGIN").overridable, false);
+  assert.equal(launch.assignments.get("LANGFLOW_DEACTIVATE_TRACING").overridable, true);
+  assert.equal(launch.assignments.get("LANGFLOW_DEACTIVATE_TRACING").value, "true");
+  assert.equal(launch.flags.get("LANGFLOW_WORKERS").value, "1");
 
+  const mirrored = readMirroredNames(readFileSync(join(REPO_ROOT, "scripts/run-e2e.sh"), "utf8"));
+  assert.ok(mirrored.has("LANGFLOW_SQLITE_PRAGMAS"), "the composer no longer carries the pragmas");
+  assert.equal(mirrored.size, 4);
+});
+
+test("the CLI refuses a bad mode and lists what it knows", () => {
+  // The person holding an odd verdict is on the QA VM, not in the unit lane. The same
+  // code has to answer both, or the two answers can disagree.
   const cli = spawnSync(process.execPath, [CLI, "--mode=nonsense"], { encoding: "utf8", cwd: REPO_ROOT });
   assert.equal(cli.status, 2);
+
+  const list = spawnSync(process.execPath, [CLI, "--mode=list"], { encoding: "utf8", cwd: REPO_ROOT });
+  assert.equal(list.status, 0, list.stderr);
+  assert.match(list.stdout, /LANGFLOW_SQLITE_PRAGMAS/);
+  assert.match(list.stdout, /carried by : orchestrator/);
 });
 
 test("the pragmas' value survives being read out of the workflow", () => {

--- a/scripts/check-vm-env-parity.test.mjs
+++ b/scripts/check-vm-env-parity.test.mjs
@@ -1,0 +1,220 @@
+// Unit tests for scripts/lib/vm-env-parity.mjs and its CLI.
+// Run with: npm run test:scripts
+//
+// What these protect. The guard's job is to fail when daily-stable.yml gains a service
+// variable the VM lane neither carries nor classifies — and the reason it has to be a
+// guard rather than a hand audit is that half of what it catches produces AGREEMENT
+// rather than failure, so no run can find it (#1717). A guard for an invisible class
+// is worth exactly what its own tests are worth, hence the shape below: every
+// assertion is driven by a MUTATED workflow, never by the wording of a line.
+//
+// The two failures this file is written against, both learned in #1716's review:
+//   - a comment merely SPELLING a variable must not answer for a real setting, in
+//     either direction — it must not mask one, and it must not fail a correct workflow
+//   - the read is scoped to the SERVICE block, because daily-stable.yml also sets
+//     LANGFLOW_IMAGE and LANGFLOW_VERSION as step env in later jobs, where they name
+//     the image to report rather than configure the instance under test
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readServiceEnv, checkVmEnvParity, CLASSIFICATION, WORKFLOW_PATH } from "./lib/vm-env-parity.mjs";
+import { evaluateWorkflowValue } from "./lib/gh-expression.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..");
+const CLI = join(HERE, "check-vm-env-parity.mjs");
+
+/** A minimal workflow with the same shape as daily-stable.yml's service block. */
+const workflowWith = (envLines, tail = "") =>
+  [
+    "name: Daily",
+    "jobs:",
+    "  test:",
+    "    services:",
+    "      langflow:",
+    "        image: langflowai/langflow-nightly:latest",
+    "        env:",
+    ...envLines.map((l) => `          ${l}`),
+    "        options: >-",
+    '          --health-cmd "curl -f http://localhost:7860/health_check"',
+    "      ollama:",
+    "        image: ghcr.io/x/ollama-e2e:llama3.2-1b",
+    tail,
+  ].join("\n");
+
+const MINIMAL = ["LANGFLOW_AUTO_LOGIN: \"true\"", "LANGFLOW_DEACTIVATE_TRACING: \"false\""];
+const CLASSES = {
+  LANGFLOW_AUTO_LOGIN: { carrier: "starter", reason: "auto-login" },
+  LANGFLOW_DEACTIVATE_TRACING: { carrier: "orchestrator", reason: "tracing" },
+};
+const check = (workflow, over = {}) =>
+  checkVmEnvParity({
+    workflow,
+    orchestrator: "LANGFLOW_DEACTIVATE_TRACING=x",
+    starter: "LANGFLOW_AUTO_LOGIN=true",
+    classification: CLASSES,
+    ...over,
+  });
+
+test("the repository as it stands passes, and the CLI agrees", () => {
+  // Not a tautology: it is the assertion that keeps the three variables #1717 named
+  // present. Delete one from run-e2e.sh and this fails.
+  const result = checkVmEnvParity();
+  assert.ok(result.ok, result.findings.map((f) => f.message).join("\n"));
+
+  const r = spawnSync(process.execPath, [CLI, "--mode=check"], { encoding: "utf8", cwd: REPO_ROOT });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /VM env parity OK/);
+});
+
+test("a variable the workflow gains and nobody classified fails the guard", () => {
+  // THE mutation this file exists for: the 11th variable the daily grows has to force
+  // a decision when it is written, not whenever someone next notices an odd verdict.
+  const result = check(workflowWith([...MINIMAL, 'LANGFLOW_BRAND_NEW_KNOB: "1"']));
+  assert.equal(result.ok, false);
+  const found = result.findings.find((f) => f.name === "LANGFLOW_BRAND_NEW_KNOB");
+  assert.ok(found, `expected a finding for the new variable, got: ${JSON.stringify(result.findings)}`);
+  assert.equal(found.kind, "unclassified");
+  // The message has to say what to DO, because the reader meeting it is mid-edit on
+  // the workflow and has no reason to know this file exists.
+  assert.match(found.message, /run-e2e\.sh/);
+  assert.match(found.message, /out of scope with a reason/);
+});
+
+test("a comment naming a variable is not a setting", () => {
+  // #1300's failure, and #1716's first draft reintroduced it: a `#` line spelling a
+  // variable both masks a real setting and FAILS A CORRECT WORKFLOW. Here it would
+  // invent an unclassified variable out of prose.
+  const result = check(
+    workflowWith([...MINIMAL, "# LANGFLOW_BRAND_NEW_KNOB is deliberately not set here", "# LANGFLOW_ALSO_NOT_SET: yes"]),
+  );
+  assert.ok(result.ok, result.findings.map((f) => f.message).join("\n"));
+});
+
+test("a variable set outside the service block is not the service's", () => {
+  // daily-stable.yml really does this: LANGFLOW_IMAGE and LANGFLOW_VERSION are step env
+  // in the reporting jobs. Counted as service variables they would be permanent,
+  // unfixable gaps — nothing can "carry" the name of an image to a source instance.
+  const result = check(
+    workflowWith(MINIMAL, ["  report:", "    steps:", "      - env:", "          LANGFLOW_IMAGE: langflow:latest"].join("\n")),
+  );
+  assert.ok(result.ok, result.findings.map((f) => f.message).join("\n"));
+  assert.equal(result.declared.has("LANGFLOW_IMAGE"), false);
+});
+
+test("a variable classified as carried, that its carrier never names, fails", () => {
+  // The half a classification table cannot promise on its own: an entry saying
+  // run-e2e.sh carries a value is a claim about another file, and claims rot.
+  const result = check(workflowWith(MINIMAL), { orchestrator: "# the tracing line was deleted here" });
+  assert.equal(result.ok, false);
+  const found = result.findings.find((f) => f.name === "LANGFLOW_DEACTIVATE_TRACING");
+  assert.equal(found?.kind, "not-carried");
+  assert.match(found.message, /scripts\/run-e2e\.sh/);
+});
+
+test("a carrier's own comments do not count as carrying", () => {
+  // Same asymmetry as the workflow side. A script that only MENTIONS a variable in a
+  // comment — "we deliberately do not set LANGFLOW_X" — has not carried it, and the
+  // most likely way this guard would be defeated is by satisfying it with prose.
+  const result = check(workflowWith(MINIMAL), {
+    orchestrator: "# LANGFLOW_DEACTIVATE_TRACING is handled elsewhere\necho hi",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.findings.find((f) => f.name === "LANGFLOW_DEACTIVATE_TRACING")?.kind, "not-carried");
+});
+
+test("out of scope without a reason is not out of scope", () => {
+  // #1581's rule: the reason is the whole content of the entry, because it is what a
+  // future reader acts on. An empty one is a decision nobody can review.
+  const result = check(workflowWith(MINIMAL), {
+    classification: { ...CLASSES, LANGFLOW_AUTO_LOGIN: { carrier: null } },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.findings.find((f) => f.name === "LANGFLOW_AUTO_LOGIN")?.kind, "no-reason");
+});
+
+test("out of scope WITH a reason passes, and is reported as out of scope", () => {
+  const result = check(workflowWith(MINIMAL), {
+    classification: { ...CLASSES, LANGFLOW_AUTO_LOGIN: { carrier: null, reason: "a container-only concept" } },
+  });
+  assert.ok(result.ok, result.findings.map((f) => f.message).join("\n"));
+  assert.equal(result.carried.find((c) => c.name === "LANGFLOW_AUTO_LOGIN").carrier, null);
+});
+
+test("a classification for a variable the workflow dropped fails as stale", () => {
+  // A reason that outlives its variable is worse than no reason: a future reader will
+  // trust it about a decision that no longer exists.
+  const result = check(workflowWith(MINIMAL), {
+    classification: { ...CLASSES, LANGFLOW_LONG_GONE: { carrier: "starter", reason: "was a thing once" } },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.findings.find((f) => f.name === "LANGFLOW_LONG_GONE")?.kind, "stale");
+});
+
+test("every finding is reported, not just the first", () => {
+  // An enumeration guard that stops at one gap makes the reader run it once per
+  // variable, and the second gap is found a day later than the first.
+  const result = check(workflowWith([...MINIMAL, 'LANGFLOW_ONE: "1"', 'LANGFLOW_TWO: "2"']));
+  assert.equal(result.findings.filter((f) => f.kind === "unclassified").length, 2);
+});
+
+test("a workflow this cannot read fails instead of reading as clean", () => {
+  // #1012's rule: unevaluated is not clean. A shape the reader does not understand
+  // must never come back as "no gaps found" — that is a green verdict nobody produced.
+  for (const broken of ["name: no services here", workflowWith([]).replace("        env:", "        # env:")]) {
+    const result = check(broken);
+    assert.equal(result.ok, false, `expected a refusal for: ${broken.slice(0, 40)}`);
+    assert.equal(result.findings[0].kind, "unreadable");
+  }
+});
+
+test("the same variable set twice in the service env is refused, not silently halved", () => {
+  const result = check(workflowWith([...MINIMAL, 'LANGFLOW_AUTO_LOGIN: "false"']));
+  assert.equal(result.ok, false);
+  assert.equal(result.findings[0].kind, "unreadable");
+  assert.match(result.findings[0].message, /set twice/);
+});
+
+test("the CLI exits 1 on a gap and names it, so the lane and a terminal agree", () => {
+  // The person holding an odd verdict is on the QA VM, not in the unit lane. Same code
+  // has to answer both, or the two answers can disagree.
+  const r = spawnSync(process.execPath, ["--input-type=module", "-e", `
+    import { checkVmEnvParity } from ${JSON.stringify(join(HERE, "lib/vm-env-parity.mjs"))};
+    const r = checkVmEnvParity({
+      workflow: ${JSON.stringify(workflowWith([...MINIMAL, 'LANGFLOW_SURPRISE: "1"']))},
+      orchestrator: "LANGFLOW_DEACTIVATE_TRACING", starter: "LANGFLOW_AUTO_LOGIN",
+      classification: ${JSON.stringify(CLASSES)},
+    });
+    process.stdout.write(JSON.stringify(r.findings.map((f) => f.name)));
+  `], { encoding: "utf8" });
+  assert.equal(r.status, 0, r.stderr);
+  assert.deepEqual(JSON.parse(r.stdout), ["LANGFLOW_SURPRISE"]);
+
+  const cli = spawnSync(process.execPath, [CLI, "--mode=nonsense"], { encoding: "utf8", cwd: REPO_ROOT });
+  assert.equal(cli.status, 2);
+});
+
+test("the pragmas' value survives being read out of the workflow", () => {
+  // The one declared value that is neither a bare word nor a quoted boolean: a
+  // single-quoted YAML scalar holding JSON. run-e2e.test.mjs compares the script's
+  // default against THIS, so a reader that mangled it would pin the wrong string.
+  const declared = readServiceEnv(readFileSync(join(REPO_ROOT, WORKFLOW_PATH), "utf8"));
+  const raw = declared.get("LANGFLOW_SQLITE_PRAGMAS");
+  assert.ok(raw, "daily-stable.yml no longer sets LANGFLOW_SQLITE_PRAGMAS");
+  assert.equal(JSON.parse(evaluateWorkflowValue(raw, {})).foreign_keys, "ON");
+});
+
+test("every classification entry carries a reason a human wrote", () => {
+  // A one-word reason is the shape this decays into, and it is the shape that stops
+  // being worth reading. Cheap to satisfy honestly, and it fails the copy-paste entry.
+  for (const [name, entry] of Object.entries(CLASSIFICATION)) {
+    assert.ok(entry.reason && entry.reason.length > 30, `${name}'s reason is too thin to act on: ${entry.reason}`);
+    assert.ok(
+      entry.carrier === null || ["orchestrator", "starter"].includes(entry.carrier),
+      `${name} names an unknown carrier: ${entry.carrier}`,
+    );
+  }
+});

--- a/scripts/lib/vm-env-parity.mjs
+++ b/scripts/lib/vm-env-parity.mjs
@@ -1,0 +1,273 @@
+// Read daily-stable.yml's Langflow service environment and say, for EVERY variable in
+// it, how the VM lane carries that variable to its instance — or why it deliberately
+// does not.
+//
+// WHY THIS EXISTS. #1714 was a single variable: LANGFLOW_DEACTIVATE_TRACING, pinned off
+// in the source starter while daily-stable.yml runs it on. It cost a full ~50-minute VM
+// run to surface and a PR to fix. It was an instance of a class, and the rest of that
+// class was still open when #1717 was filed.
+//
+// The class has two halves, and only one of them can be found by running the lane:
+//
+//   - The LOUD half turns the lane red. LANGFLOW_ALLOW_CUSTOM_COMPONENTS looked like
+//     this from the outside and turned out not to be: measured on the machine, the
+//     custom-component specs pass 8/8 without it, because the workflow sets it to
+//     override a default the nightly IMAGE bakes in and a source instance bakes in
+//     nothing. So the two lanes agree today for DIFFERENT REASONS — which is the
+//     second half wearing the first half's clothes.
+//   - The SILENT half produces agreement, not failure. Without
+//     LANGFLOW_SQLITE_PRAGMAS' `foreign_keys: ON`, a cascade/orphan defect (the
+//     upstream #13955 class) is invisible on the VM and visible on Actions: the raw
+//     DELETE "succeeds" leaving orphaned rows and the spec passes for the wrong
+//     reason. No amount of running the lane exposes that. This lane exists to COMPARE
+//     verdicts with the Actions daily, so a green that should not be green corrupts
+//     the exact product stage 1 of the migration was built to deliver.
+//
+// Hence a fail-closed enumeration rather than three more lines in a script: every
+// LANGFLOW_* on the workflow's service must either REACH the target or be RECORDED out
+// of scope with a reason, and the 11th variable the daily gains forces that decision
+// when it is written instead of opening a gap that surfaces whenever someone next
+// notices an odd verdict. Same shape watch-upstream-areas.mjs --mode=check uses for the
+// `lfx` subtrees (#1581's rule: the reason is what a future reader acts on).
+//
+// WHAT THIS FILE DOES NOT DECIDE. It matches NAMES against the files that carry them.
+// Whether run-e2e.sh's default for a variable equals the workflow's declared VALUE is
+// asserted by run-e2e.test.mjs, which sources the script and reads the value it would
+// actually send — text here, behaviour there. Both are needed: a name present with the
+// wrong value passes this file, and a value that never crosses the ssh boundary passes
+// that one.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = join(HERE, "..", "..");
+
+export const WORKFLOW_PATH = ".github/workflows/daily-stable.yml";
+export const ORCHESTRATOR_PATH = "scripts/run-e2e.sh";
+export const STARTER_PATH = "scripts/start-langflow-source.sh";
+
+// Full-line comments only, and never a trailing `#`. The failure this exists for
+// (#1300, repeated by #1716's first draft) is a comment line that merely SPELLS a
+// variable: it both masks a real setting and fails a CORRECT workflow. Trailing `#`
+// is left alone because a value may legitimately contain one, and cutting at the
+// first `#` would silently truncate it — the same class of wrong answer one layer down.
+export const stripComments = (text) =>
+  text
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+
+const indentOf = (line) => line.match(/^\s*/)[0].length;
+const isBlank = (line) => /^\s*$/.test(line);
+
+/**
+ * The VALUES are read by scripts/lib/gh-expression.mjs, not here and not by a regex —
+ * #1226's rule. That module already unquotes both YAML scalar forms, evaluates a
+ * `${{ … }}` expression against a supplied context, and THROWS on a shape it cannot
+ * read rather than returning the raw text as if it were a value. This file returns
+ * raw text and leaves the reading to it; a second unquoter here would be a second
+ * answer that can disagree with the first.
+ */
+
+/**
+ * The `env:` mapping of one service in a workflow's job, as a Map of name -> raw text.
+ *
+ * Scoped to the SERVICE BLOCK rather than grepped file-wide, and the difference is not
+ * cosmetic: daily-stable.yml also sets LANGFLOW_IMAGE and LANGFLOW_VERSION as step-level
+ * env in later jobs, where they name the image to report rather than configure the
+ * instance under test. A file-wide grep counts those as gaps in the VM lane forever.
+ */
+export function readServiceEnv(text, service = "langflow") {
+  const lines = stripComments(text).split("\n");
+
+  const enter = (from, indent, pattern, what) => {
+    const hits = [];
+    for (let i = from; i < lines.length; i += 1) {
+      if (isBlank(lines[i])) continue;
+      if (indent !== null && indentOf(lines[i]) <= indent) break;
+      if (pattern.test(lines[i])) hits.push(i);
+    }
+    // More than one match means this reader is looking at a file it does not
+    // understand, and the honest answer is to say so rather than to pick the first.
+    if (hits.length !== 1) throw new Error(`expected exactly one \`${what}\` block, found ${hits.length}`);
+    return hits[0];
+  };
+
+  const servicesAt = enter(0, null, /^\s*services:\s*$/, "services:");
+  const serviceAt = enter(servicesAt + 1, indentOf(lines[servicesAt]), new RegExp(`^\\s*${service}:\\s*$`), `${service}:`);
+  const envAt = enter(serviceAt + 1, indentOf(lines[serviceAt]), /^\s*env:\s*$/, `${service}.env:`);
+
+  const envIndent = indentOf(lines[envAt]);
+  const out = new Map();
+  for (let i = envAt + 1; i < lines.length; i += 1) {
+    if (isBlank(lines[i])) continue;
+    if (indentOf(lines[i]) <= envIndent) break;
+    const m = lines[i].match(/^\s*([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
+    if (!m) throw new Error(`unreadable line in ${service}.env: ${lines[i]}`);
+    if (out.has(m[1])) throw new Error(`${m[1]} is set twice in ${service}.env`);
+    out.set(m[1], m[2]);
+  }
+  if (out.size === 0) throw new Error(`${service}.env is empty, which cannot be right`);
+  return out;
+}
+
+/**
+ * How the VM lane carries each of daily-stable.yml's service variables.
+ *
+ * `carrier` is the file that must name the variable:
+ *   "orchestrator"  scripts/run-e2e.sh — the file whose declared job is mirroring the
+ *                   workflow. This is where a variable goes when the starters must NOT
+ *                   carry it: their environment blocks are asserted identical to
+ *                   start-langflow-pip.sh's precisely so that a spec cannot tell which
+ *                   starter brought its instance up (#1716's relocation).
+ *   "starter"       scripts/start-langflow-source.sh — where a value is right for any
+ *                   local instance, not just for this lane.
+ *
+ * `carrier: null` is out of scope, and then `reason` is mandatory.
+ *
+ * `sameValue: false` records a variable the VM lane carries with a DIFFERENT value on
+ * purpose; the reason is then the whole content of the decision, because nothing else
+ * in the repo will state it.
+ */
+export const CLASSIFICATION = {
+  LANGFLOW_AUTO_LOGIN: {
+    carrier: "starter",
+    reason: "every starter runs auto-login; the suite authenticates through /api/v1/auto_login",
+  },
+  LANGFLOW_SUPERUSER: {
+    carrier: "starter",
+    reason: "the credentials the suite logs in with, identical in all three starters",
+  },
+  LANGFLOW_SUPERUSER_PASSWORD: {
+    carrier: "starter",
+    reason:
+      "the other half of those credentials; the starter defaults both so a local instance and this lane authenticate identically",
+  },
+  LANGFLOW_WORKERS: {
+    carrier: "starter",
+    reason:
+      "carried as the `--workers` flag rather than the variable: `langflow run` takes it on the command line, and the starter has defaulted it to 1 since #888",
+  },
+  LANGFLOW_WORKER_TIMEOUT: {
+    carrier: "orchestrator",
+    reason:
+      "caps what one wedge costs (#1048). Not a starter default: 120 is chosen for THIS lane's load, and a developer's own instance has no reason to inherit it",
+  },
+  LANGFLOW_ALLOW_CUSTOM_COMPONENTS: {
+    carrier: "orchestrator",
+    reason:
+      "the workflow sets it to override a default the nightly IMAGE bakes in (`false`); a source instance bakes in nothing, so today the two lanes agree for different reasons. Mirrored so the day the product default moves, both lanes move with it — measured: the custom-component specs already pass 8/8 on the VM without it, so this is latent agreement, not a red lane (#1717)",
+  },
+  LANGFLOW_A2A_ENABLED: {
+    carrier: "starter",
+    reason:
+      "product default is OFF and its router is ALWAYS mounted, so with the flag off the three /api/v1/a2a/* routes answer 404 and every A2A spec passes while testing nothing (#1240, #1195). Right for any instance, so the starter carries it",
+  },
+  LANGFLOW_DEACTIVATE_TRACING: {
+    carrier: "orchestrator",
+    reason:
+      "both starters default it OFF — right for a developer's instance, wrong for the lane that must match CI. Relocated here by #1716 rather than changed in the starter",
+  },
+  LANGFLOW_SQLITE_PRAGMAS: {
+    carrier: "orchestrator",
+    reason:
+      "`foreign_keys: ON`. The silent half of #1717: with SQLite foreign keys off, a cascade/orphan defect (upstream #13955) is invisible on the VM and visible on Actions, so the lane agrees for the wrong reason and no run can refute it",
+  },
+  LANGFLOW_SSRF_ALLOWED_HOSTS: {
+    carrier: "starter",
+    sameValue: false,
+    reason:
+      "the CIDRs match; the workflow's extra `ollama` entry is a DOCKER SERVICE NAME that resolves only inside the Actions job network. On the VM the Ollama starter reports an RFC-1918 address and the run targets it by IP, which the shared CIDRs already authorise — so mirroring the literal string would add a hostname that resolves to nothing. Loopback stays out of both, because security/ssrf-url-validation.spec.ts asserts the refusal",
+  },
+};
+
+/**
+ * Compare the workflow's service env against the classification and the files that
+ * are supposed to carry it.
+ *
+ * Returns findings rather than throwing, so a caller can report all of them at once —
+ * an enumeration guard that stops at the first gap makes the reader run it N times.
+ */
+export function checkVmEnvParity({
+  workflow = readFileSync(join(REPO_ROOT, WORKFLOW_PATH), "utf8"),
+  orchestrator = readFileSync(join(REPO_ROOT, ORCHESTRATOR_PATH), "utf8"),
+  starter = readFileSync(join(REPO_ROOT, STARTER_PATH), "utf8"),
+  classification = CLASSIFICATION,
+} = {}) {
+  const findings = [];
+  const carried = [];
+
+  let env;
+  try {
+    env = readServiceEnv(workflow);
+  } catch (err) {
+    return {
+      ok: false,
+      carried,
+      findings: [{ kind: "unreadable", name: null, message: `cannot read the workflow's service env: ${err.message}` }],
+    };
+  }
+
+  const sources = {
+    orchestrator: { text: stripComments(orchestrator), path: ORCHESTRATOR_PATH },
+    starter: { text: stripComments(starter), path: STARTER_PATH },
+  };
+
+  const wanted = [...env.keys()].filter((name) => name.startsWith("LANGFLOW_"));
+
+  for (const name of wanted) {
+    const entry = classification[name];
+    if (!entry) {
+      findings.push({
+        kind: "unclassified",
+        name,
+        message:
+          `${name} is set on daily-stable.yml's Langflow service and the VM lane says nothing about it. ` +
+          `Either carry it (scripts/run-e2e.sh for a value chosen FOR this lane, the starter for one right ` +
+          `for any local instance) or record it out of scope with a reason in CLASSIFICATION.`,
+      });
+      continue;
+    }
+    if (entry.carrier === null) {
+      if (!entry.reason) {
+        findings.push({ kind: "no-reason", name, message: `${name} is out of scope with no reason recorded` });
+        continue;
+      }
+      carried.push({ name, carrier: null, reason: entry.reason });
+      continue;
+    }
+    const source = sources[entry.carrier];
+    if (!source) {
+      findings.push({ kind: "bad-carrier", name, message: `${name} names an unknown carrier: ${entry.carrier}` });
+      continue;
+    }
+    // The name, anywhere in the carrier — including as `--workers`' source variable,
+    // which is why this is a name search and not an assignment match. What the value
+    // becomes is run-e2e.test.mjs's question.
+    if (!source.text.includes(name)) {
+      findings.push({
+        kind: "not-carried",
+        name,
+        message: `${name} is classified as reaching the target through ${source.path}, and that file never names it`,
+      });
+      continue;
+    }
+    carried.push({ name, carrier: entry.carrier, reason: entry.reason, sameValue: entry.sameValue !== false });
+  }
+
+  // A classification entry for a variable the workflow no longer sets is not harmless:
+  // it is a reason a future reader will trust about a decision that no longer exists.
+  for (const name of Object.keys(classification)) {
+    if (!wanted.includes(name)) {
+      findings.push({
+        kind: "stale",
+        name,
+        message: `${name} is classified here but daily-stable.yml's service no longer sets it — drop the entry`,
+      });
+    }
+  }
+
+  return { ok: findings.length === 0, findings, carried, declared: env };
+}

--- a/scripts/lib/vm-env-parity.mjs
+++ b/scripts/lib/vm-env-parity.mjs
@@ -24,20 +24,45 @@
 //     the exact product stage 1 of the migration was built to deliver.
 //
 // Hence a fail-closed enumeration rather than three more lines in a script: every
-// LANGFLOW_* on the workflow's service must either REACH the target or be RECORDED out
+// variable on the workflow's service must either REACH the target or be RECORDED out
 // of scope with a reason, and the 11th variable the daily gains forces that decision
 // when it is written instead of opening a gap that surfaces whenever someone next
 // notices an odd verdict. Same shape watch-upstream-areas.mjs --mode=check uses for the
 // `lfx` subtrees (#1581's rule: the reason is what a future reader acts on).
 //
-// WHAT THIS FILE DOES NOT DECIDE. It matches NAMES against the files that carry them.
-// Whether run-e2e.sh's default for a variable equals the workflow's declared VALUE is
-// asserted by run-e2e.test.mjs, which sources the script and reads the value it would
-// actually send — text here, behaviour there. Both are needed: a name present with the
-// wrong value passes this file, and a value that never crosses the ssh boundary passes
-// that one.
+// EVERY variable, not every `LANGFLOW_*`. The first version filtered on that prefix
+// with no comment, which quietly made `DO_NOT_TRACK`, a `LANGSMITH_*` or a
+// `PYTHONUNBUFFERED` on the service read as clean — and a fail-closed promise is what
+// makes the next reader stop looking. All ten today happen to carry the prefix; the
+// enumeration does not depend on that.
+//
+// THREE PLACES A VARIABLE CAN GO WRONG, and this file covers the first two:
+//
+//   1. NOT CARRIED — no file forwards it. The original gap (#1717).
+//   2. SHADOWED — the orchestrator forwards it and the STARTER overwrites it. A
+//      `VAR=value` prefix on `uv run` does not "add to" the inherited environment for
+//      that name; it REPLACES it for that command. The first version of this file said
+//      otherwise, and the gap was measured on this branch: one line added to the
+//      starter's launch block, in the same shape `LANGFLOW_AUTO_LOGIN=true` is written
+//      two lines above it, left every guard green while the server lost
+//      `foreign_keys: ON` — the silent half of #1717 reintroduced one layer down. So a
+//      variable the orchestrator carries must be ABSENT from that block or written
+//      `${NAME:-…}`, which inherits. Shape borrowed from a2a-flag-lanes.test.mjs's
+//      "the default is true, not merely present".
+//   3. CARRIED WITH THE WRONG VALUE. Split, and the split is worth stating because
+//      neither half covers the other:
+//        - starter-carried names are compared HERE, textually: the default written in
+//          the launch block against the workflow's declared value
+//        - orchestrator-carried names are compared in run-e2e.test.mjs, which SOURCES
+//          the script and reads the value it would really send, then watches it cross
+//          the ssh boundary. Text cannot answer that, and this file does not try
+//
+// VALUES ARE READ, NEVER RE-PARSED. Both halves go through scripts/lib/gh-expression.mjs
+// — #1226's rule. A second unquoter here would be a second answer able to disagree with
+// the first.
 
 import { readFileSync } from "node:fs";
+import { evaluateWorkflowValue } from "./gh-expression.mjs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -63,13 +88,63 @@ const indentOf = (line) => line.match(/^\s*/)[0].length;
 const isBlank = (line) => /^\s*$/.test(line);
 
 /**
- * The VALUES are read by scripts/lib/gh-expression.mjs, not here and not by a regex —
- * #1226's rule. That module already unquotes both YAML scalar forms, evaluates a
- * `${{ … }}` expression against a supplied context, and THROWS on a shape it cannot
- * read rather than returning the raw text as if it were a value. This file returns
- * raw text and leaves the reading to it; a second unquoter here would be a second
- * answer that can disagree with the first.
+ * The prefix assignments the source starter puts on `uv run`, plus the flags it
+ * derives from an environment variable.
+ *
+ * Read by walking BACK from the `${RUN_CMD}` line rather than forward from a marker,
+ * because the block's beginning is a comment and its end is the command — and the end
+ * is the only one of the two that cannot move without the launch itself changing.
+ *
+ * THROWS when it finds no assignments at all: that means the starter's launch no
+ * longer has this shape, and the honest answer is to say so rather than to report an
+ * empty block as "nothing shadowed" (#1012 — unevaluated is not clean).
  */
+export function readStarterLaunchEnv(text) {
+  const lines = stripComments(text).split("\n");
+  const runAt = lines.findIndex((l) => l.includes("${RUN_CMD}"));
+  if (runAt < 0) throw new Error("the starter has no ${RUN_CMD} launch line");
+
+  const assignments = new Map();
+  for (let i = runAt - 1; i >= 0; i -= 1) {
+    const m = lines[i].match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*?)\s*\\$/);
+    if (!m) break;
+    const [, name, rawValue] = m;
+    // `NAME="${NAME:-default}"` is the overridable shape: the caller's value wins, so
+    // a variable written this way is forwarded, not shadowed. Greedy on purpose —
+    // LANGFLOW_DATABASE_URL's default itself contains `${STATE_DIR}`, and the closing
+    // brace of the expansion is the LAST one on the line.
+    const overridable = rawValue.match(new RegExp(`^"?\\$\\{${name}:-(.*)\\}"?$`));
+    assignments.set(name, {
+      raw: rawValue,
+      overridable: Boolean(overridable),
+      value: overridable ? overridable[1] : rawValue.replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1"),
+    });
+  }
+  if (assignments.size === 0) throw new Error("no prefix assignments found before the starter's ${RUN_CMD}");
+
+  // Flags whose value comes from a variable — `--workers "${LANGFLOW_WORKERS:-1}"`.
+  // The workflow sets LANGFLOW_WORKERS as an environment variable and the starter
+  // spends it on the command line, so a name-only check would call it missing.
+  const flags = new Map();
+  for (const m of text.matchAll(/--[a-z-]+\s+"?\$\{([A-Za-z_][A-Za-z0-9_]*):-([^}]*)\}"?/g)) {
+    flags.set(m[1], { value: m[2] });
+  }
+  return { assignments, flags };
+}
+
+/**
+ * The names the orchestrator actually composes into the remote environment.
+ *
+ * Read out of `mirrored_target_env`'s BODY, not out of the whole file. "The file names
+ * it somewhere" was the first version's test and it is not the property: a variable
+ * mentioned in a string, or left behind in a stale branch, would satisfy it while
+ * nothing reached the target.
+ */
+export function readMirroredNames(text) {
+  const body = stripComments(text).match(/mirrored_target_env\(\)\s*\{([\s\S]*?)\n\}/);
+  if (!body) throw new Error("the orchestrator has no mirrored_target_env() function");
+  return new Set([...body[1].matchAll(/([A-Za-z_][A-Za-z0-9_]*)=\$\(shq /g)].map((m) => m[1]));
+}
 
 /**
  * The `env:` mapping of one service in a workflow's job, as a Map of name -> raw text.
@@ -210,12 +285,29 @@ export function checkVmEnvParity({
     };
   }
 
-  const sources = {
-    orchestrator: { text: stripComments(orchestrator), path: ORCHESTRATOR_PATH },
-    starter: { text: stripComments(starter), path: STARTER_PATH },
+  let launch;
+  let mirrored;
+  try {
+    launch = readStarterLaunchEnv(starter);
+    mirrored = readMirroredNames(orchestrator);
+  } catch (err) {
+    return {
+      ok: false,
+      carried,
+      findings: [{ kind: "unreadable", name: null, message: `cannot read the VM lane's carriers: ${err.message}` }],
+    };
+  }
+
+  /** What the workflow declares, or null when it is a shape gh-expression refuses. */
+  const declaredValue = (name) => {
+    try {
+      return { value: evaluateWorkflowValue(env.get(name), {}) };
+    } catch (err) {
+      return { error: err.message };
+    }
   };
 
-  const wanted = [...env.keys()].filter((name) => name.startsWith("LANGFLOW_"));
+  const wanted = [...env.keys()];
 
   for (const name of wanted) {
     const entry = classification[name];
@@ -238,21 +330,81 @@ export function checkVmEnvParity({
       carried.push({ name, carrier: null, reason: entry.reason });
       continue;
     }
-    const source = sources[entry.carrier];
-    if (!source) {
+    if (!["orchestrator", "starter"].includes(entry.carrier)) {
       findings.push({ kind: "bad-carrier", name, message: `${name} names an unknown carrier: ${entry.carrier}` });
       continue;
     }
-    // The name, anywhere in the carrier — including as `--workers`' source variable,
-    // which is why this is a name search and not an assignment match. What the value
-    // becomes is run-e2e.test.mjs's question.
-    if (!source.text.includes(name)) {
+
+    const shadow = launch.assignments.get(name);
+
+    if (entry.carrier === "orchestrator") {
+      // Composed into the remote environment — read out of the function, not out of
+      // the file, so a stale mention cannot answer for a live one.
+      if (!mirrored.has(name)) {
+        findings.push({
+          kind: "not-carried",
+          name,
+          message: `${name} is classified as reaching the target through ${ORCHESTRATOR_PATH}, and mirrored_target_env() does not compose it`,
+        });
+        continue;
+      }
+      // …and NOT overwritten on arrival. This is the door #1716 walked through, one
+      // layer down: a prefix assignment on `uv run` replaces the inherited value for
+      // that name, so the orchestrator's value never reaches the server and every
+      // other check here still passes.
+      if (shadow && !shadow.overridable) {
+        findings.push({
+          kind: "shadowed",
+          name,
+          message:
+            `${name} is carried by ${ORCHESTRATOR_PATH} and then OVERWRITTEN by ${STARTER_PATH}'s launch block ` +
+            `(\`${name}=${shadow.raw}\`). A prefix assignment on \`uv run\` replaces the inherited value for that ` +
+            `name, so the value this lane sends never reaches the server — and nothing goes red. Write it ` +
+            `\`${name}="\${${name}:-…}"\` so the caller's value wins, or drop the line.`,
+        });
+        continue;
+      }
+      carried.push({ name, carrier: entry.carrier, reason: entry.reason, sameValue: entry.sameValue !== false });
+      continue;
+    }
+
+    // carrier === "starter": it must be in the launch block, or spent on a flag the
+    // way `--workers "${LANGFLOW_WORKERS:-1}"` spends LANGFLOW_WORKERS.
+    const flag = launch.flags.get(name);
+    if (!shadow && !flag) {
       findings.push({
         kind: "not-carried",
         name,
-        message: `${name} is classified as reaching the target through ${source.path}, and that file never names it`,
+        message: `${name} is classified as reaching the target through ${STARTER_PATH}, and its launch block neither sets it nor spends it on a flag`,
       });
       continue;
+    }
+
+    // The starter's own default against the workflow's declared value. Nothing else in
+    // the repo compares these six: run-e2e.test.mjs measures the orchestrator's four by
+    // sourcing the script, and a2a-flag-lanes.test.mjs pins the A2A shape in the docker
+    // and pip starters — not in this one, which is the starter this lane actually uses.
+    if (entry.sameValue !== false) {
+      const declared = declaredValue(name);
+      if (declared.error) {
+        findings.push({
+          kind: "unreadable-value",
+          name,
+          message: `${name}'s value in the workflow cannot be read, so parity is unverified — ${declared.error}`,
+        });
+        continue;
+      }
+      const mine = (shadow ?? flag).value;
+      if (mine !== declared.value) {
+        findings.push({
+          kind: "value-drift",
+          name,
+          message:
+            `${name}: daily-stable.yml declares ${JSON.stringify(declared.value)} and ${STARTER_PATH} uses ` +
+            `${JSON.stringify(mine)}. Match it, or record the difference with \`sameValue: false\` and the reason.`,
+        });
+        continue;
+      }
     }
     carried.push({ name, carrier: entry.carrier, reason: entry.reason, sameValue: entry.sameValue !== false });
   }

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -205,11 +205,16 @@ export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="${PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-u
 # starter brought its instance up, and a lane-specific value written there would either
 # break that assertion or defeat its purpose (#1716's relocation).
 #
-# How these actually arrive. Each is passed as a `VAR=value` prefix on the remote
-# `bash -s`, which puts it in THAT shell's environment; the starter never names them and
-# does not need to — its own settings are prefix assignments on `uv run`, which add to
-# the inherited environment rather than replace it, so the server sees both. That is
-# what lets a variable be mirrored here without touching the starter at all.
+# How these actually arrive, stated precisely because the first draft of this comment
+# was wrong and the error was load-bearing. Each is passed as a `VAR=value` prefix on
+# the remote `bash -s`, which puts it in THAT shell's environment, and the starter
+# inherits it. The starter does not need to name them — but if it DOES name one with a
+# literal, its own `uv run` prefix assignment REPLACES the inherited value for that name
+# instead of adding to it, and what this file sends never reaches the server. Nothing
+# turns red when that happens: it is the silent half of #1717, one layer down. So the
+# rule is checked rather than trusted — scripts/check-vm-env-parity.mjs refuses a
+# mirrored name that start-langflow-source.sh's launch block sets to anything other than
+# `${NAME:-…}`, which is the shape that lets the caller's value win.
 #
 # Every value is overridable, and an override is how a MACHINE records a measured
 # exception — the qa VM overrides tracing while #1720 is open, with the reason written
@@ -272,7 +277,7 @@ LANGFLOW_SQLITE_PRAGMAS="${LANGFLOW_SQLITE_PRAGMAS:-$DEFAULT_SQLITE_PRAGMAS}"
 # reason the tracing override is: a machine may need a measured exception, and it
 # records the reason where it makes it.
 node -e 'const v=process.argv[1];let p;try{p=JSON.parse(v)}catch(e){console.error("LANGFLOW_SQLITE_PRAGMAS is not valid JSON ("+e.message+"): "+v);process.exit(1)}if(p===null||typeof p!=="object"||Array.isArray(p)){console.error("LANGFLOW_SQLITE_PRAGMAS must be a JSON object, got: "+v);process.exit(1)}' \
-  "$LANGFLOW_SQLITE_PRAGMAS" || exit 1
+  "$LANGFLOW_SQLITE_PRAGMAS"
 
 # ---------------------------------------------------------------------------
 # UTILITIES

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -194,22 +194,85 @@ export PATH="$HOME/.local/bin:$PATH"
 # globalSetup — see the migration's divergence list, entry 1.
 export PLAYWRIGHT_HOST_PLATFORM_OVERRIDE="${PLAYWRIGHT_HOST_PLATFORM_OVERRIDE:-ubuntu24.04-x64}"
 
+# ---------------------------------------------------------------------------
+# THE DAILY'S SERVICE ENVIRONMENT, MIRRORED
+# ---------------------------------------------------------------------------
+# daily-stable.yml configures the instance under test through its service `env:` block.
+# Everything there that is right for ANY local instance already lives in the starters;
+# what is chosen FOR THIS LANE belongs here, in the file whose declared job is
+# mirroring that workflow. The split is not a preference: the starters' env blocks are
+# asserted identical to start-langflow-pip.sh's precisely so a spec cannot tell which
+# starter brought its instance up, and a lane-specific value written there would either
+# break that assertion or defeat its purpose (#1716's relocation).
+#
+# How these actually arrive. Each is passed as a `VAR=value` prefix on the remote
+# `bash -s`, which puts it in THAT shell's environment; the starter never names them and
+# does not need to — its own settings are prefix assignments on `uv run`, which add to
+# the inherited environment rather than replace it, so the server sees both. That is
+# what lets a variable be mirrored here without touching the starter at all.
+#
+# Every value is overridable, and an override is how a MACHINE records a measured
+# exception — the qa VM overrides tracing while #1720 is open, with the reason written
+# beside it. What is pinned here is the DEFAULT: scripts/check-vm-env-parity.mjs fails
+# when the workflow gains a service variable this file neither carries nor classifies,
+# and run-e2e.test.mjs reads each default OUT OF the workflow instead of out of a copy,
+# so a value changed there cannot leave this one behind (#1717).
+
+# Rejecting a value that is neither `true` nor `false` instead of passing it through:
+# these flags read anything that is not "true" as false, so `0`, `FALSE` or a value
+# carrying a space would go in silently and invert the setting with nothing said —
+# #1714's failure class, arriving through the caller rather than through a file.
+require_bool() {
+  case "$2" in
+    true | false) ;;
+    *) echo "$1 must be exactly 'true' or 'false', got: '$2'" >&2; exit 1 ;;
+  esac
+}
+
 # Tracing ON, because daily-stable.yml runs with it on and the traces/observability
 # specs assert against a traced instance. Both starters default it OFF — right for a
-# developer's own instance, wrong for the lane that has to match CI — so the value
-# belongs here, in the file whose whole job is mirroring that workflow. Measured, not
-# assumed: on 2026-09-04 eight @stable specs failed on the VM while the same day's
-# Actions daily was green, for no reason other than this variable (#1714). Read the
-# workflow before changing it — run-e2e.test.mjs asserts the two agree.
+# developer's own instance, wrong for the lane that has to match CI. Measured, not
+# assumed: on 2026-09-04 nine @stable specs failed on the VM while the same day's
+# Actions daily was green, for no reason other than this variable (#1714).
 LANGFLOW_DEACTIVATE_TRACING="${LANGFLOW_DEACTIVATE_TRACING:-false}"
-# Checked because this is the first CALLER-supplied value to be interpolated into
-# the remote command bare, and because the flag reads anything that is not "true"
-# as false. `0`, `FALSE` or a value carrying a space would go in silently and land
-# the lane back in #1714 — tracing off, nothing said.
-case "$LANGFLOW_DEACTIVATE_TRACING" in
-  true | false) ;;
-  *) echo "LANGFLOW_DEACTIVATE_TRACING must be exactly 'true' or 'false', got: '$LANGFLOW_DEACTIVATE_TRACING'" >&2; exit 1 ;;
+require_bool LANGFLOW_DEACTIVATE_TRACING "$LANGFLOW_DEACTIVATE_TRACING"
+
+# Caps what ONE wedge costs (#1048). The value is a heartbeat watchdog on the event
+# loop, not a per-request deadline, and a wedged worker never recovers on its own. Not
+# a starter default: 120 is chosen for THIS lane's load, and a developer's instance has
+# no reason to inherit it. Read daily-stable.yml's comment before changing it — it
+# records why the product's own docs argue for the opposite and are wrong.
+LANGFLOW_WORKER_TIMEOUT="${LANGFLOW_WORKER_TIMEOUT:-120}"
+case "$LANGFLOW_WORKER_TIMEOUT" in
+  '' | *[!0-9]*) echo "LANGFLOW_WORKER_TIMEOUT must be a positive integer of seconds, got: '$LANGFLOW_WORKER_TIMEOUT'" >&2; exit 1 ;;
 esac
+[ "$LANGFLOW_WORKER_TIMEOUT" -gt 0 ] || { echo "LANGFLOW_WORKER_TIMEOUT must be greater than zero." >&2; exit 1; }
+
+# The workflow sets this to OVERRIDE a default the nightly image bakes in (`false`, a
+# security default). A source instance bakes in nothing, so the two lanes agree today
+# for DIFFERENT REASONS — measured on 2026-09-04, the custom-component specs pass 8/8
+# on the VM without it. Mirrored anyway, and that is exactly #1717's point: latent
+# agreement is the half of this class no run can report, because the day the product
+# default moves, only one lane notices.
+LANGFLOW_ALLOW_CUSTOM_COMPONENTS="${LANGFLOW_ALLOW_CUSTOM_COMPONENTS:-true}"
+require_bool LANGFLOW_ALLOW_CUSTOM_COMPONENTS "$LANGFLOW_ALLOW_CUSTOM_COMPONENTS"
+
+# `foreign_keys: ON`. The dict replaces the product default wholesale, so the default
+# pragmas are repeated here rather than merged. This is the SILENT half of #1717: with
+# SQLite foreign keys off, a cascade/orphan defect (upstream #13955, the span -> trace
+# FK) leaves the raw DELETE "succeeding" with orphaned rows, so traces-delete-cascade
+# passes on the VM and fails on Actions. This lane's entire product is the comparison
+# between those two verdicts, so this one cannot be found by running anything: it
+# produces agreement, not failure.
+DEFAULT_SQLITE_PRAGMAS='{"synchronous": "NORMAL", "journal_mode": "WAL", "busy_timeout": 30000, "foreign_keys": "ON"}'
+LANGFLOW_SQLITE_PRAGMAS="${LANGFLOW_SQLITE_PRAGMAS:-$DEFAULT_SQLITE_PRAGMAS}"
+# Parseability, not content. Malformed JSON is never intentional and Langflow falls
+# back to its own defaults without saying so — this variable's failure mode arriving
+# through the caller. WHICH pragmas are set stays the operator's call, for the same
+# reason the tracing override is: a machine may need a measured exception, and it
+# records the reason where it makes it.
+node -e 'const v=process.argv[1];let p;try{p=JSON.parse(v)}catch(e){console.error("LANGFLOW_SQLITE_PRAGMAS is not valid JSON ("+e.message+"): "+v);process.exit(1)}if(p===null||typeof p!=="object"||Array.isArray(p)){console.error("LANGFLOW_SQLITE_PRAGMAS must be a JSON object, got: "+v);process.exit(1)}' \
+  "$LANGFLOW_SQLITE_PRAGMAS" || exit 1
 
 # ---------------------------------------------------------------------------
 # UTILITIES
@@ -223,6 +286,39 @@ die()  { err "$*"; exit 1; }
 
 # shellcheck disable=SC2086
 target_ssh() { ssh -o BatchMode=yes -o ConnectTimeout=15 $TARGET_SSH_OPTS "$TARGET_SSH" "$@"; }
+
+# Shell-quote a value for the shell on the OTHER side of ssh. ssh joins its arguments
+# with spaces and hands ONE string to a shell over there, so anything unquoted is
+# re-split on arrival. Every mirrored value used to be a bare word and survived that;
+# LANGFLOW_SQLITE_PRAGMAS is a JSON object, and unquoted it would set the variable to
+# `{"synchronous":` and feed the remaining five words to `bash -s` as arguments.
+# Single quotes, closed and reopened around each embedded one (`'\''`) — the POSIX
+# form, so it does not depend on the login shell ssh happens to start over there, and
+# it stays readable in a log. `printf %q` round-trips too, but its output is
+# bash-specific and unreadable at a glance.
+#
+# Written with sed rather than `${1//\'/…}` because the parameter-expansion form is
+# what the first version used and it was WRONG: inside double quotes the backslashes
+# are consumed twice, and it produced `'it\'\\'\'s'`, which does not parse at all. No
+# mirrored value carries a quote today — this would arrive the day someone overrides
+# one from a wrapper, and the failure would be a syntax error in a remote command
+# nobody ever printed.
+shq() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+
+# The environment the target's shell must carry for its instance to match the one
+# daily-stable.yml's service brings up — see THE DAILY'S SERVICE ENVIRONMENT above for
+# why each value lives here and not in the starter.
+#
+# A function rather than a string spelled into the ssh line, so the unit tests can read
+# exactly what would be sent, quoting included, without a machine to send it to. The
+# trailing space is part of the contract: the caller concatenates.
+mirrored_target_env() {
+  printf '%s' \
+    "LANGFLOW_DEACTIVATE_TRACING=$(shq "$LANGFLOW_DEACTIVATE_TRACING") " \
+    "LANGFLOW_WORKER_TIMEOUT=$(shq "$LANGFLOW_WORKER_TIMEOUT") " \
+    "LANGFLOW_ALLOW_CUSTOM_COMPONENTS=$(shq "$LANGFLOW_ALLOW_CUSTOM_COMPONENTS") " \
+    "LANGFLOW_SQLITE_PRAGMAS=$(shq "$LANGFLOW_SQLITE_PRAGMAS") "
+}
 
 # Should this run place the target's clone, and if not, why not?
 #
@@ -676,7 +772,7 @@ start_backend_for_shard() {
   # clone, and its absence fails with the right message for the wrong reason.
   # shellcheck disable=SC2086
   ssh -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 $TARGET_SSH_OPTS "$TARGET_SSH" \
-    "PATH=\$HOME/.local/bin:\$PATH LANGFLOW_SRC_REPO=\${LANGFLOW_SRC_REPO:-\$HOME/langflow} LANGFLOW_REQUIRE_BUILD_STAMP=$STAMP_REQUIRED LANGFLOW_DEACTIVATE_TRACING=$LANGFLOW_DEACTIVATE_TRACING ${bind_env}LANGFLOW_PORT=$port bash -s; sleep 86400" \
+    "PATH=\$HOME/.local/bin:\$PATH LANGFLOW_SRC_REPO=\${LANGFLOW_SRC_REPO:-\$HOME/langflow} LANGFLOW_REQUIRE_BUILD_STAMP=$STAMP_REQUIRED $(mirrored_target_env)${bind_env}LANGFLOW_PORT=$port bash -s; sleep 86400" \
     < scripts/start-langflow-source.sh > "$holder_log" 2>&1 &
   HELD_SESSIONS+=("$!")
 

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -213,10 +213,29 @@ test("a custom-components value that is neither true nor false stops the run", (
 test("a worker timeout that is not a positive integer stops the run", () => {
   // gunicorn hands this to a watchdog. A non-numeric value is not a slow ceiling, it
   // is no ceiling — and #1048's whole point is bounding what one wedge costs.
-  for (const bad of ["", "abc", "12s", "-5", "0"]) {
-    const r = sourced(`echo unreachable`, { LANGFLOW_WORKER_TIMEOUT: bad || "x" });
+  //
+  // The empty string is NOT in this list, and both reviewers caught it there: the
+  // first version wrote `bad || "x"`, which substituted "x" for it, so the empty case
+  // was never sent while a failure would have printed `LANGFLOW_WORKER_TIMEOUT=""`
+  // about a value it did not test. It also cannot belong here — `:-` treats empty as
+  // unset, so empty legitimately takes the default. That is the test below.
+  for (const bad of ["abc", "12s", "-5", "0", "1 2"]) {
+    const r = sourced(`echo unreachable`, { LANGFLOW_WORKER_TIMEOUT: bad });
     assert.notEqual(r.status, 0, `LANGFLOW_WORKER_TIMEOUT=${JSON.stringify(bad)} should have been refused`);
     assert.match(r.stderr, /LANGFLOW_WORKER_TIMEOUT must be/);
+  }
+});
+
+test("an empty override is an absent one, for every mirrored variable", () => {
+  // The property the dead case was hiding, and it is worth pinning in its own right:
+  // `${VAR:-default}` treats empty as unset, so a wrapper that exports a mirrored name
+  // and leaves it blank gets the workflow's value rather than an empty one handed to
+  // the server. It is also what makes every other test in this file honest, since they
+  // all blank the environment to measure the defaults.
+  for (const name of MIRRORED) {
+    const raw = DECLARED.get(name);
+    const r = sourced(`printf '<<%s>>' "$${name}"`, { ...BLANKED, [name]: "" });
+    assert.equal(r.stdout.match(/<<([\s\S]*)>>/)?.[1], evaluateWorkflowValue(raw, {}), `${name} empty should take the default`);
   }
 });
 

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -29,6 +29,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { evaluateWorkflowValue } from "./lib/gh-expression.mjs";
+import { readServiceEnv, CLASSIFICATION } from "./lib/vm-env-parity.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..");
@@ -138,53 +139,57 @@ test("the publish switches are OFF by default, all four of them", () => {
   assert.equal(r.stdout.trim(), "0 0 0 0");
 });
 
-// Comment lines go before anything is matched, for the reason watch-tokens.test.mjs
-// already paid for at #1300: a `#` line merely SPELLING the old value could both mask
-// a real setting and fail a CORRECT workflow — and the failure message would then
-// invite the next reader to "fix" this lane by restoring the value that caused #1714.
-const stripComments = (text) =>
-  text
-    .split("\n")
-    .filter((line) => !/^\s*#/.test(line))
-    .join("\n");
+// daily-stable.yml's Langflow service environment, read once. The reader strips
+// full-line comments for the reason watch-tokens.test.mjs already paid for at #1300 —
+// a `#` line merely SPELLING a value both masks a real setting and fails a CORRECT
+// workflow — and scopes the read to the SERVICE block, so the LANGFLOW_IMAGE and
+// LANGFLOW_VERSION that later jobs set as step env cannot read as gaps in this lane.
+const DECLARED = readServiceEnv(readFileSync(join(REPO_ROOT, ".github/workflows/daily-stable.yml"), "utf8"));
 
-test("the lane runs tracing the way the workflow does, read out of the workflow", () => {
+// The variables this script is the declared carrier for. DERIVED from the
+// classification rather than listed here as well: a variable added there and given no
+// default in the script would otherwise be pinned by nothing, which is the gap the
+// classification exists to close.
+const MIRRORED = Object.entries(CLASSIFICATION)
+  .filter(([, entry]) => entry.carrier === "orchestrator" && entry.sameValue !== false)
+  .map(([name]) => name);
+
+// `sourced()` forwards process.env, so an exported LANGFLOW_* — on the VM, or in the
+// shell of whoever was debugging #1714 — would answer for the default and let these
+// tests pass with the line deleted. `:-` treats empty as unset, so blanking measures
+// the default itself.
+const BLANKED = Object.fromEntries(MIRRORED.map((name) => [name, ""]));
+
+test("this lane mirrors the workflow's own values, read out of the workflow", () => {
   // What this pins cost nine @stable tests on 2026-09-04: the VM lane came back red
   // while the same day's Actions daily was green, because all three starters keep
-  // tracing OFF and daily-stable.yml runs it ON. A literal here would drift the moment
-  // the workflow changed, so the expectation is READ from the workflow, never copied.
-  const wf = stripComments(readFileSync(join(REPO_ROOT, ".github/workflows/daily-stable.yml"), "utf8"));
+  // tracing OFF and daily-stable.yml runs it ON (#1714). A literal here would drift
+  // the moment the workflow changed, so every expectation is READ from the workflow,
+  // never copied — and the loop is over the classification, so the next variable to be
+  // mirrored is covered by this test on the day it is classified.
+  assert.ok(MIRRORED.length >= 4, `expected the lane to mirror several variables, found ${MIRRORED.length}`);
 
-  // EVERY occurrence, not the first: a second setting further down the file would
-  // otherwise pass unnoticed while this lane mirrored only one of them.
-  const settings = [...wf.matchAll(/LANGFLOW_DEACTIVATE_TRACING:\s*(.+)/g)].map((m) => m[1].trim());
-  assert.equal(
-    settings.length,
-    1,
-    `daily-stable.yml must set the tracing flag exactly once for this to be readable; found ${settings.length}`,
-  );
+  for (const name of MIRRORED) {
+    const raw = DECLARED.get(name);
+    assert.ok(raw !== undefined, `${name} is mirrored here, but daily-stable.yml's service does not set it`);
 
-  // Evaluated rather than string-compared, for the day the value becomes an
-  // expression — it already is one on pr-validation.yml. An expression this cannot
-  // evaluate fails here deliberately: a guard that cannot read the value is a guard
-  // that is not checking it.
-  let declared;
-  try {
-    declared = evaluateWorkflowValue(settings[0], {});
-  } catch (err) {
-    assert.fail(`cannot evaluate daily-stable.yml's tracing setting, so it is unverified — ${err.message}`);
+    // Evaluated rather than string-compared, for the day a value becomes an expression
+    // — it already is one on pr-validation.yml. An expression this cannot evaluate
+    // fails deliberately: a guard that cannot read the value is a guard that is not
+    // checking it (#1226).
+    let declared;
+    try {
+      declared = evaluateWorkflowValue(raw, {});
+    } catch (err) {
+      assert.fail(`cannot evaluate daily-stable.yml's ${name}, so it is unverified — ${err.message}`);
+    }
+
+    // Delimited, because an empty value and a value this failed to read are otherwise
+    // the same empty string.
+    const r = sourced(`printf '<<%s>>' "$${name}"`, BLANKED);
+    const got = r.stdout.match(/<<([\s\S]*)>>/)?.[1];
+    assert.equal(got, declared, `this lane has to run ${name} the way daily-stable.yml does`);
   }
-
-  // The environment is blanked, not inherited. `sourced()` forwards process.env, so an
-  // exported LANGFLOW_DEACTIVATE_TRACING — on the VM, or in the shell of whoever was
-  // debugging #1714 — would answer for the default and let this test pass with the
-  // line deleted. `:-` treats empty as unset, so this measures the default itself.
-  const r = sourced(`echo "$LANGFLOW_DEACTIVATE_TRACING"`, { LANGFLOW_DEACTIVATE_TRACING: "" });
-  assert.equal(
-    r.stdout.trim(),
-    declared,
-    `this lane has to trace the way daily-stable.yml does (${declared})`,
-  );
 });
 
 test("a tracing value that is neither true nor false stops the run", () => {
@@ -194,6 +199,36 @@ test("a tracing value that is neither true nor false stops the run", () => {
   const r = sourced(`echo unreachable`, { LANGFLOW_DEACTIVATE_TRACING: "0" });
   assert.notEqual(r.status, 0);
   assert.match(r.stderr, /must be exactly 'true' or 'false'/);
+});
+
+test("a custom-components value that is neither true nor false stops the run", () => {
+  // Same reader, same class: `0` here would disable the feature while reading as a
+  // deliberate setting, and the custom-component specs would fail against a disabled
+  // surface rather than exercise it.
+  const r = sourced(`echo unreachable`, { LANGFLOW_ALLOW_CUSTOM_COMPONENTS: "0" });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /LANGFLOW_ALLOW_CUSTOM_COMPONENTS must be exactly 'true' or 'false'/);
+});
+
+test("a worker timeout that is not a positive integer stops the run", () => {
+  // gunicorn hands this to a watchdog. A non-numeric value is not a slow ceiling, it
+  // is no ceiling — and #1048's whole point is bounding what one wedge costs.
+  for (const bad of ["", "abc", "12s", "-5", "0"]) {
+    const r = sourced(`echo unreachable`, { LANGFLOW_WORKER_TIMEOUT: bad || "x" });
+    assert.notEqual(r.status, 0, `LANGFLOW_WORKER_TIMEOUT=${JSON.stringify(bad)} should have been refused`);
+    assert.match(r.stderr, /LANGFLOW_WORKER_TIMEOUT must be/);
+  }
+});
+
+test("pragmas that are not a JSON object stop the run", () => {
+  // Langflow falls back to its own defaults on a value it cannot parse, without saying
+  // so — which is this variable's own failure mode (a silent loss of foreign_keys)
+  // arriving through the caller.
+  for (const bad of ["{oops", '["foreign_keys"]', '"ON"']) {
+    const r = sourced(`echo unreachable`, { LANGFLOW_SQLITE_PRAGMAS: bad });
+    assert.notEqual(r.status, 0, `LANGFLOW_SQLITE_PRAGMAS=${bad} should have been refused`);
+    assert.match(r.stderr, /LANGFLOW_SQLITE_PRAGMAS/);
+  }
 });
 
 test("the lane does not append to the daily's token series", () => {
@@ -207,15 +242,78 @@ test("the lane does not append to the daily's token series", () => {
   assert.match(line, /TOKENS_SUPPRESS_HISTORY=1/);
 });
 
-test("the tracing value crosses the ssh boundary, which a default alone does not", () => {
-  // The failure mode this catches LOOKS fixed: the value is set here, the shell that
+test("the mirrored values cross the ssh boundary, which a default alone does not", () => {
+  // The failure mode this catches LOOKS fixed: the values are set here, the shell that
   // runs the starter is on the other machine, and it inherits nothing from this one.
   // A variable that never crosses is a variable that never applied.
   const line = readFileSync(SCRIPT, "utf8")
     .split("\n")
     .find((l) => l.includes("bash -s; sleep 86400"));
   assert.ok(line, "could not find the command that starts the backend on the target");
-  assert.match(line, /LANGFLOW_DEACTIVATE_TRACING=\$LANGFLOW_DEACTIVATE_TRACING/);
+  assert.match(line, /\$\(mirrored_target_env\)/);
+
+  // And what that composer would actually produce, rather than the fact that it is
+  // called: a variable dropped from the function is invisible to the line above.
+  const r = sourced(`mirrored_target_env`, BLANKED);
+  for (const name of MIRRORED) {
+    assert.match(r.stdout, new RegExp(`(^|\\s)${name}=`), `${name} never reaches the target's shell`);
+  }
+});
+
+test("the remote quoting survives a value carrying a quote, which no current value does", () => {
+  // The branch none of today's values reach, and therefore the one that will be wrong
+  // when it is first needed — the day someone overrides a mirrored variable from the
+  // qa wrapper. The first implementation was wrong here and passed every other test in
+  // this file: `${1//\\'/…}` eats its backslashes twice inside double quotes and
+  // produced a string that did not parse.
+  const hostile = `it's {"a": "b"} and $x`;
+  // Handed over through the ENVIRONMENT, not spelled into the body: a double-quoted
+  // literal would let this shell expand the `$x` before shq ever saw it, and the test
+  // would then be quoting a string it had already flattened.
+  const r = sourced(
+    [
+      `q="$(shq "$HOSTILE")"`,
+      `printf '%s\\n' 'printf "%s" "$X"' | env -u X bash -c "X=$q bash -s"`,
+    ].join("\n"),
+    { HOSTILE: hostile },
+  );
+  assert.equal(r.status, 0, r.stderr);
+  // Not just "it parsed": `$x` must arrive unexpanded, which is the other half of what
+  // quoting is for here.
+  assert.equal(r.stdout, hostile);
+});
+
+test("a mirrored value survives the shell on the far side, spaces and quotes included", () => {
+  // ssh joins its arguments and hands ONE string to a shell over there, so anything
+  // unquoted is re-split on arrival. Every mirrored value used to be a bare word and
+  // survived that by luck; LANGFLOW_SQLITE_PRAGMAS is a JSON object, and unquoted it
+  // sets the variable to `{"synchronous":` and feeds five loose words to `bash -s`.
+  //
+  // `bash -c "$remote"` is the far side: same concatenated string, same re-split.
+  //
+  // Every mirrored name is UNSET for it, and that is the load-bearing half. ssh
+  // forwards no environment, so the only way a value can arrive there is inside the
+  // command string — while this test's own shell holds all of them, exported by the
+  // harness. Without the `env -u` the far side would read them by inheritance and the
+  // test would pass with the composer emptied, which is the exact failure the test
+  // above exists for, reintroduced one layer down. Measured: dropping the pragmas from
+  // the composer left this assertion green until the unsets were added.
+  const unset = MIRRORED.map((name) => `-u ${name}`).join(" ");
+  const r = sourced(
+    [
+      `remote="$(mirrored_target_env)LANGFLOW_PORT=7999 bash -s"`,
+      `printf '%s\\n' 'printf "%s" "$LANGFLOW_SQLITE_PRAGMAS"' | env ${unset} bash -c "$remote"`,
+    ].join("\n"),
+    BLANKED,
+  );
+  assert.equal(r.status, 0, r.stderr);
+  // Parsed, not string-matched: the property is that the far side can still READ it.
+  const pragmas = JSON.parse(r.stdout);
+  assert.equal(
+    pragmas.foreign_keys,
+    "ON",
+    "the pragmas arrived unreadable, so the cascade class silently stops being compared",
+  );
 });
 
 test("the version check is on by default, and so is enforcing it", () => {


### PR DESCRIPTION
Closes #1717.

## What was measured

`daily-stable.yml` sets **ten** `LANGFLOW_*` variables on the Langflow service it tests. The VM path — `run-e2e.sh` → ssh → `start-langflow-source.sh` — carried **seven**. Three never reached the instance, and they are not equally visible:

| Variable | What its absence costs |
|---|---|
| `LANGFLOW_SQLITE_PRAGMAS` | **The silent one.** `foreign_keys: ON` is what makes a cascade/orphan defect (upstream #13955) visible. Without it the raw DELETE "succeeds" leaving orphaned rows, so `traces-delete-cascade` passes on the VM and fails on Actions — the comparison reports agreement, and no run can refute it |
| `LANGFLOW_ALLOW_CUSTOM_COMPONENTS` | **Latent agreement.** The workflow sets it to override a default the nightly *image* bakes in; a source instance bakes in nothing, so the two lanes agree today for different reasons. The day the product default moves, only one lane notices |
| `LANGFLOW_WORKER_TIMEOUT` | Bounds what one wedge costs (#1048), so the two lanes attribute flakes the same way |

The issue's table marked `LANGFLOW_ALLOW_CUSTOM_COMPONENTS` **Red** and offered it as the ninth failure of the run that raised #1714. That was already corrected in the issue's own comments, and this PR follows the correction: measured on the machine, the custom-component specs pass **8/8** on the VM without the variable. It is mirrored because it is latent, not because it is failing.

## Where the fix lives, and why not in the starter

In `run-e2e.sh`. The starters' environment blocks are asserted identical to `start-langflow-pip.sh`'s precisely so **a spec cannot tell which starter brought its instance up**; a lane-specific value written there would either break that assertion or defeat its purpose. Same relocation #1716 made for tracing.

No starter change was needed, and the mechanism is worth stating because it is the load-bearing part: a `VAR=value` prefix on the remote `bash -s` lands in **that shell's environment**, and the starter's own settings are prefix assignments on `uv run`, which *add to* the inherited environment rather than replace it. The server sees both.

## The quoting bug the new values exposed

`ssh` joins its arguments and hands **one** string to a shell on the far side, so anything unquoted is re-split there. Every mirrored value so far was a bare word and survived that by luck. `LANGFLOW_SQLITE_PRAGMAS` is a JSON object: unquoted, the variable arrives as `{"synchronous":` with five loose words after it.

`shq` quotes for the remote shell and `mirrored_target_env` composes the prefix as a **function**, so the tests can read exactly what would be sent — quoting included — without a machine to send it to.

## The guard, which is the point of the issue

Three lines in a script fix today. The enumeration is what makes the 11th variable force a decision when it is written:

```
node scripts/check-vm-env-parity.mjs --mode=check   # fail-closed verdict
node scripts/check-vm-env-parity.mjs --mode=list    # the table
```

Every `LANGFLOW_*` on the workflow's service must either **reach the target** or be **recorded out of scope with a reason** — the shape `watch-upstream-areas.mjs --mode=check` already uses. It runs in `npm run test:scripts`, and as a CLI too, because the person holding an odd verdict is on the QA VM.

Two things the reader gets right, both learned in #1716's review:

- **full-line comments are stripped first**, and a comment naming a variable counts in *neither* direction — it must not mask a real setting, and it must not fail a correct workflow (#1300)
- **the read is scoped to the service block.** `daily-stable.yml` also sets `LANGFLOW_IMAGE` and `LANGFLOW_VERSION` as step env in its reporting jobs; counted as service variables they would be permanent, unfixable gaps. That is also why the count here is 10 and the issue said 12
- values go through `scripts/lib/gh-expression.mjs`, not a regex — #1226's rule. The first draft of the reader duplicated that unquoting and would have been a second answer able to disagree with the first

## Machine exceptions still work, deliberately

Every mirrored value stays overridable. That is how a **machine** records a measured exception — the qa VM overrides tracing while #1720 is open, with the reason beside it. What is pinned is the **default**, and it is read *out of the workflow* rather than copied, so a value changed there cannot leave this one behind. The parity test loops over the classification, so the next variable to be mirrored is covered by it on the day it is classified.

Pragma **content** is left to the operator for the same reason; only parseability is enforced, because malformed JSON is never intentional and Langflow falls back to its own defaults without saying so.

## Pinned by mutation, and two of the pins exist because the mutation failed first

- removing a variable from the composer → caught
- a workflow default changed without the script following → caught
- **the far-side test did not catch the first case.** It ran the remote shell with *this* shell's environment, so the value arrived by inheritance and the assertion stayed green with the composer emptied — the exact failure it was written for, one layer down. `env -u` per mirrored name is what makes it a real boundary
- **the first `shq` was wrong.** The `${1//\'/…}` form eats its backslashes twice inside double quotes and produced `'it\'\\'\'s'`, which does not parse. No current value carries a quote, so nothing else in the suite would have found it; there is now a test for the branch none of today's values reach
- guard side: an unclassified variable fails; a comment naming one does not; a classification claiming a carrier that never names the variable fails; a carrier's own *comment* does not count as carrying; out of scope with no reason is not out of scope; a stale entry fails; an unreadable workflow fails rather than reading as clean (#1012)

Writing the classification is what found the first gap: `LANGFLOW_A2A_ENABLED` was missing from it, and the guard said so on its first run against the real repository.

## Verification

- `npm run test:scripts` — 1116 passing, 0 failing. Each of the three commits is green on its own.
- `npm run lint` — 0 errors (pre-existing warnings only, none in the changed files).
- The end-to-end mutation: adding an unclassified `LANGFLOW_*` to the real `daily-stable.yml` fails the lane and names it.
- The composed remote environment, round-tripped through a shell the way ssh would: the pragmas arrive **parseable**, with `foreign_keys: ON`.

Not smoked on the VMs yet — the run this affects is Monday's, and it only picks the change up once the mirror has synced.

Unrelated, noticed while running the lane repeatedly: `scripts/wait-for-backend.test.mjs`'s "healthy backend: returns ok on the first attempt" flaked once in five full runs under load. Untouched here.
