### PR TITLE
fix(helpers): derive the autosave debounce from the instance and add watchFlowSave (#1741)

### DIFF
--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -7,6 +7,10 @@ import * as path from "node:path";
 import * as dotenv from "dotenv";
 import { getAuthToken } from "./helpers/auth/get-auth-token";
 import {
+  describeAutosaveInterval,
+  publishAutosaveInterval,
+} from "./helpers/flows/autosave-interval";
+import {
   degradeProviders,
   providersForEnvKeys,
   readProviderHealth,
@@ -456,11 +460,57 @@ function freezeCatalog(): void {
   );
 }
 
+/**
+ * Resolve the flow autosave debounce for this run and publish it (#1741).
+ *
+ * The number is `GET /api/v1/config.auto_saving_interval`, and it is neither the
+ * 300 ms `SAVE_DEBOUNCE_TIME` upstream's frontend constant names nor a value we
+ * can pin: this repo has measured 1000 and, on `1.13.0.dev4`, 2000. Every
+ * save-timing helper derives its deadline from it, so it is read once here, from
+ * the instance actually under test, and inherited by the forked workers through
+ * the environment — the same channel and the same reason as the frozen model
+ * catalog above.
+ *
+ * Never fatal, and never silently defaulted: a run that cannot read it says so
+ * and the consumers use a documented fallback that is larger than any interval
+ * upstream has shipped (#1012 — an unknown value is unknown, not clean).
+ * Authenticates explicitly, because the endpoint answers 200 with a PUBLIC
+ * payload that omits the field entirely — the failure mode is a resolved-looking
+ * `undefined`, not an error.
+ */
+async function resolveAutosaveInterval(ctx: APIRequestContext): Promise<void> {
+  try {
+    const auth = await getAuthToken(ctx).catch(() => "");
+    const res = await ctx.get("/api/v1/config", {
+      headers: auth ? { Authorization: auth } : undefined,
+      timeout: 15000,
+    });
+    if (!res.ok()) throw new Error(`HTTP ${res.status()}`);
+    const body = (await res.json()) as { auto_saving_interval?: unknown };
+    const interval = body.auto_saving_interval;
+    if (typeof interval !== "number" || !Number.isInteger(interval) || interval <= 0) {
+      throw new Error(
+        `auto_saving_interval is ${JSON.stringify(interval)} ` +
+          `(an unauthenticated read returns the public payload, which omits it)`,
+      );
+    }
+    publishAutosaveInterval(interval);
+    console.log(`[preflight] ${describeAutosaveInterval(interval)}`);
+  } catch (e) {
+    publishAutosaveInterval(null);
+    console.warn(
+      `[preflight] WARNING: could not read the flow autosave debounce ` +
+        `(${String(e)}). ${describeAutosaveInterval(null)}.`,
+    );
+  }
+}
+
 export default async function globalSetup(): Promise<void> {
   freezeCatalog();
   const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL });
   try {
     await assertBackendHealthy(ctx);
+    await resolveAutosaveInterval(ctx);
     if (truthy(process.env.PREFLIGHT_SKIP_CREDENTIALS)) {
       console.log(
         "[preflight] PREFLIGHT_SKIP_CREDENTIALS set — skipping the credential check (credential-importing run).",

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -385,7 +385,13 @@ async function reportCatalogDrift(ctx: APIRequestContext): Promise<void> {
     // never happens, and every CI lane's `Collect models` step would have warned
     // "could not read the component catalog" on every run. A warning that always
     // fires is the noise #1084 was raised about.
-    const auth = await getAuthToken(ctx).catch(() => "");
+    // Not `.catch(() => "")`: `getAuthToken` throws only when the backend never
+    // answered its retry budget, and its header forbids degrading that into the
+    // empty token (#1086). Swallowed, a wedged backend was reported here as
+    // "could not read the component catalog (HTTP 403)" — the authentication
+    // story, not the outage. The explicit authentication this comment is about
+    // is unaffected.
+    const auth = await getAuthToken(ctx);
     const res = await ctx.get("/api/v1/all", {
       headers: auth ? { Authorization: auth } : undefined,
       timeout: 30000,
@@ -493,7 +499,25 @@ async function resolveAutosaveInterval(ctx: APIRequestContext): Promise<void> {
       timeout: 15000,
     });
     if (!res.ok()) throw new Error(`HTTP ${res.status()}`);
-    const body = (await res.json()) as { auto_saving_interval?: unknown };
+    const body = (await res.json()) as {
+      auto_saving?: unknown;
+      auto_saving_interval?: unknown;
+    };
+    // The same payload says whether autosave runs AT ALL, and an instance with
+    // it off still reports a plausible interval — so publishing the number
+    // without this check prints a confident debounce for a backend that will
+    // never issue a PATCH, and every save-dependent call site then fails
+    // blaming the node-dirty state. Knowable at the gate, so named at the gate
+    // (#1012). `auto-save-off.spec.ts` is the lane that runs this way.
+    if (body.auto_saving === false) {
+      publishAutosaveInterval(null);
+      console.warn(
+        "[preflight] WARNING: flow autosave is DISABLED on this instance " +
+          "(auto_saving=false). No PATCH /api/v1/flows/{id} will be issued by an " +
+          "edit, so anything waiting on a save will time out by design.",
+      );
+      return;
+    }
     const interval = body.auto_saving_interval;
     if (typeof interval !== "number" || !Number.isInteger(interval) || interval <= 0) {
       throw new Error(

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -480,7 +480,14 @@ function freezeCatalog(): void {
  */
 async function resolveAutosaveInterval(ctx: APIRequestContext): Promise<void> {
   try {
-    const auth = await getAuthToken(ctx).catch(() => "");
+    // NOT `.catch(() => "")`. `getAuthToken` returns "" for an environment
+    // without auth and THROWS only when the backend never answered its retry
+    // budget — its own header forbids degrading that into the empty token,
+    // because the caller then proceeds unauthenticated and fails somewhere far
+    // less diagnosable (#1086). Swallowed here, a wedged backend would be
+    // reported below as "the public payload omits the field", which is a true
+    // sentence about the wrong cause.
+    const auth = await getAuthToken(ctx);
     const res = await ctx.get("/api/v1/config", {
       headers: auth ? { Authorization: auth } : undefined,
       timeout: 15000,

--- a/tests/helpers/flows/autosave-interval.test.ts
+++ b/tests/helpers/flows/autosave-interval.test.ts
@@ -12,8 +12,10 @@ import {
   AUTOSAVE_INTERVAL_ENV,
   AUTOSAVE_INTERVAL_FALLBACK_MS,
   describeAutosaveInterval,
+  pendingSaveQuietMs,
   publishAutosaveInterval,
   readAutosaveIntervalMs,
+  SAVE_COMPLETION_BUDGET_MS,
   saveScheduledDeadlineMs,
 } from "./autosave-interval";
 
@@ -67,4 +69,25 @@ test("the description names which of the two states produced the number", () => 
   assert.match(describeAutosaveInterval(2000), /auto_saving_interval/);
   assert.match(describeAutosaveInterval(null), /UNKNOWN/);
   assert.match(describeAutosaveInterval(null), new RegExp(String(AUTOSAVE_INTERVAL_FALLBACK_MS)));
+});
+
+test("the pending-save quiet window is longer than the debounce itself", () => {
+  // The gap waitForFlowSaveSettled leaves open is a save that is SCHEDULED and
+  // not yet issued; only a window longer than the debounce closes it.
+  assert.ok(pendingSaveQuietMs(2000) > 2000);
+  assert.equal(pendingSaveQuietMs(2000, { slackMs: 500 }), 2500);
+  assert.ok(
+    pendingSaveQuietMs(null) > AUTOSAVE_INTERVAL_FALLBACK_MS - 1,
+    "an unknown interval must not shrink the window",
+  );
+});
+
+test("the completion budget is separate from, and larger than, the issuance slack", () => {
+  // Folding them into one makes a healthy-but-slow round trip indistinguishable
+  // from an edit that never marked the node dirty.
+  assert.ok(SAVE_COMPLETION_BUDGET_MS > 0);
+  assert.ok(
+    SAVE_COMPLETION_BUDGET_MS > saveScheduledDeadlineMs(2000) - 2000,
+    "the completion budget must exceed the issuance slack it was split from",
+  );
 });

--- a/tests/helpers/flows/autosave-interval.test.ts
+++ b/tests/helpers/flows/autosave-interval.test.ts
@@ -1,0 +1,70 @@
+// Unit tests for the run-scoped autosave interval (#1741).
+// Run with: npm run test:units
+//
+// Why these are unit-tested: every consumer's guarantee is a DEADLINE derived
+// from this value, and a deadline that is too short fails silently — the barrier
+// returns on a save that was never issued, and the run is green. The cases below
+// pin the two directions that matter: an unreadable value must degrade to the
+// conservative fallback, never to zero, and a readable one must be used as-is.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  AUTOSAVE_INTERVAL_ENV,
+  AUTOSAVE_INTERVAL_FALLBACK_MS,
+  describeAutosaveInterval,
+  publishAutosaveInterval,
+  readAutosaveIntervalMs,
+  saveScheduledDeadlineMs,
+} from "./autosave-interval";
+
+const env = (value?: string): NodeJS.ProcessEnv =>
+  value === undefined ? {} : { [AUTOSAVE_INTERVAL_ENV]: value };
+
+test("reads a published interval back", () => {
+  assert.equal(readAutosaveIntervalMs(env("2000")), 2000);
+});
+
+test("an absent or blank value is UNKNOWN, not a default", () => {
+  assert.equal(readAutosaveIntervalMs(env()), null);
+  assert.equal(readAutosaveIntervalMs(env("   ")), null);
+});
+
+test("a non-positive or non-integer value reads as unknown", () => {
+  // A 0 would collapse every derived deadline to 'already due' — the one state
+  // no caller can recover from, so it must not survive as a value.
+  for (const bad of ["0", "-1", "abc", "2000.5", "NaN", "Infinity"]) {
+    assert.equal(readAutosaveIntervalMs(env(bad)), null, `${bad} must be unknown`);
+  }
+});
+
+test("publish round-trips through the real environment, and null clears it", () => {
+  const before = process.env[AUTOSAVE_INTERVAL_ENV];
+  try {
+    publishAutosaveInterval(1234);
+    assert.equal(readAutosaveIntervalMs(), 1234);
+    publishAutosaveInterval(null);
+    assert.equal(readAutosaveIntervalMs(), null);
+  } finally {
+    if (before === undefined) delete process.env[AUTOSAVE_INTERVAL_ENV];
+    else process.env[AUTOSAVE_INTERVAL_ENV] = before;
+  }
+});
+
+test("the deadline allows a full debounce plus slack", () => {
+  assert.equal(saveScheduledDeadlineMs(2000, { slackMs: 1500 }), 3500);
+});
+
+test("an unknown interval falls back ABOVE every value upstream has shipped", () => {
+  const deadline = saveScheduledDeadlineMs(null, { slackMs: 0 });
+  assert.equal(deadline, AUTOSAVE_INTERVAL_FALLBACK_MS);
+  // 300 (SAVE_DEBOUNCE_TIME) -> 1000 -> 2000 are the values this repo has
+  // measured; the fallback must not be a regression against the largest.
+  assert.ok(deadline > 2000, "the fallback must exceed the largest known interval");
+});
+
+test("the description names which of the two states produced the number", () => {
+  assert.match(describeAutosaveInterval(2000), /2000 ms/);
+  assert.match(describeAutosaveInterval(2000), /auto_saving_interval/);
+  assert.match(describeAutosaveInterval(null), /UNKNOWN/);
+  assert.match(describeAutosaveInterval(null), new RegExp(String(AUTOSAVE_INTERVAL_FALLBACK_MS)));
+});

--- a/tests/helpers/flows/autosave-interval.ts
+++ b/tests/helpers/flows/autosave-interval.ts
@@ -1,0 +1,92 @@
+/**
+ * The flow autosave debounce, resolved once per run (#1741).
+ *
+ * ## Why this is a run-scoped value and not a constant
+ *
+ * Every flow-mutating edit schedules a debounced `PATCH /api/v1/flows/{id}`. The
+ * delay is NOT the 300 ms `SAVE_DEBOUNCE_TIME` that upstream's frontend constant
+ * names — that is only the store's pre-fetch default. The effective value is
+ * `autoSavingInterval`, seeded from `GET /api/v1/config.auto_saving_interval`
+ * (`use-get-config.ts`), and the server has already moved it: this repo measured
+ * **1000** while writing `SimpleAgentTemplatePage.ts` and **2000** on
+ * `1.13.0.dev4`. Any number pasted into our source goes stale the next time
+ * upstream edits its default, and the failure is silent — a barrier that expires
+ * early still returns, it just returns on a save that was never issued.
+ *
+ * So it is read from the instance under test, once, in `globalSetup`, and passed
+ * to the workers through the environment. That is the same channel and the same
+ * reason as the frozen model catalog (`provider-setup/catalog-snapshot.ts`):
+ * `globalSetup` runs before the load task, workers are forked after it and
+ * inherit `process.env`, and a module-level cache could not cross the process
+ * boundary.
+ *
+ * ## Unknown is not a default
+ *
+ * A run that could not read the config gets `null`, never a fabricated number,
+ * and every consumer states which of the two it is using (#1012). The fallback
+ * below is deliberately larger than any interval upstream has shipped: when the
+ * value is unknown the safe direction is to wait too long, because the failure
+ * of waiting too little is a test that asserts against a save that never left
+ * the browser.
+ */
+
+/** Environment variable carrying the resolved interval to the workers. */
+export const AUTOSAVE_INTERVAL_ENV = "PW_AUTOSAVE_INTERVAL_MS";
+
+/**
+ * Used when the interval could not be read. Above every value upstream has
+ * shipped (300 → 1000 → 2000), because over-waiting costs seconds and
+ * under-waiting costs a false green.
+ */
+export const AUTOSAVE_INTERVAL_FALLBACK_MS = 3000;
+
+/** Publish the resolved interval for the workers. `null` clears it. */
+export function publishAutosaveInterval(intervalMs: number | null): void {
+  if (intervalMs === null) {
+    delete process.env[AUTOSAVE_INTERVAL_ENV];
+    return;
+  }
+  process.env[AUTOSAVE_INTERVAL_ENV] = String(intervalMs);
+}
+
+/**
+ * The interval resolved for this run, or `null` when it is unknown.
+ *
+ * Anything that is not a positive finite integer reads as unknown rather than as
+ * a value: a `0` here would collapse every derived deadline to "already due",
+ * which is the one state no caller can recover from.
+ */
+export function readAutosaveIntervalMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number | null {
+  const raw = env[AUTOSAVE_INTERVAL_ENV];
+  if (raw === undefined || raw.trim() === "") return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * How long to allow for a save that an edit has just scheduled to be ISSUED.
+ *
+ * The debounce is trailing and restarted by every flow mutation, so the earliest
+ * a PATCH can appear is one full interval after the last edit; the slack covers
+ * the render and the request setup that follow it.
+ */
+export function saveScheduledDeadlineMs(
+  intervalMs: number | null = readAutosaveIntervalMs(),
+  { slackMs = 1500 }: { slackMs?: number } = {},
+): number {
+  return (intervalMs ?? AUTOSAVE_INTERVAL_FALLBACK_MS) + slackMs;
+}
+
+/** One line naming the interval and where it came from, for a run's output. */
+export function describeAutosaveInterval(
+  intervalMs: number | null = readAutosaveIntervalMs(),
+): string {
+  return intervalMs === null
+    ? `autosave debounce UNKNOWN for this run — using the ${AUTOSAVE_INTERVAL_FALLBACK_MS} ms fallback`
+    : `autosave debounce ${intervalMs} ms (GET /api/v1/config.auto_saving_interval)`;
+}

--- a/tests/helpers/flows/autosave-interval.ts
+++ b/tests/helpers/flows/autosave-interval.ts
@@ -69,6 +69,37 @@ export function readAutosaveIntervalMs(
 }
 
 /**
+ * How long to allow a save to COMPLETE once it has been issued.
+ *
+ * Deliberately separate from the issuance budget below, and deliberately
+ * generous. They are different failures: a save that is late to be *issued* is
+ * usually a follow-on mutation restarting the trailing debounce, while a save
+ * that is late to *complete* is a slow backend. Folding them into one budget
+ * makes a healthy-but-slow round trip indistinguishable from an edit that never
+ * marked the node dirty, and reports the wrong one. Over-waiting costs a slow
+ * red on a run that is already failing; under-waiting costs a red on a healthy
+ * save — and the first call sites to migrate are `@stable` specs in the daily,
+ * where a hard failure removes the tag by unreviewed commit.
+ */
+export const SAVE_COMPLETION_BUDGET_MS = 10000;
+
+/**
+ * How long the editor must be quiet before NO save can still be pending.
+ *
+ * The gap `waitForFlowSaveSettled` leaves open is a save that is scheduled but
+ * not yet issued, and the only window that closes it is one longer than the
+ * debounce itself. Callers that must start from a clean slate — including
+ * anything arming `watchFlowSave` after an earlier mutation — pass this as that
+ * helper's `quietMs`.
+ */
+export function pendingSaveQuietMs(
+  intervalMs: number | null = readAutosaveIntervalMs(),
+  { slackMs = 500 }: { slackMs?: number } = {},
+): number {
+  return (intervalMs ?? AUTOSAVE_INTERVAL_FALLBACK_MS) + slackMs;
+}
+
+/**
  * How long to allow for a save that an edit has just scheduled to be ISSUED.
  *
  * The debounce is trailing and restarted by every flow mutation, so the earliest

--- a/tests/helpers/flows/wait-for-flow-save-settled.ts
+++ b/tests/helpers/flows/wait-for-flow-save-settled.ts
@@ -19,8 +19,34 @@ import type { Page, Request } from "@playwright/test";
  * or a rename that is reverted to the pre-rename name (issue #995).
  *
  * Resolves once **no flow-save PATCH is in flight** and none has completed for
- * `quietMs` (chosen comfortably above the 300 ms autosave debounce), or after
- * `timeout` as a safety cap so a quiet flow never hangs the caller.
+ * `quietMs`, or after `timeout` as a safety cap so a quiet flow never hangs the
+ * caller.
+ *
+ * ## What it does NOT do, and why the header used to imply otherwise (#1741)
+ *
+ * This is a DRAIN, not a proof that your edit was saved. The quiet window arms
+ * immediately when nothing is in flight, so called right after an edit it
+ * returns having tracked no request at all — the save is still only SCHEDULED.
+ * The header used to justify `quietMs = 700` as "comfortably above the 300 ms
+ * autosave debounce", and that is wrong twice over: 300 ms is
+ * `SAVE_DEBOUNCE_TIME`, merely the store's pre-fetch default, while the
+ * effective delay is `GET /api/v1/config.auto_saving_interval` — measured
+ * **1000** in `SimpleAgentTemplatePage.ts` and **2000** on `1.13.0.dev4`. Both
+ * exceed the window, so the barrier expires first, by design of the numbers
+ * rather than by accident of load.
+ *
+ * Measured 3/3 on `1.13.0.dev4`: called after two node-body fills it returned
+ * ~1.0 s later with ZERO patches sent and the database still holding the
+ * pre-edit value. Two other call sites had already measured the same gap
+ * independently (`SimpleAgentTemplatePage.ts`, which rejected this helper as a
+ * fix for exactly this reason, and `general-bugs-save-changes-on-node.spec.ts`,
+ * which replaced it with a server-side gate).
+ *
+ * **If the next assertion depends on the edit having reached the server** — a
+ * reload, a navigation away, an API read of the flow — use `watchFlowSave(page)`
+ * instead: arm it before the edit and await it after, and it FAILS when no save
+ * appears rather than reporting a silence it cannot interpret. This helper stays
+ * the right tool for draining traffic you did not cause.
  *
  * Tracking requests — not just responses — is what makes this a barrier rather
  * than a silence probe (issue #995). The response-only version armed its quiet

--- a/tests/helpers/flows/watch-flow-save.test.ts
+++ b/tests/helpers/flows/watch-flow-save.test.ts
@@ -1,0 +1,143 @@
+// Unit tests for watchFlowSave (#1741).
+// Run with: npm run test:units
+//
+// Why this helper is unit-tested: its guarantee is that a save was OBSERVED, and
+// the bug it exists to prevent is a watcher that returns having observed nothing
+// — indistinguishable from a correct one on a green E2E run, because the assert
+// that follows usually passes anyway (the value is in the client store; only the
+// server is behind). The boundary is a debounce that an E2E run cannot pin, so
+// the timing is driven directly here.
+//
+// Timings are deliberately small; the helper reads the real clock, so assertions
+// are on ORDER and on generous bounds, never on exact durations.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Page } from "@playwright/test";
+import { watchFlowSave } from "./watch-flow-save";
+
+type Handler = (req: { url(): string; method(): string }) => void;
+const SAVE_URL = "http://localhost:7860/api/v1/flows/abc-123";
+
+function fakePage() {
+  const handlers = new Map<string, Set<Handler>>();
+  const page = {
+    on(event: string, handler: Handler) {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)!.add(handler);
+    },
+    off(event: string, handler: Handler) {
+      handlers.get(event)?.delete(handler);
+    },
+    async waitForTimeout(ms: number) {
+      await new Promise((resolve) => setTimeout(resolve, ms));
+    },
+  };
+  const emit = (event: string, url: string, method: string) => {
+    for (const handler of handlers.get(event) ?? [])
+      handler({ url: () => url, method: () => method });
+  };
+  return {
+    page: page as unknown as Page,
+    get listeners() {
+      return [...handlers.values()].reduce((n, set) => n + set.size, 0);
+    },
+    request: (url = SAVE_URL, method = "PATCH") => emit("request", url, method),
+    finished: (url = SAVE_URL, method = "PATCH") => emit("requestfinished", url, method),
+    failed: (url = SAVE_URL, method = "PATCH") => emit("requestfailed", url, method),
+  };
+}
+
+test("resolves once a save issued after arming has completed", async () => {
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  setTimeout(() => f.request(), 20);
+  setTimeout(() => f.finished(), 60);
+  await watch.settled({ timeout: 2000 });
+});
+
+test("does NOT resolve on silence — the whole point of the primitive", async () => {
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  await assert.rejects(
+    () => watch.settled({ timeout: 200 }),
+    /no flow-save PATCH was issued within 200 ms/,
+  );
+});
+
+test("waits for the save to COMPLETE, not merely to be issued", async () => {
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  f.request();
+  const started = Date.now();
+  setTimeout(() => f.finished(), 150);
+  await watch.settled({ timeout: 2000 });
+  assert.ok(
+    Date.now() - started >= 140,
+    `must not return before the response settles (waited ${Date.now() - started} ms)`,
+  );
+});
+
+test("a failed save settles it too — a rejected PATCH is not a pending one", async () => {
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  f.request();
+  setTimeout(() => f.failed(), 20);
+  await watch.settled({ timeout: 2000 });
+});
+
+test("reports the in-flight count when a save never completes", async () => {
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  f.request();
+  await assert.rejects(() => watch.settled({ timeout: 200 }), /still in flight/);
+});
+
+test("ignores traffic that is not a flow save", async () => {
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  f.request("http://localhost:7860/api/v1/flows/abc", "GET");
+  f.request("http://localhost:7860/api/v1/variables/", "PATCH");
+  // The path is matched on the PATHNAME: a build asset quoting the prefix in its
+  // query string must not count.
+  f.request("http://localhost:7860/assets/index.js?x=/api/v1/flows/abc");
+  await assert.rejects(() => watch.settled({ timeout: 150 }), /no flow-save PATCH/);
+});
+
+test("detaches its listeners on every exit path", async () => {
+  const ok = fakePage();
+  const watch = watchFlowSave(ok.page);
+  assert.equal(ok.listeners, 3);
+  ok.request();
+  setTimeout(() => ok.finished(), 10);
+  await watch.settled({ timeout: 2000 });
+  assert.equal(ok.listeners, 0, "resolved path must detach");
+
+  const bad = fakePage();
+  const failing = watchFlowSave(bad.page);
+  await assert.rejects(() => failing.settled({ timeout: 100 }));
+  assert.equal(bad.listeners, 0, "timeout path must detach");
+
+  const aborted = fakePage();
+  watchFlowSave(aborted.page).dispose();
+  assert.equal(aborted.listeners, 0, "dispose must detach");
+});
+
+test("is single-use: a second settled() throws instead of resolving blind", async () => {
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  f.request();
+  setTimeout(() => f.finished(), 10);
+  await watch.settled({ timeout: 2000 });
+  await assert.rejects(() => watch.settled({ timeout: 100 }), /single-use/);
+});
+
+test("dispose is idempotent and safe after settled()", async () => {
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  f.request();
+  setTimeout(() => f.finished(), 10);
+  await watch.settled({ timeout: 2000 });
+  watch.dispose();
+  watch.dispose();
+  assert.equal(f.listeners, 0);
+});

--- a/tests/helpers/flows/watch-flow-save.test.ts
+++ b/tests/helpers/flows/watch-flow-save.test.ts
@@ -15,9 +15,21 @@ import assert from "node:assert/strict";
 import type { Page } from "@playwright/test";
 import { watchFlowSave } from "./watch-flow-save";
 
-type Handler = (req: { url(): string; method(): string }) => void;
+type FakeRequest = { url(): string; method(): string };
+type Handler = (req: FakeRequest) => void;
 const SAVE_URL = "http://localhost:7860/api/v1/flows/abc-123";
 
+/**
+ * A Page stand-in exposing only what the helper touches.
+ *
+ * Requests are OBJECTS handed back to the caller, not re-created per event,
+ * because Playwright emits the same `Request` instance on `request` and on
+ * `requestfinished`/`requestfailed` and the helper keys on that identity. A fake
+ * that minted a fresh object per event would let a watcher which cannot tell two
+ * concurrent saves apart pass every test here (it did: the counter version this
+ * replaced was green against that fake and released early on the interleaving
+ * below).
+ */
 function fakePage() {
   const handlers = new Map<string, Set<Handler>>();
   const page = {
@@ -32,26 +44,37 @@ function fakePage() {
       await new Promise((resolve) => setTimeout(resolve, ms));
     },
   };
-  const emit = (event: string, url: string, method: string) => {
-    for (const handler of handlers.get(event) ?? [])
-      handler({ url: () => url, method: () => method });
+  const emit = (event: string, req: FakeRequest) => {
+    for (const handler of handlers.get(event) ?? []) handler(req);
   };
+  const make = (url = SAVE_URL, method = "PATCH"): FakeRequest => ({
+    url: () => url,
+    method: () => method,
+  });
   return {
     page: page as unknown as Page,
     get listeners() {
       return [...handlers.values()].reduce((n, set) => n + set.size, 0);
     },
-    request: (url = SAVE_URL, method = "PATCH") => emit("request", url, method),
-    finished: (url = SAVE_URL, method = "PATCH") => emit("requestfinished", url, method),
-    failed: (url = SAVE_URL, method = "PATCH") => emit("requestfailed", url, method),
+    /** Start a request and return it, so the same object can be settled later. */
+    request: (url = SAVE_URL, method = "PATCH") => {
+      const req = make(url, method);
+      emit("request", req);
+      return req;
+    },
+    finished: (req: FakeRequest) => emit("requestfinished", req),
+    failed: (req: FakeRequest) => emit("requestfailed", req),
+    /** A request the watch never saw start — in flight before it was armed. */
+    settleUnobserved: (url = SAVE_URL) => emit("requestfinished", make(url)),
   };
 }
 
 test("resolves once a save issued after arming has completed", async () => {
   const f = fakePage();
   const watch = watchFlowSave(f.page);
-  setTimeout(() => f.request(), 20);
-  setTimeout(() => f.finished(), 60);
+  let req: ReturnType<typeof f.request>;
+  setTimeout(() => (req = f.request()), 20);
+  setTimeout(() => f.finished(req!), 60);
   await watch.settled({ timeout: 2000 });
 });
 
@@ -67,9 +90,9 @@ test("does NOT resolve on silence — the whole point of the primitive", async (
 test("waits for the save to COMPLETE, not merely to be issued", async () => {
   const f = fakePage();
   const watch = watchFlowSave(f.page);
-  f.request();
+  const req = f.request();
   const started = Date.now();
-  setTimeout(() => f.finished(), 150);
+  setTimeout(() => f.finished(req), 150);
   await watch.settled({ timeout: 2000 });
   assert.ok(
     Date.now() - started >= 140,
@@ -80,8 +103,8 @@ test("waits for the save to COMPLETE, not merely to be issued", async () => {
 test("a failed save settles it too — a rejected PATCH is not a pending one", async () => {
   const f = fakePage();
   const watch = watchFlowSave(f.page);
-  f.request();
-  setTimeout(() => f.failed(), 20);
+  const req = f.request();
+  setTimeout(() => f.failed(req), 20);
   await watch.settled({ timeout: 2000 });
 });
 
@@ -107,8 +130,8 @@ test("detaches its listeners on every exit path", async () => {
   const ok = fakePage();
   const watch = watchFlowSave(ok.page);
   assert.equal(ok.listeners, 3);
-  ok.request();
-  setTimeout(() => ok.finished(), 10);
+  const okReq = ok.request();
+  setTimeout(() => ok.finished(okReq), 10);
   await watch.settled({ timeout: 2000 });
   assert.equal(ok.listeners, 0, "resolved path must detach");
 
@@ -125,8 +148,8 @@ test("detaches its listeners on every exit path", async () => {
 test("is single-use: a second settled() throws instead of resolving blind", async () => {
   const f = fakePage();
   const watch = watchFlowSave(f.page);
-  f.request();
-  setTimeout(() => f.finished(), 10);
+  const req = f.request();
+  setTimeout(() => f.finished(req), 10);
   await watch.settled({ timeout: 2000 });
   await assert.rejects(() => watch.settled({ timeout: 100 }), /single-use/);
 });
@@ -134,10 +157,44 @@ test("is single-use: a second settled() throws instead of resolving blind", asyn
 test("dispose is idempotent and safe after settled()", async () => {
   const f = fakePage();
   const watch = watchFlowSave(f.page);
-  f.request();
-  setTimeout(() => f.finished(), 10);
+  const req = f.request();
+  setTimeout(() => f.finished(req), 10);
   await watch.settled({ timeout: 2000 });
   watch.dispose();
   watch.dispose();
   assert.equal(f.listeners, 0);
+});
+
+test("a save in flight BEFORE arming cannot release the watch (#1742 review)", async () => {
+  // The interleaving that a counter cannot survive: the caller's edit starts a
+  // save, then an OLDER save — in flight since before this watch existed —
+  // finishes. A counting watcher drops to zero and returns while the save it was
+  // asked about is still open, which is the early return this primitive exists
+  // to prevent, reintroduced inside it.
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  const mine = f.request();
+  f.settleUnobserved();
+  let released = false;
+  const settled = watch.settled({ timeout: 3000 }).then(() => (released = true));
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  assert.equal(released, false, "must not release while the observed save is open");
+  f.finished(mine);
+  await settled;
+  assert.equal(released, true);
+});
+
+test("two concurrent saves: both must complete", async () => {
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  const first = f.request();
+  const second = f.request();
+  let released = false;
+  const settled = watch.settled({ timeout: 3000 }).then(() => (released = true));
+  f.finished(first);
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  assert.equal(released, false, "one of two settling is not enough");
+  f.finished(second);
+  await settled;
+  assert.equal(released, true);
 });

--- a/tests/helpers/flows/watch-flow-save.test.ts
+++ b/tests/helpers/flows/watch-flow-save.test.ts
@@ -75,14 +75,14 @@ test("resolves once a save issued after arming has completed", async () => {
   let req: ReturnType<typeof f.request>;
   setTimeout(() => (req = f.request()), 20);
   setTimeout(() => f.finished(req!), 60);
-  await watch.settled({ timeout: 2000 });
+  await watch.settled({ issueTimeout: 2000, completionTimeout: 2000 });
 });
 
 test("does NOT resolve on silence — the whole point of the primitive", async () => {
   const f = fakePage();
   const watch = watchFlowSave(f.page);
   await assert.rejects(
-    () => watch.settled({ timeout: 200 }),
+    () => watch.settled({ issueTimeout: 200, completionTimeout: 200 }),
     /no flow-save PATCH was issued within 200 ms/,
   );
 });
@@ -93,7 +93,7 @@ test("waits for the save to COMPLETE, not merely to be issued", async () => {
   const req = f.request();
   const started = Date.now();
   setTimeout(() => f.finished(req), 150);
-  await watch.settled({ timeout: 2000 });
+  await watch.settled({ issueTimeout: 2000, completionTimeout: 2000 });
   assert.ok(
     Date.now() - started >= 140,
     `must not return before the response settles (waited ${Date.now() - started} ms)`,
@@ -105,14 +105,14 @@ test("a failed save settles it too — a rejected PATCH is not a pending one", a
   const watch = watchFlowSave(f.page);
   const req = f.request();
   setTimeout(() => f.failed(req), 20);
-  await watch.settled({ timeout: 2000 });
+  await watch.settled({ issueTimeout: 2000, completionTimeout: 2000 });
 });
 
 test("reports the in-flight count when a save never completes", async () => {
   const f = fakePage();
   const watch = watchFlowSave(f.page);
   f.request();
-  await assert.rejects(() => watch.settled({ timeout: 200 }), /still in flight/);
+  await assert.rejects(() => watch.settled({ issueTimeout: 200, completionTimeout: 200 }), /still in flight/);
 });
 
 test("ignores traffic that is not a flow save", async () => {
@@ -123,7 +123,7 @@ test("ignores traffic that is not a flow save", async () => {
   // The path is matched on the PATHNAME: a build asset quoting the prefix in its
   // query string must not count.
   f.request("http://localhost:7860/assets/index.js?x=/api/v1/flows/abc");
-  await assert.rejects(() => watch.settled({ timeout: 150 }), /no flow-save PATCH/);
+  await assert.rejects(() => watch.settled({ issueTimeout: 150, completionTimeout: 150 }), /no flow-save PATCH/);
 });
 
 test("detaches its listeners on every exit path", async () => {
@@ -132,12 +132,12 @@ test("detaches its listeners on every exit path", async () => {
   assert.equal(ok.listeners, 3);
   const okReq = ok.request();
   setTimeout(() => ok.finished(okReq), 10);
-  await watch.settled({ timeout: 2000 });
+  await watch.settled({ issueTimeout: 2000, completionTimeout: 2000 });
   assert.equal(ok.listeners, 0, "resolved path must detach");
 
   const bad = fakePage();
   const failing = watchFlowSave(bad.page);
-  await assert.rejects(() => failing.settled({ timeout: 100 }));
+  await assert.rejects(() => failing.settled({ issueTimeout: 100, completionTimeout: 100 }));
   assert.equal(bad.listeners, 0, "timeout path must detach");
 
   const aborted = fakePage();
@@ -150,8 +150,8 @@ test("is single-use: a second settled() throws instead of resolving blind", asyn
   const watch = watchFlowSave(f.page);
   const req = f.request();
   setTimeout(() => f.finished(req), 10);
-  await watch.settled({ timeout: 2000 });
-  await assert.rejects(() => watch.settled({ timeout: 100 }), /single-use/);
+  await watch.settled({ issueTimeout: 2000, completionTimeout: 2000 });
+  await assert.rejects(() => watch.settled({ issueTimeout: 100, completionTimeout: 100 }), /single-use/);
 });
 
 test("dispose is idempotent and safe after settled()", async () => {
@@ -159,7 +159,7 @@ test("dispose is idempotent and safe after settled()", async () => {
   const watch = watchFlowSave(f.page);
   const req = f.request();
   setTimeout(() => f.finished(req), 10);
-  await watch.settled({ timeout: 2000 });
+  await watch.settled({ issueTimeout: 2000, completionTimeout: 2000 });
   watch.dispose();
   watch.dispose();
   assert.equal(f.listeners, 0);
@@ -176,7 +176,7 @@ test("a save in flight BEFORE arming cannot release the watch (#1742 review)", a
   const mine = f.request();
   f.settleUnobserved();
   let released = false;
-  const settled = watch.settled({ timeout: 3000 }).then(() => (released = true));
+  const settled = watch.settled({ issueTimeout: 3000, completionTimeout: 3000 }).then(() => (released = true));
   await new Promise((resolve) => setTimeout(resolve, 300));
   assert.equal(released, false, "must not release while the observed save is open");
   f.finished(mine);
@@ -190,11 +190,46 @@ test("two concurrent saves: both must complete", async () => {
   const first = f.request();
   const second = f.request();
   let released = false;
-  const settled = watch.settled({ timeout: 3000 }).then(() => (released = true));
+  const settled = watch.settled({ issueTimeout: 3000, completionTimeout: 3000 }).then(() => (released = true));
   f.finished(first);
   await new Promise((resolve) => setTimeout(resolve, 200));
   assert.equal(released, false, "one of two settling is not enough");
   f.finished(second);
   await settled;
   assert.equal(released, true);
+});
+
+test("a save that already completed is honoured even with the budget spent (#1742 review)", async () => {
+  // The condition must be evaluated at least once, BEFORE the clock is
+  // consulted. The `while (Date.now() < deadline)` version this replaces
+  // discarded a save that completed during its final sleep and threw
+  // "1 issued but 0 still in flight" — a message that disproves itself. Budgets
+  // of 0 reproduce that ordering deterministically, with no clock race.
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  const req = f.request();
+  f.finished(req);
+  await watch.settled({ issueTimeout: 0, completionTimeout: 0 });
+});
+
+test("the issuance and completion budgets are independent", async () => {
+  // An issued-but-slow save must not be reported as "never issued": the two
+  // failures have different causes (a follow-on mutation restarting the trailing
+  // debounce vs a slow backend) and the error has to say which.
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  const req = f.request();
+  const settled = watch.settled({ issueTimeout: 0, completionTimeout: 1000 });
+  setTimeout(() => f.finished(req), 120);
+  await settled;
+});
+
+test("a disposed watch says so, instead of blaming re-use (#1742 review)", async () => {
+  const f = fakePage();
+  const watch = watchFlowSave(f.page);
+  watch.dispose();
+  await assert.rejects(
+    () => watch.settled({ issueTimeout: 100, completionTimeout: 100 }),
+    /disposed before settled\(\) was called/,
+  );
 });

--- a/tests/helpers/flows/watch-flow-save.ts
+++ b/tests/helpers/flows/watch-flow-save.ts
@@ -75,22 +75,32 @@ export interface FlowSaveWatch {
  * server — a reload, a navigation away, or an API read of the flow.
  */
 export function watchFlowSave(page: Page): FlowSaveWatch {
-  let inFlight = 0;
+  /**
+   * The saves this watch actually OBSERVED start, by request identity.
+   *
+   * Identity, not a counter, and that is the whole correctness argument. A PATCH
+   * already in flight when the watch was armed settles here too, and a counter
+   * cannot tell it apart from the one the caller's edit triggered: an older save
+   * finishing while the new one is still open would decrement the count to zero
+   * and release the watch on a save that had not completed — the exact early
+   * return this primitive exists to prevent, reintroduced inside it. Playwright
+   * emits the same `Request` object on `request` and on
+   * `requestfinished`/`requestfailed`, so membership answers it exactly:
+   * unobserved settles are not in the set and are ignored.
+   */
+  const pending = new Set<Request>();
   let started = 0;
-  let settledCount = 0;
   let attached = true;
 
   const onRequest = (req: Request) => {
     if (!isFlowSave(req)) return;
     started++;
-    inFlight++;
+    pending.add(req);
   };
   const onSettled = (req: Request) => {
-    if (!isFlowSave(req)) return;
-    // Clamp: a PATCH already in flight when this watch was armed would settle
-    // here without ever having been counted as started.
-    inFlight = Math.max(0, inFlight - 1);
-    settledCount++;
+    // No `isFlowSave` test needed: only saves were ever added, and `delete`
+    // reports whether this request was one of them.
+    pending.delete(req);
   };
 
   page.on("request", onRequest);
@@ -116,7 +126,7 @@ export function watchFlowSave(page: Page): FlowSaveWatch {
       const deadline = Date.now() + timeout;
       try {
         while (Date.now() < deadline) {
-          if (started > 0 && inFlight === 0 && settledCount >= started) return;
+          if (started > 0 && pending.size === 0) return;
           await page.waitForTimeout(50);
         }
         throw new Error(
@@ -125,7 +135,7 @@ export function watchFlowSave(page: Page): FlowSaveWatch {
               `(${describeAutosaveInterval()}). The edit did not reach the server — ` +
               `it may not have marked the node dirty (a fill() on a controlled input ` +
               `does not), or the flow is read-only.`
-            : `watchFlowSave: ${started} flow-save PATCH(es) issued but ${inFlight} ` +
+            : `watchFlowSave: ${started} flow-save PATCH(es) issued but ${pending.size} ` +
               `still in flight after ${timeout} ms.`,
         );
       } finally {

--- a/tests/helpers/flows/watch-flow-save.ts
+++ b/tests/helpers/flows/watch-flow-save.ts
@@ -1,0 +1,136 @@
+import type { Page, Request } from "@playwright/test";
+import {
+  describeAutosaveInterval,
+  saveScheduledDeadlineMs,
+} from "./autosave-interval";
+
+/** A flow autosave is a `PATCH` on this path prefix. */
+const FLOWS_PATH_PREFIX = "/api/v1/flows/";
+
+/**
+ * Anchored on the PATHNAME, never on a substring of the whole URL — the repo has
+ * been bitten by `url.includes("/build/")` matching `/assets/build/index.js`
+ * (see `tests/fixtures/flow-error-policy.ts`).
+ */
+function isFlowSave(req: Request): boolean {
+  if (req.method() !== "PATCH") return false;
+  try {
+    return new URL(req.url()).pathname.startsWith(FLOWS_PATH_PREFIX);
+  } catch {
+    return false;
+  }
+}
+
+export interface FlowSaveWatch {
+  /**
+   * Resolve once a save that started AFTER this watch was armed has completed.
+   *
+   * Throws if none was ever issued by `timeout`. That is the whole point of the
+   * primitive: "no save appeared" is the state `waitForFlowSaveSettled` reports
+   * as success, and it is indistinguishable from a persisted edit on a green
+   * run (#1741).
+   *
+   * **Single-use**, for the reason its sibling `watchNodeRefresh` is: the
+   * listeners are detached on the way out, so a second call could never observe
+   * a request and would resolve on a save it did not see.
+   */
+  settled(opts?: { timeout?: number }): Promise<void>;
+  /**
+   * Detach without waiting. Only needed on the abort path — if the edit between
+   * `watchFlowSave(page)` and `settled()` throws, the listeners would otherwise
+   * outlive the step. Idempotent, and safe after `settled()`.
+   */
+  dispose(): void;
+}
+
+/**
+ * Watch for the autosave an edit is about to schedule.
+ *
+ * Arm it BEFORE the edit, await it after:
+ *
+ * ```ts
+ * const save = watchFlowSave(page);
+ * await field.fill("8");
+ * await save.settled();
+ * ```
+ *
+ * ## Why this exists next to `waitForFlowSaveSettled`
+ *
+ * They answer different questions, and only one of them is the question most
+ * callers have. `waitForFlowSaveSettled` DRAINS what is already in flight: it
+ * arms a quiet window immediately, so when nothing has been issued yet it
+ * returns after that window with no request ever tracked. Since the autosave is
+ * scheduled one full debounce after the edit — 2000 ms on `1.13.0.dev4` against
+ * that helper's 700 ms window — a barrier called right after an edit routinely
+ * returns BEFORE the save exists (measured 3/3, with the database still holding
+ * the pre-edit value at the moment it returned; #1741).
+ *
+ * That is correct behaviour for "let the editor go quiet" and wrong for "my edit
+ * is persisted". This watcher answers the second: it observes the save being
+ * issued and waits for it to complete, and it FAILS when none appears rather
+ * than reporting a silence it cannot interpret (#1012).
+ *
+ * Use `waitForFlowSaveSettled` when you are draining traffic you did not cause;
+ * use this when the next assertion depends on the edit having reached the
+ * server — a reload, a navigation away, or an API read of the flow.
+ */
+export function watchFlowSave(page: Page): FlowSaveWatch {
+  let inFlight = 0;
+  let started = 0;
+  let settledCount = 0;
+  let attached = true;
+
+  const onRequest = (req: Request) => {
+    if (!isFlowSave(req)) return;
+    started++;
+    inFlight++;
+  };
+  const onSettled = (req: Request) => {
+    if (!isFlowSave(req)) return;
+    // Clamp: a PATCH already in flight when this watch was armed would settle
+    // here without ever having been counted as started.
+    inFlight = Math.max(0, inFlight - 1);
+    settledCount++;
+  };
+
+  page.on("request", onRequest);
+  page.on("requestfinished", onSettled);
+  page.on("requestfailed", onSettled);
+
+  const dispose = () => {
+    if (!attached) return;
+    attached = false;
+    page.off("request", onRequest);
+    page.off("requestfinished", onSettled);
+    page.off("requestfailed", onSettled);
+  };
+
+  return {
+    dispose,
+    async settled({ timeout = saveScheduledDeadlineMs() } = {}) {
+      if (!attached) {
+        throw new Error(
+          "watchFlowSave: settled() is single-use — arm a new watch per edit.",
+        );
+      }
+      const deadline = Date.now() + timeout;
+      try {
+        while (Date.now() < deadline) {
+          if (started > 0 && inFlight === 0 && settledCount >= started) return;
+          await page.waitForTimeout(50);
+        }
+        throw new Error(
+          started === 0
+            ? `watchFlowSave: no flow-save PATCH was issued within ${timeout} ms ` +
+              `(${describeAutosaveInterval()}). The edit did not reach the server — ` +
+              `it may not have marked the node dirty (a fill() on a controlled input ` +
+              `does not), or the flow is read-only.`
+            : `watchFlowSave: ${started} flow-save PATCH(es) issued but ${inFlight} ` +
+              `still in flight after ${timeout} ms.`,
+        );
+      } finally {
+        dispose();
+      }
+    },
+  };
+}

--- a/tests/helpers/flows/watch-flow-save.ts
+++ b/tests/helpers/flows/watch-flow-save.ts
@@ -1,11 +1,15 @@
 import type { Page, Request } from "@playwright/test";
 import {
   describeAutosaveInterval,
+  SAVE_COMPLETION_BUDGET_MS,
   saveScheduledDeadlineMs,
 } from "./autosave-interval";
 
 /** A flow autosave is a `PATCH` on this path prefix. */
 const FLOWS_PATH_PREFIX = "/api/v1/flows/";
+
+/** Poll spacing. Each turn is a traced Playwright call, so it is not free. */
+const POLL_INTERVAL_MS = 50;
 
 /**
  * Anchored on the PATHNAME, never on a substring of the whole URL — the repo has
@@ -34,7 +38,19 @@ export interface FlowSaveWatch {
    * listeners are detached on the way out, so a second call could never observe
    * a request and would resolve on a save it did not see.
    */
-  settled(opts?: { timeout?: number }): Promise<void>;
+  settled(opts?: {
+    /**
+     * Budget for the save to be ISSUED. Defaults to one debounce plus slack,
+     * derived from the instance.
+     */
+    issueTimeout?: number;
+    /**
+     * Budget for an issued save to COMPLETE, on top of `issueTimeout`. Two
+     * budgets rather than one because they fail for different reasons and the
+     * error has to say which.
+     */
+    completionTimeout?: number;
+  }): Promise<void>;
   /**
    * Detach without waiting. Only needed on the abort path — if the edit between
    * `watchFlowSave(page)` and `settled()` throws, the listeners would otherwise
@@ -73,6 +89,24 @@ export interface FlowSaveWatch {
  * Use `waitForFlowSaveSettled` when you are draining traffic you did not cause;
  * use this when the next assertion depends on the edit having reached the
  * server — a reload, a navigation away, or an API read of the flow.
+ *
+ * ## Precondition: arm it from a quiescent editor
+ *
+ * This watch resolves on the first save it OBSERVES, and it cannot know which
+ * mutation produced it. A save already SCHEDULED when it was armed — an earlier
+ * interaction's pending debounce — is issued after arming and therefore counts,
+ * even though it carries pre-edit state. The identity `Set` closes the
+ * in-flight case; nothing closes the scheduled one from inside, because a
+ * pending debounce is invisible until it fires.
+ *
+ * It matters most where the watcher is most useful: when the edit did NOT mark
+ * the node dirty (a `fill()` on a controlled input does not), a prior pending
+ * save satisfies the watch and the test passes instead of naming the cause.
+ *
+ * So arm it when the editor is quiet. After an earlier mutation, drain first
+ * with a window longer than the debounce — `waitForFlowSaveSettled(page,
+ * { quietMs: pendingSaveQuietMs() })`, which is exactly the window that helper's
+ * 700 ms default is too short to be (#1741).
  */
 export function watchFlowSave(page: Page): FlowSaveWatch {
   /**
@@ -91,6 +125,11 @@ export function watchFlowSave(page: Page): FlowSaveWatch {
   const pending = new Set<Request>();
   let started = 0;
   let attached = true;
+  // Separate from `attached` on purpose: conflating them reports a DISPOSED
+  // watch as a re-used one, which is the wrong diagnosis on the documented abort
+  // path (dispose() in a catch, then settled() awaited). The sibling
+  // `watchNodeRefresh` keeps the same two flags for the same reason.
+  let spent = false;
 
   const onRequest = (req: Request) => {
     if (!isFlowSave(req)) return;
@@ -117,27 +156,49 @@ export function watchFlowSave(page: Page): FlowSaveWatch {
 
   return {
     dispose,
-    async settled({ timeout = saveScheduledDeadlineMs() } = {}) {
-      if (!attached) {
+    async settled({
+      issueTimeout = saveScheduledDeadlineMs(),
+      completionTimeout = SAVE_COMPLETION_BUDGET_MS,
+    } = {}) {
+      if (spent) {
         throw new Error(
           "watchFlowSave: settled() is single-use — arm a new watch per edit.",
         );
       }
-      const deadline = Date.now() + timeout;
-      try {
-        while (Date.now() < deadline) {
-          if (started > 0 && pending.size === 0) return;
-          await page.waitForTimeout(50);
-        }
+      if (!attached) {
         throw new Error(
-          started === 0
-            ? `watchFlowSave: no flow-save PATCH was issued within ${timeout} ms ` +
-              `(${describeAutosaveInterval()}). The edit did not reach the server — ` +
-              `it may not have marked the node dirty (a fill() on a controlled input ` +
-              `does not), or the flow is read-only.`
-            : `watchFlowSave: ${started} flow-save PATCH(es) issued but ${pending.size} ` +
-              `still in flight after ${timeout} ms.`,
+          "watchFlowSave: this watch was disposed before settled() was called.",
         );
+      }
+      spent = true;
+      const issueDeadline = Date.now() + issueTimeout;
+      const overallDeadline = issueDeadline + completionTimeout;
+      try {
+        // The condition is tested BEFORE either deadline, every turn, which is
+        // what keeps a save that completed during the last sleep from being
+        // discarded — the loop would otherwise exit on the clock and throw
+        // `1 issued but 0 still in flight`, a message that disproves itself.
+        // Same ordering as the sibling `watchNodeRefresh`.
+        for (;;) {
+          if (started > 0 && pending.size === 0) return;
+          const now = Date.now();
+          if (started === 0 && now >= issueDeadline) {
+            throw new Error(
+              `watchFlowSave: no flow-save PATCH was issued within ${issueTimeout} ms ` +
+                `(${describeAutosaveInterval()}). The edit did not reach the server — ` +
+                `it may not have marked the node dirty (a fill() on a controlled input ` +
+                `does not), the flow is read-only, or autosave is disabled on this ` +
+                `instance.`,
+            );
+          }
+          if (now >= overallDeadline) {
+            throw new Error(
+              `watchFlowSave: ${started} flow-save PATCH(es) issued but ${pending.size} ` +
+                `still in flight ${completionTimeout} ms after the last one started.`,
+            );
+          }
+          await page.waitForTimeout(POLL_INTERVAL_MS);
+        }
       } finally {
         dispose();
       }

--- a/tests/pages/SimpleAgentTemplatePage.ts
+++ b/tests/pages/SimpleAgentTemplatePage.ts
@@ -37,11 +37,14 @@ export interface LoadSimpleAgentOptions {
  *    cannot work from here: it is attached AFTER the model click, and the rebind
  *    chain is a 300 ms `mutateTemplate` debounce → `POST
  *    /api/v1/custom_component/update` → the editor's autosave debounce, which is
- *    `GET /api/v1/config.auto_saving_interval` and answers **1000** on the running
- *    nightly (the 300 ms in `wait-for-flow-save-settled.ts` is only the store's
- *    pre-fetch default). The earliest `PATCH /api/v1/flows/{id}` is therefore
- *    ~1.3 s + a round trip away, while the helper's quiet window is 700 ms with
- *    nothing in flight at attach time — so it expires first. Measured locally: it
+ *    `GET /api/v1/config.auto_saving_interval` and answered **1000** on the nightly
+ *    when this was measured — **2000** on `1.13.0.dev4`, so the margin below is
+ *    the old, smaller one and the conclusion only got safer (#1741; the 300 ms in
+ *    `wait-for-flow-save-settled.ts` is only the store's pre-fetch default, and
+ *    the run-scoped value now comes from `helpers/flows/autosave-interval.ts`).
+ *    The earliest `PATCH /api/v1/flows/{id}` is therefore ~1.3 s + a round trip
+ *    away, while the helper's quiet window is 700 ms with nothing in flight at
+ *    attach time — so it expires first. Measured locally: it
  *    resolved at ~0.7 s on a settle that completed at 1.5 s, having tracked no
  *    request at all. Under load it degenerates into a 700 ms sleep.
  *  - **Waiting on the refresh POST itself** (armable in `load()` before the setup


### PR DESCRIPTION
**Closes #1741.** Approved exception — `qa-infra`, surfaced while measuring #1739 (PR #1740). Three commits, deliberately atomic: the resolved value, the primitive, the corrected claims.

## The defect

`waitForFlowSaveSettled` arms a **700 ms** quiet window and, when nothing is in flight, arms it **immediately**. The flow autosave debounce on the nightly is **2000 ms**. So a call placed right after an edit returns *before that edit's PATCH has been issued at all* — and its header justified the 700 ms as "comfortably above the 300 ms autosave debounce".

Measured on `1.13.0.dev4`, reading the database at the instant the barrier returns:

```
BARRIER RETURNED 1045 / 1071 / 1015 ms after the fill — patches sent so far: 0
PERSISTED AT BARRIER RETURN = 15   (wanted 3, default 15)
```

3/3. The 300 ms is `SAVE_DEBOUNCE_TIME`, only the store's pre-fetch default; the effective delay is `GET /api/v1/config.auto_saving_interval`, seeded into the frontend by `use-get-config.ts`.

**This is the third independent rediscovery in this repo**, which is why the fix belongs where the helper is defined and not at another call site: `SimpleAgentTemplatePage.ts:25-56` rejected the barrier for exactly this reason ("under load it degenerates into a 700 ms sleep") and `general-bugs-save-changes-on-node.spec.ts:70-85` replaced it with a server-side gate. Both fixed it locally; the shared helper kept the wrong number.

## What this PR does

| Commit | Change |
|---|---|
| `44c379b3` | `helpers/flows/autosave-interval.ts` — the interval becomes a **run-scoped value read from the instance**, resolved once in `globalSetup` and inherited by the forked workers through the environment (same channel and same reason as the frozen model catalog). Unknown is `null`, never a fabricated number; a `0` or non-integer reads as unknown, because a 0 collapses every derived deadline to "already due". 7 unit tests |
| `81b1bff2` | `helpers/flows/watch-flow-save.ts` — armed **before** the edit, awaited after; resolves once a PATCH issued after arming has **completed**, and **fails** when none appears rather than reporting an uninterpretable silence (#1012). Single-use + `dispose()`, pathname-anchored matching — mirroring `watchNodeRefresh`. 9 unit tests |
| `0907ab86` | The barrier's header now states what it is (a **drain**) and points callers who need persistence at the new primitive. `SimpleAgentTemplatePage.ts`'s older value is dated rather than overwritten — its 1.3 s margin was derived from it, and the conclusion only got safer |

The `globalSetup` read **authenticates explicitly**: `/api/v1/config` answers `200` with a PUBLIC payload that omits the field, so an unauthenticated read fails as a resolved-looking `undefined` rather than as an error. The step is never fatal — an unreadable value is a `::warning::` plus a documented fallback larger than any interval upstream has shipped (300 → 1000 → 2000).

## Validation

**Live proof — same edit, both arms, database read at the instant each returns** (`1.13.0.dev4`, `--workers=1 --retries=0`):

```
[preflight] autosave debounce 2000 ms (GET /api/v1/config.auto_saving_interval)

OLD waitForFlowSaveSettled  → returned in 1072 / 1041 ms   persisted = 15  ❌ (default)
NEW watchFlowSave           → returned in 2425 / 2436 ms   persisted =  3  ✅
```

`readAutosaveIntervalMs()` returned `2000` **inside the worker**, which is what proves the value crosses the fork. Cost of the new primitive: **+1.4 s per guarded edit**, paid only where it is used.

**Unit tests — the barrier had none; there are 16 now.** `npm run test:units`: 1046 → **1062 pass / 0 fail**.

**Force-fails — executed, mutating the mechanism** (`watch-flow-save.ts`):

- `FF-1` accept silence (`if (inFlight === 0) return`) → **3 tests failed**
- `FF-2` return as soon as the PATCH is issued, without waiting for it to settle → **2 failed**
- `FF-3` substring URL match instead of pathname anchoring → **1 failed**
- revert proven: correct predicate back, **9/9 green**

`npm run typecheck` ✅ · `npm run check:checklist-coverage` ✅ · eslint 0 errors — one `no-wait-for-timeout` warning on the poll loop, **identical to its sibling `watch-node-refresh.ts`** · zero orphan flows left on the instance.

No `QA-CHECKLIST.md` change: no spec added, no `@stable` change.

## Deliberately NOT in this PR

**Nothing uses `watchFlowSave` yet.** The audit found **9 spec files** with the exposed shape — the barrier followed by a reload, a navigation away, or an API read of the flow: `agent-config-persistence`, `agent-context-id-continuity`, `agent-context-id-isolation`, `agent-structured-output`, `agent-tool-error-handling`, `sidebar-add-component`, `azure-ai-foundry-provider-setup`, `export-import-flow`, `human-input-node-config`, plus the `leave-flow-editor.ts` helper.

Migrating them is a behaviour change across 9 specs, several of them `@stable` and in the daily — where a hard failure removes the tag by automatic commit, without review. One PR of 9 multiplies that exposure by 9, and each file owes its own force-fail. It is filed as a follow-up with the list and the exposure criterion, to be worked a file at a time.

The additions here are inert until then: no existing call site changes behaviour, and the only globally-reaching piece is the `globalSetup` step, which is fail-open behind an already-completed health check.


---

## CI evidence for the one globally-reaching piece

`tests/globalSetup.ts` is a global hook, so the impacted-specs resolver selected the whole suite and the lane ran its cap — **39 tests across 20 spec files, all passed (9.5 min)**, with the new step live:

```
[preflight] autosave debounce 2000 ms (GET /api/v1/config.auto_saving_interval)
```

That line appears on both the main run and the destructive lane, which is the part worth having: the authenticated read works on CI's auth path and against CI's own Langflow container, not only against a local one — the failure mode it guards (an unauthenticated read resolving to a silent `undefined`) would have shown up here as the fallback warning instead.

One unrelated line was observed in the container log at teardown — a single `op=update_flow … failed with InvalidRequestError` at 21:01:40, adjacent to `Build cancelled` / `Vertex build failed`. It is teardown noise from a run being cancelled while a save was in flight, not something this diff can cause: the only traffic added here is one `GET /api/v1/config` in `globalSetup`, before any test starts, and no existing call site changes behaviour. Recorded rather than omitted.


---

## Post-review addendum (4 commits)

Two review passes — Copilot's and an independent one with clean context — found **six defects**, all in code this PR introduced, all fixed with a regression test that fails against the version it replaces.

**`c7d96d92` — `watchFlowSave` could release on a save it never observed.** The counter decremented for *any* matching PATCH settling, including one already in flight when the watch was armed: an older save finishing dropped the count to zero while the caller's own save was still open. That is the early return this primitive exists to prevent, reintroduced inside it. Now keyed on request identity — Playwright emits the same `Request` object on `request` and on `requestfinished`/`requestfailed`, so membership answers exactly what a counter could only approximate. **The unit fake was complicit**: it minted a fresh request object per event, so the identity the helper keys on did not exist and the broken version was green against all 9 tests. It now hands back the request it started, the way Playwright does.

**`8db8f80e` — a wedged backend was reported as the wrong cause.** `getAuthToken(ctx).catch(() => "")` swallowed the one error that matters: that helper returns `""` for an environment without auth and throws *only* when the backend never answered its retry budget, and its header forbids degrading that into the empty token (#1086). Swallowed, a wedge surfaced as "the public payload omits the field" — a true sentence about the wrong cause, on the step whose job is to name what it could not resolve.

**`46b91869` — three defects in the poll loop and its budgets.** The loop tested the deadline *before* the condition, so a save completing during the final 50 ms sleep was discarded and the watch threw `1 flow-save PATCH(es) issued but 0 still in flight` — a message that disproves itself. One budget covered both issuance and completion while its own header called it the issuance allowance, leaving ~1.1 s for the round trip at the measured debounce — and since the debounce is *trailing*, any follow-on mutation restarts it and fails a healthy save. And `attached` doubled as both the disposed and the spent flag, reporting a disposed watch as a re-used one.

**`7d36dc49` — an instance with autosave switched off now says so.** `GET /api/v1/config` carries `auto_saving` beside the interval, and an instance running with it false still reports a plausible integer: the preflight printed a confident debounce for a backend that will never issue a PATCH. Same commit aligns `reportCatalogDrift`, which still swallowed the same throw the sibling step now documents as forbidden.

**Also documented rather than silently fixed**, because it cannot be closed from inside the helper: a save already **scheduled** when the watch is armed is issued after arming and satisfies it, carrying pre-edit state — a pending debounce is invisible until it fires. The header states the precondition and hands callers the window that closes it, `pendingSaveQuietMs()`.

### Validation after the fixes

- Unit tests **1046 → 1069 pass / 0 fail** (watcher 9 → 14, interval 7 → 9)
- Force-fails, executed: identity → counter **1 fails** · deadline-first loop **2 fail** · collapsed budgets **1 fails** · conflated flags **1 fails** · accepting silence **3 fail** · returning before completion **2 fail** · substring URL match **1 fails**. Revert proven each time
- `npm run typecheck` ✅ · eslint 0 errors · live: `[preflight] autosave debounce 2000 ms` still resolves and **86 API tests pass** with the auth change

One thing recorded rather than explained: a single run of the unit suite reported 27 failures and every run since has been clean — **5 consecutive clean runs (1069/1069), one of them concurrent with a real Playwright run** to reproduce it under load. The failing run's test names were not captured. Not reproducible, not attributed, and noted here rather than omitted.
