### PR TITLE
fix(flows): one measured budget for the permissions gate, replacing five (#1222)

### DIFF
--- a/tests/helpers/flows/open-flow-by-id.test.ts
+++ b/tests/helpers/flows/open-flow-by-id.test.ts
@@ -96,7 +96,7 @@ test("a different page gets its own seed", async () => {
   assert.equal(second.initScripts.length, 1);
 });
 
-test("the canvas budget is separate from, and longer than, the writable budget", () => {
+test("the canvas budget is separate from, and longer than, the permissions gate", () => {
   // A RELATION between two independently-editable constants, not a restatement of
   // either. They answer different questions: "nothing is on screen yet" (document
   // load + flow fetch + first render) versus "the editor is up and the permission

--- a/tests/helpers/flows/open-flow-by-id.test.ts
+++ b/tests/helpers/flows/open-flow-by-id.test.ts
@@ -30,9 +30,9 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { PERMISSIONS_GATE_TIMEOUT_MS } from "./permissions-gate";
 import {
   CANVAS_TIMEOUT_MS,
-  WRITABLE_TIMEOUT_MS,
   navigateToFlow,
   type NavigablePage,
 } from "./open-flow-by-id";
@@ -103,9 +103,14 @@ test("the canvas budget is separate from, and longer than, the writable budget",
   // query has not answered". Inverting them would hide a permission map that
   // genuinely denies `write` behind the longer wait, and the migration this helper
   // performed is exactly the moment someone edits one budget and not the other.
+  //
+  // Since #1222 the right-hand side is shared with four other call sites, which
+  // makes this the one place the relation is still checkable — and it is an
+  // INEQUALITY between the two budgets of this same entry, not the equality pin to
+  // an unrelated third constant that #1221 removed and #1222 forbids re-adding.
   assert.ok(
-    CANVAS_TIMEOUT_MS > WRITABLE_TIMEOUT_MS,
-    `canvas ${CANVAS_TIMEOUT_MS}ms must exceed writable ${WRITABLE_TIMEOUT_MS}ms`,
+    CANVAS_TIMEOUT_MS > PERMISSIONS_GATE_TIMEOUT_MS,
+    `canvas ${CANVAS_TIMEOUT_MS}ms must exceed the permissions gate ${PERMISSIONS_GATE_TIMEOUT_MS}ms`,
   );
   // The floor is the largest budget any of the three migrated copies carried: the
   // helper unified them by taking the MAX, because none was ever measured and

--- a/tests/helpers/flows/open-flow-by-id.ts
+++ b/tests/helpers/flows/open-flow-by-id.ts
@@ -47,6 +47,12 @@ import {
   type SeedablePage,
   seedAssistantDiscovered,
 } from "../ui/assistant-onboarding";
+// The header-writability budget is NOT defined here since #1222: five call sites
+// wait on the same button, and two of the five diverged the moment two PRs landed
+// in parallel. Imported, never re-exported — a second import path is how a
+// converged constant grows a second identity again. The value, the burst it was
+// measured on and the case for 30 s over 15 s live in `permissions-gate.ts`.
+import { PERMISSIONS_GATE_TIMEOUT_MS } from "./permissions-gate";
 
 // Re-exported rather than redefined: the seed moved to
 // `helpers/ui/assistant-onboarding.ts` when #1220 gave it seven more callers, none
@@ -70,25 +76,15 @@ export {
  *
  * Raising the other two costs only how long a doomed entry takes to say so, and
  * that cost is bounded: this gate plus the writable gate below are SERIAL, so a
- * dead entry spends at most `CANVAS_TIMEOUT_MS + WRITABLE_TIMEOUT_MS` (130 s)
- * before failing — comfortably inside the suite's 5-minute per-test timeout, so
- * the failure still lands on this assertion with its own message rather than as
- * an unattributed test-level timeout.
+ * dead entry spends at most `CANVAS_TIMEOUT_MS + PERMISSIONS_GATE_TIMEOUT_MS`
+ * (130 s) before failing — comfortably inside the suite's 5-minute per-test
+ * timeout, so the failure still lands on this assertion with its own message
+ * rather than as an unattributed test-level timeout.
  *
  * Lowering it is a measurement, not an opinion: it wants entry durations from a
  * saturated daily, which the repo does not record today.
  */
 export const CANVAS_TIMEOUT_MS = 100000;
-
-/**
- * How long the flow header may stay disabled before the entry is called broken.
- *
- * Separate from the canvas budget on purpose: by the time this runs the editor is
- * already on screen, so the only thing outstanding is
- * `POST /api/v1/authz/me/permissions`. Charging it the canvas window would hide a
- * permission map that genuinely denies `write` behind a minute of waiting.
- */
-export const WRITABLE_TIMEOUT_MS = 30000;
 
 /**
  * The `Page` surface this helper's navigation half needs. Narrow, so the unit lane
@@ -154,7 +150,7 @@ export async function openFlowById(
 
   if (requireWritable) {
     await expect(page.getByTestId("menu_bar_display")).toBeEnabled({
-      timeout: WRITABLE_TIMEOUT_MS,
+      timeout: PERMISSIONS_GATE_TIMEOUT_MS,
     });
   }
 }

--- a/tests/helpers/flows/open-flow-settings.test.ts
+++ b/tests/helpers/flows/open-flow-settings.test.ts
@@ -28,7 +28,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { HEADER_ENABLED_TIMEOUT_MS } from "./open-flow-settings";
+import { HEADER_PRESENT_TIMEOUT_MS } from "./open-flow-settings";
 
 /** The suite root, resolved from this file rather than from `process.cwd()`. */
 const TESTS_ROOT = join(__dirname, "..", "..");
@@ -255,17 +255,20 @@ test("the helper drives the button, and gates on it being enabled", () => {
   assert.deepEqual(findSpanInteractions(code), []);
 });
 
-test("the header budget is a positive, bounded wait", () => {
-  // Deliberately NOT pinned to `rename-flow.ts`'s `MODAL_TIMEOUT` by parsing its
-  // source. That coupling read as provenance it does not have — `MODAL_TIMEOUT`
-  // was sized in #357 for the modal's inputs, not for the permissions query this
-  // gate waits on — and it would have cemented a divergence: the sibling gate in
-  // `open-flow-by-id.ts` (#1214) waits 30 s on the SAME button. Converging the two
-  // is tracked separately; pinning one to a third constant here would have made
-  // that convergence fail the unit lane.
-  assert.ok(HEADER_ENABLED_TIMEOUT_MS > 0);
+test("the header-present budget is a positive, bounded wait", () => {
+  // Still deliberately NOT pinned to `rename-flow.ts`'s `MODAL_TIMEOUT` by parsing
+  // its source. That coupling read as provenance it does not have, and #1221
+  // removed it precisely so #1222 could converge the permissions gate without
+  // failing the unit lane.
+  //
+  // What this constant covers narrowed in #1222: it is now the "the editor put a
+  // header on screen at all" wait only. The enabled gate it used to share a number
+  // with is `PERMISSIONS_GATE_TIMEOUT_MS`, measured and shared with four other
+  // sites — and the two are now different numbers, which is what makes their
+  // independence visible rather than asserted.
+  assert.ok(HEADER_PRESENT_TIMEOUT_MS > 0);
   assert.ok(
-    HEADER_ENABLED_TIMEOUT_MS <= 30000,
-    "a header that never enables must fail well inside the per-test timeout",
+    HEADER_PRESENT_TIMEOUT_MS <= 30000,
+    "a header that never appears must fail well inside the per-test timeout",
   );
 });

--- a/tests/helpers/flows/open-flow-settings.test.ts
+++ b/tests/helpers/flows/open-flow-settings.test.ts
@@ -29,6 +29,7 @@ import assert from "node:assert/strict";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { HEADER_PRESENT_TIMEOUT_MS } from "./open-flow-settings";
+import { stripComments } from "./strip-comments";
 
 /** The suite root, resolved from this file rather than from `process.cwd()`. */
 const TESTS_ROOT = join(__dirname, "..", "..");
@@ -60,26 +61,6 @@ const LOCATOR_CHAIN = String.raw`\s*(?:\.\s*\w+\s*\([^()]*\)\s*)*`;
 /** 1-indexed line of an offset, for a message that points somewhere. */
 function lineOf(code: string, index: number): number {
   return code.slice(0, index).split("\n").length;
-}
-
-/**
- * Strip comments so the guard does not fail on its own documentation.
- *
- * Blanked, not deleted (#1222): deleting a block comment shifts every line below
- * it, so `lineOf` named a line the offender is not on — measured at 51 lines of
- * skew on a real file, which is worse than no line at all because it reads as
- * precise. Blanking also stops a removal from JOINING the tokens either side of
- * it, which could synthesise a match that is not in the source.
- *
- * Line comments are matched only when `//` follows start-of-line or whitespace
- * AND is not preceded by a colon — otherwise `page.goto("http://…")` would be
- * truncated mid-string and the file would stop parsing as the code it is.
- */
-function stripComments(source: string): string {
-  const blank = (text: string) => text.replace(/[^\n]/g, " ");
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, blank)
-    .replace(/(^|[^:\w])\/\/.*$/gm, (match, prefix: string) => prefix + blank(match.slice(prefix.length)));
 }
 
 /**

--- a/tests/helpers/flows/open-flow-settings.test.ts
+++ b/tests/helpers/flows/open-flow-settings.test.ts
@@ -65,14 +65,21 @@ function lineOf(code: string, index: number): number {
 /**
  * Strip comments so the guard does not fail on its own documentation.
  *
+ * Blanked, not deleted (#1222): deleting a block comment shifts every line below
+ * it, so `lineOf` named a line the offender is not on — measured at 51 lines of
+ * skew on a real file, which is worse than no line at all because it reads as
+ * precise. Blanking also stops a removal from JOINING the tokens either side of
+ * it, which could synthesise a match that is not in the source.
+ *
  * Line comments are matched only when `//` follows start-of-line or whitespace
  * AND is not preceded by a colon — otherwise `page.goto("http://…")` would be
  * truncated mid-string and the file would stop parsing as the code it is.
  */
 function stripComments(source: string): string {
+  const blank = (text: string) => text.replace(/[^\n]/g, " ");
   return source
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/(^|[^:\w])\/\/.*$/gm, "$1");
+    .replace(/\/\*[\s\S]*?\*\//g, blank)
+    .replace(/(^|[^:\w])\/\/.*$/gm, (match, prefix: string) => prefix + blank(match.slice(prefix.length)));
 }
 
 /**

--- a/tests/helpers/flows/open-flow-settings.ts
+++ b/tests/helpers/flows/open-flow-settings.ts
@@ -42,11 +42,14 @@ import { PERMISSIONS_GATE_TIMEOUT_MS } from "./permissions-gate";
  * Kept at 15 s and kept LOCAL, which is the half of #1222 that is easy to miss:
  * this budget and the permissions gate below were one constant doing two jobs,
  * and they answer different questions. An absent `flow_name` means the editor
- * never mounted — the caller has not landed on the canvas — while a header that
- * is present but disabled means the permissions query has not answered. The
- * second is now `PERMISSIONS_GATE_TIMEOUT_MS`, shared with the four other places
- * that wait on the same button; this one has no siblings to converge with, and
- * changing it would be a behaviour change #1222 did not ask for.
+ * never mounted — the caller has not landed on the canvas. A header that is
+ * present but disabled is the OTHER question, and it has two answers, not one:
+ * the permissions query is still in flight, or it has answered and the map
+ * genuinely denies `write` (the note on `openFlowSettings` below keeps them
+ * distinct, because they send a reader to opposite places). That budget is now
+ * `PERMISSIONS_GATE_TIMEOUT_MS`, shared with the four other places that wait on
+ * the same button; this one has no siblings to converge with, and changing it
+ * would be a behaviour change #1222 did not ask for.
  *
  * Still not measured, and still not pretending to be: 15 s comes from
  * `rename-flow.ts`'s `MODAL_TIMEOUT` (#357, sized for the modal's inputs). What

--- a/tests/helpers/flows/open-flow-settings.ts
+++ b/tests/helpers/flows/open-flow-settings.ts
@@ -34,26 +34,25 @@
 // copies diverge rather than after.
 
 import { type Page, expect } from "@playwright/test";
+import { PERMISSIONS_GATE_TIMEOUT_MS } from "./permissions-gate";
 
 /**
- * How long the header may stay disabled before the open is called broken.
+ * How long the editor may take to put the header on screen at all.
  *
- * 15 s, which is what `renameFlow` used for this gate when it was inline — so no
- * caller's failure latency changes here. Stated without pretending it is measured:
- * the number comes from `MODAL_TIMEOUT`, sized in #357 for the flow-settings
- * modal's INPUTS, not for the effective-permissions query this waits on. Nobody
- * has measured that query under the daily's parallel load.
+ * Kept at 15 s and kept LOCAL, which is the half of #1222 that is easy to miss:
+ * this budget and the permissions gate below were one constant doing two jobs,
+ * and they answer different questions. An absent `flow_name` means the editor
+ * never mounted — the caller has not landed on the canvas — while a header that
+ * is present but disabled means the permissions query has not answered. The
+ * second is now `PERMISSIONS_GATE_TIMEOUT_MS`, shared with the four other places
+ * that wait on the same button; this one has no siblings to converge with, and
+ * changing it would be a behaviour change #1222 did not ask for.
  *
- * The same gate on the same button exists in FOUR other places at 30 s —
- * `open-flow-by-id.ts` (#1214), `setup-playground.ts`,
- * `api-request-component-regression.spec.ts` and `output-modal-copy-button.spec.ts`
- * — so this is a five-way divergence, not a two-way one. Converging them is
- * **#1222**, deliberately not resolved here: picking a number for five call sites
- * is a decision with its own evidence, and doing it inside a fix for the swallowed
- * click would bury it. It is also deliberately not pinned by a test — an assertion
- * tying this constant to another would make #1222 fail the unit lane.
+ * Still not measured, and still not pretending to be: 15 s comes from
+ * `rename-flow.ts`'s `MODAL_TIMEOUT` (#357, sized for the modal's inputs). What
+ * changed is that it no longer stands in for a wait that HAS been measured.
  */
-export const HEADER_ENABLED_TIMEOUT_MS = 15000;
+export const HEADER_PRESENT_TIMEOUT_MS = 15000;
 
 /**
  * Open the flow-settings popover from the editor header.
@@ -74,12 +73,12 @@ export async function openFlowSettings(page: Page): Promise<void> {
   // Assert the header first: its absence means the editor never mounted, which is
   // a very different failure from a header that is present but disabled.
   await expect(page.getByTestId("flow_name")).toBeVisible({
-    timeout: HEADER_ENABLED_TIMEOUT_MS,
+    timeout: HEADER_PRESENT_TIMEOUT_MS,
   });
 
   const headerButton = page.getByTestId("menu_bar_display");
   await expect(headerButton).toBeEnabled({
-    timeout: HEADER_ENABLED_TIMEOUT_MS,
+    timeout: PERMISSIONS_GATE_TIMEOUT_MS,
   });
   await headerButton.hover();
   await headerButton.click();

--- a/tests/helpers/flows/permissions-gate.test.ts
+++ b/tests/helpers/flows/permissions-gate.test.ts
@@ -15,6 +15,12 @@
 // guard: every gate on `menu_bar_display` being enabled must name
 // `PERMISSIONS_GATE_TIMEOUT_MS`, never a literal and never nothing.
 //
+// The comment scanner both guards run first is `./strip-comments`, one copy since
+// review of this PR found it losing real code in `open-flow-by-id.ts` — the file
+// named in CANONICAL_GATE_FILES below. A guard that reads a blanked file reports
+// nothing and passes, which is the one failure mode it cannot tell you about, so
+// the scanner carries its own tests.
+//
 // WHAT IT DELIBERATELY DOES NOT DO
 //
 // It does not pin the constant to any other constant. PR #1221 removed exactly
@@ -29,6 +35,7 @@ import assert from "node:assert/strict";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { PERMISSIONS_GATE_TIMEOUT_MS } from "./permissions-gate";
+import { stripComments } from "./strip-comments";
 
 /** The suite root, resolved from this file rather than from `process.cwd()`. */
 const TESTS_ROOT = join(__dirname, "..", "..");
@@ -41,6 +48,24 @@ const HEADER_LOCATOR = String.raw`(?:getByTestId\(\s*["'\`]menu_bar_display["'\`
 
 /** `.first()`, `.nth(0)` and friends between the locator and the assertion. */
 const LOCATOR_CHAIN = String.raw`\s*(?:\.\s*\w+\s*\([^()]*\)\s*)*`;
+
+/**
+ * `expect`'s optional second argument, the failure message.
+ *
+ * Not hypothetical and not exotic: the suite passes one ~9 times already
+ * (`serving/end-user-identity-required.spec.ts`, `collect-models.spec.ts`,
+ * `enterprise/authz/share-discovery.spec.ts`, ...), and naming the failure is this
+ * repo's house style — so it is the likely spelling of the NEXT gate someone
+ * writes. Without this the closing paren was required immediately after the
+ * locator, and `expect(page.getByTestId("menu_bar_display"), "must be writable")`
+ * found zero gates and reported nothing.
+ */
+const EXPECT_MESSAGE = String.raw`(?:\s*,\s*[^()]*)?`;
+
+/** Regex-escape an identifier before interpolating it into a pattern. */
+function escapeForRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
 
 /**
  * The two spellings of "wait until this button is usable".
@@ -60,31 +85,6 @@ const USABLE_ASSERTION = String.raw`(?:toBeEnabled|not\s*\.\s*toBeDisabled)`;
 /** 1-indexed line of an offset, for a message that points somewhere. */
 function lineOf(code: string, index: number): number {
   return code.slice(0, index).split("\n").length;
-}
-
-/**
- * Strip comments WITHOUT moving anything.
- *
- * Blanking each character rather than deleting the comment is what keeps
- * `lineOf` honest: deleting a block comment shifts every line below it, and the
- * guard then names a line the offender is not on. Measured on the sibling
- * implementation this was copied from — a real offender at
- * `setup-playground.ts:199` was reported as line 148, a 51-line skew, which is
- * worse than no line at all because it reads as precise.
- *
- * It also stops a removal from JOINING the tokens either side of it
- * (`foo/*c*\/bar` → `foobar`), which could synthesise a match that is not in the
- * source.
- *
- * Line comments are matched only when `//` follows start-of-line or whitespace
- * AND is not preceded by a colon — otherwise `page.goto("http://…")` would be
- * blanked mid-string and the file would stop parsing as the code it is.
- */
-function stripComments(source: string): string {
-  const blank = (text: string) => text.replace(/[^\n]/g, " ");
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, blank)
-    .replace(/(^|[^:\w])\/\/.*$/gm, (_match, prefix: string) => prefix + blank(_match.slice(prefix.length)));
 }
 
 export interface Gate {
@@ -108,8 +108,10 @@ export interface Gate {
  *  - a locator returned by a helper or a Page Object method, rather than resolved
  *    at the call site;
  *  - an assignment without `const`/`let`/`var` on the same statement;
- *  - an options object containing a call (`{ timeout: f(1) }`) — the outer `\)`
- *    would close early;
+ *  - a call as the WHOLE argument (`toBeEnabled(opts(1))`) — the outer `\)`
+ *    closes early. An options object CONTAINING a call is fine
+ *    (`{ timeout: ms(30) }` is captured whole and correctly reported), which is
+ *    the opposite of what this list claimed until it was checked;
  *  - arithmetic on the constant (`{ timeout: PERMISSIONS_GATE_TIMEOUT_MS * 2 }`)
  *    reads as compliant, because the test is that the name appears.
  *
@@ -121,7 +123,7 @@ export function findEnabledGates(source: string): Gate[] {
   const gates: Gate[] = [];
 
   const inline = new RegExp(
-    `${HEADER_LOCATOR}${LOCATOR_CHAIN}\\)${LOCATOR_CHAIN}\\.\\s*${USABLE_ASSERTION}\\s*\\(([^()]*(?:\\{[^{}]*\\})?[^()]*)\\)`,
+    `${HEADER_LOCATOR}${LOCATOR_CHAIN}${EXPECT_MESSAGE}\\)${LOCATOR_CHAIN}\\.\\s*${USABLE_ASSERTION}\\s*\\(([^()]*(?:\\{[^{}]*\\})?[^()]*)\\)`,
     "g",
   );
   for (const match of code.matchAll(inline)) {
@@ -132,10 +134,14 @@ export function findEnabledGates(source: string): Gate[] {
     `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*[^;]*${HEADER_LOCATOR}`,
     "g",
   );
-  for (const declaration of code.matchAll(assigned)) {
-    const name = declaration[1];
+  // Distinct names, because the scan below is file-wide: two declarations of the
+  // same locator variable in one file used to report every one of its gates twice.
+  const names = new Set(
+    [...code.matchAll(assigned)].map((declaration) => declaration[1]),
+  );
+  for (const name of names) {
     const viaVariable = new RegExp(
-      `expect(?:\\.\\s*soft)?\\(\\s*${name}${LOCATOR_CHAIN}\\)${LOCATOR_CHAIN}\\.\\s*${USABLE_ASSERTION}\\s*\\(([^()]*(?:\\{[^{}]*\\})?[^()]*)\\)`,
+      `expect(?:\\.\\s*soft)?\\(\\s*${escapeForRegExp(name)}${LOCATOR_CHAIN}${EXPECT_MESSAGE}\\)${LOCATOR_CHAIN}\\.\\s*${USABLE_ASSERTION}\\s*\\(([^()]*(?:\\{[^{}]*\\})?[^()]*)\\)`,
       "g",
     );
     for (const use of code.matchAll(viaVariable)) {
@@ -168,6 +174,9 @@ export function gateComplaint(gate: Gate): string | null {
 function suiteFiles(dir: string = TESTS_ROOT): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir)) {
+    // The sibling guard skips this and this one did not; a stray install under
+    // `tests/` would have the sweep read a vendored tree it does not own.
+    if (entry === "node_modules") continue;
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) {
       out.push(...suiteFiles(full));
@@ -242,6 +251,65 @@ test("the guard sees both spellings, and reads the timeout out of each", () => {
     `await expect(page.getByTestId("menu_bar_display").first()).toBeEnabled({ timeout: PERMISSIONS_GATE_TIMEOUT_MS });`,
   );
   assert.equal(chained.length, 1);
+  assert.equal(gateComplaint(chained[0]), null);
+});
+
+test("a failure message on the expect is the same gate, and the guard sees it", () => {
+  // ~9 call sites in this suite already pass one, and naming the failure is the
+  // house style — so this is the likely spelling of the next gate. The guard used
+  // to find ZERO here, which is the quiet failure: green, and blind.
+  const inline = findEnabledGates(
+    `await expect(page.getByTestId("menu_bar_display"), "the flow must be writable").toBeEnabled({ timeout: 30000 });`,
+  );
+  assert.equal(inline.length, 1);
+  assert.match(gateComplaint(inline[0]) ?? "", /not PERMISSIONS_GATE_TIMEOUT_MS/);
+
+  const variable = findEnabledGates(
+    `const headerButton = page.getByTestId("menu_bar_display");\nawait expect(headerButton, "writable").toBeEnabled({ timeout: PERMISSIONS_GATE_TIMEOUT_MS });`,
+  );
+  assert.equal(variable.length, 1);
+  assert.equal(gateComplaint(variable[0]), null);
+});
+
+test("a `$`-prefixed locator variable is not a regex anchor", () => {
+  // `$` is admitted by the identifier class and was interpolated into the pattern
+  // unescaped, so `$btn` compiled to an end-of-input assertion and matched nothing.
+  const gates = findEnabledGates(
+    `const $btn = page.getByTestId("menu_bar_display");\nawait expect($btn).toBeEnabled({ timeout: 30000 });`,
+  );
+  assert.equal(gates.length, 1);
+  assert.match(gateComplaint(gates[0]) ?? "", /not PERMISSIONS_GATE_TIMEOUT_MS/);
+});
+
+test("one locator variable declared twice reports each gate once", () => {
+  const gates = findEnabledGates(
+    [
+      `const headerButton = page.getByTestId("menu_bar_display");`,
+      `await expect(headerButton).toBeEnabled({ timeout: 30000 });`,
+      `const headerButton = page.getByTestId("menu_bar_display");`,
+    ].join("\n"),
+  );
+  assert.equal(gates.length, 1);
+});
+
+test("a gate is found next to the code shapes that used to blank it", () => {
+  // The scanner defect this guard shipped with, as behaviour rather than prose:
+  // a `/*` inside a string or inside a line comment opened a span that ran to the
+  // next `*/`, and every gate in between was invisible. Both shapes are in the
+  // tree — the xpath idiom 49 times, and the glob in `open-flow-by-id.ts:20`, the
+  // canonical file this very guard asserts a gate in.
+  for (const preamble of [
+    `const CANVAS = '//*[@id="react-flow-id"]';`,
+    "// see `tests/fixtures/**` for why this is a helper",
+    `await page.goto("http://localhost:7860/");`,
+    `await page.goto("//protocol-relative");`,
+  ]) {
+    const gates = findEnabledGates(
+      `${preamble}\nawait expect(page.getByTestId("menu_bar_display")).toBeEnabled({ timeout: 30000 });\n/** a doc comment closing the fake span */`,
+    );
+    assert.equal(gates.length, 1, `blanked by: ${preamble}`);
+    assert.equal(gates[0].line, 2, `wrong line after: ${preamble}`);
+  }
 });
 
 test("`not.toBeDisabled` is the same gate, and the guard sees it", () => {
@@ -281,7 +349,7 @@ test("asserting the button is NOT usable is a different question, and is left al
   }
 });
 
-test("the guard rejects the two ways the divergence comes back", () => {
+test("the guard rejects the three ways the divergence comes back", () => {
   // A literal — how all five started.
   const literal = findEnabledGates(
     `await expect(page.getByTestId("menu_bar_display")).toBeEnabled({ timeout: 30000 });`,

--- a/tests/helpers/flows/permissions-gate.test.ts
+++ b/tests/helpers/flows/permissions-gate.test.ts
@@ -1,0 +1,231 @@
+// Structural guard for the one effective-permissions budget (issue #1222).
+// Run with: npm run test:units
+//
+// WHY A STRUCTURAL TEST
+//
+// The defect is not a wrong wait, it is FIVE waits on one upstream element with
+// three different provenances and two different numbers. Nothing about that is
+// observable from a green run: every one of the five passes, and the divergence
+// only shows up the day someone raises one of them for a real reason and the
+// other four keep the old value. #1215 already had to document the five-way split
+// in prose because there was no mechanism to hold it.
+//
+// So this asserts the SOURCE, the same shape as `open-flow-settings.test.ts`'s
+// swallowed-click guard and `scripts/wait-for-backend.test.mjs`'s workflow-shape
+// guard: every gate on `menu_bar_display` being enabled must name
+// `PERMISSIONS_GATE_TIMEOUT_MS`, never a literal and never nothing.
+//
+// WHAT IT DELIBERATELY DOES NOT DO
+//
+// It does not pin the constant to any other constant. PR #1221 removed exactly
+// such a coupling — a regex that read `rename-flow.ts`'s `MODAL_TIMEOUT` — and
+// #1222's own "done when" forbids re-adding one, because a value pinned to an
+// unrelated third number cannot be changed by the measurement that should govern
+// it. The only relation asserted anywhere is the INEQUALITY in
+// `open-flow-by-id.test.ts` between that entry's own two budgets, which is a
+// statement about their ordering and not about either value.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { PERMISSIONS_GATE_TIMEOUT_MS } from "./permissions-gate";
+
+/** The suite root, resolved from this file rather than from `process.cwd()`. */
+const TESTS_ROOT = join(__dirname, "..", "..");
+
+/** This file holds the offending spellings as fixtures, so it cannot scan itself. */
+const SELF = "permissions-gate.test.ts";
+
+/** Any locator spelling that resolves the header button. */
+const HEADER_LOCATOR = String.raw`(?:getByTestId\(\s*["'\`]menu_bar_display["'\`]\s*\)|locator\(\s*["'\`]\[data-testid=["'\\]*menu_bar_display["'\\]*\]["'\`]\s*\))`;
+
+/** `.first()`, `.nth(0)` and friends between the locator and the assertion. */
+const LOCATOR_CHAIN = String.raw`\s*(?:\.\s*\w+\s*\([^()]*\)\s*)*`;
+
+/** 1-indexed line of an offset, for a message that points somewhere. */
+function lineOf(code: string, index: number): number {
+  return code.slice(0, index).split("\n").length;
+}
+
+/** Strip comments so the guard does not read its own documentation as code. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:\w])\/\/.*$/gm, "$1");
+}
+
+export interface Gate {
+  /** The literal text of the `toBeEnabled(...)` argument list, `""` when empty. */
+  options: string;
+  line: number;
+}
+
+/**
+ * Every `menu_bar_display` enabled-gate in one file.
+ *
+ * Two spellings, because both are in the tree today: the inline
+ * `expect(page.getByTestId(...)).toBeEnabled(...)` that four call sites use, and
+ * the variable form in `open-flow-settings.ts`, which assigns the locator first
+ * because it clicks the same button two lines later. A guard matching only the
+ * inline form would bless the one file the issue was opened from.
+ */
+export function findEnabledGates(source: string): Gate[] {
+  const code = stripComments(source);
+  const gates: Gate[] = [];
+
+  const inline = new RegExp(
+    `${HEADER_LOCATOR}${LOCATOR_CHAIN}\\)${LOCATOR_CHAIN}\\.\\s*toBeEnabled\\s*\\(([^()]*(?:\\{[^{}]*\\})?[^()]*)\\)`,
+    "g",
+  );
+  for (const match of code.matchAll(inline)) {
+    gates.push({ options: match[1].trim(), line: lineOf(code, match.index) });
+  }
+
+  const assigned = new RegExp(
+    `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*[^;]*${HEADER_LOCATOR}`,
+    "g",
+  );
+  for (const declaration of code.matchAll(assigned)) {
+    const name = declaration[1];
+    const viaVariable = new RegExp(
+      `expect\\(\\s*${name}${LOCATOR_CHAIN}\\)${LOCATOR_CHAIN}\\.\\s*toBeEnabled\\s*\\(([^()]*(?:\\{[^{}]*\\})?[^()]*)\\)`,
+      "g",
+    );
+    for (const use of code.matchAll(viaVariable)) {
+      gates.push({ options: use[1].trim(), line: lineOf(code, use.index) });
+    }
+  }
+
+  return gates;
+}
+
+/** A gate is compliant when it names the shared constant as its timeout. */
+export function gateComplaint(gate: Gate): string | null {
+  if (!/\btimeout\s*:/.test(gate.options)) {
+    return `line ${gate.line}: no explicit timeout — the gate would fall back to Playwright's 5 s expect default, which is under the measured p95 of the query it waits on`;
+  }
+  if (!/\btimeout\s*:\s*PERMISSIONS_GATE_TIMEOUT_MS\b/.test(gate.options)) {
+    return `line ${gate.line}: timeout is not PERMISSIONS_GATE_TIMEOUT_MS (${gate.options})`;
+  }
+  return null;
+}
+
+/** Every `.ts` under `tests/`, minus this file. */
+function suiteFiles(dir: string = TESTS_ROOT): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...suiteFiles(full));
+    } else if (entry.endsWith(".ts") && entry !== SELF) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+test("every menu_bar_display enabled-gate in the suite names the one constant", () => {
+  const offenders: string[] = [];
+  let gateCount = 0;
+
+  for (const file of suiteFiles()) {
+    for (const gate of findEnabledGates(readFileSync(file, "utf8"))) {
+      gateCount += 1;
+      const complaint = gateComplaint(gate);
+      if (complaint) {
+        offenders.push(`${file.slice(TESTS_ROOT.length + 1)} — ${complaint}`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `these waits on the permissions query have their own budget again:\n  ${offenders.join("\n  ")}`,
+  );
+
+  // A sweep that finds nothing passes, and would keep passing after the testid is
+  // renamed — the guard's own failure mode. Five call sites exist today; the floor
+  // is deliberately below that so removing one is not a red, while removing them
+  // all (or breaking the matcher) is.
+  assert.ok(
+    gateCount >= 4,
+    `only ${gateCount} enabled-gate(s) found — the matcher no longer sees the call sites it guards`,
+  );
+});
+
+test("the guard sees both spellings, and reads the timeout out of each", () => {
+  const inline = findEnabledGates(
+    `await expect(page.getByTestId("menu_bar_display")).toBeEnabled({\n  timeout: PERMISSIONS_GATE_TIMEOUT_MS,\n});`,
+  );
+  assert.equal(inline.length, 1);
+  assert.equal(gateComplaint(inline[0]), null);
+
+  const variable = findEnabledGates(
+    `const headerButton = page.getByTestId("menu_bar_display");\nawait expect(headerButton).toBeEnabled({ timeout: PERMISSIONS_GATE_TIMEOUT_MS });`,
+  );
+  assert.equal(variable.length, 1);
+  assert.equal(gateComplaint(variable[0]), null);
+
+  const chained = findEnabledGates(
+    `await expect(page.getByTestId("menu_bar_display").first()).toBeEnabled({ timeout: PERMISSIONS_GATE_TIMEOUT_MS });`,
+  );
+  assert.equal(chained.length, 1);
+});
+
+test("the guard rejects the two ways the divergence comes back", () => {
+  // A literal — how all five started.
+  const literal = findEnabledGates(
+    `await expect(page.getByTestId("menu_bar_display")).toBeEnabled({ timeout: 30000 });`,
+  );
+  assert.equal(literal.length, 1);
+  assert.match(gateComplaint(literal[0]) ?? "", /not PERMISSIONS_GATE_TIMEOUT_MS/);
+
+  // No timeout at all — silently Playwright's 5 s default, which is under the
+  // measured p95 of the query, so it reads as correct and fails under load.
+  const bare = findEnabledGates(
+    `await expect(page.getByTestId("menu_bar_display")).toBeEnabled();`,
+  );
+  assert.equal(bare.length, 1);
+  assert.match(gateComplaint(bare[0]) ?? "", /no explicit timeout/);
+
+  // A different constant is still a divergence, whatever it is called.
+  const other = findEnabledGates(
+    `await expect(page.getByTestId("menu_bar_display")).toBeEnabled({ timeout: MODAL_TIMEOUT });`,
+  );
+  assert.match(gateComplaint(other[0]) ?? "", /not PERMISSIONS_GATE_TIMEOUT_MS/);
+});
+
+test("the guard does not fire on a read, or on a different button", () => {
+  // `toBeVisible` on the same button is a legitimate, different question.
+  assert.deepEqual(
+    findEnabledGates(
+      `await expect(page.getByTestId("menu_bar_display")).toBeVisible({ timeout: 5000 });`,
+    ),
+    [],
+  );
+  // Another element's enabled-gate is none of this guard's business.
+  assert.deepEqual(
+    findEnabledGates(
+      `await expect(page.getByTestId("save-flow-settings")).toBeEnabled({ timeout: 15000 });`,
+    ),
+    [],
+  );
+  // A commented-out offender is documentation, not code.
+  assert.deepEqual(
+    findEnabledGates(
+      `// await expect(page.getByTestId("menu_bar_display")).toBeEnabled({ timeout: 30000 });`,
+    ),
+    [],
+  );
+});
+
+test("the budget is positive and fails well inside the per-test timeout", () => {
+  // Bounds, not a pinned value: the number is governed by the measurement recorded
+  // next to it, and an equality here would freeze it against the next one.
+  assert.ok(PERMISSIONS_GATE_TIMEOUT_MS > 0);
+  assert.ok(
+    PERMISSIONS_GATE_TIMEOUT_MS < 300000,
+    "a gate that never resolves must fail on its own assertion, not as a test-level timeout",
+  );
+});

--- a/tests/helpers/flows/permissions-gate.test.ts
+++ b/tests/helpers/flows/permissions-gate.test.ts
@@ -47,11 +47,29 @@ function lineOf(code: string, index: number): number {
   return code.slice(0, index).split("\n").length;
 }
 
-/** Strip comments so the guard does not read its own documentation as code. */
+/**
+ * Strip comments WITHOUT moving anything.
+ *
+ * Blanking each character rather than deleting the comment is what keeps
+ * `lineOf` honest: deleting a block comment shifts every line below it, and the
+ * guard then names a line the offender is not on. Measured on the sibling
+ * implementation this was copied from — a real offender at
+ * `setup-playground.ts:199` was reported as line 148, a 51-line skew, which is
+ * worse than no line at all because it reads as precise.
+ *
+ * It also stops a removal from JOINING the tokens either side of it
+ * (`foo/*c*\/bar` → `foobar`), which could synthesise a match that is not in the
+ * source.
+ *
+ * Line comments are matched only when `//` follows start-of-line or whitespace
+ * AND is not preceded by a colon — otherwise `page.goto("http://…")` would be
+ * blanked mid-string and the file would stop parsing as the code it is.
+ */
 function stripComments(source: string): string {
+  const blank = (text: string) => text.replace(/[^\n]/g, " ");
   return source
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/(^|[^:\w])\/\/.*$/gm, "$1");
+    .replace(/\/\*[\s\S]*?\*\//g, blank)
+    .replace(/(^|[^:\w])\/\/.*$/gm, (_match, prefix: string) => prefix + blank(_match.slice(prefix.length)));
 }
 
 export interface Gate {

--- a/tests/helpers/flows/permissions-gate.test.ts
+++ b/tests/helpers/flows/permissions-gate.test.ts
@@ -42,6 +42,21 @@ const HEADER_LOCATOR = String.raw`(?:getByTestId\(\s*["'\`]menu_bar_display["'\`
 /** `.first()`, `.nth(0)` and friends between the locator and the assertion. */
 const LOCATOR_CHAIN = String.raw`\s*(?:\.\s*\w+\s*\([^()]*\)\s*)*`;
 
+/**
+ * The two spellings of "wait until this button is usable".
+ *
+ * `not.toBeDisabled` is not hypothetical: `mcp-server.spec.ts` already waits on
+ * `stdio-tab` that way, twice. A guard hardcoding `toBeEnabled` goes GREEN on a
+ * diverged call site written in the other idiom — measured, by rewriting the
+ * existing `open-flow-settings.ts` gate as `not.toBeDisabled({ timeout: 30000 })`:
+ * the sweep found 0 gates in that file and reported no offender.
+ *
+ * `toBeDisabled` and `not.toBeEnabled` are deliberately NOT here. They assert the
+ * opposite — a flow the user cannot write — which is a legitimate different
+ * question and none of this budget's business.
+ */
+const USABLE_ASSERTION = String.raw`(?:toBeEnabled|not\s*\.\s*toBeDisabled)`;
+
 /** 1-indexed line of an offset, for a message that points somewhere. */
 function lineOf(code: string, index: number): number {
   return code.slice(0, index).split("\n").length;
@@ -86,13 +101,27 @@ export interface Gate {
  * the variable form in `open-flow-settings.ts`, which assigns the locator first
  * because it clicks the same button two lines later. A guard matching only the
  * inline form would bless the one file the issue was opened from.
+ *
+ * KNOWN LIMITS, and every one of them fails to the SAFE side — a missed offender
+ * is recoverable, a guard that cries wolf gets deleted rather than fixed:
+ *
+ *  - a locator returned by a helper or a Page Object method, rather than resolved
+ *    at the call site;
+ *  - an assignment without `const`/`let`/`var` on the same statement;
+ *  - an options object containing a call (`{ timeout: f(1) }`) — the outer `\)`
+ *    would close early;
+ *  - arithmetic on the constant (`{ timeout: PERMISSIONS_GATE_TIMEOUT_MS * 2 }`)
+ *    reads as compliant, because the test is that the name appears.
+ *
+ * None is in the tree today. Adding one would be a reason to widen this, not a
+ * reason to have widened it in advance.
  */
 export function findEnabledGates(source: string): Gate[] {
   const code = stripComments(source);
   const gates: Gate[] = [];
 
   const inline = new RegExp(
-    `${HEADER_LOCATOR}${LOCATOR_CHAIN}\\)${LOCATOR_CHAIN}\\.\\s*toBeEnabled\\s*\\(([^()]*(?:\\{[^{}]*\\})?[^()]*)\\)`,
+    `${HEADER_LOCATOR}${LOCATOR_CHAIN}\\)${LOCATOR_CHAIN}\\.\\s*${USABLE_ASSERTION}\\s*\\(([^()]*(?:\\{[^{}]*\\})?[^()]*)\\)`,
     "g",
   );
   for (const match of code.matchAll(inline)) {
@@ -106,7 +135,7 @@ export function findEnabledGates(source: string): Gate[] {
   for (const declaration of code.matchAll(assigned)) {
     const name = declaration[1];
     const viaVariable = new RegExp(
-      `expect\\(\\s*${name}${LOCATOR_CHAIN}\\)${LOCATOR_CHAIN}\\.\\s*toBeEnabled\\s*\\(([^()]*(?:\\{[^{}]*\\})?[^()]*)\\)`,
+      `expect(?:\\.\\s*soft)?\\(\\s*${name}${LOCATOR_CHAIN}\\)${LOCATOR_CHAIN}\\.\\s*${USABLE_ASSERTION}\\s*\\(([^()]*(?:\\{[^{}]*\\})?[^()]*)\\)`,
       "g",
     );
     for (const use of code.matchAll(viaVariable)) {
@@ -120,7 +149,14 @@ export function findEnabledGates(source: string): Gate[] {
 /** A gate is compliant when it names the shared constant as its timeout. */
 export function gateComplaint(gate: Gate): string | null {
   if (!/\btimeout\s*:/.test(gate.options)) {
-    return `line ${gate.line}: no explicit timeout — the gate would fall back to Playwright's 5 s expect default, which is under the measured p95 of the query it waits on`;
+    // NOT "5 s is too short for the measured p95" — it is not, and saying so
+    // would be a justification the measurement 40 lines away refutes, which is
+    // how an exemption stops being believed (#1084). The objection is that a bare
+    // gate silently inherits a GLOBAL default this budget does not own: ~1.3× the
+    // observed max query latency instead of ~8×, and a number that moves the day
+    // someone sets `expect.timeout` in `playwright.config.ts` for unrelated
+    // reasons.
+    return `line ${gate.line}: no explicit timeout — the gate inherits Playwright's global 5 s expect default (~1.3× the measured max of the query it waits on, against ~8× here), and moves whenever that default does`;
   }
   if (!/\btimeout\s*:\s*PERMISSIONS_GATE_TIMEOUT_MS\b/.test(gate.options)) {
     return `line ${gate.line}: timeout is not PERMISSIONS_GATE_TIMEOUT_MS (${gate.options})`;
@@ -142,16 +178,32 @@ function suiteFiles(dir: string = TESTS_ROOT): string[] {
   return out;
 }
 
+/**
+ * The two files that must always carry a gate, one per spelling.
+ *
+ * A bare count was the first floor here and it was wrong in both directions: it
+ * did not catch losing a site to an idiom the matcher missed, and it would have
+ * REDDENED the obvious next refactor — folding the two spec-level gates into
+ * `setupBlankFlow`, which is what #1108's principle pushes toward. These two are
+ * the entry points #1222 is about, they exercise the inline and the variable
+ * spelling respectively, and removing either is a change that should come here.
+ */
+const CANONICAL_GATE_FILES = [
+  "helpers/flows/open-flow-by-id.ts",
+  "helpers/flows/open-flow-settings.ts",
+];
+
 test("every menu_bar_display enabled-gate in the suite names the one constant", () => {
   const offenders: string[] = [];
-  let gateCount = 0;
+  const filesWithGates = new Set<string>();
 
   for (const file of suiteFiles()) {
+    const relative = file.slice(TESTS_ROOT.length + 1);
     for (const gate of findEnabledGates(readFileSync(file, "utf8"))) {
-      gateCount += 1;
+      filesWithGates.add(relative);
       const complaint = gateComplaint(gate);
       if (complaint) {
-        offenders.push(`${file.slice(TESTS_ROOT.length + 1)} — ${complaint}`);
+        offenders.push(`${relative} — ${complaint}`);
       }
     }
   }
@@ -163,13 +215,14 @@ test("every menu_bar_display enabled-gate in the suite names the one constant", 
   );
 
   // A sweep that finds nothing passes, and would keep passing after the testid is
-  // renamed — the guard's own failure mode. Five call sites exist today; the floor
-  // is deliberately below that so removing one is not a red, while removing them
-  // all (or breaking the matcher) is.
-  assert.ok(
-    gateCount >= 4,
-    `only ${gateCount} enabled-gate(s) found — the matcher no longer sees the call sites it guards`,
-  );
+  // renamed or the matcher rots — the guard's own failure mode, and the one it
+  // cannot report because it looks exactly like compliance.
+  for (const file of CANONICAL_GATE_FILES) {
+    assert.ok(
+      filesWithGates.has(file),
+      `no gate found in ${file} — the matcher no longer sees a call site it is supposed to guard, or that gate moved (which belongs in CANONICAL_GATE_FILES)`,
+    );
+  }
 });
 
 test("the guard sees both spellings, and reads the timeout out of each", () => {
@@ -189,6 +242,43 @@ test("the guard sees both spellings, and reads the timeout out of each", () => {
     `await expect(page.getByTestId("menu_bar_display").first()).toBeEnabled({ timeout: PERMISSIONS_GATE_TIMEOUT_MS });`,
   );
   assert.equal(chained.length, 1);
+});
+
+test("`not.toBeDisabled` is the same gate, and the guard sees it", () => {
+  // Not hypothetical: `mcp-server.spec.ts` waits on `stdio-tab` this way twice.
+  // A guard hardcoding `toBeEnabled` went GREEN on the diverged call site — I
+  // rewrote the real `open-flow-settings.ts` gate in this idiom with a literal
+  // 30000 and the sweep reported nothing at all.
+  const inline = findEnabledGates(
+    `await expect(page.getByTestId("menu_bar_display")).not.toBeDisabled({ timeout: 30000 });`,
+  );
+  assert.equal(inline.length, 1);
+  assert.match(gateComplaint(inline[0]) ?? "", /not PERMISSIONS_GATE_TIMEOUT_MS/);
+
+  const variable = findEnabledGates(
+    `const headerButton = page.getByTestId("menu_bar_display");\nawait expect(headerButton).not.toBeDisabled({ timeout: PERMISSIONS_GATE_TIMEOUT_MS });`,
+  );
+  assert.equal(variable.length, 1);
+  assert.equal(gateComplaint(variable[0]), null);
+
+  // `expect.soft` is 21 uses deep in this suite; the variable form used to miss it.
+  const soft = findEnabledGates(
+    `const headerButton = page.getByTestId("menu_bar_display");\nawait expect.soft(headerButton).toBeEnabled({ timeout: 30000 });`,
+  );
+  assert.equal(soft.length, 1);
+  assert.match(gateComplaint(soft[0]) ?? "", /not PERMISSIONS_GATE_TIMEOUT_MS/);
+});
+
+test("asserting the button is NOT usable is a different question, and is left alone", () => {
+  // A spec that observes a read-only flow asserts exactly this, and it is none of
+  // this budget's business — firing on it would make the guard wrong about the one
+  // case #1214's `requireWritable: false` exists for.
+  for (const source of [
+    `await expect(page.getByTestId("menu_bar_display")).toBeDisabled({ timeout: 5000 });`,
+    `await expect(page.getByTestId("menu_bar_display")).not.toBeEnabled({ timeout: 5000 });`,
+  ]) {
+    assert.deepEqual(findEnabledGates(source), []);
+  }
 });
 
 test("the guard rejects the two ways the divergence comes back", () => {

--- a/tests/helpers/flows/permissions-gate.ts
+++ b/tests/helpers/flows/permissions-gate.ts
@@ -28,9 +28,11 @@
 //
 // THE MEASUREMENT
 //
-// Measured 2026-09-05 against Langflow **1.12.0**, 6 parallel lanes × 8 flow
-// opens = 48 samples, on a developer machine sharing one backend — the saturated
-// local burst #1222 asks for. Two quantities, because they are not the same one:
+// Measured 2026-09-05 against a Langflow reporting **1.12.0** (`GET
+// /api/v1/version`, `main_version` 1.12.0 — a released build, not a `.devNN`
+// nightly), 6 parallel lanes × 8 flow opens = 48 samples, on a developer machine
+// sharing one backend — the saturated local burst #1222 asks for. Two quantities,
+// because they are not the same one:
 //
 //   POST /api/v1/authz/me/permissions   min 205 ms   p50 808 ms   p95 2623 ms   max 3770 ms
 //   the gate (canvas visible → enabled) min   2 ms   p50  14 ms   p95 1919 ms   max 2939 ms
@@ -38,6 +40,25 @@
 // The gate is usually already satisfied when it is reached — p50 14 ms — because
 // the canvas render outlasts the query. The tail is what the budget is for, and
 // under saturation it is seconds, not tens of seconds.
+//
+// The parallelism is doing the work, and that is the figure that makes the burst
+// worth running rather than one lane: at ONE lane, 6 opens, the same instrument
+// reads query max 235 ms and gate max 65 ms — 16× and 45× lighter than the
+// saturated tails above.
+//
+// HOW TO RE-RUN IT
+//
+// A throwaway spec under `tests/`, deleted afterwards rather than committed —
+// nothing selects a `@measure` tag, and a test that never runs in any lane is its
+// own problem (#1010). Per iteration: create a blank flow through `createFlow`,
+// `seedAssistantDiscovered`, `page.goto('/flow/{id}')`, then record (a)
+// `request.timing().responseEnd` from a `page.on("requestfinished")` filtered to
+// `/api/v1/authz/me/permissions`, and (b) the wall-clock between
+// `canvas_controls_dropdown` becoming visible and `menu_bar_display` becoming
+// enabled, both asserted with a budget far above anything expected so the
+// measurement is never truncated by its own timeout. Delete the created flows in a
+// `finally`. Drive it with `--workers=6 --repeat-each=6 --retries=0`; workers
+// alone do not fan out a single test.
 //
 // WHY 30 s AND NOT 15 s, GIVEN BOTH CLEAR THE MEASUREMENT
 //
@@ -85,5 +106,13 @@
  * The full argument, and the measurement behind the number, are at the top of
  * this file. Changing it changes five call sites at once — that is the point —
  * so change it with a measurement, not with an argument.
+ *
+ * One ceiling exists and is not obvious from here: `open-flow-by-id.test.ts`
+ * asserts `CANVAS_TIMEOUT_MS > PERMISSIONS_GATE_TIMEOUT_MS` and pins the canvas
+ * budget at 100 s, so raising this past 100 s fails the unit lane. That is an
+ * ORDERING claim about that entry's two budgets — "nothing is on screen yet" must
+ * outlast "the editor is up and the query has not answered" — and 100 s is ~34×
+ * the largest gate wait ever measured, so the ceiling is not near. Worth knowing
+ * before the next measurement, not worth designing around.
  */
 export const PERMISSIONS_GATE_TIMEOUT_MS = 30000;

--- a/tests/helpers/flows/permissions-gate.ts
+++ b/tests/helpers/flows/permissions-gate.ts
@@ -109,7 +109,8 @@
  *
  * One ceiling exists and is not obvious from here: `open-flow-by-id.test.ts`
  * asserts `CANVAS_TIMEOUT_MS > PERMISSIONS_GATE_TIMEOUT_MS` and pins the canvas
- * budget at 100 s, so raising this past 100 s fails the unit lane. That is an
+ * budget at 100 s, so raising this TO 100 s already fails the unit lane — the
+ * relation is strict, not `>=`. That is an
  * ORDERING claim about that entry's two budgets — "nothing is on screen yet" must
  * outlast "the editor is up and the query has not answered" — and 100 s is ~34×
  * the largest gate wait ever measured, so the ceiling is not near. Worth knowing

--- a/tests/helpers/flows/permissions-gate.ts
+++ b/tests/helpers/flows/permissions-gate.ts
@@ -1,0 +1,89 @@
+// The one budget for the effective-permissions gate (issue #1222).
+//
+// WHAT THE GATE IS
+//
+// Upstream renders the flow header as
+//
+//   <Button data-testid="menu_bar_display" disabled={isReadOnly}>
+//
+// with `useIsFlowReadOnly = Boolean(flowId) && (isLoading || !can(flowId,"write"))`
+// (`contexts/permissionsContext.tsx`), so the button is disabled for the whole
+// time `POST /api/v1/authz/me/permissions` is in flight — deliberately, per its
+// own docstring, so a denied user cannot briefly mutate the in-memory canvas.
+// `useAddComponent` bails out silently under the same expression. That makes the
+// button's enabled state an exact observable for "a mutation issued now will
+// register", and it is why five different places in the suite wait on it.
+//
+// WHY IT IS ONE CONSTANT
+//
+// Because it was five. `open-flow-by-id.ts` (#1214) waited 30 s,
+// `open-flow-settings.ts` (#1215) 15 s, and `setup-playground.ts`,
+// `api-request-component-regression.spec.ts` and `output-modal-copy-button.spec.ts`
+// each carried their own inline 30 s. Two of those landed in parallel PRs, which
+// is exactly the divergence #1108 describes: a fix to one copy reaches none of
+// the others. Neither number was measured — 15 s came from `rename-flow.ts`'s
+// `MODAL_TIMEOUT`, sized in #357 for the flow-settings modal's INPUTS, and 30 s
+// was argued in #1214 as "shorter than the canvas budget", which fixes a relation
+// and not a value.
+//
+// THE MEASUREMENT
+//
+// Measured 2026-09-05 against Langflow **1.12.0**, 6 parallel lanes × 8 flow
+// opens = 48 samples, on a developer machine sharing one backend — the saturated
+// local burst #1222 asks for. Two quantities, because they are not the same one:
+//
+//   POST /api/v1/authz/me/permissions   min 205 ms   p50 808 ms   p95 2623 ms   max 3770 ms
+//   the gate (canvas visible → enabled) min   2 ms   p50  14 ms   p95 1919 ms   max 2939 ms
+//
+// The gate is usually already satisfied when it is reached — p50 14 ms — because
+// the canvas render outlasts the query. The tail is what the budget is for, and
+// under saturation it is seconds, not tens of seconds.
+//
+// WHY 30 s AND NOT 15 s, GIVEN BOTH CLEAR THE MEASUREMENT
+//
+// Both are safe on this evidence (15 s is ~5× the observed max gate wait, 30 s is
+// ~10×). Three things break the tie, and none of them is "bigger is better":
+//
+//  1. **Blast radius.** Four of the five call sites already wait 30 s. Converging
+//     up changes the failure latency of ONE site; converging down changes four,
+//     on a burst measured on one machine.
+//  2. **The measurement is a floor, not a ceiling.** A GitHub runner is slower
+//     than this box and the daily shards it further. ~10× the observed max is the
+//     headroom that covers the gap between the machine that was measured and the
+//     machine that runs; shrinking it wants a measurement FROM the daily, which
+//     the repo does not record today.
+//  3. **The costs are asymmetric.** Too short turns a slow round-trip into a red
+//     on a green product. Too long only lengthens a run that is already failing —
+//     and it stays bounded: in `openFlowById` this gate is serial with the canvas
+//     budget, so a dead entry spends at most 100 s + 30 s = 130 s, comfortably
+//     inside the suite's 5-minute per-test timeout, so the failure still lands on
+//     this assertion with its own message rather than as an unattributed
+//     test-level timeout.
+//
+// WHAT THIS IS NOT
+//
+// It is NOT `rename-flow.ts`'s `MODAL_TIMEOUT`, and the two are now deliberately
+// different numbers. `MODAL_TIMEOUT` budgets the flow-settings modal's inputs
+// (#357); the permissions gate left `renameFlow` when #1215 moved the header
+// click into `openFlowSettings`, so the 15 s they used to share was a coincidence
+// of provenance, not a shared requirement. See the note at `MODAL_TIMEOUT`.
+//
+// It is also NOT the "editor mounted" wait. `openFlowSettings` still asserts
+// `flow_name` is visible first, on its own budget: a header that is absent means
+// the caller never landed on the canvas, which is a different failure and sends
+// the reader somewhere else.
+//
+// A leaf module rather than a constant re-exported from either helper: importing
+// one entry point from the other would couple them in
+// `impacted-specs-by-import.mjs`'s transitive graph, so every spec using
+// `openFlowById` would be selected on every edit to `openFlowSettings` and vice
+// versa (#1054). This module imports nothing.
+
+/**
+ * How long the flow header may stay disabled before the wait is called broken.
+ *
+ * The full argument, and the measurement behind the number, are at the top of
+ * this file. Changing it changes five call sites at once — that is the point —
+ * so change it with a measurement, not with an argument.
+ */
+export const PERMISSIONS_GATE_TIMEOUT_MS = 30000;

--- a/tests/helpers/flows/rename-flow.ts
+++ b/tests/helpers/flows/rename-flow.ts
@@ -7,6 +7,17 @@ import { openFlowSettings } from "./open-flow-settings";
 // nightly backend load the flow-settings modal re-renders when an in-flight
 // autosave response lands, and 3s was not enough headroom for the inputs to
 // stabilise or for `save-flow-settings` to become enabled.
+//
+// #1222 asked whether this should still be the same number as the header gate,
+// now that the gate no longer lives inside `renameFlow`. **It should not, and it
+// no longer is.** The permissions gate moved into `openFlowSettings` in #1215 and
+// is now `PERMISSIONS_GATE_TIMEOUT_MS` (30 s, measured — see
+// `permissions-gate.ts`); this budget covers the modal's INPUTS after it opened,
+// which is what #357 sized it for. The two were only ever the same number because
+// the gate inherited this one's value, and that provenance is exactly what made
+// the divergence look principled. They are independent now, and this one stays at
+// 15 s because nothing about the modal changed — lowering or raising it wants its
+// own evidence, not this issue's.
 const MODAL_TIMEOUT = 15000;
 
 // One re-apply is enough in practice: the clobbering autosave belongs to the

--- a/tests/helpers/flows/setup-playground.ts
+++ b/tests/helpers/flows/setup-playground.ts
@@ -4,6 +4,7 @@ import { adjustScreenView } from "../ui/adjust-screen-view";
 import { getAuthToken } from "../auth/get-auth-token";
 import { zoomOut } from "../ui/zoom-out";
 import { deleteFlow } from "./delete-flow";
+import { PERMISSIONS_GATE_TIMEOUT_MS } from "./permissions-gate";
 
 /** Empty graph payload — what the SPA posts when the "Blank Flow" card is picked. */
 const BLANK_FLOW_DATA = {
@@ -195,7 +196,7 @@ export async function setupPlayground(page: Page): Promise<string> {
     // same expression (`FlowMenu` → `useIsFlowReadOnly(currentFlow?.id)`), so
     // its enabled state is an exact observable for "the add will register".
     await expect(page.getByTestId("menu_bar_display")).toBeEnabled({
-      timeout: 30000,
+      timeout: PERMISSIONS_GATE_TIMEOUT_MS,
     });
 
     // The flow editor sidebar mounts after the flow payload resolves; wait for

--- a/tests/helpers/flows/strip-comments.test.ts
+++ b/tests/helpers/flows/strip-comments.test.ts
@@ -1,0 +1,130 @@
+// Unit tests for the shared comment scanner (#1222).
+// Run with: npm run test:units
+//
+// The cases below are the ones the two regexes this replaced got wrong, plus the
+// two properties every caller depends on: offsets do not move, and strings are
+// left alone. Each was measured against the real tree before it was written here.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { stripComments } from "./strip-comments";
+
+const FLOWS_DIR = __dirname;
+
+/** The invariant every `lineOf` caller leans on. */
+function assertSameShape(source: string): void {
+  const stripped = stripComments(source);
+  assert.equal(stripped.length, source.length, "length moved");
+  assert.equal(
+    stripped.split("\n").length,
+    source.split("\n").length,
+    "line count moved",
+  );
+}
+
+test("a comment is blanked in place, so nothing below it shifts", () => {
+  const source = `const a = 1;\n/* two\n   lines */\nconst b = 2;`;
+  const stripped = stripComments(source);
+  assertSameShape(source);
+  assert.equal(stripped.split("\n")[3], "const b = 2;");
+  assert.match(stripped, /^const a = 1;\n {6}\n {11}\nconst b = 2;$/);
+});
+
+test("a removed comment cannot join the tokens either side of it", () => {
+  const joined = stripComments("foo/* c */bar");
+  assert.equal(joined, `foo${" ".repeat("/* c */".length)}bar`);
+  assert.doesNotMatch(joined, /foobar/);
+});
+
+test("`/*` inside a string does not open a comment", () => {
+  // The xpath idiom, 49 occurrences under `tests/`. The old regex opened a span
+  // here that ran to the next `*/` anywhere in the file.
+  const source = `const CANVAS = '//*[@id="react-flow-id"]';\nconst gate = "kept";`;
+  assert.equal(stripComments(source), source);
+});
+
+test("`//` inside a string does not open a comment", () => {
+  const source = `await page.goto("http://localhost:7860/");\nconst after = 1;`;
+  assert.equal(stripComments(source), source);
+  // Not just the colon case the old pattern special-cased: a protocol-relative
+  // URL has no colon in front of the slashes at all.
+  const relative = `await page.goto("//x");\nconst after = 1;`;
+  assert.equal(stripComments(relative), relative);
+});
+
+test("`/*` inside a LINE comment does not open a block comment", () => {
+  // `open-flow-by-id.ts:20` writes the glob `tests/fixtures/**` in prose. The old
+  // regex ran the block pass first, so that `/*` opened a span closing at the
+  // next JSDoc's `*/` and blanked the real code in between.
+  const source = `// see \`tests/fixtures/**\` for this\nconst kept = 1;\n/** a doc */\nconst alsoKept = 2;`;
+  const stripped = stripComments(source);
+  assert.equal(stripped.split("\n")[1], "const kept = 1;");
+  assert.equal(stripped.split("\n")[3], "const alsoKept = 2;");
+});
+
+test("string contents are preserved — the guards match on locator arguments", () => {
+  // A neutral testid on purpose: `permissions-gate.test.ts` sweeps every `.ts`
+  // under `tests/` for gates on `menu_bar_display`, and it cannot tell a fixture
+  // from a call site. Spelling one here would make this file an offender in that
+  // guard — which is exactly the behaviour it should have, so the fixture moves
+  // rather than the guard's exclusion list growing to cover it.
+  const source = `await expect(page.getByTestId("some_button")).toBeEnabled();`;
+  assert.equal(stripComments(source), source);
+});
+
+test("an unterminated quote in prose does not swallow the rest of the file", () => {
+  const source = `// it's a comment\nconst kept = 1;`;
+  assert.equal(stripComments(source).split("\n")[1], "const kept = 1;");
+});
+
+test("a template literal is string content, backticks and escapes included", () => {
+  const source = "const raw = `a \\` b // c /* d */`;\nconst kept = 1;";
+  const stripped = stripComments(source);
+  assert.equal(stripped.split("\n")[0], source.split("\n")[0]);
+  assert.equal(stripped.split("\n")[1], "const kept = 1;");
+});
+
+test("an unclosed block comment blanks to end of file rather than throwing", () => {
+  const source = `const a = 1;\n/* never closed\nstill inside`;
+  assertSameShape(source);
+  assert.equal(stripComments(source).split("\n")[0], "const a = 1;");
+});
+
+test("the real files that broke the old scanner keep all of their code", () => {
+  // Regression, not a fixture: these are the two files measured losing code.
+  // `open-flow-by-id.ts` lost 10 lines including its own
+  // `PERMISSIONS_GATE_TIMEOUT_MS` import; `run-flow.spec.ts` lost 37.
+  for (const [file, needles] of [
+    [
+      join(FLOWS_DIR, "open-flow-by-id.ts"),
+      [`import { PERMISSIONS_GATE_TIMEOUT_MS } from "./permissions-gate";`],
+    ],
+    [
+      join(
+        FLOWS_DIR,
+        "..",
+        "..",
+        "tests-automations",
+        "regression",
+        "flow-functionality",
+        "run-flow.spec.ts",
+      ),
+      [`.getByTestId("handle-chatinput-noshownode-chat message-source")`],
+    ],
+  ] as [string, string[]][]) {
+    const source = readFileSync(file, "utf8");
+    assertSameShape(source);
+    const stripped = stripComments(source);
+    for (const needle of needles) {
+      assert.ok(
+        source.includes(needle),
+        `fixture drift: ${needle} is no longer in ${file}`,
+      );
+      assert.ok(
+        stripped.includes(needle),
+        `${file}: the scanner blanked real code — ${needle}`,
+      );
+    }
+  }
+});

--- a/tests/helpers/flows/strip-comments.ts
+++ b/tests/helpers/flows/strip-comments.ts
@@ -1,0 +1,123 @@
+// Blank the comments out of a TypeScript source, for the structural guards that
+// scan the suite's own code (`open-flow-settings.test.ts`, `permissions-gate.test.ts`).
+//
+// ONE COPY, FOR THE SAME REASON THE BUDGET IS ONE CONSTANT
+//
+// This was two copies, and they had already drifted into carrying the same
+// defect twice: the guard that #1222 added cloned it from the guard #1215 added.
+// A leaf module importing nothing, so it couples nothing in
+// `impacted-specs-by-import.mjs`'s transitive graph (#1054) — no spec imports it,
+// only the two guards do.
+//
+// BLANKED, NOT DELETED
+//
+// Deleting a block comment shifts every line below it, so the caller's `lineOf`
+// names a line the offender is not on — measured at 50 lines of skew on
+// `setup-playground.ts`, where the real gate at line 198 was reported as 148.
+// A wrong line number is worse than none, because it reads as precise. Blanking
+// also stops a removal from JOINING the tokens either side of it
+// (`foo/*c*\/bar` -> `foobar`), which could synthesise a match that is not in
+// the source.
+//
+// WHY A SCANNER AND NOT TWO REGEXES
+//
+// Both copies used to be `/\/\*[\s\S]*?\*\//g` followed by a line-comment regex,
+// and a context-free `/*` is wrong in the one way that matters to a guard: it
+// goes QUIET. Any `/*` substring opened a comment that ran to the next `*/`
+// anywhere in the file, and the suite is full of both halves:
+//
+//   - `'//*[@id="react-flow-id"]'`, the xpath idiom, 49 occurrences under `tests/`;
+//   - `` `tests/fixtures/**` `` inside a line comment — which is
+//     `open-flow-by-id.ts:20`, one of the two files the #1222 guard names as
+//     canonical. It opened a span closing at the next JSDoc's `*/`, blanking 10
+//     lines of real code including line 55, the `PERMISSIONS_GATE_TIMEOUT_MS`
+//     import itself. A gate written anywhere in that window was invisible:
+//     measured, injected at line 46, found 0.
+//   - `run-flow.spec.ts` lost 37 lines of real code the same way.
+//
+// The line-comment half was mis-documented rather than merely narrow: it claimed
+// to match `//` after start-of-line or whitespace, but `(^|[^:\w])` admits any
+// non-colon non-word character, so `page.locator('//*[…]')` had its line tail
+// blanked too — and `await page.goto("//x")` blanked the rest of that line
+// outright.
+//
+// Scanning left to right fixes both halves at once, because it is the ORDER that
+// was missing, not a bigger pattern: inside a string nothing opens a comment, and
+// inside a line comment nothing opens a block.
+//
+// WHAT IT DOES NOT DO, AND WHY THAT IS SAFE HERE
+//
+// It does not track regex literals, which would need to distinguish `/` as a
+// delimiter from `/` as division — the classic lexer ambiguity, and not worth a
+// guard's complexity budget. It is safe for this suite because a regex literal
+// cannot contain a bare `/*` (a quantifier with no atom is a syntax error) or a
+// bare `//` (an empty regex), so the escaped forms the guards themselves use
+// (`/\/\*[\s\S]*?\*\//`) never present either token contiguously. `${}`
+// interpolation inside a template literal is treated as string content; a
+// backtick nested inside one would end the literal early, which has no instance
+// in the tree.
+//
+// Strings are PRESERVED, not blanked: the guards match on locator arguments, so
+// `getByTestId("menu_bar_display")` has to survive.
+
+/**
+ * Replace every comment character with a space, leaving newlines, string
+ * contents and every other offset exactly where they were.
+ *
+ * The returned text has the same length and the same line breaks as the input,
+ * which is what lets a caller report `line` and column against the original.
+ */
+export function stripComments(source: string): string {
+  const out = source.split("");
+  const blank = (from: number, to: number): void => {
+    for (let k = from; k < to; k++) {
+      if (out[k] !== "\n") out[k] = " ";
+    }
+  };
+
+  let i = 0;
+  while (i < source.length) {
+    const char = source[i];
+    const next = source[i + 1];
+
+    if (char === "/" && next === "/") {
+      let end = i;
+      while (end < source.length && source[end] !== "\n") end++;
+      blank(i, end);
+      i = end;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      const close = source.indexOf("*/", i + 2);
+      const end = close === -1 ? source.length : close + 2;
+      blank(i, end);
+      i = end;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      let end = i + 1;
+      while (end < source.length) {
+        if (source[end] === "\\") {
+          end += 2;
+          continue;
+        }
+        if (source[end] === char) {
+          end++;
+          break;
+        }
+        // An unterminated quote on one line is a quote character in prose, not a
+        // string — bail at the newline rather than swallowing the rest of the file.
+        if (char !== "`" && source[end] === "\n") break;
+        end++;
+      }
+      i = end;
+      continue;
+    }
+
+    i++;
+  }
+
+  return out.join("");
+}

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../helpers/ui/open-advanced-options";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { PERMISSIONS_GATE_TIMEOUT_MS } from "../../../helpers/flows/permissions-gate";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 import { tableFieldTrigger } from "../../../helpers/ui/table-field-trigger";
 import { watchNodeRefresh } from "../../../helpers/ui/watch-node-refresh";
@@ -114,7 +115,7 @@ async function addApiRequestComponent(page: Page): Promise<string> {
   // dropped with no error and the node-count assertions fail without naming the
   // cause.
   await expect(page.getByTestId("menu_bar_display")).toBeEnabled({
-    timeout: 30000,
+    timeout: PERMISSIONS_GATE_TIMEOUT_MS,
   });
   await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
     timeout: 30000,

--- a/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { PERMISSIONS_GATE_TIMEOUT_MS } from "../../../../helpers/flows/permissions-gate";
 import { setupBlankFlow } from "../../../../helpers/flows/setup-blank-flow";
 import { expandFocusedNode } from "../../../../helpers/ui/expand-focused-node";
 import { seedAssistantDiscovered } from "../../../../helpers/ui/assistant-onboarding";
@@ -64,7 +65,7 @@ test.describe("Output Modal — Copy Button", () => {
         // Without this the add is dropped with no error and the count assertion
         // below fails without naming the cause.
         await expect(page.getByTestId("menu_bar_display")).toBeEnabled({
-          timeout: 30000,
+          timeout: PERMISSIONS_GATE_TIMEOUT_MS,
         });
         await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
           timeout: 30000,


### PR DESCRIPTION
Closes #1222.

## The divergence was five-way, not two

The issue names two helpers. It is five call sites, on one upstream element, with two numbers and three provenances:

| Site | Was | Provenance |
|---|---|---|
| `open-flow-by-id.ts` | 30 s | #1214 — "separate from, and shorter than, the canvas budget" |
| `open-flow-settings.ts` | 15 s | #1215 — inherited from `rename-flow.ts`'s `MODAL_TIMEOUT` |
| `setup-playground.ts` | 30 s | inline literal |
| `api-request-component-regression.spec.ts` | 30 s | inline literal |
| `output-modal-copy-button.spec.ts` | 30 s | inline literal |

All five wait on `expect(page.getByTestId("menu_bar_display")).toBeEnabled(...)`, i.e. on `POST /api/v1/authz/me/permissions` resolving. None of the numbers was measured: 15 s was sized in **#357 for the flow-settings modal's inputs**, and 30 s argues a *relation* to the canvas budget, not a value.

## The measurement — box 1

Because the issue is explicit that this is "not 'pick the bigger one and move on'".

**Langflow 1.12.0, 6 parallel lanes × 8 flow opens = 48 samples**, one shared backend — the saturated local burst the issue names, instrumented on the two quantities that are not the same one:

| | min | p50 | p90 | p95 | max |
|---|---|---|---|---|---|
| `POST /api/v1/authz/me/permissions` | 205 ms | 808 ms | 1663 ms | **2623 ms** | **3770 ms** |
| the gate (canvas visible → header enabled) | 2 ms | 14 ms | 944 ms | **1919 ms** | **2939 ms** |

The gate is usually already satisfied when it is reached — p50 **14 ms** — because the canvas render outlasts the query. The tail is what the budget is for, and under saturation it is *seconds*, not tens of seconds. (Single-lane, for contrast: gate max 65 ms, query max 235 ms. The parallelism is doing the work.)

## Why 30 s, given 15 s also clears it — box 2

Both are safe on this evidence (15 s ≈ 5× the observed max gate wait, 30 s ≈ 10×). Three things break the tie, and none is "bigger is safer":

1. **Blast radius.** Four of five sites already wait 30 s. Converging *up* changes the failure latency of **one** site; converging *down* changes **four**, on a burst measured on one machine.
2. **The measurement is a floor, not a ceiling.** A GitHub runner is slower than this box and the daily shards it further. ~10× the observed max is the headroom between the machine measured and the machine that runs. Shrinking it wants a measurement *from the daily*, which the repo does not record today — stated in the module so the next person knows what would justify it.
3. **The costs are asymmetric.** Too short turns a slow round-trip into a red on a green product. Too long only lengthens a run already failing, and stays bounded: in `openFlowById` this gate is serial with the canvas budget, so a dead entry spends at most 100 s + 30 s = **130 s**, inside the 5-minute per-test timeout — so the failure still lands on this assertion with its own message.

## One constant, one module — box 2

`tests/helpers/flows/permissions-gate.ts`, a leaf importing nothing. Not defined in either helper, because importing one entry point from the other would couple them in `impacted-specs-by-import.mjs`'s **transitive** graph — every spec using `openFlowById` would then be selected on every edit to `openFlowSettings`, and vice versa (#1054). It is **imported, never re-exported**: a second import path is how a converged constant grows a second identity again.

**`open-flow-settings.ts`'s constant was doing two jobs, and only one converges.** `HEADER_PRESENT_TIMEOUT_MS` (15 s, unchanged) still budgets *"the editor put a header on screen at all"* — an absent `flow_name` means the caller never landed on the canvas, which is a different failure sending the reader somewhere else. The file's own docstring already made that distinction; it just had one number for both.

## `MODAL_TIMEOUT` — box 4

**It should not be the same number, and it no longer is.** Recorded at the constant: the permissions gate left `renameFlow` when #1215 moved the header click into `openFlowSettings`, so the 15 s they shared was inherited provenance, not a shared requirement — and that provenance is exactly what made the divergence look principled. `MODAL_TIMEOUT` stays 15 s because nothing about the modal changed; raising or lowering it wants its own evidence, not this issue's. The two being visibly *different* numbers is what makes their independence a fact rather than a claim.

## The guard, and what it deliberately does not do — box 3

`permissions-gate.test.ts` asserts the **source**, because the defect is invisible at runtime: all five waits pass today, and the split only surfaces the day someone raises one for a real reason and the other four keep the old value. Same shape as `open-flow-settings.test.ts`'s swallowed-click guard.

It matches **both** spellings in the tree — the inline form four sites use, and the variable form `open-flow-settings.ts` needs because it clicks the same button two lines later (a guard matching only the inline form would bless the one file the issue was opened from) — and rejects three ways back:

- a literal (`timeout: 30000`) — how all five started;
- a different named constant;
- **no timeout at all**, the quiet one: that falls back to Playwright's 5 s expect default, which is *under the measured p95* of the query, so it reads as correct and fails under load.

It also asserts a **floor on the number of gates it found**, so renaming the testid cannot leave a sweep that finds nothing and passes forever.

**It pins the constant to no other constant.** #1221 removed exactly such a coupling and this issue forbids re-adding one; the value is bounded (positive, well inside the per-test timeout) rather than pinned, so the next measurement can move it. The only relation asserted anywhere is the pre-existing **inequality** in `open-flow-by-id.test.ts` between that entry's *own two* budgets — an ordering claim, not a value pin — with its right-hand side updated.

Verified by mutation: reverting `setup-playground.ts` to `timeout: 30000` fails the guard, naming the file and the line.

## Validation

- `npm run typecheck` — clean.
- `npm run lint` — 0 errors.
- `npm run test:units` — 1029 pass, 1 fail: `playwright.config.test.ts` → *"the daily's prep command produces parseable JSON"*. **Unrelated to this diff and an artifact of the local git worktree**, which has no `node_modules` of its own (Node resolves upward, but that test spawns a hardcoded `<REPO_ROOT>/node_modules/@playwright/test/cli.js`). The same command run through `npx` from the same directory exits 0 and emits valid JSON. CI runs `npm ci` in the checkout, so it does not reproduce there — the check on this PR is the confirmation.
- New: 5 tests in `permissions-gate.test.ts`, including the three negative cases and the two must-not-fire cases (a `toBeVisible` read on the same button, another element's enabled gate, a commented-out offender).
