### PR TITLE
Keep the daily's three series in a ledger outside the clone

### DIFF
--- a/reports/README.md
+++ b/reports/README.md
@@ -39,7 +39,8 @@ comment so a reader of a number finds its limits in the same place:
   summary call does not write **here**, all the same: while both dailies run, the Actions one
   owns this file, and a second line a day for the same `@stable` sweep would double-count the
   trend and halve the anomaly window. It writes its own series to a **ledger outside the clone**
-  (`LEDGER_DIR`, default `$XDG_STATE_HOME/langflow-e2e`), one file per series with the same
+  (`LEDGER_DIR`, defaulting to `$XDG_STATE_HOME/langflow-e2e` and, when that is unset,
+  `$HOME/.local/state/langflow-e2e`), one file per series with the same
   schemas as the three here, and every line it writes carries `workflow: "daily-stable-vm"` — so
   when the two are merged, which era a row came from is still readable. Outside the clone because
   `reports/` is tracked: a line written here by the VM lane is an uncommitted change that the

--- a/reports/README.md
+++ b/reports/README.md
@@ -36,10 +36,14 @@ comment so a reader of a number finds its limits in the same place:
 - **The scheduled VM lane traces, and still writes nothing here (#1714).** It is not a local
   instance: `scripts/run-e2e.sh` overrides that default and runs with tracing ON, the way
   `daily-stable.yml` does, because the traces specs assert against a traced instance. Its
-  summary call carries `TOKENS_SUPPRESS_HISTORY=1` all the same — while both dailies run, the
-  Actions one owns this series, and a second line a day for the same `@stable` sweep would
-  double-count the trend and halve the anomaly window. The VM lane's own series lives outside
-  that clone until the switch makes it the only writer.
+  summary call does not write **here**, all the same: while both dailies run, the Actions one
+  owns this file, and a second line a day for the same `@stable` sweep would double-count the
+  trend and halve the anomaly window. It writes its own series to a **ledger outside the clone**
+  (`LEDGER_DIR`, default `$XDG_STATE_HOME/langflow-e2e`), one file per series with the same
+  schemas as the three here, and every line it writes carries `workflow: "daily-stable-vm"` — so
+  when the two are merged, which era a row came from is still readable. Outside the clone because
+  `reports/` is tracked: a line written here by the VM lane is an uncommitted change that the
+  machine's next `git pull --ff-only` refuses, silently, the following morning.
 - **`Collect models` spend enters the totals with no spec name.** That pre-flight sweep drives the
   same Langflow instance the token poller watches, but it is not a spec run, so its traces land in
   `unattributed`, never in `by_spec`.

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -552,12 +552,17 @@ durations_table() {
 
 # Where this run's spend line goes, as one KEY=VALUE per line. A function so the
 # composition is testable rather than read: the two outcomes are mutually exclusive by
-# construction, and WORKFLOW can never be dropped while the history path is set —
-# without it the summarizer writes `workflow: "unknown"`, which reads as an Actions row
-# that lost its label rather than as a VM one.
+# construction, and neither label can be dropped while the history path is set.
+#
+# WORKFLOW, because without it the summarizer writes `workflow: "unknown"`, which reads
+# as an Actions row that lost its label rather than as a VM one. GITHUB_RUN_ID because
+# the summarizer takes the run's identity from the environment, which in Actions is
+# simply there and here is not: a smoke found the spend row landing with
+# `run_id: null` while the history row for the SAME run carried the id, and a row that
+# cannot be joined back to its run is dropped by every consumer that groups by run.
 tokens_history_env() {
   if ledger_active; then
-    printf '%s\n' "TOKENS_HISTORY=$LEDGER_TOKENS" "WORKFLOW=$WORKFLOW_ID"
+    printf '%s\n' "TOKENS_HISTORY=$LEDGER_TOKENS" "WORKFLOW=$WORKFLOW_ID" "GITHUB_RUN_ID=$RUN_ID"
   else
     printf '%s\n' "TOKENS_SUPPRESS_HISTORY=1"
   fi

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -122,6 +122,47 @@ REPORT_URL="$RUN_URL_BASE/$RUN_ID/playwright-report/index.html"
 EVENT_NAME="${EVENT_NAME:-schedule}"
 WORKFLOW_ID="${WORKFLOW_ID:-daily-stable-vm}"
 
+# ---------------------------------------------------------------------------
+# THE LEDGER — the three series this lane has to keep
+# ---------------------------------------------------------------------------
+# reports/daily-history.jsonl, reports/token-history.jsonl and
+# reports/spec-durations.json only grow because the Actions daily writes them, and the
+# next etapa turns that daily off. Nothing else appends, so the gap would run from
+# there to the day this lane commits: build-triage-dataset.mjs would read a base that
+# starts partial, and the shard matrix — which balances by measured duration — would
+# degrade with it, both for a reason no run reports. This lane starts keeping the three
+# now, while the Actions series is still complete enough to seed from.
+#
+# OUTSIDE the clone, and that is not a preference. `reports/` is tracked, so a run that
+# writes there leaves the tree dirty and the wrapper's next `git pull --ff-only`
+# refuses — and that refusal is a guarantee worth keeping, not an obstacle: it is what
+# stops a machine from silently discarding local work. So the series moves, not the
+# protection. ledger_dir_is_outside_repo() checks it rather than trusting the default,
+# because the cost of getting it wrong is paid once a day, quietly, by the pull.
+#
+# WORKFLOW_ID above is what keeps the two eras apart inside one file: every line this
+# lane writes carries `daily-stable-vm`, so the Actions rows stay distinguishable after
+# the two series are merged.
+KEEP_LEDGER="${KEEP_LEDGER:-1}"
+# `$XDG_STATE_HOME` is the right shelf for this: state that must survive between runs,
+# is not a cache (losing it loses history), and is not config. Empty rather than a
+# fallback path when neither variable is set — an unwritable ledger is refused in
+# preflight, where it costs a variable, instead of guessed at into a directory nobody
+# looks in.
+LEDGER_HOME="${XDG_STATE_HOME:-${HOME:+$HOME/.local/state}}"
+LEDGER_DIR="${LEDGER_DIR:-${LEDGER_HOME:+$LEDGER_HOME/langflow-e2e}}"
+LEDGER_HISTORY="${LEDGER_HISTORY:-${LEDGER_DIR:+$LEDGER_DIR/daily-history.jsonl}}"
+LEDGER_TOKENS="${LEDGER_TOKENS:-${LEDGER_DIR:+$LEDGER_DIR/token-history.jsonl}}"
+LEDGER_DURATIONS="${LEDGER_DURATIONS:-${LEDGER_DIR:+$LEDGER_DIR/spec-durations.json}}"
+# The READ side, and it stays off here on purpose. While both dailies run, the product
+# is a comparison, and a matrix balanced by VM-measured durations puts specs on
+# different shards than the Actions lane does — so a failure's neighbours differ for a
+# reason that has nothing to do with the product. It turns on when the Actions daily
+# stops and the comparison is over. (Step 11 may want it earlier, with SHARDS above 1
+# and the comparison narrowed on purpose; that is a measurement decision, not a
+# default.)
+USE_LEDGER_DURATIONS="${USE_LEDGER_DURATIONS:-0}"
+
 # Which Langflow this lane SHOULD be testing. The rule is upstream's — the newest
 # `release-X.Y.Z` branch, never `main` — and scripts/resolve-target-version.mjs owns
 # it. Here the run only REPORTS the gap: moving and rebuilding the clone is a second
@@ -401,6 +442,95 @@ gh_out() {
   ' "$file" "$key"
 }
 
+# --- The ledger ------------------------------------------------------------------
+
+# Does THIS run keep the three series? Asked in three places, answered once.
+#
+# `schedule` mirrors the workflow, where all three steps carry
+# `if: github.event_name == 'schedule'`, and the reason is the one #1183 already
+# states for the token series: a manual run's scope is whatever grep was typed, while
+# every reader of these files assumes one full @stable sweep per entry. Such a line
+# does not read as noise — it reads as a bad day, and the anomaly baseline moves with
+# it. KEEP_LEDGER=0 is for the runs that ARE schedule-shaped and still must not be
+# recorded, a smoke through the real systemd unit being exactly that.
+ledger_active() {
+  [ "$KEEP_LEDGER" = "1" ] && [ "$EVENT_NAME" = "schedule" ] && [ -n "$LEDGER_DIR" ]
+}
+
+# Refuses a ledger inside the clone, which is the one way this change could defeat its
+# own purpose. Both sides go through `pwd -P`, so a symlink pointing back into the
+# working tree is caught too — the question is where the bytes land, not how the path
+# is spelled.
+#
+# It answers for a path that does not exist yet, by resolving the nearest ancestor that
+# does and carrying the remainder back on. That is what lets preflight refuse BEFORE
+# creating anything: a rejected ledger must not leave its own directory behind inside
+# the clone as the trace of the check that rejected it.
+ledger_dir_is_outside_repo() {
+  local dir="$1" probe="$1" rest="" real repo
+  while [ ! -d "$probe" ]; do
+    case "$probe" in
+      */*) rest="/${probe##*/}$rest"; probe="${probe%/*}"; [ -n "$probe" ] || probe="/" ;;
+      # No slash left: a relative path, and this script runs from $REPO_DIR.
+      *)   rest="/$probe$rest"; probe="."; break ;;
+    esac
+  done
+  real="$(cd "$probe" && pwd -P)$rest"
+  repo="$(cd "$REPO_DIR" && pwd -P)"
+  case "$real/" in "$repo"/*) return 1 ;; *) return 0 ;; esac
+}
+
+# The Actions series is what this one continues, so a ledger file that does not exist
+# yet is seeded from the tracked one instead of starting empty. Day zero is not free:
+# the durations file is what balances the matrix, and the token summary's anomaly
+# baseline is a median over recent entries — both answer badly from three lines, and
+# answer badly in the direction of looking fine. One-way and once; after the copy the
+# tracked file is never read again, and it is never written.
+ledger_seed() {
+  local ledger="$1" tracked="$2"
+  [ -n "$ledger" ] || return 0
+  if [ -e "$ledger" ]; then return 0; fi
+  if [ ! -f "$tracked" ]; then return 0; fi
+  cp "$tracked" "$ledger" && info "ledger: seeded ${ledger##*/} from $tracked"
+}
+
+# Settles the ledger BEFORE the run rather than at publish time, and split out of
+# phase_preflight so the decision is testable without ssh. A ledger that cannot be
+# written is a day of data lost, and if the first write is also the first check the
+# loss is found at 08:50, after the whole hour has been spent — while here it is still
+# the cheapest failure in this script to fix, one variable.
+preflight_ledger() {
+  if ledger_active; then
+    # Placement is settled before creation, so a refused ledger leaves nothing behind.
+    ledger_dir_is_outside_repo "$LEDGER_DIR" \
+      || die "LEDGER_DIR ($LEDGER_DIR) is inside the clone. The three series live outside it precisely so that a run cannot leave the tree dirty — and a dirty tree is what the wrapper's next \`git pull --ff-only\` refuses, every morning, without saying why."
+    mkdir -p "$LEDGER_DIR" || die "cannot create the ledger directory ($LEDGER_DIR)."
+    [ -w "$LEDGER_DIR" ] || die "the ledger directory is not writable ($LEDGER_DIR)."
+    info "ledger: $LEDGER_DIR"
+  elif [ "$KEEP_LEDGER" = "1" ] && [ "$EVENT_NAME" = "schedule" ]; then
+    # Reached only with LEDGER_DIR empty, which means neither XDG_STATE_HOME nor HOME
+    # was set — the systemd shape of #1715, where what a unit inherits is not what a
+    # login shell has. Fatal rather than a warning: a scheduled run that quietly keeps
+    # no series is indistinguishable, months later, from a machine that was down.
+    die "LEDGER_DIR is unset and neither XDG_STATE_HOME nor HOME is set, so this run has nowhere to keep the three series. Set LEDGER_DIR, or KEEP_LEDGER=0 for a run that must not be recorded."
+  else
+    info "ledger: not kept for this run (KEEP_LEDGER=$KEEP_LEDGER, event=$EVENT_NAME)"
+  fi
+}
+
+# Where this run's spend line goes, as one KEY=VALUE per line. A function so the
+# composition is testable rather than read: the two outcomes are mutually exclusive by
+# construction, and WORKFLOW can never be dropped while the history path is set —
+# without it the summarizer writes `workflow: "unknown"`, which reads as an Actions row
+# that lost its label rather than as a VM one.
+tokens_history_env() {
+  if ledger_active; then
+    printf '%s\n' "TOKENS_HISTORY=$LEDGER_TOKENS" "WORKFLOW=$WORKFLOW_ID"
+  else
+    printf '%s\n' "TOKENS_SUPPRESS_HISTORY=1"
+  fi
+}
+
 HELD_SESSIONS=()
 
 # Which of the given ports have no local listener. `ssh -L` opens its listener as soon
@@ -511,6 +641,8 @@ phase_preflight() {
 
   mkdir -p "$RUN_DIR"/{logs,all-blobs,all-liveness,all-tokens}
   info "run dir: $RUN_DIR"
+
+  preflight_ledger
 
   # The suite this run executes, recorded before anything else can move it. Without a
   # repository on the target this is also the only record of which starter version ran

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -476,7 +476,7 @@ ledger_active() {
 # creating anything: a rejected ledger must not leave its own directory behind inside
 # the clone as the trace of the check that rejected it.
 ledger_dir_is_outside_repo() {
-  local dir="$1" probe="$1" rest="" real repo
+  local probe="$1" rest="" real repo
   while [ ! -d "$probe" ]; do
     case "$probe" in
       */*) rest="/${probe##*/}$rest"; probe="${probe%/*}"; [ -n "$probe" ] || probe="/" ;;

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -500,7 +500,16 @@ ledger_seed() {
   [ -n "$ledger" ] || return 0
   if [ -e "$ledger" ]; then return 0; fi
   if [ ! -f "$tracked" ]; then return 0; fi
-  cp "$tracked" "$ledger" && info "ledger: seeded ${ledger##*/} from $tracked"
+  # Fail-soft, like every other step in phase_publish. A seed that cannot be copied
+  # costs this series its baseline and nothing else, while aborting would take the
+  # day's verdict down with it — the run has already happened, and the verdict is what
+  # this lane exists to produce.
+  if cp "$tracked" "$ledger"; then
+    info "ledger: seeded ${ledger##*/} from $tracked"
+  else
+    warn "could not seed ${ledger##*/} from $tracked — this series starts from nothing."
+  fi
+  return 0
 }
 
 # Settles the ledger BEFORE the run rather than at publish time, and split out of
@@ -525,6 +534,20 @@ preflight_ledger() {
   else
     info "ledger: not kept for this run (KEEP_LEDGER=$KEEP_LEDGER, event=$EVENT_NAME)"
   fi
+}
+
+# Which duration table balances the matrix. A switch that is ON and finds nothing must
+# say so: falling back in silence is how a run comes to be balanced by numbers nobody
+# chose, and the symptom — shards of uneven length — looks like the suite's own drift.
+durations_table() {
+  if [ "$USE_LEDGER_DURATIONS" = "1" ]; then
+    if [ -n "$LEDGER_DURATIONS" ] && [ -f "$LEDGER_DURATIONS" ]; then
+      printf '%s\n' "$LEDGER_DURATIONS"
+      return 0
+    fi
+    warn "USE_LEDGER_DURATIONS=1 but the ledger has no durations table yet (${LEDGER_DURATIONS:-<no ledger>}) — this run balances on the tracked one instead."
+  fi
+  printf '%s\n' "reports/spec-durations.json"
 }
 
 # Where this run's spend line goes, as one KEY=VALUE per line. A function so the
@@ -898,10 +921,8 @@ phase_prep() {
   # neighbours — and the load its backend was under — differ for a reason that has
   # nothing to do with the product. The ledger's own timings take over with
   # USE_LEDGER_DURATIONS, which is the next etapa's switch to throw.
-  local durations=reports/spec-durations.json
-  if [ "$USE_LEDGER_DURATIONS" = "1" ] && [ -n "$LEDGER_DURATIONS" ] && [ -f "$LEDGER_DURATIONS" ]; then
-    durations="$LEDGER_DURATIONS"
-  fi
+  local durations
+  durations="$(durations_table)"
   info "durations: $durations"
 
   node scripts/partition-shards.mjs matrix \
@@ -1293,7 +1314,7 @@ phase_publish() {
     # copy every day would re-merge Actions timings into this lane's series forever and
     # the VM's own numbers would never take over.
     if node scripts/partition-shards.mjs extract "$RUN_DIR/results.json" "$LEDGER_DURATIONS" > "$next"; then
-      mv "$next" "$LEDGER_DURATIONS"
+      mv "$next" "$LEDGER_DURATIONS" || warn "could not replace $LEDGER_DURATIONS — the table is left as it was."
     else
       warn "duration extraction FAILED — $LEDGER_DURATIONS is left as it was (#1252)."
     fi

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -24,9 +24,11 @@
 #     services.go-httpbin               |   start-echo-source.sh     on the TARGET host
 #     actions/upload-artifact           |   copies into $RUN_DIR
 #   job `merge`                         | phase_merge + phase_publish
+#     "Append daily history"            |   the same appenders, writing to the LEDGER
+#     "Commit daily history"            |   nothing — see difference 6
 #   "Fail scheduled run on ..."         | phase_verdict
 #
-# ## The five differences that matter
+# ## The six differences that matter
 #
 # 1. TWO MACHINES, NOT ONE. Playwright runs here (the runner host); Langflow, the
 #    echo endpoint and Ollama run on the TARGET host, driven over
@@ -60,11 +62,20 @@
 #    acted on. The code paths exist and are off by default; they turn on when the
 #    webhook and the secrets exist.
 #
+# 6. THE THREE SERIES ARE WRITTEN, NOT COMMITTED. daily-history.jsonl,
+#    token-history.jsonl and spec-durations.json are appended to a LEDGER outside the
+#    clone rather than to `reports/`, and no commit happens here at all. Writing inside
+#    the clone would leave the tree dirty, and the wrapper's `git pull --ff-only` then
+#    refuses the next morning — the protection working exactly as designed, against
+#    us. Committing them back is a later etapa's job and is absent code today, not a
+#    switch set to zero: a switch reads as implemented and disabled.
+#
 # ## Usage
 #
 #   TARGET_SSH=<ssh-alias> ./scripts/run-e2e.sh              # 4 shards
 #   TARGET_SSH=<alias> SHARDS=2 ./scripts/run-e2e.sh
 #   TARGET_SSH=<alias> DRY_RUN=1 ./scripts/run-e2e.sh        # preflight + partition only
+#   TARGET_SSH=<alias> KEEP_LEDGER=0 ./scripts/run-e2e.sh    # a smoke: record nothing
 #
 # The target host is never named in this repository: it is internal topology, and it
 # lives in the destination wiki. TARGET_SSH is required and has no default.
@@ -110,8 +121,6 @@ WITH_OLLAMA="${WITH_OLLAMA:-1}"
 CREATE_ISSUE="${CREATE_ISSUE:-0}"
 NOTIFY_SLACK="${NOTIFY_SLACK:-0}"
 POST_QA_PLATFORM="${POST_QA_PLATFORM:-0}"
-COMMIT_HISTORY="${COMMIT_HISTORY:-0}"
-REFRESH_DURATIONS="${REFRESH_DURATIONS:-0}"
 
 RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
 RUNS_ROOT="${RUNS_ROOT:-$REPO_DIR/runs}"
@@ -883,8 +892,20 @@ phase_prep() {
   # stderr precisely because of this (#1024).
   npx playwright test --grep "@stable" --list --reporter=json > "$RUN_DIR/stable-list.json"
 
+  # Which timings balance the matrix. The TRACKED file while both dailies run: the
+  # product of this etapa is a comparison, and a matrix balanced by VM-measured
+  # durations puts specs on different shards than the Actions lane does, so a failure's
+  # neighbours — and the load its backend was under — differ for a reason that has
+  # nothing to do with the product. The ledger's own timings take over with
+  # USE_LEDGER_DURATIONS, which is the next etapa's switch to throw.
+  local durations=reports/spec-durations.json
+  if [ "$USE_LEDGER_DURATIONS" = "1" ] && [ -n "$LEDGER_DURATIONS" ] && [ -f "$LEDGER_DURATIONS" ]; then
+    durations="$LEDGER_DURATIONS"
+  fi
+  info "durations: $durations"
+
   node scripts/partition-shards.mjs matrix \
-    "$RUN_DIR/stable-list.json" reports/spec-durations.json "$SHARDS" > "$RUN_DIR/matrix.json"
+    "$RUN_DIR/stable-list.json" "$durations" "$SHARDS" > "$RUN_DIR/matrix.json"
 
   SHARD_TOTAL="$(node -p "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).shard_total" "$RUN_DIR/matrix.json")"
   info "$SHARD_TOTAL shard(s)"
@@ -1261,34 +1282,62 @@ phase_publish() {
     fi
   fi
 
-  if [ "$REFRESH_DURATIONS" = "1" ] && [ "$RUN_EMPTY" = "false" ] && [ "$RUN_PARTIAL" = "false" ]; then
-    log "Refreshing reports/spec-durations.json"
+  # The durations series. Empty and partial are excluded for the workflow's own reason:
+  # `extract` merges onto what it is given, and a sweep that ran a fraction of the
+  # specs would rewrite the balance of the whole matrix from a fraction of the evidence.
+  if ledger_active && [ "$RUN_EMPTY" = "false" ] && [ "$RUN_PARTIAL" = "false" ]; then
+    log "Recording the spec durations"
+    ledger_seed "$LEDGER_DURATIONS" reports/spec-durations.json
     local next="$RUN_DIR/spec-durations.next.json"
-    if node scripts/partition-shards.mjs extract "$RUN_DIR/results.json" reports/spec-durations.json > "$next"; then
-      mv "$next" reports/spec-durations.json
+    # The PREVIOUS file is the ledger's own, never the tracked one: reading the tracked
+    # copy every day would re-merge Actions timings into this lane's series forever and
+    # the VM's own numbers would never take over.
+    if node scripts/partition-shards.mjs extract "$RUN_DIR/results.json" "$LEDGER_DURATIONS" > "$next"; then
+      mv "$next" "$LEDGER_DURATIONS"
     else
-      warn "duration extraction FAILED — spec-durations.json is left as it was (#1252)."
+      warn "duration extraction FAILED — $LEDGER_DURATIONS is left as it was (#1252)."
     fi
   fi
 
-  # TOKENS_SUPPRESS_HISTORY, because with tracing on this lane HAS spend to record and
-  # would otherwise append a line to reports/token-history.jsonl — a git-tracked file,
-  # inside the clone this run does not own. Two costs, both concrete: the line is an
-  # uncommitted modification that the next `git pull --ff-only` refuses (that refusal is
-  # the guarantee, so breaking it daily is not an option), and once committing is on
-  # there would be TWO lines a day for one scope — a double-counted trend and an
-  # anomaly window half as wide. The PR and manual lanes carry the same flag for the
-  # neighbouring reason, scope rather than duplication (#1183). This lane's own series
-  # belongs in the ledger outside the clone, which is a step of its own.
-  TOKENS_DIR="$RUN_DIR/all-tokens" TOKENS_SUPPRESS_HISTORY=1 node scripts/watch-tokens.mjs --summarize \
+  # The spend series. It was suppressed until now for a reason that has since been
+  # removed, not because this lane has nothing to record: the summarizer's default
+  # target is reports/token-history.jsonl, tracked, inside a clone this run does not
+  # own, and the line it appends is an uncommitted change the next `git pull --ff-only`
+  # refuses every morning. Pointed at the ledger it is neither, and #1183's argument
+  # turns around — that one excludes the PR and manual lanes because their scope is not
+  # the daily's sweep, and this lane's scope IS the daily's sweep. What must not happen
+  # is the two ending up in one series, and WORKFLOW is what prevents it: without it
+  # the summarizer writes `workflow: "unknown"`, which is indistinguishable from an
+  # Actions row that lost its label.
+  if ledger_active; then
+    ledger_seed "$LEDGER_TOKENS" reports/token-history.jsonl
+  fi
+  local tokens_env=() kv
+  while IFS= read -r kv; do tokens_env+=("$kv"); done < <(tokens_history_env)
+  env "${tokens_env[@]}" TOKENS_DIR="$RUN_DIR/all-tokens" \
+    node scripts/watch-tokens.mjs --summarize \
     > "$RUN_DIR/logs/token-summary.log" 2>&1 || warn "the token summary failed (not blocking)."
 
-  if [ "$COMMIT_HISTORY" = "1" ] && [ "$EVENT_NAME" = "schedule" ]; then
+  # The run series — one line per scheduled sweep, and the switch that used to gate it
+  # was named for something this script does not do. COMMIT_HISTORY implied a commit;
+  # the code under it only ever wrote a file, so the append was being held back by a
+  # decision that belonged to a later etapa, and the series it feeds would have had a
+  # hole exactly as wide as the wait. Committing is what stays behind, and it stays
+  # behind as absent code rather than as a switch set to zero.
+  #
+  # LIVENESS_DIR and SHARD_TOTAL are passed for the same reason the workflow passes
+  # them: without the expected count a shard that died before writing its summary
+  # vanishes from the row instead of reading as a gap (#1012), and the wedge this lane
+  # is measuring (#1720) is exactly what those fields carry.
+  if ledger_active; then
     log "Recording the daily history"
+    ledger_seed "$LEDGER_HISTORY" reports/daily-history.jsonl
     PLAYWRIGHT_JSON="$RUN_DIR/results.json" \
-    HISTORY_FILE=reports/daily-history.jsonl \
+    HISTORY_FILE="$LEDGER_HISTORY" \
     WORKFLOW="$WORKFLOW_ID" \
     GITHUB_RUN_ID="$RUN_ID" \
+    LIVENESS_DIR="$RUN_DIR/all-liveness" \
+    SHARD_TOTAL="${SHARD_TOTAL:-}" \
       node scripts/append-weekly-history.mjs || warn "history append failed (not blocking)."
   fi
 

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -715,9 +715,19 @@ test("the spend line carries its label, and the two outcomes cannot both happen"
   // Without WORKFLOW the summarizer writes `workflow: "unknown"`, which in a merged
   // series reads as an Actions row that lost its label rather than as a VM one — and
   // the whole point of keeping a separate series is being able to tell the two eras
-  // apart afterwards.
-  const kept = sourced(`tokens_history_env`, { LEDGER_DIR: "/tmp/led", EVENT_NAME: "schedule" }).stdout.trim().split("\n");
-  assert.deepEqual(kept, ["TOKENS_HISTORY=/tmp/led/token-history.jsonl", "WORKFLOW=daily-stable-vm"]);
+  // apart afterwards. Both labels are pinned here, not just the path.
+  const kept = sourced(`tokens_history_env`, { LEDGER_DIR: "/tmp/led", EVENT_NAME: "schedule", RUN_ID: "r-1" })
+    .stdout.trim()
+    .split("\n");
+  assert.deepEqual(kept, [
+    "TOKENS_HISTORY=/tmp/led/token-history.jsonl",
+    "WORKFLOW=daily-stable-vm",
+    // Found by a smoke: the summarizer takes the run's identity from the environment,
+    // which in Actions is simply there. Without it the spend row lands with
+    // `run_id: null` while the history row for the SAME run carries the id, and every
+    // consumer that groups by run drops the VM's rows.
+    "GITHUB_RUN_ID=r-1",
+  ]);
 
   const suppressed = sourced(`tokens_history_env`, { EVENT_NAME: "manual" }).stdout.trim().split("\n");
   assert.deepEqual(suppressed, ["TOKENS_SUPPRESS_HISTORY=1"]);

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -24,7 +24,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, symlinkSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -604,4 +604,153 @@ test("the stop scripts run before the holders are killed", () => {
     cleanup.indexOf("stop-langflow-source.sh") < cleanup.indexOf('kill "$pid"'),
     "cleanup kills the holding sessions before asking the stop scripts to run",
   );
+});
+// ---------------------------------------------------------------------------
+// THE LEDGER — the three series this lane has to keep
+// ---------------------------------------------------------------------------
+// reports/daily-history.jsonl, reports/token-history.jsonl and
+// reports/spec-durations.json have exactly one writer today, the Actions daily, and the
+// next etapa turns it off. What these tests protect is therefore a failure with no
+// symptom: a lane that keeps the series in the wrong place, under the wrong label, or
+// not at all still produces a green run and a report that opens fine, and the damage
+// only shows up later, as a base that begins partial and a matrix balanced on nothing.
+
+/** Runs `preflight_ledger` under a given environment. `die` exits, so status is the verdict. */
+function preflightLedger(env = {}) {
+  return sourced(`preflight_ledger`, env);
+}
+
+test("the ledger has a default, it sits outside the clone, and it names all three series", () => {
+  const r = sourced(`echo "$LEDGER_DIR"; echo "$LEDGER_HISTORY"; echo "$LEDGER_TOKENS"; echo "$LEDGER_DURATIONS"`, {
+    HOME: "/home/nobody",
+    XDG_STATE_HOME: "",
+    LEDGER_DIR: "",
+  });
+  const [dir, history, tokens, durations] = r.stdout.trim().split("\n");
+  assert.equal(dir, "/home/nobody/.local/state/langflow-e2e");
+  assert.equal(history, `${dir}/daily-history.jsonl`);
+  assert.equal(tokens, `${dir}/token-history.jsonl`);
+  assert.equal(durations, `${dir}/spec-durations.json`);
+});
+
+test("XDG_STATE_HOME wins over HOME, which is what makes the ledger relocatable per machine", () => {
+  const r = sourced(`echo "$LEDGER_DIR"`, { HOME: "/home/nobody", XDG_STATE_HOME: "/srv/state", LEDGER_DIR: "" });
+  assert.equal(r.stdout.trim(), "/srv/state/langflow-e2e");
+});
+
+test("a ledger inside the clone is refused, however the path is spelled", () => {
+  // The one way this change defeats its own purpose. Each of these writes into the
+  // working tree, and the cost is paid the NEXT morning, by a `git pull --ff-only`
+  // that refuses for a reason nobody is watching at 08:00.
+  const tmp = mkdtempSync(join(tmpdir(), "ledger-refuse-"));
+  const sneaky = join(tmp, "looks-outside");
+  symlinkSync(join(REPO_ROOT, "reports"), sneaky);
+  const cases = [
+    [REPO_ROOT, "the clone itself"],
+    [join(REPO_ROOT, "reports"), "the tracked directory the series live in"],
+    [join(REPO_ROOT, "runs/ledger"), "a path that does not exist yet"],
+    ["runs/ledger", "a relative path, which resolves against the clone"],
+    [sneaky, "a symlink that resolves back into the clone"],
+  ];
+  try {
+    for (const [dir, why] of cases) {
+      const r = sourced(`set +e; ledger_dir_is_outside_repo ${JSON.stringify(dir)}; echo "EXIT=$?"`);
+      assert.match(r.stdout, /EXIT=1/, `${why} was accepted (${dir})`);
+    }
+    const ok = sourced(`set +e; ledger_dir_is_outside_repo ${JSON.stringify(tmp)}; echo "EXIT=$?"`);
+    assert.match(ok.stdout, /EXIT=0/, "a directory genuinely outside the clone must be accepted");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("preflight refuses a ledger inside the clone, and creates nothing on the way out", () => {
+  const inside = join(REPO_ROOT, "runs/ledger-should-not-exist");
+  const r = preflightLedger({ LEDGER_DIR: inside });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /inside the clone/);
+  assert.equal(existsSync(inside), false, "a refused ledger must not leave its own directory behind");
+});
+
+test("preflight refuses when there is nowhere to put the ledger, rather than skipping it", () => {
+  // A scheduled run that quietly keeps no series is indistinguishable, months later,
+  // from a machine that was down — which is the same confusion the watchdog exists to
+  // remove, one layer down. (With HOME truly UNSET this script dies earlier still, on
+  // the PATH export: that is #1715, and it is a different bug.)
+  const r = preflightLedger({ LEDGER_DIR: "", HOME: "", XDG_STATE_HOME: "" });
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /nowhere to keep the three series/);
+  assert.match(r.stderr, /KEEP_LEDGER=0/, "the message has to name the way out it expects");
+});
+
+test("KEEP_LEDGER=0 passes preflight and says so, which is what a smoke needs", () => {
+  const r = preflightLedger({ KEEP_LEDGER: "0", LEDGER_DIR: "", HOME: "", XDG_STATE_HOME: "" });
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /ledger: not kept for this run/);
+});
+
+test("only a scheduled run keeps the series", () => {
+  // Mirrors the workflow, where all three steps are on `github.event_name ==
+  // 'schedule'`, for the reason #1183 gives for the token series: every reader of
+  // these files assumes one full @stable sweep per entry, so a line from a run that
+  // executed a grep does not read as noise — it reads as a bad day.
+  const active = (env) => sourced(`set +e; ledger_active; echo "EXIT=$?"`, env).stdout.match(/EXIT=(\d)/)[1];
+  assert.equal(active({ LEDGER_DIR: "/tmp/led", EVENT_NAME: "schedule" }), "0");
+  assert.equal(active({ LEDGER_DIR: "/tmp/led", EVENT_NAME: "manual" }), "1");
+  assert.equal(active({ LEDGER_DIR: "/tmp/led", KEEP_LEDGER: "0" }), "1");
+  assert.equal(active({ LEDGER_DIR: "", HOME: "", XDG_STATE_HOME: "" }), "1");
+});
+
+test("the spend line carries its label, and the two outcomes cannot both happen", () => {
+  // Without WORKFLOW the summarizer writes `workflow: "unknown"`, which in a merged
+  // series reads as an Actions row that lost its label rather than as a VM one — and
+  // the whole point of keeping a separate series is being able to tell the two eras
+  // apart afterwards.
+  const kept = sourced(`tokens_history_env`, { LEDGER_DIR: "/tmp/led", EVENT_NAME: "schedule" }).stdout.trim().split("\n");
+  assert.deepEqual(kept, ["TOKENS_HISTORY=/tmp/led/token-history.jsonl", "WORKFLOW=daily-stable-vm"]);
+
+  const suppressed = sourced(`tokens_history_env`, { EVENT_NAME: "manual" }).stdout.trim().split("\n");
+  assert.deepEqual(suppressed, ["TOKENS_SUPPRESS_HISTORY=1"]);
+
+  for (const out of [kept, suppressed]) {
+    const names = out.map((kv) => kv.split("=")[0]);
+    assert.ok(
+      !(names.includes("TOKENS_HISTORY") && names.includes("TOKENS_SUPPRESS_HISTORY")),
+      "a suppressed summary with a history path set would silently pick one and drop the other",
+    );
+  }
+});
+
+test("the ledger is seeded once from the Actions series, and an existing one is never overwritten", () => {
+  // Day zero is not free: the durations file is what balances the matrix and the token
+  // summary's anomaly baseline is a median over recent entries, and both answer badly
+  // from three lines — badly in the direction of looking fine.
+  const tmp = mkdtempSync(join(tmpdir(), "ledger-seed-"));
+  try {
+    const tracked = join(tmp, "tracked.jsonl");
+    const ledger = join(tmp, "ledger.jsonl");
+    writeFileSync(tracked, "from-actions\n");
+
+    const first = sourced(`ledger_seed ${JSON.stringify(ledger)} ${JSON.stringify(tracked)}`);
+    assert.equal(first.status, 0);
+    assert.equal(readFileSync(ledger, "utf8"), "from-actions\n");
+
+    writeFileSync(ledger, "from-the-vm\n");
+    writeFileSync(tracked, "a-later-actions-run\n");
+    const second = sourced(`ledger_seed ${JSON.stringify(ledger)} ${JSON.stringify(tracked)}`);
+    assert.equal(second.status, 0);
+    assert.equal(
+      readFileSync(ledger, "utf8"),
+      "from-the-vm\n",
+      "re-seeding would replay the Actions series over the VM's own, every single day",
+    );
+
+    // A tracked file that does not exist is not an error: spec-durations.json has been
+    // absent from the tree before (#1252).
+    const missing = sourced(`ledger_seed ${JSON.stringify(join(tmp, "b.json"))} ${JSON.stringify(join(tmp, "nope.json"))}`);
+    assert.equal(missing.status, 0);
+    assert.equal(existsSync(join(tmp, "b.json")), false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
 });

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -24,7 +24,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, symlinkSync, existsSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, symlinkSync, existsSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -760,6 +760,47 @@ test("the ledger is seeded once from the Actions series, and an existing one is 
     const missing = sourced(`ledger_seed ${JSON.stringify(join(tmp, "b.json"))} ${JSON.stringify(join(tmp, "nope.json"))}`);
     assert.equal(missing.status, 0);
     assert.equal(existsSync(join(tmp, "b.json")), false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("a seed that cannot be copied warns, and does not take the day's verdict with it", () => {
+  // phase_publish runs under `set -e`, so a bare `cp` failing here would abort the
+  // whole phase — after the run, before the verdict. The series is worth less than the
+  // day it would cost, and every other step in that phase already says so.
+  const tmp = mkdtempSync(join(tmpdir(), "ledger-ro-"));
+  try {
+    const tracked = join(tmp, "tracked.jsonl");
+    writeFileSync(tracked, "a line\n");
+    const unwritable = join(tmp, "locked");
+    mkdirSync(unwritable, { mode: 0o500 });
+    const r = sourced(`ledger_seed ${JSON.stringify(join(unwritable, "ledger.jsonl"))} ${JSON.stringify(tracked)}; echo "EXIT=$?"`);
+    assert.match(r.stdout, /EXIT=0/, "a failed seed must not fail the caller");
+    assert.match(r.stderr, /starts from nothing/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("asking for the ledger's durations and finding none is said out loud", () => {
+  // Falling back in silence is how a run ends up balanced by numbers nobody chose,
+  // and the symptom — shards of uneven length — reads as the suite's own drift.
+  const tracked = "reports/spec-durations.json";
+  const off = sourced(`durations_table`);
+  assert.equal(off.stdout.trim(), tracked);
+  assert.equal(off.stderr.trim(), "");
+
+  const missing = sourced(`durations_table`, { USE_LEDGER_DURATIONS: "1", LEDGER_DIR: "/tmp/no-such-ledger-dir" });
+  assert.equal(missing.stdout.trim(), tracked, "a missing table must not become an empty argument");
+  assert.match(missing.stderr, /USE_LEDGER_DURATIONS=1 but the ledger has no durations table yet/);
+
+  const tmp = mkdtempSync(join(tmpdir(), "ledger-dur-"));
+  try {
+    writeFileSync(join(tmp, "spec-durations.json"), "{}\n");
+    const present = sourced(`durations_table`, { USE_LEDGER_DURATIONS: "1", LEDGER_DIR: tmp });
+    assert.equal(present.stdout.trim(), join(tmp, "spec-durations.json"));
+    assert.equal(present.stderr.trim(), "");
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -131,12 +131,31 @@ test("gh_out reads plain and heredoc values, which the outage report needs", () 
   rmSync(dir, { recursive: true, force: true });
 });
 
-test("the publish switches are OFF by default, all four of them", () => {
+test("the publish switches are OFF by default, all three of them", () => {
   // Not a preference: while both dailies run, only the Actions one has consequence.
   // A second issue or a second Slack message for one day's verdict is worse than
   // none, and this is where that decision is enforced.
-  const r = sourced(`echo "$CREATE_ISSUE $NOTIFY_SLACK $POST_QA_PLATFORM $COMMIT_HISTORY"`);
-  assert.equal(r.stdout.trim(), "0 0 0 0");
+  const r = sourced(`echo "$CREATE_ISSUE $NOTIFY_SLACK $POST_QA_PLATFORM"`);
+  assert.equal(r.stdout.trim(), "0 0 0");
+});
+
+test("writing back to the repository is absent, not merely switched off", () => {
+  // The fourth switch used to be COMMIT_HISTORY, and it gated an append that committed
+  // nothing — so the series this lane has to keep was being held back by a decision
+  // that belonged to a later etapa. Now the append happens and the COMMIT is what is
+  // missing. Pinned by absence rather than by a default, because a variable set to
+  // zero reads as "implemented, disabled" and invites someone to flip it on a machine
+  // that has no write credentials and no review.
+  // Comments are stripped first, for the reason #1716 paid for: a comment that merely
+  // SPELLS the thing under test fails a correct file, and the paragraph explaining why
+  // COMMIT_HISTORY was removed is exactly such a comment.
+  const code = readFileSync(SCRIPT, "utf8")
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("#"))
+    .join("\n");
+  const writes = code.split("\n").filter((l) => /\bgit\s+(commit|push|add)\b/.test(l));
+  assert.deepEqual(writes, [], "this lane must not write to the repository");
+  assert.doesNotMatch(code, /COMMIT_HISTORY/, "the switch is gone, not renamed");
 });
 
 // daily-stable.yml's Langflow service environment, read once. The reader strips
@@ -250,16 +269,6 @@ test("pragmas that are not a JSON object stop the run", () => {
   }
 });
 
-test("the lane does not append to the daily's token series", () => {
-  // With tracing ON this lane has spend to record, and the summarizer's default is to
-  // append one line to reports/token-history.jsonl — a git-tracked file, in a clone
-  // this run does not own, whose `git pull --ff-only` would then refuse every day.
-  const line = readFileSync(SCRIPT, "utf8")
-    .split("\n")
-    .find((l) => l.includes("watch-tokens.mjs --summarize"));
-  assert.ok(line, "could not find the token summary invocation");
-  assert.match(line, /TOKENS_SUPPRESS_HISTORY=1/);
-});
 
 test("the mirrored values cross the ssh boundary, which a default alone does not", () => {
   // The failure mode this catches LOOKS fixed: the values are set here, the shell that
@@ -605,6 +614,7 @@ test("the stop scripts run before the holders are killed", () => {
     "cleanup kills the holding sessions before asking the stop scripts to run",
   );
 });
+
 // ---------------------------------------------------------------------------
 // THE LEDGER — the three series this lane has to keep
 // ---------------------------------------------------------------------------
@@ -753,4 +763,35 @@ test("the ledger is seeded once from the Actions series, and an existing one is 
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
+});
+
+test("nothing in the publish phase writes into the tracked series", () => {
+  // The three paths may appear there ONLY as the source ledger_seed copies FROM. A
+  // write to any of them is the dirty tree this whole change exists to avoid, and it
+  // would look exactly like a working run until the next morning's pull.
+  const script = readFileSync(SCRIPT, "utf8");
+  const publish = script.slice(script.indexOf("phase_publish() {"), script.indexOf("phase_verdict() {"));
+  assert.ok(publish.length > 0, "could not isolate phase_publish");
+  const TRACKED = ["reports/daily-history.jsonl", "reports/token-history.jsonl", "reports/spec-durations.json"];
+  for (const line of publish.split("\n")) {
+    const code = line.trim();
+    if (code.startsWith("#")) continue;
+    for (const path of TRACKED) {
+      if (!code.includes(path)) continue;
+      assert.ok(code.startsWith("ledger_seed "), `${path} is touched by something other than the seed: ${code}`);
+    }
+  }
+  // And the appenders are pointed somewhere, rather than left on their defaults —
+  // whose defaults are precisely the tracked paths above.
+  assert.match(publish, /HISTORY_FILE="\$LEDGER_HISTORY"/);
+  assert.match(publish, /mv "\$next" "\$LEDGER_DURATIONS"/);
+});
+
+test("the matrix still balances on the tracked durations while both dailies run", () => {
+  // Turning this on early would move specs onto different shards than the Actions lane
+  // puts them, so a failure's neighbours — and the load its backend was under —
+  // would differ for a reason that has nothing to do with the product. The comparison
+  // is the product of this etapa; the switch belongs to the one after it.
+  const r = sourced(`echo "$USE_LEDGER_DURATIONS"`);
+  assert.equal(r.stdout.trim(), "0");
 });


### PR DESCRIPTION
## Why

`reports/daily-history.jsonl`, `reports/token-history.jsonl` and `reports/spec-durations.json` only grow because `daily-stable.yml` writes them, and the migration's next etapa turns that lane off. Nothing else appends. The gap would run from there to the day the VM lane commits: `build-triage-dataset.mjs` would read a base that starts partial, and the shard matrix — which balances by measured duration — would degrade with it, both for a reason no run reports.

So the VM lane starts keeping the three now, while the Actions series is still complete enough to seed from.

## Where they go, and why it is not `reports/`

Outside the clone. `reports/` is tracked, so a run that writes there leaves the tree dirty, and the machine's next `git pull --ff-only` refuses the following morning — the protection working exactly as designed, against us. The series moves; the protection stays.

That decision is checked rather than trusted. `ledger_dir_is_outside_repo()` resolves both sides through `pwd -P`, so a symlink pointing back into the working tree is caught too, and it answers for a path that does not exist yet — preflight has to refuse **before** creating anything, or the trace left by the rejected check is a directory inside the clone.

Default is `$XDG_STATE_HOME/langflow-e2e`, then `$HOME/.local/state/...`. With neither set the value is empty and preflight **dies** rather than guessing a path: a scheduled run that quietly keeps no series is indistinguishable, months later, from a machine that was down. Preflight is also where it is checked, not publish — an unwritable ledger discovered at publish costs the whole hour the run just spent; discovered in preflight it costs one variable.

## Two switches retired

**`COMMIT_HISTORY` was named for something this script does not do.** The code under it only ever wrote a file — no commit, no push — so the run series was gated on a decision belonging to a later etapa, and the hole in the data would have been exactly as wide as the wait. Committing is what stays behind, and it stays behind as **absent code**, not as a switch set to zero: a switch reads as implemented and disabled, and invites someone to flip it on a machine with no write credentials. A test pins the absence.

**`REFRESH_DURATIONS` goes for the same reason in reverse** — it was off because it wrote into the tracked tree, and it no longer does.

## The token series

The summary stops carrying `TOKENS_SUPPRESS_HISTORY` on a scheduled run. #1183's argument excludes the PR and manual lanes because their scope is not the daily's sweep; this lane's scope **is** the daily's sweep. What must not happen is the two ending up in one series, and `WORKFLOW` is what prevents it: without it the summarizer writes `workflow: "unknown"`, which in a merged file reads as an Actions row that lost its label rather than as a VM one. `tokens_history_env()` exists so that composition is unit-tested rather than read — the two outcomes are mutually exclusive by construction, and the label cannot be dropped while the path is set.

The history line also gains `LIVENESS_DIR` and `SHARD_TOTAL`, which the workflow passes and this lane did not: without the expected count a shard that died before writing its summary vanishes from the row instead of reading as a gap (#1012), and those fields are exactly where the wedge in #1720 shows up.

## What deliberately did NOT change

The **read** side. The matrix still balances on the tracked `reports/spec-durations.json`. While both dailies run the product is a comparison, and a matrix balanced by VM-measured timings puts specs on different shards than the Actions lane does — so a failure's neighbours, and the load its backend was under, would differ for a reason that has nothing to do with the product. `USE_LEDGER_DURATIONS` is the next etapa's switch to throw.

## Seeding

A ledger file that does not exist yet is copied once from the tracked one. Day zero is not free: the durations file is what balances the matrix, and the token summary's anomaly baseline is a median over recent entries — both answer badly from three lines, and badly in the direction of looking fine. One-way and once; after the copy the tracked file is never read again by this lane, and never written.

## Tests

12 new cases in `scripts/run-e2e.test.mjs` (52 in that file, 1135 in `test:scripts`). The ones that matter:

- a ledger inside the clone is refused however the path is spelled — the clone, `reports/`, a path that does not exist yet, a relative path, and a symlink that resolves back in
- preflight refuses such a ledger **and creates nothing on the way out**
- preflight refuses when there is nowhere to put one, and the message names `KEEP_LEDGER=0` as the way out
- only a scheduled run keeps the series
- the spend line carries its label, and the two outcomes cannot both happen
- seeding is one-way and once — re-seeding would replay the Actions series over the VM's own, every single day
- nothing in `phase_publish` writes into the tracked series: the three paths may appear there only as the source `ledger_seed` copies *from*
- writing back to the repository is absent, not switched off

The switch-absence test strips comments before reading the file, for the reason #1716 paid for: a comment that merely spells the thing under test fails a correct file, and the paragraph explaining why `COMMIT_HISTORY` was removed is exactly such a comment.

Closes the migration's step 17.