### PR TITLE
fix(auth): attribute the login response wait instead of timing out blind (#1713)

### DIFF
--- a/docs/core-functionality/auth/login-invalid-credentials.md
+++ b/docs/core-functionality/auth/login-invalid-credentials.md
@@ -1,6 +1,6 @@
 # Auth — login with invalid credentials
 
-**Last validated:** Langflow 1.12.x (validated on nightly `1.12.0.dev33`)
+**Last validated:** Langflow 1.13.x (validated on nightly `1.13.0.dev2`)
 
 ---
 
@@ -41,6 +41,20 @@ nothing created.
 - **The auto-login kill switch is client-side** (`page.route` → 500 on
   `/api/v1/auto_login`), the directory's shared pattern — the server is
   untouched.
+- **The `POST /api/v1/login` wait is ATTRIBUTED, not bare** (#1713). The 30 s
+  budget is unchanged — only the failure path is. A bare `waitForResponse` fails
+  as `TimeoutError: page.waitForResponse: Timeout 30000ms exceeded while waiting
+  for event "response"`, a string that cannot tell apart the only two states that
+  produce it: a backend that accepted the POST and never answered, or a login
+  form that stopped issuing it. On timeout the helper probes `/api/v1/version`
+  and reports which state it observed — the contract
+  `helpers/other/page-entry-barrier.ts` already applies to entry selectors
+  (#1262/#1265): an unreachable or non-2xx backend carries
+  `[backend-unreachable]` and embeds the probe's own transport error, which the
+  existing `api-request-timeout` signature matches with **no new entry added**; a
+  **healthy** probe deliberately gets no prefix, so a frontend that stops sending
+  the POST still costs the tag; a probe that could not run reads UNKNOWN, never
+  clean (#1012).
 
 ---
 
@@ -56,6 +70,33 @@ nothing created.
 
 Nothing is created; the browser context and its mock are discarded with the
 test.
+
+---
+
+## Notes *(optional)*
+
+- **Why the login wait is attributed (#1713).** This test flaked in the
+  2026-08-26 and 2026-09-04 dailies under a byte-identical signature
+  (`page.waitForResponse: Timeout 30000ms`, `infra_signature: null` on both
+  rows), and the 2026-09-04 attempt's own error context settles what the string
+  could not: the form still held `wronguser`/`wrongpassword`, an inline `Too
+  many requests` alert showed the first submit had been refused `429`, and a
+  blocking `Connection timed out` dialog was open over the page. That dialog is
+  the frontend's health-check overlay — `GET /health_check` raced against a 10 s
+  timer — so the page itself had already observed the backend as unreachable,
+  independently of the run's liveness recorder (shard 2: 29.1 % of its span
+  down, the failing attempt entirely inside a 96 s outage). The nightly's bundle
+  configures no client-side request timeout, so the login POST is never aborted
+  by the app: once issued it waits for the backend, and a `waitForResponse`
+  shorter than the outage is guaranteed to expire. The fix therefore attributes
+  the wait instead of extending it — the flake is wedge collateral, and the
+  defect the suite owned was that its own error message could not say so.
+- **`page.waitForResponse: Timeout` must NOT be added to
+  `scripts/lib/infra-signature-patterns.json`.** It is ambiguous by
+  construction — a frontend that stops issuing a request produces it too — which
+  is the same argument `helpers/other/page-entry-barrier.ts` records for
+  `locator.waitFor: Timeout`. Attribution belongs at the call site, where the
+  probe can tell the two states apart.
 
 ---
 

--- a/docs/core-functionality/auth/logout-flow.md
+++ b/docs/core-functionality/auth/logout-flow.md
@@ -1,6 +1,6 @@
 # Logout flow
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev33`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev2`)
 
 ---
 
@@ -53,6 +53,20 @@ credentials.
 - After **Logout**, the login form (`sign in to langflow`) is visible and
   `mainpage_title` is hidden.
 - Direct navigation to `/` and a reload after logout both stay on the login page.
+- **The `POST /api/v1/login` wait is ATTRIBUTED, not bare** (#1713). The 30 s
+  budget is unchanged — only the failure path is. A bare `waitForResponse` fails
+  as `TimeoutError: page.waitForResponse: Timeout 30000ms exceeded while waiting
+  for event "response"`, a string that cannot tell apart the only two states that
+  produce it: a backend that accepted the POST and never answered, or a login
+  form that stopped issuing it. On timeout the helper probes `/api/v1/version`
+  and reports which state it observed — the contract
+  `helpers/other/page-entry-barrier.ts` already applies to entry selectors
+  (#1262/#1265): an unreachable or non-2xx backend carries
+  `[backend-unreachable]` and embeds the probe's own transport error, which the
+  existing `api-request-timeout` signature matches with **no new entry added**; a
+  **healthy** probe deliberately gets no prefix, so a frontend that stops sending
+  the POST still costs the tag; a probe that could not run reads UNKNOWN, never
+  clean (#1012).
 
 ---
 
@@ -64,7 +78,8 @@ credentials.
   through the 429-absorbing helper: `POST /api/v1/login` is limited to 5/min
   per client IP (fixed window, counted before authentication), and this
   file's three logins used to be the ones that met a window exhausted by
-  the auth specs running before it.
+  the auth specs running before it. Since #1713 the same helper also
+  ATTRIBUTES the response wait — see Notes.
 - `src/frontend/src/pages/MainPage/components/header/**` — renders
   `data-testid="mainpage_title"`, the post-login landing assertion.
 - `src/backend/base/langflow/api/v1/login.py` — `/api/v1/login` and
@@ -86,6 +101,13 @@ credentials.
 
 ## Notes *(optional)*
 
+- **The shared login wait is attributed (#1713).** The first test in this file
+  flaked in the 2026-09-04 daily under the same signature as
+  `login-invalid-credentials.spec.ts` — the same `waitForResponse`, in the same
+  helper, inside a measured 92 s shard-1 outage. It is not separately
+  quarantined and needs no change of its own: the attribution lands in
+  `tests/helpers/auth/sign-in-through-form.ts`, the single call site all three
+  logins in this file go through.
 - **Legacy default password (issue #510).** Since nightly `1.11.0.dev29`, a
   superuser password equal to the legacy default `langflow` is rejected under
   `LANGFLOW_AUTO_LOGIN=true` (a random bootstrap password is generated instead, so a

--- a/tests/helpers/auth/sign-in-through-form.ts
+++ b/tests/helpers/auth/sign-in-through-form.ts
@@ -1,5 +1,14 @@
 import type { Page, Response } from "@playwright/test";
+import { waitForAttributedResponse } from "../other/response-barrier";
 import { retryAfterMs } from "./login-request";
+
+/**
+ * Budget for the login response. Unchanged since the helper was written, and
+ * deliberately not widened by #1713: the outages that expire it lasted 92s and
+ * 96s, so a barrier long enough to outlast one would report a green run through
+ * a broken backend.
+ */
+const LOGIN_RESPONSE_TIMEOUT_MS = 30000;
 
 /**
  * Fills the login form, submits, and absorbs the endpoint's per-IP rate limit.
@@ -14,8 +23,14 @@ import { retryAfterMs } from "./login-request";
  * keeps its values. Any other status is the caller's verdict: 200 callers gate
  * on the workspace, 401 callers on the error toast, and neither is hidden.
  *
- * The response is captured via `waitForResponse` registered BEFORE the click,
- * so the status read cannot race the navigation that a 200 triggers.
+ * The response is captured via a `waitForResponse` registered BEFORE the click,
+ * so the status read cannot race the navigation that a 200 triggers — and it is
+ * ATTRIBUTED (#1713): a bare wait fails as `page.waitForResponse: Timeout
+ * 30000ms exceeded`, which cannot say whether the backend accepted the POST and
+ * never answered or the login form stopped issuing it. On timeout the barrier
+ * probes `/api/v1/version` and names the state it observed; see
+ * `helpers/other/response-barrier.ts` for the measurement and for why
+ * `page.waitForResponse: Timeout` must not be added to the infra-signature list.
  *
  * Returns the final HTTP status, for callers that want to assert it directly.
  */
@@ -38,11 +53,16 @@ export async function signInThroughForm(
   });
 
   const submitOnce = async (): Promise<Response> => {
-    const responsePromise = page.waitForResponse(
+    const responsePromise = waitForAttributedResponse(
+      page,
       (response) =>
         new URL(response.url()).pathname.endsWith("/api/v1/login") &&
         response.request().method() === "POST",
-      { timeout: 30000 },
+      {
+        observable: "POST /api/v1/login",
+        timeoutMs: LOGIN_RESPONSE_TIMEOUT_MS,
+        surface: "login",
+      },
     );
     await page.getByRole("button", { name: "Sign In" }).click();
     return responsePromise;

--- a/tests/helpers/other/response-barrier.test.ts
+++ b/tests/helpers/other/response-barrier.test.ts
@@ -1,0 +1,253 @@
+// Unit tests for the response barrier's attribution message (issue #1713).
+// Run with: npm run test:units
+//
+// What rides on this function: whether a red daily gets triaged as an outage or
+// as a product regression.
+//
+// On the 2026-09-04 daily (run 33873006780) two @stable auth tests flaked in
+// different shards with a byte-identical signature,
+//
+//   TimeoutError: page.waitForResponse: Timeout 30000ms exceeded while waiting
+//   for event "response"
+//
+// produced by the same `waitForResponse` in `helpers/auth/sign-in-through-form.ts`.
+// That string cannot tell apart the only two states that produce it: a backend
+// that accepted `POST /api/v1/login` and never answered, or a login form that
+// stopped issuing it — the second being a product regression. Both history rows
+// carry `infra_signature: null` for exactly that reason, and the same test had
+// already flaked under the same string on 2026-08-26.
+//
+// Measured on nightly 1.13.0.dev2 by docker-pausing the container (connections
+// accepted, never answered — the gunicorn wedge shape): the frontend DID issue
+// the POST, it was never aborted (the bundle configures no client-side request
+// timeout), no response ever arrived, and a probe taken WHILE still wedged
+// returned `apiRequestContext.get: Timeout 5000ms exceeded.` So the two states
+// are distinguishable at the call site even though the Playwright string is not,
+// which is the same argument `page-entry-barrier.ts` records for
+// `locator.waitFor: Timeout`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyInfraError } from "../../../scripts/lib/infra-signatures";
+import { INFRA_PREFIX, PROBE_PATH } from "./page-entry-barrier";
+import {
+  REQUEST_SURFACE,
+  responseBarrierMessage,
+  waitForAttributedResponse,
+} from "./response-barrier";
+
+const CAUSE =
+  'TimeoutError: page.waitForResponse: Timeout 30000ms exceeded while waiting for event "response"';
+
+const OBSERVABLE = "POST /api/v1/login";
+
+const WEDGED = {
+  state: "unreachable" as const,
+  ms: 5019,
+  url: "http://localhost:7860/api/v1/version",
+  detail: "apiRequestContext.get: Timeout 5000ms exceeded.",
+};
+
+test("a wedged backend is named as the cause, with the infra prefix", () => {
+  const msg = responseBarrierMessage({
+    observable: OBSERVABLE,
+    timeoutMs: 30000,
+    probe: WEDGED,
+    cause: CAUSE,
+    surface: "login",
+  });
+
+  assert.ok(
+    msg.startsWith(INFRA_PREFIX),
+    `expected the infra prefix so triage can classify it, got: ${msg}`,
+  );
+  assert.match(msg, /POST \/api\/v1\/login/);
+  assert.match(msg, /did not answer within 30000ms/);
+  assert.match(msg, new RegExp(`did not answer GET ${PROBE_PATH.replace(/\//g, "\\/")}`));
+  assert.match(msg, /apiRequestContext\.get: Timeout 5000ms exceeded\./);
+  // Playwright's transport errors already end in a period; the sentence must not
+  // add a second one, which is what the entry barrier's template does today.
+  assert.ok(!msg.includes(".."), `double period in: ${msg}`);
+  // The surface names WHICH wait failed, so a reader does not have to decode the
+  // predicate — #1265's flake was mis-triaged because the message named neither.
+  assert.match(msg, /login barrier/);
+  assert.ok(msg.includes(CAUSE), "the original Playwright error must survive");
+});
+
+test("the wedged message is what the REAL classifier already exempts", () => {
+  // The load-bearing claim of this fix: no new entry on
+  // scripts/lib/infra-signature-patterns.json. It works because the message
+  // embeds the probe's own transport error, which `api-request-timeout` matches.
+  const wedged = responseBarrierMessage({
+    observable: OBSERVABLE,
+    timeoutMs: 30000,
+    probe: WEDGED,
+    cause: CAUSE,
+    surface: "login",
+  });
+  assert.equal(classifyInfraError(wedged)?.id, "api-request-timeout");
+
+  // And the bare string this replaces is unclassifiable — which is the defect,
+  // not an omission: a frontend that stops issuing the request emits it too, so
+  // it must NEVER be added to the pattern list.
+  assert.equal(classifyInfraError(CAUSE), null);
+});
+
+test("a backend that is up but failing to serve is still not the app's fault", () => {
+  const msg = responseBarrierMessage({
+    observable: OBSERVABLE,
+    timeoutMs: 30000,
+    probe: {
+      state: "http_error",
+      ms: 42,
+      url: "http://localhost:7860/api/v1/version",
+      status: 502,
+    },
+    cause: CAUSE,
+    surface: "login",
+  });
+  assert.ok(msg.startsWith(INFRA_PREFIX));
+  assert.match(msg, /HTTP 502/);
+});
+
+test("a HEALTHY probe deliberately gets no infra prefix", () => {
+  // The half that keeps the fix honest. A backend that answers while the request
+  // goes unanswered is the product-regression shape the issue directive named
+  // first — a login form that stopped sending the POST. Prefixing it would
+  // exempt a real regression from @stable auto-removal.
+  const msg = responseBarrierMessage({
+    observable: OBSERVABLE,
+    timeoutMs: 30000,
+    probe: {
+      state: "healthy",
+      ms: 31,
+      url: "http://localhost:7860/api/v1/version",
+      status: 200,
+    },
+    cause: CAUSE,
+    surface: "login",
+  });
+  assert.ok(
+    !msg.startsWith(INFRA_PREFIX),
+    `a healthy backend must NOT be reported as unreachable, got: ${msg}`,
+  );
+  assert.match(msg, /IS a product\/UI failure/);
+  assert.equal(classifyInfraError(msg), null);
+});
+
+test("a probe that could not run reads UNKNOWN, never healthy", () => {
+  const msg = responseBarrierMessage({
+    observable: OBSERVABLE,
+    timeoutMs: 30000,
+    probe: {
+      state: "unknown",
+      ms: 3,
+      url: "http://localhost:7860/api/v1/version",
+      detail: "probe could not run: Target page, context or browser has been closed",
+    },
+    cause: CAUSE,
+  });
+  assert.ok(!msg.startsWith(INFRA_PREFIX));
+  assert.match(msg, /UNKNOWN/);
+  assert.match(msg, /Do not read this as a healthy backend/);
+  assert.equal(classifyInfraError(msg), null);
+});
+
+test("the default surface is generic, so a caller that names none still reads", () => {
+  const msg = responseBarrierMessage({
+    observable: OBSERVABLE,
+    timeoutMs: 30000,
+    probe: WEDGED,
+    cause: CAUSE,
+  });
+  assert.match(msg, new RegExp(`${REQUEST_SURFACE} barrier`));
+});
+
+// --- the wrapper -----------------------------------------------------------
+
+function fakePage(waitForResponse: () => Promise<any>, probeResult?: () => Promise<any>) {
+  return {
+    url: () => "http://localhost:7860/flows",
+    waitForResponse,
+    request: {
+      get: probeResult ?? (async () => ({ ok: () => true, status: () => 200 })),
+    },
+  } as any;
+}
+
+test("the wait is REGISTERED synchronously, before the caller acts", async () => {
+  // Load-bearing: the helper registers the wait and only then clicks Sign In, so
+  // the status read cannot race the navigation a 200 triggers. A wrapper that
+  // deferred registration to the first await would reopen that race silently.
+  let registered = false;
+  const page = fakePage(() => {
+    registered = true;
+    return Promise.resolve("response-object");
+  });
+
+  const pending = waitForAttributedResponse(page, () => true, {
+    observable: OBSERVABLE,
+    timeoutMs: 30000,
+  });
+  assert.equal(registered, true, "waitForResponse must be called synchronously");
+  assert.equal(await pending, "response-object");
+});
+
+test("a successful wait resolves untouched and never probes", async () => {
+  let probed = 0;
+  const page = fakePage(
+    () => Promise.resolve("response-object"),
+    async () => {
+      probed += 1;
+      return { ok: () => true, status: () => 200 };
+    },
+  );
+  assert.equal(
+    await waitForAttributedResponse(page, () => true, {
+      observable: OBSERVABLE,
+      timeoutMs: 30000,
+    }),
+    "response-object",
+  );
+  assert.equal(probed, 0, "a green wait must not pay for a liveness probe");
+});
+
+test("the timeout is passed through unchanged — attribution never widens the budget", async () => {
+  let seen: number | undefined;
+  const page = fakePage((..._args: any[]) => Promise.resolve("ok"));
+  const spy = (predicate: any, options: any) => {
+    seen = options?.timeout;
+    return Promise.resolve("ok");
+  };
+  (page as any).waitForResponse = spy;
+  await waitForAttributedResponse(page, () => true, {
+    observable: OBSERVABLE,
+    timeoutMs: 30000,
+  });
+  assert.equal(seen, 30000);
+});
+
+test("a timed-out wait rejects with the ATTRIBUTED message, not the bare one", async () => {
+  const page = fakePage(
+    () => Promise.reject(new Error(CAUSE)),
+    async () => {
+      throw new Error("apiRequestContext.get: Timeout 5000ms exceeded.");
+    },
+  );
+
+  await assert.rejects(
+    waitForAttributedResponse(page, () => true, {
+      observable: OBSERVABLE,
+      timeoutMs: 30000,
+      surface: "login",
+    }),
+    (error: Error) => {
+      assert.ok(
+        error.message.startsWith(INFRA_PREFIX),
+        `expected an attributed failure, got: ${error.message}`,
+      );
+      assert.equal(classifyInfraError(error.message)?.id, "api-request-timeout");
+      assert.ok(error.message.includes(CAUSE));
+      return true;
+    },
+  );
+});

--- a/tests/helpers/other/response-barrier.ts
+++ b/tests/helpers/other/response-barrier.ts
@@ -1,0 +1,180 @@
+import type { Page, Response } from "@playwright/test";
+import {
+  INFRA_PREFIX,
+  PROBE_PATH,
+  probeBackend,
+  type BackendProbe,
+} from "./page-entry-barrier";
+
+/**
+ * The `page-entry-barrier` contract (#1262/#1265), applied to a RESPONSE wait
+ * instead of a selector (#1713).
+ *
+ * `page.waitForResponse` has the same ambiguity `waitForSelector` had, and it
+ * cost the same mis-triage. On the 2026-09-04 daily (run 33873006780) two
+ * `@stable` auth tests flaked in different shards with a byte-identical string:
+ *
+ *   TimeoutError: page.waitForResponse: Timeout 30000ms exceeded while waiting
+ *   for event "response"
+ *
+ * Both came from the same `waitForResponse` in
+ * `helpers/auth/sign-in-through-form.ts`, and that string cannot tell apart the
+ * only two states that produce it:
+ *
+ *   1. the backend accepted the request and never answered — a wedge, collateral
+ *      damage, nothing to do with the test;
+ *   2. the frontend stopped issuing the request — a product regression, and the
+ *      shape the issue's investigation directive named as prime suspect.
+ *
+ * Which is why `page.waitForResponse: Timeout` is deliberately NOT on
+ * `scripts/lib/infra-signature-patterns.json` and must not be added: exempting
+ * it would exempt (2) as well. Both history rows for this flake therefore carry
+ * `infra_signature: null`, and `remove-stable-from-failures.ts` had no way to
+ * tell whether the tag was owed.
+ *
+ * Measured rather than assumed, on nightly `1.13.0.dev2`, by `docker pause`ing
+ * the container — connections accepted and never answered, the gunicorn wedge
+ * shape — and driving the real helper against it, twice:
+ *
+ *   - the production signature reproduced verbatim;
+ *   - the frontend DID issue `POST /api/v1/login` (`page.on("request")`), and it
+ *     was never aborted (`requestfailed` empty — the nightly's bundle configures
+ *     no client-side request timeout, so once issued the POST waits for the
+ *     backend however long that takes);
+ *   - no response ever arrived, so a 30 s wait inside a 96 s outage cannot do
+ *     anything but expire;
+ *   - a probe taken WHILE still wedged returned `unreachable` in 5019 ms with
+ *     `apiRequestContext.get: Timeout 5000ms exceeded.`
+ *
+ * That last line is what makes this cost nothing: the message embeds the probe's
+ * own transport error, which the EXISTING `api-request-timeout` signature
+ * already matches — so a wedge is classifiable with no new pattern anywhere,
+ * while a healthy probe stays unclassified on purpose.
+ *
+ * Three rules the unit tests pin, the same three the entry barrier pins:
+ *
+ *  - unreachable or non-2xx ⇒ `INFRA_PREFIX`, the marker meaning "the harness
+ *    could not talk to Langflow";
+ *  - a HEALTHY probe deliberately does NOT get that prefix — that failure is the
+ *    product's, and mislabelling it would let a real regression through
+ *    unquarantined;
+ *  - a probe that could not run is UNKNOWN, never healthy (#1012).
+ *
+ * The budget is never widened. A barrier that outlasted the outage would report
+ * a green run through a broken backend, which is the opposite of the point.
+ *
+ * KNOWN LIMITATION, inherited from the entry barrier and stated rather than
+ * papered over: the probe runs AFTER the wait's budget is spent, so it reports
+ * the backend's state then, not during. A wedge shorter than the wait clears
+ * before the probe and reads `healthy`, and the message then blames the app.
+ * That asymmetry is deliberate — over-claiming an outage is the more expensive
+ * mistake.
+ */
+
+/** Default `surface` label for a caller that names none. */
+export const REQUEST_SURFACE = "request";
+
+export interface ResponseBarrierContext {
+  /**
+   * Human-readable description of the request waited on, e.g.
+   * `POST /api/v1/login`. Named in the message because a predicate function is
+   * not readable from a report — #1265's flake was mis-triaged for exactly that.
+   */
+  observable: string;
+  timeoutMs: number;
+  probe: BackendProbe;
+  /** The original Playwright error text. */
+  cause: string;
+  /**
+   * Which wait this barrier guards, e.g. `login`. Defaults to
+   * `REQUEST_SURFACE`.
+   */
+  surface?: string;
+}
+
+/**
+ * Build the attributed failure message. Pure — the unit tests drive it directly
+ * with each probe state.
+ */
+export function responseBarrierMessage(ctx: ResponseBarrierContext): string {
+  const { observable, timeoutMs, probe, cause } = ctx;
+  const surface = ctx.surface?.trim() || REQUEST_SURFACE;
+  // Playwright's transport errors already end in a period, and the entry
+  // barrier's template appends another — `Timeout 5000ms exceeded..` shows up in
+  // every wedge message it has ever written. Trimmed here rather than inherited.
+  const detail = (probe.detail ?? "").replace(/\.\s*$/, "");
+  const barrier = `${surface} barrier "${observable}" did not answer within ${timeoutMs}ms`;
+  const url = probe.url;
+
+  let head: string;
+  switch (probe.state) {
+    case "unreachable":
+      head =
+        `${INFRA_PREFIX} ${barrier} — and the backend did not answer GET ` +
+        `${PROBE_PATH} within ${probe.ms}ms (${url}): ${detail}. ` +
+        `Langflow was unreachable or restarting, so the request was accepted and ` +
+        `never answered — this is NOT a frontend that stopped issuing it.`;
+      break;
+    case "http_error":
+      head =
+        `${INFRA_PREFIX} ${barrier} — the backend answered GET ${PROBE_PATH} ` +
+        `with HTTP ${probe.status} in ${probe.ms}ms (${url}). Langflow is up but ` +
+        `failing to serve, so this is NOT a frontend that stopped issuing the ` +
+        `request.`;
+      break;
+    case "healthy":
+      head =
+        `${barrier} — the backend answered GET ${PROBE_PATH} with HTTP ` +
+        `${probe.status} in ${probe.ms}ms (${url}), so the backend was reachable ` +
+        `and the request was either never issued or never answered by the app: ` +
+        `this IS a product/UI failure at the ${surface} surface.`;
+      break;
+    default:
+      head =
+        `${barrier} — backend liveness could not be probed ` +
+        `(${detail}), so whether Langflow was reachable is UNKNOWN. ` +
+        `Do not read this as a healthy backend.`;
+  }
+
+  return `${head}\n\nOriginal error:\n${cause}`;
+}
+
+export interface AttributedResponseOptions {
+  observable: string;
+  timeoutMs: number;
+  surface?: string;
+  baseURL?: string;
+}
+
+/**
+ * `page.waitForResponse` with the timeout attributed.
+ *
+ * Drop-in: same predicate, same budget, same resolved `Response`. Only the
+ * failure path changes.
+ *
+ * NOT `async` on purpose. Callers register the wait BEFORE the action that
+ * triggers it — `signInThroughForm` registers, then clicks **Sign In**, so the
+ * status read cannot race the navigation a `200` triggers. `page.waitForResponse`
+ * subscribes synchronously, and this function must preserve that: making it
+ * `async` would defer the subscription to the first `await` and silently reopen
+ * the race. Pinned by a unit test.
+ */
+export function waitForAttributedResponse(
+  page: Page,
+  predicate: (response: Response) => boolean,
+  options: AttributedResponseOptions,
+): Promise<Response> {
+  const pending = page.waitForResponse(predicate, { timeout: options.timeoutMs });
+  return pending.catch(async (error: any) => {
+    const probe = await probeBackend(page, { baseURL: options.baseURL });
+    throw new Error(
+      responseBarrierMessage({
+        observable: options.observable,
+        timeoutMs: options.timeoutMs,
+        probe,
+        surface: options.surface,
+        cause: String(error?.message ?? error),
+      }),
+    );
+  });
+}


### PR DESCRIPTION
## Type

- [ ] `feat` — new test or new helper/page object
- [x] `fix` — fix for a broken or flaky test
- [ ] `chore` — CI, checklist, dependencies, internal refactoring
- [ ] `docs` — documentation update

---

## Roadmap linkage (required — do not delete)

- [ ] **Current wave** — a `roadmap`-labeled issue in the current wave's milestone: #___
- [x] **Exception** — off-wave work backed by an issue: a follow-up, a `daily-failure` triage issue, or a `community`-labeled regression. Issue #1713 (`daily-failure`)

---

## What this PR does

### Problem

Two `@stable` auth tests flaked in the **green** daily of 2026-09-04 (run [33873006780](https://github.com/oriontech-me/langflow-e2e/actions/runs/33873006780)), in different shards, with a **byte-identical** signature:

```
TimeoutError: page.waitForResponse: Timeout 30000ms exceeded while waiting for event "response"
```

Both come from the same `waitForResponse` in `tests/helpers/auth/sign-in-through-form.ts`, and `login-invalid-credentials` had already flaked under the same string on 2026-08-26 — a same-signature recurrence inside the 30-day window.

That message cannot tell apart the only two states that produce it:

1. the backend accepted `POST /api/v1/login` and never answered — a wedge, collateral damage;
2. the frontend stopped issuing the request — a **product regression**, and the shape the issue's directive named as prime suspect.

Which is exactly why `page.waitForResponse: Timeout` is deliberately **not** on `scripts/lib/infra-signature-patterns.json`, and why both history rows carry `infra_signature: null`.

### Root cause — measured, not inferred

Reproduced deterministically on nightly `1.13.0.dev2` by `docker pause`ing the container (connections accepted, never answered — the gunicorn wedge shape), 2 of 2 runs:

```
signature: page.waitForResponse: Timeout 30000ms exceeded while waiting for event "response"
login POSTs issued by the frontend: ["POST /api/v1/login"]
login requests that FAILED (aborted): []
login responses received: []
form still holds credentials: true
probe while STILL wedged: {"state":"unreachable","ms":5019,
  "detail":"apiRequestContext.get: Timeout 5000ms exceeded."}
```

This closes the prime suspect **by measurement**: the frontend does issue the POST, and it is never aborted — the nightly's bundle configures no client-side request timeout, so once issued the POST waits for the backend however long that takes. Two corroborating reads from inside the container: the `Connection timed out` dialog in the 2026-09-04 error-context is the frontend's **health-check** overlay (`GET /health_check` raced against a 10 s timer), i.e. the page had independently observed the backend as unreachable; and the failing attempts sat inside measured outages of 96 s (shard 2) and 92 s (shard 1), so a 30 s wait cannot do anything but expire.

**Verdict: `transient-saturation` (wedge collateral).** The defect the suite owned was that its own error message could not say so.

### Fix

Applies the `page-entry-barrier` contract (#1262/#1265) to a **response** wait.

- **The 30 s budget is unchanged.** A barrier long enough to outlast a 96 s outage would report a green run through a broken backend — the opposite of the point. Only the failure path is wrapped.
- On timeout the barrier probes `/api/v1/version` and names the state it observed. Same wedge, after the fix:

```
[backend-unreachable] login barrier "POST /api/v1/login" did not answer within 30000ms
— and the backend did not answer GET /api/v1/version within 5011ms
(http://localhost:7893/api/v1/version): apiRequestContext.get: Timeout 5000ms exceeded.
Langflow was unreachable or restarting, so the request was accepted and never
answered — this is NOT a frontend that stopped issuing it.
```

- That message embeds the probe's own transport error, which the **existing** `api-request-timeout` signature already matches — so a wedge becomes classifiable with **no new entry added anywhere**.
- A **healthy** probe deliberately gets **no** prefix: that failure is the product's, and prefixing it would exempt a real regression from `@stable` auto-removal.
- A probe that could not run reads `UNKNOWN`, never clean (#1012).

**Rejected alternatives, explicitly:**

- *Adding `page.waitForResponse: Timeout` to `infra-signature-patterns.json`* — refused. It is ambiguous by construction (case 2 above emits it too); attribution belongs at the call site, which is the same argument `page-entry-barrier.ts` records for `locator.waitFor: Timeout`.
- *Raising the timeout* — refused. It would trade a red test for a green run through a wedged backend.
- *Sweeping all 96 `waitForResponse` call sites* — out of scope for this issue; see *What this PR does not cover*.
- *Quarantining first* — the quarantine PR the issue owed was never opened, so `@stable` is still on both specs and there is nothing to lift. Recorded on the issue.

### Scope note

**No `.spec.ts` file is touched and no tag changes.** `logout-flow` needs no treatment of its own: the attribution lands in the single call site all of its logins go through — recorded in its spec doc, per the issue's deliverable asking for that decision.

---

## Tests covered

No test is added or modified. The two specs the issue claims are unchanged and keep `@stable`; what changed is the shared helper they both call.

| # | Test | What it validates (unchanged) |
|---|---|---|
| 1 | `login with invalid credentials must show error and stay on login page` | The refusal is a **credential** refusal: the final `POST /api/v1/login` status is `401` (pinned because the UI shows the same "Error signing in" toast for a `429`), the error surface appears, `mainpage_title` is never reached, and the form stays usable |
| 2 | `login with empty credentials must not redirect to main page` | An empty submit does not navigate: `mainpage_title` absent, `Username` still visible |
| 3 | `logout must redirect user to login page` | Logout revokes the session: `mainpage_title` visible before, then the login form back and `mainpage_title` hidden |
| 4 | `after logout, navigating to root must redirect to login` | A direct `goto /` after logout does not resume the session |
| 5 | `after logout, reload must stay on login page` | A reload after logout does not resume the session |

---

## How the tests were built

The change is HTTP-level, so no selector work was involved.

`tests/helpers/other/response-barrier.ts` (new) holds a **pure** `responseBarrierMessage()` plus a `waitForAttributedResponse()` drop-in for `page.waitForResponse`, reusing `INFRA_PREFIX`, `PROBE_PATH`, `BackendProbe` and `probeBackend` from `page-entry-barrier.ts` so the marker stays in one place. Its wording is a separate function rather than a reuse of `entryBarrierMessage`, whose text says "did not render" / "entry-point regression" and would misdescribe a response wait.

`waitForAttributedResponse` is deliberately **not** `async`: callers register the wait *before* the action that triggers it (`signInThroughForm` registers, then clicks **Sign In**, so the status read cannot race the navigation a `200` triggers). `page.waitForResponse` subscribes synchronously, and making the wrapper `async` would defer that subscription to the first `await` and silently reopen the race. Pinned by a unit test.

`tests/helpers/other/response-barrier.test.ts` (new, 10 tests) mirrors `page-entry-barrier.test.ts`: it drives the message with every probe state and asserts against the **real** classifier (`classifyInfraError`) that unreachable/`http_error` carry the prefix and resolve to `api-request-timeout`, that a healthy probe carries no prefix and classifies `null`, that `unknown` reads UNKNOWN, and that the bare Playwright string this replaces classifies `null` — the property that makes "no new pattern" a fact rather than a claim.

---

## Dependencies

None new. No LLM, no provider key, no flow created — so nothing to clean up. Both specs run parallel-safe; the shared `POST /api/v1/login` per-IP budget (5/min, fixed window) is absorbed by the helper exactly as before.

---

## What this PR does not cover

- **The other 95 `waitForResponse` call sites** across 60 files carry the same ambiguity — including `agent-input-sources.spec.ts:142`, the *third* flake with this exact string in the same run. Scope is limited to the login helper, which covers both specs this issue claims; the sweep is a follow-up.
- **Any change to `scripts/lib/infra-signature-patterns.json`** — argued above, not an omission.
- **The mid-run worker wedge itself** — #1686 owns the lever that relieves it; this PR only makes its collateral attributable.

---

## Known limitations

Inherited from the entry barrier and stated rather than papered over: the probe runs **after** the wait's budget is spent, so it reports the backend's state then, not during. A wedge shorter than the wait clears before the probe and reads `healthy`, and the message then blames the app. That asymmetry is deliberate — over-claiming an outage would let a real regression through unquarantined, which costs more.

Also honest: the health-check overlay seen in the CI snapshot did **not** appear inside the ~35 s reproduction window (the poll plus its 10 s race did not elapse). The CI outages were 92 s and 96 s, which is why the modal was open there.

---

## Related issue

Closes #1713

---

## Validation

Instance: dedicated container on `:7893`, **Langflow Nightly `1.13.0.dev2`** (the nightly moved to `dev3` mid-session; measurements stand on `dev2`, the same `1.13.x` cycle both spec docs record).

**Bursts — 12 runs over the 4 specs that import the changed helper, `--retries=0 --workers=1`, all clean:**

| Spec | Runs | Result |
|---|---|---|
| `login-invalid-credentials.spec.ts` | 3/3 | `expected=2 unexpected=0 flaky=0 skipped=0` |
| `logout-flow.spec.ts` | 3/3 | `expected=3 unexpected=0 flaky=0 skipped=0` |
| `auto-login-off.spec.ts` | 3/3 | `expected=1 unexpected=0 flaky=0 skipped=0` |
| `admin-password-change.spec.ts` | 3/3 | `expected=2 unexpected=0 flaky=0 skipped=0` |

**Pre-fix flake baseline:** `repro-run` on the unmodified spec measured **0/5 failures (0 %)** — expected, since a healthy backend cannot produce the defect. The mechanism was proved with the `docker pause` reproduction above instead.

**Force-fail — 5 mutations, each recorded with `unexpected=1`:**

| Test | Mutation |
|---|---|
| `login with invalid credentials must show error and stay on login page` | the attributed wait's predicate pointed at `/api/v1/login-FF`, an endpoint that never answers |
| `logout must redirect user to login page` | same mechanism mutation |
| `after logout, navigating to root must redirect to login` | same mechanism mutation |
| `after logout, reload must stay on login page` | same mechanism mutation |
| `login with empty credentials must not redirect to main page` | the only test that does not go through the helper: its empty submit replaced by valid superuser credentials, so the form authenticates and navigates — the exact outcome it asserts must not happen |

All reverted (`no FF-MUTATION markers in diff ✓`). Because the diff contains no `.spec.ts`, the pipeline's force-fail gate reports coverage over **0 files** — vacuous, and **not** accepted as the evidence; the post-revert green runs were executed by hand: `login-invalid-credentials` `expected=2` (7.5 s) and `logout-flow` `expected=3` (12.6 s), both `unexpected=0 flaky=0 skipped=0`.

**Other gates:**

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- `npm run test:units` ✅ — **1025/1025**, including the 10 new tests
- Zero `🚨 Backend Error:` in every run's stdout **and** stderr
- QA-CHECKLIST guards ✅ (`check:checklist-coverage`, `check-checklist-guard`) — no bullet change: no new spec, no tag change
- Spec-doc dependency paths ✅ — run the way CI runs it (`origin/main` + `release-1.13.0` + `release-1.12.1`): every path resolves
- Flow residue audited: 26 flows on the instance, **all Langflow starter projects**, zero test artifacts

Checklist:

- [ ] Ran the test in isolation with `--trace=on` and verified steps in the report — *not run: `--trace=on` hangs UI specs on this local Docker setup; substituted by the 12-run `--retries=0` burst plus the JSON-stat runs above*
- [x] Forced a failure to confirm it is not a false positive — 5 mutations, all red, all reverted
- [ ] Ran in `--debug` mode and walked through step by step — *not run by the agent (the inspector needs a human at the keyboard); the reviewer's copy-paste `--debug` command is in the issue report. The step-level walk was done instead through the `docker pause` reproduction, which drives the real helper and prints the request/response/probe state at each stage*
- [x] Confirmed there are no backend errors (`🚨 Backend Error:`) in the output
- [ ] Updated `QA-CHECKLIST.md` — *not applicable: no spec added or removed, no tag changed; both guards confirm the file is already correct*
- [ ] Updated `QA-SCENARIOS-GUIDE.md` — *not applicable: no scenario changed*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
