### PR TITLE
Record the mirrored environment that was in force, so a machine-local override stops being invisible

### DIFF
--- a/scripts/check-vm-env-parity.test.mjs
+++ b/scripts/check-vm-env-parity.test.mjs
@@ -56,13 +56,16 @@ const workflowWith = (envLines, tail = "") =>
     tail,
   ].join("\n");
 
-/** run-e2e.sh's composer, in the shape the reader expects. */
+/** run-e2e.sh's list and its composer, in the shape the reader expects. */
 const orchestratorWith = (names, extra = "") =>
   [
     extra,
+    `MIRRORED_TARGET_VARS="${names.join(" ")}"`,
     "mirrored_target_env() {",
-    "  printf '%s' \\",
-    ...names.map((n) => `    "${n}=$(shq "$${n}") " \\`),
+    "  local name",
+    "  for name in $MIRRORED_TARGET_VARS; do",
+    '    printf \'%s=%s \' "$name" "$(shq "${!name}")"',
+    "  done",
     "}",
   ].join("\n");
 
@@ -161,6 +164,28 @@ test("naming a mirrored variable outside the composer does not count as carrying
   const found = result.findings.find((f) => f.name === "LANGFLOW_DEACTIVATE_TRACING");
   assert.equal(found?.kind, "not-carried");
   assert.match(found.message, /mirrored_target_env\(\)/);
+});
+
+test("a list the composer stopped reading is refused, not believed", () => {
+  // The half of the property that moved when #1748 made MIRRORED_TARGET_VARS the single
+  // enumeration. Reading a list instead of the function body is only equivalent while
+  // the function composes FROM the list — the moment it does not, the list is precisely
+  // the stale mention the test above refuses, and believing it would report a variable
+  // as carried while nothing reached the target.
+  //
+  // Driven by a mutation of the real file rather than a fixture, because the fixture is
+  // what would be adjusted to match a broken source.
+  const real = readFileSync(join(REPO_ROOT, "scripts/run-e2e.sh"), "utf8");
+  assert.ok(readMirroredNames(real).size >= 4, "the real file should still be readable");
+
+  const noLoop = real.replace(/for name in \$MIRRORED_TARGET_VARS; do/, "for name in LANGFLOW_DEACTIVATE_TRACING; do");
+  assert.notEqual(noLoop, real, "the mutation did not apply — the composer's loop was rewritten");
+  assert.throws(() => readMirroredNames(noLoop), /no longer composes MIRRORED_TARGET_VARS/);
+
+  // And the CLI-facing half: the guard reports it rather than crashing out of the lane.
+  const result = check(workflowWith(MINIMAL), { orchestrator: noLoop });
+  assert.equal(result.ok, false);
+  assert.equal(result.findings[0]?.kind, "unreadable");
 });
 
 test("a starter-carried variable its launch block does not set fails", () => {

--- a/scripts/lib/vm-env-parity.mjs
+++ b/scripts/lib/vm-env-parity.mjs
@@ -355,8 +355,9 @@ export function checkVmEnvParity({
     const shadow = launch.assignments.get(name);
 
     if (entry.carrier === "orchestrator") {
-      // Composed into the remote environment — read out of the function, not out of
-      // the file, so a stale mention cannot answer for a live one.
+      // Composed into the remote environment — read out of MIRRORED_TARGET_VARS, and
+      // only after readMirroredNames has checked that the composer still loops it, so
+      // a stale mention cannot answer for a live one.
       if (!mirrored.has(name)) {
         findings.push({
           kind: "not-carried",

--- a/scripts/lib/vm-env-parity.mjs
+++ b/scripts/lib/vm-env-parity.mjs
@@ -135,15 +135,32 @@ export function readStarterLaunchEnv(text) {
 /**
  * The names the orchestrator actually composes into the remote environment.
  *
- * Read out of `mirrored_target_env`'s BODY, not out of the whole file. "The file names
- * it somewhere" was the first version's test and it is not the property: a variable
- * mentioned in a string, or left behind in a stale branch, would satisfy it while
- * nothing reached the target.
+ * Read out of `MIRRORED_TARGET_VARS` — but only after checking that
+ * `mirrored_target_env()` still composes FROM that list. The two halves are the
+ * property together, and neither is it alone.
+ *
+ * The earlier version read the function's body, because "the file names it somewhere"
+ * is not the property: a variable mentioned in a string, or left behind in a stale
+ * branch, would satisfy that while nothing reached the target. That reasoning is
+ * unchanged; what changed is where the names live. #1748 made the list the single
+ * enumeration — the orchestrator's metadata records the same names it sends — and a
+ * list the function loops over IS the composition. A list it stopped looping over
+ * would be exactly the stale mention the old form refused, so that is what the shape
+ * check below refuses.
  */
 export function readMirroredNames(text) {
-  const body = stripComments(text).match(/mirrored_target_env\(\)\s*\{([\s\S]*?)\n\}/);
+  const stripped = stripComments(text);
+  const body = stripped.match(/mirrored_target_env\(\)\s*\{([\s\S]*?)\n\}/);
   if (!body) throw new Error("the orchestrator has no mirrored_target_env() function");
-  return new Set([...body[1].matchAll(/([A-Za-z_][A-Za-z0-9_]*)=\$\(shq /g)].map((m) => m[1]));
+  if (!/\$\{?MIRRORED_TARGET_VARS\b/.test(body[1]) || !/\$\{!\s*\w+\s*\}/.test(body[1])) {
+    throw new Error(
+      "mirrored_target_env() no longer composes MIRRORED_TARGET_VARS by indirection, " +
+        "so the list is no longer evidence that anything reaches the target",
+    );
+  }
+  const list = stripped.match(/^MIRRORED_TARGET_VARS="([^"]*)"/m);
+  if (!list) throw new Error("the orchestrator has no MIRRORED_TARGET_VARS list");
+  return new Set(list[1].split(/\s+/).filter(Boolean));
 }
 
 /**

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1316,11 +1316,33 @@ phase_merge() {
   # and for the stage that will compare the lanes, not a field with a consumer today.
   # Stated rather than implied, because "the comparator reads it" would be a reason
   # that is not true yet. (#1726)
+  #
+  # The EFFECTIVE value of everything this file carries to the target — what was in
+  # force, not the default it pins. On 2026-09-07 the instance under test ran with
+  # tracing OFF against the workflow's `false`; the exception was an export in the
+  # wrapper on the qa VM, deliberate and documented there, and it explained 16 of that
+  # day's 20 divergences. Establishing that took a shell on the machine, because
+  # nothing the run itself produced named the value actually used (#1748).
+  #
+  # A machine may hold a measured exception — that is how a VM records one. What it
+  # may not do is hold it invisibly: scripts/check-vm-env-parity.mjs reads files in
+  # this repository, so an override that lives outside every clone is outside its
+  # reach by construction, and the run's own artifact is the only place that can
+  # answer for it.
+  local mirrored_kv=() name
+  # shellcheck disable=SC2086  # deliberate word splitting: the list holds names, never values
+  for name in $MIRRORED_TARGET_VARS; do mirrored_kv+=("$name" "${!name}"); done
+
   node -e '
     const fs = require("fs");
-    const [out, ...kv] = process.argv.slice(1);
+    const args = process.argv.slice(1);
+    const at = args.indexOf("--mirrored");
+    const [out, ...kv] = at === -1 ? args : args.slice(0, at);
+    const mirrored = at === -1 ? [] : args.slice(at + 1);
     const o = {};
     for (let i = 0; i < kv.length; i += 2) o[kv[i]] = kv[i + 1];
+    o.mirrored_target_env = {};
+    for (let i = 0; i < mirrored.length; i += 2) o.mirrored_target_env[mirrored[i]] = mirrored[i + 1];
     fs.writeFileSync(out, JSON.stringify(o, null, 2) + "\n");
   ' "$RUN_DIR/run-metadata.json" \
     run_id "$RUN_ID" \
@@ -1339,10 +1361,15 @@ phase_merge() {
     shards "$SHARD_TOTAL" \
     tunnel "$LANGFLOW_TUNNEL" \
     tests_total "${RUN_TESTS:-0}" \
-    merge_ok "${MERGE_OK:-true}"
+    merge_ok "${MERGE_OK:-true}" \
+    --mirrored "${mirrored_kv[@]}"
 
   info "tests: ${RUN_TESTS:-0} | top-level errors: ${RUN_ERRORS:-0} | empty: $RUN_EMPTY | partial: $RUN_PARTIAL"
   info "Langflow: ${LANGFLOW_VERSION:-<unknown>}"
+  # The same values in the log, quoted exactly as they were sent. The metadata is the
+  # durable record; this line is for whoever is reading the run's output at 08:00 and
+  # wondering why a family went red.
+  info "target env: $(mirrored_target_env)"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1333,18 +1333,27 @@ phase_merge() {
   # shellcheck disable=SC2086  # deliberate word splitting: the list holds names, never values
   for name in $MIRRORED_TARGET_VARS; do mirrored_kv+=("$name" "${!name}"); done
 
+  # The mirrored pairs are COUNTED and come first, not marked off by a sentinel. A
+  # sentinel is a string the data could carry: langflow_prepared_reason below is parsed
+  # out of the preparer output on the OTHER machine, so its content is not this script
+  # to promise, and a value that happened to equal the marker would truncate the list
+  # and mis-key every field after it — writing a wrong file, silently. A count cannot
+  # collide with a value.
   node -e '
     const fs = require("fs");
-    const args = process.argv.slice(1);
-    const at = args.indexOf("--mirrored");
-    const [out, ...kv] = at === -1 ? args : args.slice(0, at);
-    const mirrored = at === -1 ? [] : args.slice(at + 1);
+    const [out, count, ...rest] = process.argv.slice(1);
+    const n = Number(count);
+    if (!Number.isInteger(n) || n < 0 || n > rest.length || n % 2 !== 0) {
+      throw new Error("mirrored pair count is not usable: " + count);
+    }
+    const mirrored = rest.slice(0, n);
+    const kv = rest.slice(n);
     const o = {};
     for (let i = 0; i < kv.length; i += 2) o[kv[i]] = kv[i + 1];
     o.mirrored_target_env = {};
     for (let i = 0; i < mirrored.length; i += 2) o.mirrored_target_env[mirrored[i]] = mirrored[i + 1];
     fs.writeFileSync(out, JSON.stringify(o, null, 2) + "\n");
-  ' "$RUN_DIR/run-metadata.json" \
+  ' "$RUN_DIR/run-metadata.json" "${#mirrored_kv[@]}" "${mirrored_kv[@]}" \
     run_id "$RUN_ID" \
     suite_sha "$(git rev-parse HEAD)" \
     suite_branch "$(git rev-parse --abbrev-ref HEAD)" \
@@ -1361,8 +1370,7 @@ phase_merge() {
     shards "$SHARD_TOTAL" \
     tunnel "$LANGFLOW_TUNNEL" \
     tests_total "${RUN_TESTS:-0}" \
-    merge_ok "${MERGE_OK:-true}" \
-    --mirrored "${mirrored_kv[@]}"
+    merge_ok "${MERGE_OK:-true}"
 
   info "tests: ${RUN_TESTS:-0} | top-level errors: ${RUN_ERRORS:-0} | empty: $RUN_EMPTY | partial: $RUN_PARTIAL"
   info "Langflow: ${LANGFLOW_VERSION:-<unknown>}"

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -709,6 +709,17 @@ phase_hygiene() {
 phase_preflight() {
   log "Preflight"
 
+  # The environment this lane will put on the instance under test, quoted exactly as it
+  # will be sent — printed from the composer itself, so it cannot describe an
+  # environment other than the one that crosses the ssh boundary.
+  #
+  # HERE, and not beside the metadata write in phase_merge, because a wrong mirrored
+  # value is one of the likelier reasons the backend never comes up — and a run that
+  # dies in prep or in a shard never reaches phase_merge. The run that most needs this
+  # record would be exactly the one that produced none. First line of the first phase
+  # costs nothing and survives every abort after it.
+  info "target env: $(mirrored_target_env)"
+
   [ -n "$TARGET_SSH" ] || die "TARGET_SSH is required — this script drives a second machine and will not guess its name."
   command -v node > /dev/null || die "node is not on PATH."
   command -v npm  > /dev/null || die "npm is not on PATH."
@@ -1374,10 +1385,6 @@ phase_merge() {
 
   info "tests: ${RUN_TESTS:-0} | top-level errors: ${RUN_ERRORS:-0} | empty: $RUN_EMPTY | partial: $RUN_PARTIAL"
   info "Langflow: ${LANGFLOW_VERSION:-<unknown>}"
-  # The same values in the log, quoted exactly as they were sent. The metadata is the
-  # durable record; this line is for whoever is reading the run's output at 08:00 and
-  # wondering why a family went red.
-  info "target env: $(mirrored_target_env)"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -360,6 +360,19 @@ LANGFLOW_SQLITE_PRAGMAS="${LANGFLOW_SQLITE_PRAGMAS:-$DEFAULT_SQLITE_PRAGMAS}"
 node -e 'const v=process.argv[1];let p;try{p=JSON.parse(v)}catch(e){console.error("LANGFLOW_SQLITE_PRAGMAS is not valid JSON ("+e.message+"): "+v);process.exit(1)}if(p===null||typeof p!=="object"||Array.isArray(p)){console.error("LANGFLOW_SQLITE_PRAGMAS must be a JSON object, got: "+v);process.exit(1)}' \
   "$LANGFLOW_SQLITE_PRAGMAS"
 
+# The names above, in ONE place. Two things read this list: mirrored_target_env(),
+# which composes the remote environment out of it, and phase_merge, which records what
+# each of them was actually set to. One list rather than two enumerations with a
+# guard between them — a guard would report the drift, and not having the drift is
+# better than reporting it. Adding a variable here is what carries it AND what records
+# it; there is no way to do one without the other.
+#
+# scripts/lib/vm-env-parity.mjs reads this list to answer "does the orchestrator carry
+# it", and pins that the function below still composes FROM it — so the list cannot
+# become a name nothing consumes, which is the failure that reading the function body
+# was protecting against.
+MIRRORED_TARGET_VARS="LANGFLOW_DEACTIVATE_TRACING LANGFLOW_WORKER_TIMEOUT LANGFLOW_ALLOW_CUSTOM_COMPONENTS LANGFLOW_SQLITE_PRAGMAS"
+
 # ---------------------------------------------------------------------------
 # UTILITIES
 # ---------------------------------------------------------------------------
@@ -399,11 +412,14 @@ shq() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
 # exactly what would be sent, quoting included, without a machine to send it to. The
 # trailing space is part of the contract: the caller concatenates.
 mirrored_target_env() {
-  printf '%s' \
-    "LANGFLOW_DEACTIVATE_TRACING=$(shq "$LANGFLOW_DEACTIVATE_TRACING") " \
-    "LANGFLOW_WORKER_TIMEOUT=$(shq "$LANGFLOW_WORKER_TIMEOUT") " \
-    "LANGFLOW_ALLOW_CUSTOM_COMPONENTS=$(shq "$LANGFLOW_ALLOW_CUSTOM_COMPONENTS") " \
-    "LANGFLOW_SQLITE_PRAGMAS=$(shq "$LANGFLOW_SQLITE_PRAGMAS") "
+  local name
+  # shellcheck disable=SC2086  # deliberate word splitting: the list holds names, never values
+  for name in $MIRRORED_TARGET_VARS; do
+    # Indirection rather than four literal lines, so this function and the run's
+    # metadata read the same list. Every name is set unconditionally above, so `set -u`
+    # has nothing to trip on.
+    printf '%s=%s ' "$name" "$(shq "${!name}")"
+  done
 }
 
 # Should this run place the target's clone, and if not, why not?

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -1126,13 +1126,40 @@ test("every mirrored name reaches the metadata, because one list feeds both", ()
   assert.deepEqual(Object.keys(meta.mirrored_target_env).sort(), [...MIRRORED].sort());
 });
 
-test("the run's own log names the environment it sent, quoted as it was sent", () => {
-  // The durable record is the metadata; this line is for whoever is reading the log at
-  // 08:00 and wondering why a family went red. It prints the COMPOSER's own output
-  // rather than a second rendering of the same values, so it cannot describe an
-  // environment other than the one that crossed the ssh boundary.
-  const { stdout, stderr } = metadataFrom({ ...BLANKED, LANGFLOW_DEACTIVATE_TRACING: "true" });
-  assert.match(stdout + stderr, /target env:.*LANGFLOW_DEACTIVATE_TRACING='true'/);
+test("the log names the environment before anything that can abort the run", () => {
+  // The metadata is the durable record, and it is written in phase_merge — which a run
+  // that dies in prep or in a shard never reaches. A wrong mirrored value is one of the
+  // likelier reasons the backend never comes up, so the run that most needs the record
+  // is exactly the one that would produce none. The line therefore sits at the top of
+  // the FIRST phase, and this test drives an abort to prove it survives one.
+  //
+  // TARGET_SSH empty is the earliest die in the script, and it comes AFTER the line —
+  // so a green assertion here means the ordering holds, not merely that the line
+  // exists somewhere.
+  // No `set +e` and no exit code read: `die` calls `exit`, which leaves the sourcing
+  // shell outright, so the abort is observable as the ABSENCE of the marker — the same
+  // way the merge tests above observe one. A marker that printed would mean the run
+  // did not abort, and then this test would prove nothing.
+  const r = sourced('phase_preflight\necho "REACHED_AFTER_PREFLIGHT"', {
+    ...BLANKED,
+    LANGFLOW_DEACTIVATE_TRACING: "true",
+    TARGET_SSH: "",
+  });
+  const out = r.stdout + r.stderr;
+  assert.doesNotMatch(out, /REACHED_AFTER_PREFLIGHT/, "preflight had to abort for this test to mean anything");
+  assert.match(out, /TARGET_SSH is required/);
+
+  // Printed from the COMPOSER's own output rather than a second rendering of the same
+  // values, so it cannot describe an environment other than the one that is sent.
+  assert.match(out, /target env:.*LANGFLOW_DEACTIVATE_TRACING='true'/);
+
+  // And BEFORE the abort, which is the whole placement argument. Position, not
+  // presence: a line printed after the first die would satisfy the assertion above and
+  // still be missing from every run that fails early.
+  assert.ok(
+    out.indexOf("target env:") < out.indexOf("TARGET_SSH is required"),
+    "the environment has to be named before the first thing that can abort",
+  );
 });
 
 test("a failed merge fails the verdict, and does not call it 'zero tests executed'", () => {

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -1033,6 +1033,88 @@ test("a failed merge is NAMED and does not abort the run, so guard 2 still class
   assert.equal(meta.tests_total, "0", "the guard sees no report, which is exactly why merge_ok has to be there");
 });
 
+/**
+ * Runs phase_merge with `env` in force and returns the run-metadata.json it wrote.
+ *
+ * The merge is stubbed to FAIL, which is the cheapest way to reach the metadata write
+ * without a real four-shard report — and it costs nothing here, because the values
+ * under test are composed from this script's own variables, not from anything the
+ * merge produces. That a failed merge still writes the file is itself pinned above.
+ */
+function metadataFrom(env) {
+  const dir = makeTempDir("mirrored-meta-e2e-");
+  mkdirSync(join(dir, "logs"), { recursive: true });
+  mkdirSync(join(dir, "all-blobs"), { recursive: true });
+  writeFileSync(join(dir, "all-blobs", "shard-1.zip"), "");
+  const bin = join(dir, "bin");
+  mkdirSync(bin);
+  writeFileSync(join(bin, "npx"), "#!/usr/bin/env bash\nexit 1\n", { mode: 0o755 });
+
+  const r = sourced(
+    [
+      `RUN_DIR=${JSON.stringify(dir)} SHARD_TOTAL=1`,
+      "CHECK_TARGET_VERSION=0 TARGET_EXPECTED_VERSION= TARGET_EXPECTED_REF= TARGET_EXPECTED_SHA=",
+      "TARGET_RESOLUTION= TARGET_PREPARED_SHA= TARGET_REBUILT=no TARGET_REBUILD_REASON= TARGET_PREPARE_S=",
+      "phase_merge",
+    ].join("\n"),
+    { PATH: `${bin}:${process.env.PATH}`, ...env },
+  );
+  const file = join(dir, "run-metadata.json");
+  assert.ok(existsSync(file), `phase_merge wrote no metadata\n${r.stdout}\n${r.stderr}`);
+  return { meta: JSON.parse(readFileSync(file, "utf8")), stdout: r.stdout, stderr: r.stderr };
+}
+
+test("the metadata records the mirrored values that were IN FORCE, not the defaults", () => {
+  // The property #1748 exists for. On 2026-09-07 the instance under test ran with
+  // tracing OFF against the workflow's `false`; the override was an export in the
+  // wrapper on the qa VM — deliberate, documented there, and outside every clone, so
+  // check-vm-env-parity.mjs cannot reach it by construction. It explained 16 of that
+  // day's 20 divergences, and establishing that took a shell on the machine, because
+  // nothing the run itself produced named the value actually used.
+  //
+  // The override arrives through the ENVIRONMENT, which is how the real one arrives.
+  // And the assertion is against the OVERRIDDEN value on purpose: asserting the
+  // default is what would pass against the very bug this test is written for.
+  const { meta } = metadataFrom({ LANGFLOW_DEACTIVATE_TRACING: "true", LANGFLOW_WORKER_TIMEOUT: "45" });
+
+  assert.equal(meta.mirrored_target_env.LANGFLOW_DEACTIVATE_TRACING, "true");
+  assert.equal(meta.mirrored_target_env.LANGFLOW_WORKER_TIMEOUT, "45");
+
+  // What makes those two a DIVERGENCE rather than two strings, read out of the
+  // workflow rather than copied — the same rule the rest of this file follows.
+  assert.equal(evaluateWorkflowValue(DECLARED.get("LANGFLOW_DEACTIVATE_TRACING"), {}), "false");
+  assert.notEqual(meta.mirrored_target_env.LANGFLOW_DEACTIVATE_TRACING, "false");
+
+  // Untouched names still record the default, or the record would only describe the
+  // half someone overrode.
+  assert.equal(
+    meta.mirrored_target_env.LANGFLOW_SQLITE_PRAGMAS,
+    evaluateWorkflowValue(DECLARED.get("LANGFLOW_SQLITE_PRAGMAS"), {}),
+  );
+});
+
+test("every mirrored name reaches the metadata, because one list feeds both", () => {
+  // The drift the issue asked for a guard against, closed by construction instead:
+  // mirrored_target_env() and this record both loop MIRRORED_TARGET_VARS, so a
+  // variable cannot be carried to the target without being recorded, and a guard
+  // between two enumerations has nothing left to report.
+  //
+  // Driven by the classification rather than a list here, so the next variable to be
+  // mirrored is covered on the day it is classified — the same derivation the parity
+  // tests above use.
+  const { meta } = metadataFrom(BLANKED);
+  assert.deepEqual(Object.keys(meta.mirrored_target_env).sort(), [...MIRRORED].sort());
+});
+
+test("the run's own log names the environment it sent, quoted as it was sent", () => {
+  // The durable record is the metadata; this line is for whoever is reading the log at
+  // 08:00 and wondering why a family went red. It prints the COMPOSER's own output
+  // rather than a second rendering of the same values, so it cannot describe an
+  // environment other than the one that crossed the ssh boundary.
+  const { stdout, stderr } = metadataFrom({ ...BLANKED, LANGFLOW_DEACTIVATE_TRACING: "true" });
+  assert.match(stdout + stderr, /target env:.*LANGFLOW_DEACTIVATE_TRACING='true'/);
+});
+
 test("a failed merge fails the verdict, and does not call it 'zero tests executed'", () => {
   // The distinction is the point: a merge failure leaves no report, so guard 2 marks
   // the run empty — and the empty branch tells triage to find out why nothing ran,

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -1040,8 +1040,12 @@ test("a failed merge is NAMED and does not abort the run, so guard 2 still class
  * without a real four-shard report — and it costs nothing here, because the values
  * under test are composed from this script's own variables, not from anything the
  * merge produces. That a failed merge still writes the file is itself pinned above.
+ *
+ * `after` is shell that runs AFTER the neutralising assignments below, for a caller
+ * that needs one of them to hold a value: those are plain assignments in the sourced
+ * body, so they beat anything handed in through `env`.
  */
-function metadataFrom(env) {
+function metadataFrom(env, after = "") {
   const dir = makeTempDir("mirrored-meta-e2e-");
   mkdirSync(join(dir, "logs"), { recursive: true });
   mkdirSync(join(dir, "all-blobs"), { recursive: true });
@@ -1055,6 +1059,7 @@ function metadataFrom(env) {
       `RUN_DIR=${JSON.stringify(dir)} SHARD_TOTAL=1`,
       "CHECK_TARGET_VERSION=0 TARGET_EXPECTED_VERSION= TARGET_EXPECTED_REF= TARGET_EXPECTED_SHA=",
       "TARGET_RESOLUTION= TARGET_PREPARED_SHA= TARGET_REBUILT=no TARGET_REBUILD_REASON= TARGET_PREPARE_S=",
+      after,
       "phase_merge",
     ].join("\n"),
     { PATH: `${bin}:${process.env.PATH}`, ...env },
@@ -1091,6 +1096,21 @@ test("the metadata records the mirrored values that were IN FORCE, not the defau
     meta.mirrored_target_env.LANGFLOW_SQLITE_PRAGMAS,
     evaluateWorkflowValue(DECLARED.get("LANGFLOW_SQLITE_PRAGMAS"), {}),
   );
+});
+
+test("a metadata VALUE that looks like a delimiter does not shift the record", () => {
+  // The first version marked the mirrored pairs off with a `--mirrored` sentinel, and
+  // a sentinel is a string the data can carry: langflow_prepared_reason is parsed out
+  // of the preparer's output on the OTHER machine, so its content is not this script's
+  // to promise. A value equal to the marker truncated the key/value list and mis-keyed
+  // every field after it — writing a wrong file, with nothing said.
+  //
+  // Counted pairs cannot collide with a value, and this is the case that proves it.
+  const { meta } = metadataFrom(BLANKED, 'TARGET_REBUILD_REASON="--mirrored"');
+
+  assert.equal(meta.langflow_prepared_reason, "--mirrored");
+  assert.equal(meta.merge_ok, "false", "the fields AFTER the hostile value must still be themselves");
+  assert.deepEqual(Object.keys(meta.mirrored_target_env).sort(), [...MIRRORED].sort());
 });
 
 test("every mirrored name reaches the metadata, because one list feeds both", () => {

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -1080,7 +1080,11 @@ test("the metadata records the mirrored values that were IN FORCE, not the defau
   // The override arrives through the ENVIRONMENT, which is how the real one arrives.
   // And the assertion is against the OVERRIDDEN value on purpose: asserting the
   // default is what would pass against the very bug this test is written for.
-  const { meta } = metadataFrom({ LANGFLOW_DEACTIVATE_TRACING: "true", LANGFLOW_WORKER_TIMEOUT: "45" });
+  // BLANKED first, for the reason its own definition gives: `sourced()` forwards
+  // process.env, so a mirrored name exported in the shell running these tests would
+  // answer for the default asserted below — and on the qa VM one of them IS exported,
+  // which is the situation this test is about.
+  const { meta } = metadataFrom({ ...BLANKED, LANGFLOW_DEACTIVATE_TRACING: "true", LANGFLOW_WORKER_TIMEOUT: "45" });
 
   assert.equal(meta.mirrored_target_env.LANGFLOW_DEACTIVATE_TRACING, "true");
   assert.equal(meta.mirrored_target_env.LANGFLOW_WORKER_TIMEOUT, "45");


### PR DESCRIPTION
Closes #1748 — the parity guard reports `OK` while a machine-local override changes the target's environment, and nothing the run produces names the value actually in force.

## What the run now records

`run-metadata.json` gains `mirrored_target_env`: the **effective** value of every variable this lane sends to the instance under test, beside the suite SHA and the resolved Langflow version already there.

```json
"mirrored_target_env": {
  "LANGFLOW_DEACTIVATE_TRACING": "true",
  "LANGFLOW_WORKER_TIMEOUT": "120",
  "LANGFLOW_ALLOW_CUSTOM_COMPONENTS": "true",
  "LANGFLOW_SQLITE_PRAGMAS": "{\"synchronous\": \"NORMAL\", …, \"foreign_keys\": \"ON\"}"
}
```

The same values also go to the log, printed from `mirrored_target_env()`'s **own output** rather than rendered a second time — so the line cannot describe an environment other than the one that crossed the ssh boundary.

## Why a field is the right answer, and not a fix to the guard

`check-vm-env-parity.mjs` was **correct** on 2026-09-07. It answers "does the VM lane carry everything `daily-stable.yml` sets on its service" by reading two files in this repository, both of which said what they should. The instance nevertheless ran with `LANGFLOW_DEACTIVATE_TRACING=true` against the workflow's `"false"`, because the override is an `export` in the daily wrapper on the qa VM — **outside every clone**, where a repository-reading guard cannot reach it by construction.

That one variable explained **16 of the day's 20 divergences** — nine failures across the traces/observability family plus `credential-secret-exposure`, and seven of the fourteen VM skips in the same family. Establishing it took a shell on the machine.

A machine *may* hold a measured exception; that is how a VM records one, with the reason written beside it. What it may not do is hold it **invisibly** — and until the run's own artifact answers for its environment, Phase 2's criterion ("no open divergence can falsify a verdict") is not a claim anyone can check.

## The enumeration, and why the issue's guard is not here

The issue asked for the two enumerations — `mirrored_target_env()` and the metadata — to be kept in step by a guard. There is no guard, because **there are no longer two enumerations**:

```bash
MIRRORED_TARGET_VARS="LANGFLOW_DEACTIVATE_TRACING LANGFLOW_WORKER_TIMEOUT LANGFLOW_ALLOW_CUSTOM_COMPONENTS LANGFLOW_SQLITE_PRAGMAS"
```

Both the composer and the record loop that one list. Adding a variable is what carries it *and* what records it; there is no way to do one without the other, so a guard would have nothing to report. Same reasoning as #1724's ledger paths, where the state disappeared rather than gaining a guard.

Behaviour of the composer is byte-identical — same string, same order, same quoting (`refactor` commit, verified against the real file).

### What that cost the parity guard, and what replaced it

`readMirroredNames()` read the names out of `mirrored_target_env()`'s **body**, on the stated grounds that "the file names it somewhere" is not the property: a mention in a string, or one left behind in a stale branch, would satisfy it while nothing reached the target. That reasoning is unchanged; what moved is where the names live.

A list the function loops over **is** the composition — so the reader takes the list *and* pins the shape that makes it evidence. A body that stopped reading `MIRRORED_TARGET_VARS` is refused outright, because at that moment the list becomes precisely the stale mention the old form existed to reject. Driven by a **mutation of the real file**, not a fixture: a fixture is what would be adjusted to match a broken source.

## Measured, not asserted

Every property was checked by mutation — the fix reverted, the test expected to fail, and it does:

| mutation | result |
|---|---|
| `--mirrored` dropped from the metadata call | both metadata tests fail |
| the record writes a literal instead of `${!name}` | "values that were IN FORCE" fails |
| a name removed from `MIRRORED_TARGET_VARS` | 3 orchestrator tests + 4 parity tests fail, and `check-vm-env-parity.mjs` exits 1 naming the variable |
| the composer's loop stops reading the list | `readMirroredNames` throws; the guard reports `unreadable` rather than crashing the lane |

The effective-value test hands the override in **through the environment**, the way the real one arrives, and asserts against the **overridden** value: asserting the default is what would pass against the very bug this PR is about. The untouched names are asserted too, read out of `daily-stable.yml` rather than copied, so the record describes the whole set and not only the half someone overrode.

`npm run test:scripts` — 1233 passing, 0 failing. `typecheck` clean, `lint` 0 errors. Each commit was run through `test:scripts` on its own, so the branch bisects.

## What this does NOT do

`compare-lane-verdicts.mjs` still does not read it. The comparator works off `daily-history.jsonl`, and putting an environment on that row is a question about **both** lanes: the Actions side would have to write it too, or the comparator sees one side and reports a difference it cannot have measured. This is the evidence half; the reading half is its own change.

Said plainly rather than implied, on the model of `merge_ok` (#1736), which says the same about itself instead of claiming a consumer that does not exist.
