### PR TITLE
refactor(llm-agents): extract the shared setAgentMaxIterations helper (#1380)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-max-iterations.md
+++ b/docs/core-functionality/llm-agents/agent-max-iterations.md
@@ -1,6 +1,6 @@
 # Agent Max Iterations — agent stops at the configured limit
 
-**Last validated:** Langflow 1.12.x (`1.12.0.dev39`)
+**Last validated:** Langflow 1.13.x (`1.13.0.dev4`)
 
 ---
 
@@ -110,8 +110,10 @@ pair per run:
 | Pre-fix (unmodified spec), CI | `openai` / `gpt-4o-mini` | 3 | 3/3 clean |
 | Pre-fix (unmodified spec), CI | `google` / `gemini-3.5-flash` | 3 | 3/3 clean |
 | Post-fix, local `1.12.0.dev39` | `google` / `gemini-3.5-flash` | 3 | 3/3 clean, `flaky=0 skipped=0` |
+| Post-#1380 refactor, local `1.13.0.dev4` | `openai` / `gpt-4o-mini` | 1 | 2/2 clean, `flaky=0 skipped=0` |
 
-9 runs, 18 tests, zero failures. **`anthropic` could not be measured at all** — the
+10 runs, 20 tests, zero failures (the last is the #1380 helper extraction, a
+pure refactor — its force-fails are recorded in that PR, not here). **`anthropic` could not be measured at all** — the
 key is out of credit in CI as well as locally (`Your credit balance is too low`;
 three `provider=anthropic` dispatches exited 1 at *Resolve the run's provider
 selection*), so the one recorded non-compliance (2026-08-13,
@@ -156,8 +158,16 @@ Shared setup per test (identical except `max_iterations`):
 - Set the Agent Instructions (`textarea_str_system_prompt`) to force use of the
   URL fetch tool for any URL question, so the agent **attempts a tool call** —
   which needs more than one model call — instead of answering in one shot.
-- Open the Agent node inspector (`parameters-button`); set
-  `int_int_max_iterations`; close (`inspection-panel-close`).
+- Set `max_iterations` through the shared helper
+  `tests/helpers/ui/set-agent-max-iterations.ts`: it selects the Agent node,
+  opens the inspector (`parameters-button`), exposes the advanced field on the
+  node body (`inspector-add-max_iterations`), closes the panel
+  (`inspection-panel-close`), fills `int_int_max_iterations` **and asserts the
+  field holds the value**. The read-back is part of the contract: a fill that
+  silently no-ops would leave the template default (15) in place and this spec
+  would then assert its limit message against a cap it never set. The helper is
+  shared with `agent-multi-tool-selection.spec.ts`, which drove the same four
+  handles as a copy until #1380.
 - Set the task on the **ChatInput node** (`textarea_str_input_value`) and
   `waitForFlowSaveSettled` (the Playground prompt pre-fills from the node —
   typing into the Playground races an async default re-injection; see
@@ -320,8 +330,10 @@ model that does loop — 15 graph steps instead of 45.
 
 - If the terminal message wording changes from `Model call limits exceeded: run
   limit (N/N)`.
-- If the Agent node field testids change (`int_int_max_iterations`,
-  `inspector-add-max_iterations`, `textarea_str_system_prompt`).
+- If the Agent node field testids change: `int_int_max_iterations` and
+  `inspector-add-max_iterations`, both owned by
+  `tests/helpers/ui/set-agent-max-iterations.ts` since #1380, or
+  `textarea_str_system_prompt`.
 - If the Simple Agent template or its URL fetch tool is renamed/rewired — the
   template ships **two** tools (`URLComponent` and `UnifiedWebSearch`, both wired
   to the Agent's `tools` handle), and the asserted step name comes from the URL

--- a/docs/core-functionality/llm-agents/agent-max-iterations.md
+++ b/docs/core-functionality/llm-agents/agent-max-iterations.md
@@ -165,7 +165,9 @@ Shared setup per test (identical except `max_iterations`):
   (`inspection-panel-close`), fills `int_int_max_iterations` **and asserts the
   field holds the value**. The read-back is part of the contract: a fill that
   silently no-ops would leave the template default (15) in place and this spec
-  would then assert its limit message against a cap it never set. The helper is
+  would then assert its limit message against a cap it never set. It proves the
+  field ACCEPTED the value, not that the value survived the add-autosave — see
+  #1739. The helper is
   shared with `agent-multi-tool-selection.spec.ts`, which drove the same four
   handles as a copy until #1380.
 - Set the task on the **ChatInput node** (`textarea_str_input_value`) and

--- a/docs/core-functionality/llm-agents/agent-max-iterations.md
+++ b/docs/core-functionality/llm-agents/agent-max-iterations.md
@@ -110,14 +110,19 @@ pair per run:
 | Pre-fix (unmodified spec), CI | `openai` / `gpt-4o-mini` | 3 | 3/3 clean |
 | Pre-fix (unmodified spec), CI | `google` / `gemini-3.5-flash` | 3 | 3/3 clean |
 | Post-fix, local `1.12.0.dev39` | `google` / `gemini-3.5-flash` | 3 | 3/3 clean, `flaky=0 skipped=0` |
-| Post-#1380 refactor, local `1.13.0.dev4` | `openai` / `gpt-4o-mini` | 1 | 2/2 clean, `flaky=0 skipped=0` |
 
-10 runs, 20 tests, zero failures (the last is the #1380 helper extraction, a
-pure refactor — its force-fails are recorded in that PR, not here). **`anthropic` could not be measured at all** — the
+9 runs, 18 tests, zero failures. **`anthropic` could not be measured at all** — the
 key is out of credit in CI as well as locally (`Your credit balance is too low`;
 three `provider=anthropic` dispatches exited 1 at *Resolve the run's provider
 selection*), so the one recorded non-compliance (2026-08-13,
 `claude-haiku-4-5`, a single daily) is currently unreproducible.
+
+**Deliberately not in the table above:** the #1380 helper extraction (PR #1738)
+re-ran the pair once on `1.13.0.dev4` / `openai` / `gpt-4o-mini` — 2/2 clean,
+`flaky=0 skipped=0`, which is what `Last validated` above records. It is a
+pure-refactor smoke run, not a compliance measurement and not on `manual.yml`,
+and its force-fails live on that PR. Folding it into the count would inflate the
+evidence that justifies the `@stable` restoration with a run of a different kind.
 
 **Residual risk, stated rather than implied.** `daily-stable.yml`'s weekday
 rotation advances past an inactive provider, so anthropic (Tue/Fri) does not run

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -198,7 +198,8 @@ describe with two tests:
    a copy in both specs until #1380 extracted it). The helper asserts the field
    actually holds the value, and that read-back is load-bearing, not tuning: a
    cap that silently fails to apply leaves the default 15 and re-opens #1378 on
-   a run that still looks green. See the note below.
+   a run that still looks green. It proves the field ACCEPTED the value, not
+   that the value survived the add-autosave — see #1739. See the note below.
 5. Open the Playground, send, wait for the run to finish (Stop button hidden).
 6. **Sequence assert (API):** poll `GET /api/v1/monitor/messages` — nonce-keyed
    session lookup (same as tests 1–2); collect the **ordered** list of

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -1,6 +1,6 @@
 # Agent multi-tool selection — correct tool per prompt
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.13.x (`1.13.0.dev4`)
 
 ---
 
@@ -192,11 +192,13 @@ describe with two tests:
 3. Seed a task that makes the second tool depend on the first's result:
    *"First fetch `${FETCH_URL}` and read its exact slideshow title. Then search
    the web for that title and summarize one result. (probe `<nonce>`)"*.
-4. **Cap `max_iterations` at 8** on the Agent node (advanced field, exposed via
-   the inspector — same handles `agent-max-iterations.spec.ts` uses), and assert
-   the field actually holds that value. This is load-bearing, not tuning: a cap
-   that silently fails to apply leaves the default 15 and re-opens #1378 on a
-   run that still looks green. See the note below.
+4. **Cap `max_iterations` at 8** on the Agent node through the shared helper
+   `tests/helpers/ui/set-agent-max-iterations.ts` (advanced field, exposed via
+   the inspector — the same four handles `agent-max-iterations.spec.ts` drives,
+   a copy in both specs until #1380 extracted it). The helper asserts the field
+   actually holds the value, and that read-back is load-bearing, not tuning: a
+   cap that silently fails to apply leaves the default 15 and re-opens #1378 on
+   a run that still looks green. See the note below.
 5. Open the Playground, send, wait for the run to finish (Stop button hidden).
 6. **Sequence assert (API):** poll `GET /api/v1/monitor/messages` — nonce-keyed
    session lookup (same as tests 1–2); collect the **ordered** list of

--- a/tests/helpers/ui/set-agent-max-iterations.ts
+++ b/tests/helpers/ui/set-agent-max-iterations.ts
@@ -1,0 +1,59 @@
+import { type Page, expect } from "@playwright/test";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "./open-advanced-options";
+
+/**
+ * Set the Agent node's `max_iterations` cap and prove the value landed.
+ *
+ * dev49: `max_iterations` is an ADVANCED field — it is not on the node body by
+ * default, so it cannot simply be filled. Expose it via the node inspector
+ * (select the Agent node → `parameters-button` → `inspector-add-max_iterations`
+ * → `inspection-panel-close`), which replaced the old Controls dialog /
+ * edit-button-modal, then fill it on the body. That sequence is the reason this
+ * helper looks the way it does.
+ *
+ * The `toHaveValue` check at the end is part of the contract, not a courtesy: a
+ * fill that silently no-ops leaves the template default (15) in place. What that
+ * costs is NOT the same on both sides, and reading it as one thing gets one of
+ * them wrong. In `agent-multi-tool-selection` the cap is the only bound on an
+ * open-ended sequence, so a no-op fill is a run that still looks green while
+ * re-opening the #1378 context blow-up. In `agent-max-iterations` it is not a
+ * false green — Test 1 goes red either way, because a default of 15 produces no
+ * limit message — but it reds 30 s later on `toContainText`, blaming the missing
+ * message. Here the read-back buys ATTRIBUTION: the run stops at the fill, on the
+ * real cause.
+ *
+ * Deliberately not extended to cover `addAgentFieldsToBody` in
+ * `agent-config-persistence.spec.ts`, which drives the same four handles. Merging
+ * the two functions is ruled out on its merits: that spec adds SEVERAL fields in
+ * one inspector session and must let the add-autosave settle BEFORE writing any
+ * value, so its add and its fill are separate steps by design, and folding them
+ * back together would re-introduce the mid-edit re-render that separation exists
+ * to avoid. The option that IS viable — extract the add loop as its own helper
+ * and build this one on top of it — was declined for scope, not for design: it
+ * would pull a third `@stable` spec into this PR's blast radius, the same reason
+ * #1378 left the duplication for #1380 in the first place.
+ *
+ * The value itself is the caller's decision. Only `agent-multi-tool-selection`'s
+ * `MAX_ITERATIONS_SEQUENCE` is a MEASURED number, documented next to the
+ * constant; `agent-max-iterations` derives both of its values from the cap
+ * semantics instead, at the call site and next to `HIGH_LIMIT`.
+ */
+export async function setAgentMaxIterations(
+  page: Page,
+  maxIterations: string,
+): Promise<void> {
+  await page.locator('[data-testid^="rf__node-Agent"]').first().click();
+  await openAdvancedOptions(page);
+  await page.getByTestId("inspector-add-max_iterations").click();
+  await closeAdvancedOptions(page);
+
+  const maxIter = page.getByTestId("int_int_max_iterations");
+  await expect(maxIter).toBeVisible({ timeout: 15000 });
+  await maxIter.scrollIntoViewIfNeeded();
+  await maxIter.fill(maxIterations);
+  await maxIter.blur();
+  await expect(maxIter).toHaveValue(maxIterations, { timeout: 10000 });
+}

--- a/tests/helpers/ui/set-agent-max-iterations.ts
+++ b/tests/helpers/ui/set-agent-max-iterations.ts
@@ -5,7 +5,7 @@ import {
 } from "./open-advanced-options";
 
 /**
- * Set the Agent node's `max_iterations` cap and prove the value landed.
+ * Set the Agent node's `max_iterations` cap and read the value back.
  *
  * dev49: `max_iterations` is an ADVANCED field — it is not on the node body by
  * default, so it cannot simply be filled. Expose it via the node inspector
@@ -25,6 +25,15 @@ import {
  * message. Here the read-back buys ATTRIBUTION: the run stops at the fill, on the
  * real cause.
  *
+ * What the read-back does NOT prove is that the value SURVIVED. `toHaveValue` is
+ * a poll that returns on the first matching sample, and nothing settles between
+ * the add and the fill here — so an add-autosave PATCH response landing after it
+ * can still re-render the node at the template default, with the assertion
+ * already green. `agent-config-persistence.spec.ts` documents that window and
+ * settles for it. Closing it here is #1739, deliberately not folded into #1380:
+ * it changes the behaviour of an `@stable` daily spec and owes its own
+ * force-fails.
+ *
  * Deliberately not extended to cover `addAgentFieldsToBody` in
  * `agent-config-persistence.spec.ts`, which drives the same four handles. Merging
  * the two functions is ruled out on its merits: that spec adds SEVERAL fields in
@@ -33,7 +42,7 @@ import {
  * back together would re-introduce the mid-edit re-render that separation exists
  * to avoid. The option that IS viable — extract the add loop as its own helper
  * and build this one on top of it — was declined for scope, not for design: it
- * would pull a third `@stable` spec into this PR's blast radius, the same reason
+ * would pull a third `@stable` spec into #1380's blast radius, the same reason
  * #1378 left the duplication for #1380 in the first place.
  *
  * The value itself is the caller's decision. Only `agent-multi-tool-selection`'s

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
@@ -6,10 +6,7 @@ import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../.
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { trackCreatedFlows } from "../../../../helpers/flows/track-created-flows";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
-import {
-  closeAdvancedOptions,
-  openAdvancedOptions,
-} from "../../../../helpers/ui/open-advanced-options";
+import { setAgentMaxIterations } from "../../../../helpers/ui/set-agent-max-iterations";
 import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
@@ -99,6 +96,7 @@ const TARGET_URL = `${ECHO_BASE}/uuid`;
 // a bare announcement is compliant.
 const SYSTEM_PROMPT =
   "You have web tools. Your FIRST action MUST be a tool call — never reply with text before you have called a tool. To answer any question about a URL you MUST call the URL fetch tool. Never guess or invent responses.";
+// The template's URL tool (default) is the forcer — no extra tool needs enabling.
 const TASK = `Fetch ${TARGET_URL} and tell me the exact "uuid" value it returns.`;
 const LIMIT_MESSAGE = /model call limits exceeded/i;
 // The value only the fetch can supply — guards the causal control against a
@@ -227,23 +225,6 @@ async function setSystemPrompt(page: Page, prompt: string): Promise<void> {
   await field.blur();
 }
 
-// Open the Agent Controls dialog, set max_iterations, and close. The template's
-// URL tool (default) is the forcer — no extra tool needs enabling.
-async function setMaxIterations(page: Page, maxIterations: string): Promise<void> {
-  // dev49: max_iterations is an advanced field — expose it on the node body via
-  // the inspector (replaces the old Controls dialog / edit-button-modal), then
-  // fill it on the body.
-  await page.locator('[data-testid^="rf__node-Agent"]').first().click();
-  await openAdvancedOptions(page);
-  await page.getByTestId("inspector-add-max_iterations").click();
-  await closeAdvancedOptions(page);
-  const maxIter = page.getByTestId("int_int_max_iterations");
-  await expect(maxIter).toBeVisible({ timeout: 15000 });
-  await maxIter.scrollIntoViewIfNeeded();
-  await maxIter.fill(maxIterations);
-  await maxIter.blur();
-}
-
 // Set the task on the ChatInput node (the Playground prompt pre-fills from it;
 // typing into the Playground races an async default re-injection).
 async function setChatInputText(page: Page, text: string): Promise<void> {
@@ -307,7 +288,7 @@ for (const { label, options, skipReason } of targets) {
 
         await test.step("force a tool call, cap max_iterations at 1, set the task", async () => {
           await setSystemPrompt(page, SYSTEM_PROMPT);
-          await setMaxIterations(page, "1");
+          await setAgentMaxIterations(page, "1");
           await setChatInputText(page, TASK);
           await waitForFlowSaveSettled(page);
         });
@@ -341,7 +322,7 @@ for (const { label, options, skipReason } of targets) {
 
         await test.step("force a tool call, allow a high max_iterations, set the task", async () => {
           await setSystemPrompt(page, SYSTEM_PROMPT);
-          await setMaxIterations(page, HIGH_LIMIT);
+          await setAgentMaxIterations(page, HIGH_LIMIT);
           await setChatInputText(page, TASK);
           await waitForFlowSaveSettled(page);
         });

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -3,10 +3,7 @@ import path from "path";
 import type { Page } from "@playwright/test";
 import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
-import {
-  closeAdvancedOptions,
-  openAdvancedOptions,
-} from "../../../../helpers/ui/open-advanced-options";
+import { setAgentMaxIterations } from "../../../../helpers/ui/set-agent-max-iterations";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
@@ -76,9 +73,57 @@ const SYSTEM_PROMPT =
 const SYSTEM_PROMPT_SEQUENCE =
   "Use the connected tools to complete the task. You may call multiple tools in " +
   "sequence as the task requires; never answer from memory and never refuse.";
-// Iteration budget for the sequence test only (#1378). Empirical -- see
-// setMaxIterations for the measurements, and for why it bounds the blast radius
-// without making this test deterministic.
+// Iteration budget for the sequence test (Test 3) only, and the reason it exists
+// (#1378). Test 3 is the only one whose instruction permits an open-ended
+// sequence, and the agent does not reliably converge on it: when it doesn't, it
+// keeps calling perform_search, and every such call injects the Web Search
+// component's whole result set. That component caps nothing -- it scrapes each
+// DuckDuckGo hit's full page text (measured on 1.12.0.dev20: 10 results, 182,316
+// chars ~= 45.6k tokens in ONE call; upstream langflow-ai/langflow#14469). Since
+// the conversation is re-sent every turn, a non-converging run grows without
+// bound and the provider rejects it: #1378 recorded requests of
+// 206,881/206,902/271,317 tokens in CI and 5,060,863 locally, after which the run
+// returns no reply at all.
+//
+// Not a rate-limit tier problem: the local org allows 4M TPM (20x CI's 200k) and
+// blew through it anyway, and no model's context window holds 5M tokens. A
+// bigger tier or a wider model buys nothing; bounding the iteration count does.
+//
+// What this cap DOES and DOES NOT do -- read this before trusting it. It bounds
+// the worst case (the 5,060,863-token run above cost ~2 min of wall clock and
+// real money); it does NOT make this test deterministic. Measured on
+// 1.12.0.dev20 / gpt-4o-mini, --retries=0:
+//
+//     max_iterations   pass rate
+//     15 (default)     4/5
+//     8 (this value)   5/6   <- same rate within noise, smaller blast radius
+//     4                0/2
+//
+// 4 fails for a DIFFERENT reason and that asymmetry is why the cap cannot be
+// tightened into a fix: max_iterations=4 sets a LangGraph recursion_limit of 13,
+// the agent hits it ("Recursion limit of 13 reached without hitting a stop
+// condition"), and a run that stops that way persists no AI message at all -- so
+// the sequence assert fails on absent data rather than wrong data.
+//
+// UPSTREAM CAP LANDED (2026-08-13) -- langflow-ai/langflow#14489 bounded the
+// component (max_results=5, max_content_length=2000). It reached the nightly in
+// 1.12.0.dev25, NOT dev24: that image was cut before the merge-back, so reading
+// the fix on release-1.12.0 says nothing about the image you are running --
+// grep max_results in the INSTALLED wheel instead. Measured on dev25, same
+// query: 5 results / 10,000 chars ~= 2.5k tokens, a 17.9x reduction. That kills
+// the argument this comment used to make (that ONE search call was itself
+// unbounded -- 15,857 / 53,714 / 78,848 tokens across three queries -- so no
+// iteration cap could ever guarantee the test): a call now has a hard ceiling,
+// and 15 iterations accumulate ~37k tokens of search payload, inside both the
+// 128k window and CI's 200k TPM.
+//
+// The cap still stays at 8. Measured on dev25 / gpt-4o-mini, --retries=0:
+// 7/7 at 8 and 4/4 at 15, which is NOT evidence that it is dispensable -- the
+// same day, 10/10 passed on dev24 with the component still unbounded, so this
+// environment (a 4M TPM org) did not reproduce the failure and the two arms
+// cannot discriminate. It costs nothing and it is still what stops a
+// non-converging agent from running 15 turns.
+// Re-measure before changing this number -- do not re-derive it on paper.
 const MAX_ITERATIONS_SEQUENCE = "8";
 
 // Flows created by each test are tracked here and deleted by id in
@@ -141,74 +186,6 @@ async function setSystemPrompt(page: Page, prompt: string): Promise<void> {
   await field.click();
   await field.fill(prompt);
   await field.blur();
-}
-
-// Cap the Agent's max_iterations (test 3 only). This test is the only one whose
-// instruction permits an open-ended sequence, and the agent does not reliably
-// converge on it: when it doesn't, it keeps calling perform_search, and every
-// such call injects the Web Search component's whole result set. That component
-// caps nothing -- it scrapes each DuckDuckGo hit's full page text (measured on
-// 1.12.0.dev20: 10 results, 182,316 chars ~= 45.6k tokens in ONE call; upstream
-// langflow-ai/langflow#14469). Since the conversation is re-sent every turn, a
-// non-converging run grows without bound and the provider rejects it: #1378
-// recorded requests of 206,881/206,902/271,317 tokens in CI and 5,060,863
-// locally, after which the run returns no reply at all.
-//
-// Not a rate-limit tier problem: the local org allows 4M TPM (20x CI's 200k) and
-// blew through it anyway, and no model's context window holds 5M tokens. A
-// bigger tier or a wider model buys nothing; bounding the iteration count does.
-//
-// What this cap DOES and DOES NOT do -- read this before trusting it. It bounds
-// the worst case (the 5,060,863-token run above cost ~2 min of wall clock and
-// real money); it does NOT make this test deterministic. Measured on
-// 1.12.0.dev20 / gpt-4o-mini, --retries=0:
-//
-//     max_iterations   pass rate
-//     15 (default)     4/5
-//     8 (this value)   5/6   <- same rate within noise, smaller blast radius
-//     4                0/2
-//
-// 4 fails for a DIFFERENT reason and that asymmetry is why the cap cannot be
-// tightened into a fix: max_iterations=4 sets a LangGraph recursion_limit of 13,
-// the agent hits it ("Recursion limit of 13 reached without hitting a stop
-// condition"), and a run that stops that way persists no AI message at all -- so
-// the sequence assert fails on absent data rather than wrong data.
-//
-// UPSTREAM CAP LANDED (2026-08-13) -- langflow-ai/langflow#14489 bounded the
-// component (max_results=5, max_content_length=2000). It reached the nightly in
-// 1.12.0.dev25, NOT dev24: that image was cut before the merge-back, so reading
-// the fix on release-1.12.0 says nothing about the image you are running --
-// grep max_results in the INSTALLED wheel instead. Measured on dev25, same
-// query: 5 results / 10,000 chars ~= 2.5k tokens, a 17.9x reduction. That kills
-// the argument this comment used to make (that ONE search call was itself
-// unbounded -- 15,857 / 53,714 / 78,848 tokens across three queries -- so no
-// iteration cap could ever guarantee the test): a call now has a hard ceiling,
-// and 15 iterations accumulate ~37k tokens of search payload, inside both the
-// 128k window and CI's 200k TPM.
-//
-// The cap still stays at 8. Measured on dev25 / gpt-4o-mini, --retries=0:
-// 7/7 at 8 and 4/4 at 15, which is NOT evidence that it is dispensable -- the
-// same day, 10/10 passed on dev24 with the component still unbounded, so this
-// environment (a 4M TPM org) did not reproduce the failure and the two arms
-// cannot discriminate. It costs nothing and it is still what stops a
-// non-converging agent from running 15 turns.
-// Re-measure before changing this number -- do not re-derive it on paper.
-//
-// max_iterations is an advanced field: expose it on the node body via the
-// inspector, then fill it -- the same handles agent-max-iterations.spec.ts uses.
-async function setMaxIterations(page: Page, maxIterations: string): Promise<void> {
-  await page.locator('[data-testid^="rf__node-Agent"]').first().click();
-  await openAdvancedOptions(page);
-  await page.getByTestId("inspector-add-max_iterations").click();
-  await closeAdvancedOptions(page);
-  const maxIter = page.getByTestId("int_int_max_iterations");
-  await expect(maxIter).toBeVisible({ timeout: 15000 });
-  await maxIter.scrollIntoViewIfNeeded();
-  await maxIter.fill(maxIterations);
-  await maxIter.blur();
-  // The cap is load-bearing, not cosmetic: a fill that silently no-ops leaves
-  // the default 15 in place and re-opens #1378 on a run that still looks green.
-  await expect(maxIter).toHaveValue(maxIterations, { timeout: 10000 });
 }
 
 // Set the task on the ChatInput node (the Playground prompt pre-fills from it;
@@ -533,8 +510,8 @@ for (const { label, options, skipReason } of targets) {
           // Bound the run BEFORE it starts: this is the only test whose
           // instruction permits an open-ended sequence, so it is the only one
           // that can accumulate Web Search payloads past the model's context
-          // window (#1378 — see setMaxIterations).
-          await setMaxIterations(page, MAX_ITERATIONS_SEQUENCE);
+          // window (#1378 — see MAX_ITERATIONS_SEQUENCE).
+          await setAgentMaxIterations(page, MAX_ITERATIONS_SEQUENCE);
           await setChatInputText(page, task);
           await waitForFlowSaveSettled(page);
         });


### PR DESCRIPTION
**Closes #1380.** Follow-up of #1378 (approved exception — `follow-up`, ROADMAP → Intake). Pure refactor: no new coverage, no behaviour change intended.

## Problem

`setMaxIterations()` existed twice, copy-pasted, driving the same four handles in the same order:

- `core-functionality/llm-agents/agent-max-iterations.spec.ts` (the original, `@stable`, runs in the daily)
- `core-functionality/llm-agents/agent-multi-tool-selection.spec.ts` (added by #1378)

#1378 left it duplicated deliberately rather than pull a second `@stable` spec into its blast radius. This is that follow-up.

## Fix

New shared helper `tests/helpers/ui/set-agent-max-iterations.ts` → `setAgentMaxIterations(page, value)`, next to `open-advanced-options.ts`, which both copies already imported. Both call sites point at it.

The two details the issue said the extraction must not lose:

1. **The `dev49` note** — why the field is reached through the inspector (it replaced the Controls dialog / edit-button-modal). It is the reason the handle sequence looks the way it does, and it now lives on the helper.
2. **The `toHaveValue` read-back**, which only the `agent-multi-tool-selection` copy had. It is now in the shared helper, so both sides get it — but **what it buys is not the same on both sides**, and the header says so instead of generalising:
   - `agent-multi-tool-selection`: the cap is the only bound on an open-ended sequence, so a no-op fill leaves the default 15 and re-opens #1378 **on a run that still looks green**.
   - `agent-max-iterations`: Test 1 goes red either way (a default of 15 produces no limit message), so the read-back does not prevent a false green — it buys **attribution**, stopping at the fill instead of timing out 30 s later on `toContainText` and blaming the missing message.

**Knowledge stayed where it belongs.** The #1378 measurement block (the `15/8/4` pass-rate table, the `recursion_limit` asymmetry, the `#14489` upstream cap, "re-measure, do not re-derive") documents the **value 8**, not the mechanism — it moved to `MAX_ITERATIONS_SEQUENCE`. The helper documents only the mechanism.

## Rejected alternative, stated explicitly

`addAgentFieldsToBody` in `agent-config-persistence.spec.ts` drives the same four handles and is deliberately left alone:

- **Merging the two functions is wrong on its merits.** That spec adds several fields in one inspector session and must let the add-autosave settle **before** writing any value; its add and its fill are separate steps by design, and folding them back together would re-introduce the mid-edit re-render that separation exists to avoid.
- **Extracting the add loop and layering this helper on top would work**, and was declined for **scope**, not design: it pulls a third `@stable` spec into this PR — the same reason #1378 left the duplication for #1380.

## Scope note

No `QA-CHECKLIST.md` change (no spec added, no `@stable` change). No unit test for the helper: it is straight-line with zero branches, like its siblings `open-advanced-options.ts`, `hide-inspector-panel.ts` and `expand-focused-node.ts`, none of which carry one — the `*.test.ts` files in that directory all cover a decision.

`agent-multi-tool-selection` tests 1 and 2 do not call the helper; only the file's import changed.

## Validation (nightly `1.13.0.dev4`, `--workers=1 --retries=0`, `MODEL_TEST_ID=gpt-4o-mini`, in-network go-httpbin as `ECHO_BASE_URL`)

- `agent-max-iterations.spec.ts` — **2 passed** (34.1 s) ✅
- `agent-multi-tool-selection.spec.ts` — **3 passed** (58.0 s) ✅
- zero `🚨 Backend Error` ✅ · zero orphan flows left behind ✅
- `npm run typecheck` ✅ · `npx eslint` on the three touched files: **0 errors, 44 warnings — identical to the pre-change baseline** ✅
- `npm run test:units` (1046 pass / 0 fail) ✅ · `check:checklist-coverage` ✅ · QA-CHECKLIST guard ✅
- `scripts/impacted-specs-by-import.mjs` on the new helper resolves exactly the two specs ✅

**Force-fails — executed, mutating the SHARED helper so one mutation reaches every call site.** Each test run isolated with `--grep`, because both describes are `mode: "serial"` and the first failure would otherwise skip its siblings.

- `FF-A` — `inspector-add-max_iterations` → `inspector-add-max_iterations_FF_MUTATION` (this is the spec doc's **M5** for test 3):
  - `agent stops when max iterations is reached` → **failed**, `TimeoutError: locator.click`
  - `causal control — a high max iterations does not hit the limit` → **failed**, same
  - `agent runs the URL then Web Search tools in sequence for a chained prompt` → **failed**, same
- `FF-B` — the `fill` made a no-op, i.e. the exact defect the read-back exists for:
  - all three of the above → **failed** on `toHaveValue`, at the helper's own line

Revert proven: `grep FF_MUTATION` over the diff = **0 hits**, followed by the two green runs above.

`--trace=on` is skipped for this family — it hangs on Simple Agent–template specs on the current stack (#490/#518).

## Review

Reviewed independently with clean context before this PR: verdict **approve-with-nits**, five findings, all applied — an overstated claim in the helper header (the "both call sites look green" generalisation, corrected above), the rejected-alternative reasoning being narrower than the real one, an inaccurate pointer about where each value is measured, and two cosmetic ones. The `Last validated` finding is why the whole validation was re-run on `1.13.0.dev4` (the true `nightly:latest`) rather than the older local container, and both spec docs record that build.

---

## Post-review addendum (two text-only commits)

A second independent review pass (clean context) approved the extraction and raised one claim-accuracy finding, applied here as text only — no behaviour change, no new validation owed:

- `241c2acd` — **scoped what the read-back proves.** `toHaveValue` is a poll that returns on the first matching sample, and nothing settles between `inspector-add-max_iterations` and the fill, so an add-autosave PATCH response landing afterwards can still re-render the node at the template default with the assertion already green. `agent-config-persistence.spec.ts:117-122` documents that window and settles for it. The helper header and both spec docs said the read-back proves the cap *landed*; they now say it proves the field *accepted* the value. The same commit names #1380 where the header said "this PR", which loses its referent once merged.
- `0aa3bcad` — **kept this PR's run out of the compliance count** in `agent-max-iterations.md`. That table is introduced by *"Measured before restoring it, on `manual.yml` at `retries=0`"* and exists to justify the `@stable` restoration against model compliance; a post-restoration refactor smoke run inflated it. The run is still recorded, in its own paragraph below the table, with why it is not counted.

The window itself is filed as **#1739** rather than closed here: adding a settle changes the behaviour of a helper shared by an `@stable` daily spec and owes its own force-fails for both call sites. It is pre-existing (both copies have had it since #1378) and has never been observed — 7/7 and 4/4 at cap 8 on `1.12.0.dev25`, 2/2 + 3/3 on `1.13.0.dev4`.
