### PR TITLE
docs(llm-agents): record the measured add/fill behaviour, replacing the assumed race (#1739)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-max-iterations.md
+++ b/docs/core-functionality/llm-agents/agent-max-iterations.md
@@ -170,9 +170,10 @@ Shared setup per test (identical except `max_iterations`):
   (`inspection-panel-close`), fills `int_int_max_iterations` **and asserts the
   field holds the value**. The read-back is part of the contract: a fill that
   silently no-ops would leave the template default (15) in place and this spec
-  would then assert its limit message against a cap it never set. It proves the
-  field ACCEPTED the value, not that the value survived the add-autosave — see
-  #1739. The helper is
+  would then assert its limit message against a cap it never set. The value it reads is the
+  value the run executes — the Playground posts the client store's graph, not
+  the persisted flow — and the add-then-fill sequence was measured non-racy on
+  `1.13.0.dev4` (#1739). The helper is
   shared with `agent-multi-tool-selection.spec.ts`, which drove the same four
   handles as a copy until #1380.
 - Set the task on the **ChatInput node** (`textarea_str_input_value`) and

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -198,8 +198,10 @@ describe with two tests:
    a copy in both specs until #1380 extracted it). The helper asserts the field
    actually holds the value, and that read-back is load-bearing, not tuning: a
    cap that silently fails to apply leaves the default 15 and re-opens #1378 on
-   a run that still looks green. It proves the field ACCEPTED the value, not
-   that the value survived the add-autosave — see #1739. See the note below.
+   a run that still looks green. The value it reads is the value the run
+   executes — the Playground posts the client store's graph, not the persisted
+   flow — and the add-then-fill sequence was measured non-racy on `1.13.0.dev4`
+   (#1739). See the note below.
 5. Open the Playground, send, wait for the run to finish (Stop button hidden).
 6. **Sequence assert (API):** poll `GET /api/v1/monitor/messages` — nonce-keyed
    session lookup (same as tests 1–2); collect the **ordered** list of

--- a/tests/helpers/ui/set-agent-max-iterations.ts
+++ b/tests/helpers/ui/set-agent-max-iterations.ts
@@ -29,28 +29,43 @@ import {
  * argued, because the reasoning that says it is racy is sound and wrong (#1739,
  * on 1.13.0.dev4). Three facts, in the order they matter:
  *
- *   1. The add really does schedule its own autosave PATCH, carrying the
- *      template default — proven from the intercepted payload
- *      (`max_iterations.value = 15`), not inferred. It is sent one
- *      `auto_saving_interval` after the click: 2000 ms on that image (the
- *      installed `lfx/services/settings/groups/ui.py`, not the 300 ms
- *      `SAVE_DEBOUNCE_TIME` the frontend constant still names), so under normal
- *      timing the fill lands ~2 s BEFORE it is even issued.
- *   2. Forcing the hostile ordering anyway — holding that stale response until
- *      after the fill and the read-back, which is what a slow runner would do —
- *      does NOT revert the field: 2 of 2 runs kept the filled value, in the node
- *      and in the database. The `setCurrentFlow` re-render that
+ *   1. The add does schedule an autosave, and ON ITS OWN it carries the template
+ *      default — proven from the intercepted payload (`max_iterations.value =
+ *      15`) in an add-only run. In THIS sequence it never reaches the wire, and
+ *      the reason is worth knowing before reasoning about a new call site: the
+ *      autosave is a TRAILING debounce keyed on flow mutations (upstream
+ *      `use-autosave-flow.ts`), so the fill cancels the add's pending timer and
+ *      ONE coalesced PATCH goes out an interval later carrying the FILLED value.
+ *      The interval is `GET /api/v1/config.auto_saving_interval` — 2000 ms on
+ *      this image, and 1000 when `SimpleAgentTemplatePage.ts` measured the same
+ *      mechanism — never the 300 ms `SAVE_DEBOUNCE_TIME` that
+ *      `wait-for-flow-save-settled.ts` still quotes.
+ *   2. Forcing the hostile ordering anyway — holding a stale add-PATCH response
+ *      until after the fill and the read-back, which is what a slow runner would
+ *      do — does NOT revert the field: 2 of 2 runs kept the filled value, in the
+ *      node and in the database. The `setCurrentFlow` re-render that
  *      `agent-config-persistence.spec.ts` guards against does not reach this
- *      field on this build.
- *   3. The read-back therefore guards the right thing. The Playground run posts
- *      the CLIENT store's graph (`flowData: { nodes, edges }`, upstream
- *      `stores/flowStore.ts`), not the persisted flow — so the value this
- *      assertion reads IS the value the run executes. Persistence lags it by one
- *      debounce and is not what these two specs depend on.
+ *      field on this build. Two forced runs on one dev build is not a proof for
+ *      all time, and the exposure if it returns is asymmetric: this assertion
+ *      samples BEFORE any such revert, and `agent-multi-tool-selection` asserts
+ *      only the tool ORDER, so a cap that silently failed to apply would come
+ *      back as #1378's context blow-up rather than as a red. Re-measure there
+ *      before trusting this paragraph on a much newer nightly.
+ *   3. The read-back therefore guards the right thing. The IN-EDITOR Playground
+ *      run posts the CLIENT store's graph (`flowData: { nodes, edges }`, upstream
+ *      `flowStore.ts`) as the request's `data`, which the v2 endpoint documents
+ *      as taking priority over the saved flow — so the value this assertion reads
+ *      IS the value the run executes. Persistence lags it by one debounce and is
+ *      not what these two specs depend on. The exception is the shareable PUBLIC
+ *      playground, whose schema forbids `data`: there the persisted flow runs and
+ *      this whole argument inverts. Both specs use the in-editor playground.
  *
  * Do not add a settle between the add and the fill "to be safe": it cannot help
- * (`waitForFlowSaveSettled` arms a 700 ms quiet window and returns long before a
- * 2000 ms debounce fires) and it would buy 700 ms per call for nothing.
+ * — `waitForFlowSaveSettled` arms a 700 ms quiet window and returns long before a
+ * 2000 ms debounce fires (measured here at 701 ms having tracked no request at
+ * all; `SimpleAgentTemplatePage.ts` and `general-bugs-save-changes-on-node.spec.ts`
+ * measured the same thing independently) — and it would buy 700 ms per call for
+ * nothing. That gap belongs to the barrier, not here: #1741.
  *
  * Deliberately not extended to cover `addAgentFieldsToBody` in
  * `agent-config-persistence.spec.ts`, which drives the same four handles. Merging

--- a/tests/helpers/ui/set-agent-max-iterations.ts
+++ b/tests/helpers/ui/set-agent-max-iterations.ts
@@ -25,14 +25,32 @@ import {
  * message. Here the read-back buys ATTRIBUTION: the run stops at the fill, on the
  * real cause.
  *
- * What the read-back does NOT prove is that the value SURVIVED. `toHaveValue` is
- * a poll that returns on the first matching sample, and nothing settles between
- * the add and the fill here — so an add-autosave PATCH response landing after it
- * can still re-render the node at the template default, with the assertion
- * already green. `agent-config-persistence.spec.ts` documents that window and
- * settles for it. Closing it here is #1739, deliberately not folded into #1380:
- * it changes the behaviour of an `@stable` daily spec and owes its own
- * force-fails.
+ * The add-then-fill sequence LOOKS racy and is not — measured rather than
+ * argued, because the reasoning that says it is racy is sound and wrong (#1739,
+ * on 1.13.0.dev4). Three facts, in the order they matter:
+ *
+ *   1. The add really does schedule its own autosave PATCH, carrying the
+ *      template default — proven from the intercepted payload
+ *      (`max_iterations.value = 15`), not inferred. It is sent one
+ *      `auto_saving_interval` after the click: 2000 ms on that image (the
+ *      installed `lfx/services/settings/groups/ui.py`, not the 300 ms
+ *      `SAVE_DEBOUNCE_TIME` the frontend constant still names), so under normal
+ *      timing the fill lands ~2 s BEFORE it is even issued.
+ *   2. Forcing the hostile ordering anyway — holding that stale response until
+ *      after the fill and the read-back, which is what a slow runner would do —
+ *      does NOT revert the field: 2 of 2 runs kept the filled value, in the node
+ *      and in the database. The `setCurrentFlow` re-render that
+ *      `agent-config-persistence.spec.ts` guards against does not reach this
+ *      field on this build.
+ *   3. The read-back therefore guards the right thing. The Playground run posts
+ *      the CLIENT store's graph (`flowData: { nodes, edges }`, upstream
+ *      `stores/flowStore.ts`), not the persisted flow — so the value this
+ *      assertion reads IS the value the run executes. Persistence lags it by one
+ *      debounce and is not what these two specs depend on.
+ *
+ * Do not add a settle between the add and the fill "to be safe": it cannot help
+ * (`waitForFlowSaveSettled` arms a 700 ms quiet window and returns long before a
+ * 2000 ms debounce fires) and it would buy 700 ms per call for nothing.
  *
  * Deliberately not extended to cover `addAgentFieldsToBody` in
  * `agent-config-persistence.spec.ts`, which drives the same four handles. Merging


### PR DESCRIPTION
**Closes #1739.** Follow-up of #1380 (approved exception — `follow-up`, ROADMAP → Intake). Documentation and comments only: **no executable line changed** (`git diff` outside the JSDoc block is empty).

## The issue asked for a fix. The measurement says there is nothing to fix — and that the proposed fix could not have worked.

#1739 (raised by the independent review pass on #1738) argued that `setAgentMaxIterations` fills the field with no settle after `inspector-add-max_iterations`, so the add's autosave PATCH response could land after the `toHaveValue` read-back, re-render the node at the template default, and leave the run capped at 15 on a test that still looks green. `agent-config-persistence.spec.ts:117-122` documents exactly that window and settles for it.

The reasoning is sound. It is also wrong here. Six experiments on `1.13.0.dev4`, model-free (Simple Agent template, no provider, no LLM spend):

| # | Experiment | Result |
|---|---|---|
| A | The helper's sequence as-is | The only PATCH is sent **2.0 s after the fill**; field stable at the filled value for 6 s; persisted correctly |
| B | With `waitForFlowSaveSettled` between the add and the fill — **the proposed fix** | The barrier **returned in 701 ms having observed no PATCH at all**. The add's PATCH is issued 2.0 s after the click, so the settle closes nothing |
| C | Add only, never fill | The add **does** schedule its own PATCH, payload `max_iterations.value = 15`, persisted `15`. Half the premise is correct |
| D/E | Hostile ordering **forced**: the add's PATCH (payload proven `15`) held in flight, fill during the window, read-back green, then the stale response released | **No revert.** 2/2 runs: UI held the filled value for 15 s, database held it too |
| F | The real call-site sequence (helper → chat input → barrier) | The barrier returns **1015 / 1071 / 1045 ms** later with **zero PATCHes sent** and the database still at `15`. 3/3 |

And the fact that settles it: the Playground run posts the **client store's** graph — `flowData: { nodes, edges }` in upstream `stores/flowStore.ts` — not the persisted flow. The value the read-back asserts **is** the value the run executes. Persistence lags it by one debounce and is not what these two specs depend on.

## Why the timing is not what the helper's doc assumed

`auto_saving_interval` is **2000 ms** on this image (installed `lfx/services/settings/groups/ui.py`), not the 300 ms `SAVE_DEBOUNCE_TIME` the frontend constant still names and `wait-for-flow-save-settled.ts` still quotes. That single number explains A, B and F at once.

## What changed

- `tests/helpers/ui/set-agent-max-iterations.ts` — the header now records the measurement (the three facts, in the order they matter) instead of the caveat added on the assumed mechanism in #1738, and warns explicitly against adding the settle "to be safe": it cannot help and costs 700 ms per call.
- Both spec docs carried the same overstated claim and are corrected in one sentence each.

## Out of scope, filed separately

The measurement surfaced a real defect that is **not** this helper's: `waitForFlowSaveSettled` arms a **700 ms** quiet window against a **2000 ms** debounce, so called shortly after a mutating action it returns before the PATCH exists (F, 3/3). Its own doc still claims 300 ms and calls 700 ms "comfortably above" it. One spec already measured the same gap independently (`general-bugs-save-changes-on-node.spec.ts:70-85`, at ~1015 ms). 59 calls across 37 files; the two agent specs are **not** exposed, because their run carries the client graph. Filed as its own `qa-infra` issue rather than widened into this PR.

## Validation

- `npm run typecheck` ✅ · `npx eslint` on the touched helper ✅ 0 problems
- Diff proven comment-only: every `+`/`-` line outside the JSDoc block is empty
- **No force-fail is owed** — no assertion, no executable line and no test behaviour changed. The two specs' own force-fails are recorded on #1738 and stand unaffected.
- Zero orphan flows left on the instance (the 26 present are the starter projects, all carrying the same seeding timestamp)
- Experiments ran on `langflow-i1380` (`1.13.0.dev4`), `--workers=1 --retries=0`; the diagnostic spec was temporary and is not part of this diff


---

## Post-review addendum (`a9ff4f9c`, comment only)

An independent review pass plus Copilot's two nits, all applied. One of them corrected a real error in the first commit:

- **The autosave is a TRAILING debounce keyed on flow mutations** (`use-autosave-flow.ts`), not a fixed timer from the click. The fill therefore *cancels* the add's pending save and one coalesced PATCH carries the filled value. Experiment A had already measured this ("the only PATCH is sent 2.0 s after the **fill**") — the header's wording did not match its own evidence, and would have led a reader to predict a stale-15 PATCH that this sequence never issues. The intercepted `15` payload comes from the add-only run (C), and the header now says so.
- **Fact 2 is bounded.** Two forced runs on one dev build closes nothing permanently, and the exposure if the revert returns is asymmetric: the read-back samples *before* it, and `agent-multi-tool-selection` asserts only the tool **order**, so a cap that silently failed to apply would come back as #1378's context blow-up rather than as a red. The header now names the re-measure trigger.
- **Fact 3 is qualified.** `data` is forwarded only when the run is not public (`run-agent.ts`); the shareable **public** playground's schema forbids it, so there the persisted flow executes and the argument inverts. Both specs use the in-editor playground.
- **Copilot:** cite `GET /api/v1/config.auto_saving_interval` instead of the installed wheel path — verifiable without an upstream clone, and how `SimpleAgentTemplatePage.ts` already documents the same value. That file reads **1000** where this reads **2000**, so the drift is now visible in the header rather than only in #1741.
- **Copilot:** `stores/flowStore.ts` → `flowStore.ts`, matching the repo's three existing citations.

**Deliberately not in this PR** (review finding 4): `SimpleAgentTemplatePage.ts:40`'s stale `1000` is left alone. Correcting it here would pull a widely-imported page object into the diff and re-select a large slice of the suite for one comment line; it is now named as in-scope in #1741, together with the barrier's own "300 ms" claim, so the contradiction is owned by an open issue rather than left silent.

Also recorded in #1741 from this pass: `page.request.get("/api/v1/config")` answers **200 with the public payload**, which carries no `auto_saving_interval` — so "derive the window from the instance" needs a bearer, and is not the one-liner it looks like.
