### PR TITLE
fix(playground): attribute the setupPlayground commit gate and drop the serial collateral (#1695)

### DIFF
--- a/docs/core-functionality/playground/playground-bulk-delete.md
+++ b/docs/core-functionality/playground/playground-bulk-delete.md
@@ -1,6 +1,6 @@
 # Playground – Bulk Session Delete
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.13.x
 
 ---
 
@@ -64,6 +64,18 @@ The Default session is excluded from bulk operations by design: `selectableSessi
 - `session-selector.tsx` — `data-testid="session-${session}-checkbox"` (dynamic; rendered only when `showCheckbox={selectableSessions.includes(session)}`); a custom `div` — selected state is indicated by `.text-status-red` on the inner icon (`SquareCheck`), not by a native checked attribute
 - Default session is never selectable; its entry never has a checkbox
 
+References in this repository:
+
+- `tests/helpers/flows/setup-playground.ts` — shared helper that creates the
+  `ChatInput → ChatOutput` flow and returns its id for cleanup. Its
+  postcondition is **durability**: every canvas edit is confirmed server-side
+  (`GET /api/v1/flows/{id}`) before the next edit is made, so the three tests
+  may open the Playground immediately after it returns. When that gate expires
+  the helper must name **which** of the three exits fired — the read never
+  completed (transport), the read came back non-2xx, or the read came back and
+  the graph was stale — because only the last one is the autosave-overtake
+  race of #988; the first two are the instance, not the product (#1695).
+
 ---
 
 ## What this test does not cover *(optional)*
@@ -78,3 +90,17 @@ The Default session is excluded from bulk operations by design: `selectableSessi
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
 - No LLM or API key needed
+
+---
+
+## Notes *(optional)*
+
+- The three tests are **independent** and run without `test.describe.configure({
+  mode: "serial" })`. Each one builds its own flow through `setupPlayground`,
+  creates its own sessions and deletes its flow in `afterEach`; nothing is
+  handed from one test to the next. Serial mode had made a failure in the first
+  test mark the other two `skipped` and restart the whole group on retry, so the
+  later tests spent the retry budget without ever being measured — the collateral
+  recorded in #1695. The daily's sharded lane sets `PW_SHARD_FILE_LEVEL=1`
+  (`fullyParallel: false`), so the file still runs one test at a time there;
+  what changes is only that a failure no longer suppresses its file-mates.

--- a/docs/core-functionality/playground/playground-input-text-prefill.md
+++ b/docs/core-functionality/playground/playground-input-text-prefill.md
@@ -1,6 +1,6 @@
 # Playground — Input Text Pre-fill Behavior
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.13.x
 
 ---
 
@@ -146,3 +146,8 @@ References in this repository:
   steps
 - `page.unrouteAll({ behavior: "ignoreErrors" })` is called in `afterEach`
   to remove the interceptor between tests in the serial group
+- `setupPlayground` gates each canvas edit on the persisted graph before making
+  the next one, and `setupFlowWithPrefill` reloads the page right after — so
+  when that gate expires the failure text must say **which** exit fired: a read
+  that never completed (transport) and a read that came back stale are different
+  causes, and only the second is the autosave-overtake race of #988 (#1695)

--- a/tests/helpers/flows/graph-commit-failure.test.ts
+++ b/tests/helpers/flows/graph-commit-failure.test.ts
@@ -1,0 +1,228 @@
+// Unit tests for describeCommitFailure (issue #1695).
+// Run with: npm run test:units
+//
+// The commit gate in `setup-playground.ts` can give up for four different
+// reasons, and until #1695 all four printed the same sentence — one blaming the
+// autosave-overtake race of #988. That was measured wrong in both directions on
+// a HEALTHY 1.13.0.dev5 image: freezing the backend at t=7.5s produced the
+// "stale graph" wording and freezing it at t=8.0s produced the "no read"
+// wording, 500ms apart, with no product defect in either. So the discrimination
+// cannot be a comment — it has to be a function with assertions on its output,
+// and the load-bearing assertion is the one that runs each message back through
+// `classifyInfraError`, the exact predicate `remove-stable-from-failures.ts`
+// uses to decide whether a hard failure costs a test its `@stable`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyInfraError } from "../../../scripts/lib/infra-signatures";
+import { describeCommitFailure } from "./graph-commit-failure";
+import type { AutosaveEvidence } from "./watch-autosave-writes";
+
+/** Every write for this flow was issued, answered, and answered 2xx. */
+const ALL_SETTLED_CLEAN: AutosaveEvidence = { failures: [], issued: 2, settled: 2 };
+/** Nothing to say about the writes — the shape a caller must not read as clean. */
+const NOTHING_ISSUED: AutosaveEvidence = { failures: [], issued: 0, settled: 0 };
+
+const PROBE_TIMEOUT_ERROR =
+  "apiRequestContext.get: Timeout 5000ms exceeded.\nCall log:\n  - → GET http://localhost:7860/api/v1/flows/abc";
+
+test("a gate that never completed a read names the transport error, not #988", () => {
+  const message = describeCommitFailure({
+    expected: "1 node",
+    timeoutMs: 15000,
+    outcome: { kind: "no-read" },
+    transportError: PROBE_TIMEOUT_ERROR,
+    autosave: NOTHING_ISSUED,
+  });
+
+  assert.match(message, /no read of GET \/api\/v1\/flows\/\{id\} completed/);
+  assert.match(message, /apiRequestContext\.get: Timeout 5000ms exceeded/);
+  assert.doesNotMatch(message, /#988/);
+});
+
+test("a gate that never completed a read is classified as infrastructure", () => {
+  const message = describeCommitFailure({
+    expected: "1 node",
+    timeoutMs: 15000,
+    outcome: { kind: "no-read" },
+    transportError: PROBE_TIMEOUT_ERROR,
+    autosave: NOTHING_ISSUED,
+  });
+
+  const signature = classifyInfraError(message);
+  assert.equal(signature?.id, "api-request-timeout");
+});
+
+test("a stale graph read is NOT classified as infrastructure", () => {
+  const message = describeCommitFailure({
+    expected: "2 nodes",
+    timeoutMs: 15000,
+    outcome: { kind: "graph", nodes: 1, edges: 0 },
+    autosave: ALL_SETTLED_CLEAN,
+  });
+
+  assert.match(message, /last saw 1 node\(s\), 0 edge\(s\)/);
+  assert.match(message, /#988/);
+  assert.equal(
+    classifyInfraError(message),
+    null,
+    "the stale-graph wording must never carry a transport signature — it would exempt a real #988 recurrence from the @stable removal",
+  );
+});
+
+test("a stale graph whose autosave write failed blames the write, not #988", () => {
+  const message = describeCommitFailure({
+    expected: "2 nodes",
+    timeoutMs: 15000,
+    outcome: { kind: "graph", nodes: 1, edges: 0 },
+    autosave: {
+      failures: ["PATCH /api/v1/flows/abc → net::ERR_CONNECTION_RESET"],
+      issued: 1,
+      settled: 1,
+    },
+  });
+
+  assert.match(message, /last saw 1 node\(s\), 0 edge\(s\)/);
+  assert.match(message, /PATCH \/api\/v1\/flows\/abc → net::ERR_CONNECTION_RESET/);
+  assert.doesNotMatch(
+    message,
+    /#988/,
+    "a write that failed is not the overtake race — #988 is a write that SUCCEEDED and was committed out of order",
+  );
+  assert.equal(classifyInfraError(message)?.id, "connection-dropped");
+});
+
+test("a non-2xx read reports the status and does not blame #988", () => {
+  const message = describeCommitFailure({
+    expected: "1 edge",
+    timeoutMs: 15000,
+    outcome: { kind: "http-error", status: 502, statusText: "Bad Gateway" },
+    autosave: NOTHING_ISSUED,
+  });
+
+  assert.match(message, /GET \/api\/v1\/flows\/\{id\} → 502 Bad Gateway/);
+  assert.doesNotMatch(message, /#988/);
+});
+
+test("a 200 with an unparseable body reports the parse failure, not a node count", () => {
+  const message = describeCommitFailure({
+    expected: "1 node",
+    timeoutMs: 15000,
+    outcome: {
+      kind: "unreadable-body",
+      detail: "Unexpected token < in JSON at position 0",
+    },
+    autosave: NOTHING_ISSUED,
+  });
+
+  assert.match(message, /could not be parsed/);
+  assert.match(message, /Unexpected token < in JSON at position 0/);
+  assert.doesNotMatch(message, /node\(s\)/);
+  assert.doesNotMatch(message, /#988/);
+});
+
+test("no read and no captured error says so instead of inventing a cause", () => {
+  const message = describeCommitFailure({
+    expected: "1 node",
+    timeoutMs: 15000,
+    outcome: { kind: "no-read" },
+    autosave: NOTHING_ISSUED,
+  });
+
+  assert.match(message, /the request never returned/);
+  assert.doesNotMatch(message, /#988/);
+  assert.equal(
+    classifyInfraError(message),
+    null,
+    "with no captured error there is nothing to exempt on — the message must not fabricate a transport signature",
+  );
+});
+
+test("every message keeps the prefix triage greps for and names the budget", () => {
+  const outcomes = [
+    { kind: "no-read" as const },
+    { kind: "http-error" as const, status: 500, statusText: "Internal Server Error" },
+    { kind: "unreadable-body" as const, detail: "boom" },
+    { kind: "graph" as const, nodes: 0, edges: 0 },
+  ];
+
+  for (const outcome of outcomes) {
+    const message = describeCommitFailure({
+      expected: "1 node",
+      timeoutMs: 15000,
+      outcome,
+      autosave: ALL_SETTLED_CLEAN,
+    });
+    assert.match(
+      message,
+      /^setupPlayground: a canvas edit never reached the database — expected 1 node, /,
+      `wrong prefix for ${outcome.kind}`,
+    );
+    assert.match(message, /15000ms/, `budget missing for ${outcome.kind}`);
+  }
+});
+
+// --- absence of failure is three states, not two (#1695) -----------------
+//
+// A frozen backend leaves the autosave ISSUED and unanswered: no failure is
+// recorded, and the first version of this function read that emptiness as
+// "every write answered 2xx" and blamed #988 — a race between two COMPLETED
+// writes — for an instance in which none had completed. Measured against a
+// paused 1.13.0.dev5 container, which printed exactly that sentence.
+
+test("an autosave still in flight is not evidence for #988", () => {
+  const message = describeCommitFailure({
+    expected: "1 node",
+    timeoutMs: 15000,
+    outcome: { kind: "graph", nodes: 0, edges: 0 },
+    autosave: { failures: [], issued: 1, settled: 0 },
+  });
+
+  assert.match(message, /last saw 0 node\(s\), 0 edge\(s\)/);
+  assert.match(message, /1 autosave write\(s\) for this flow were still in flight/);
+  assert.doesNotMatch(
+    message,
+    /answered 2xx/,
+    "a write with no answer must never be reported as one that answered",
+  );
+  assert.doesNotMatch(message, /#988/);
+});
+
+test("no autosave issued at all says so instead of blaming the database", () => {
+  const message = describeCommitFailure({
+    expected: "1 node",
+    timeoutMs: 15000,
+    outcome: { kind: "graph", nodes: 0, edges: 0 },
+    autosave: NOTHING_ISSUED,
+  });
+
+  assert.match(message, /No autosave write was issued for this flow/);
+  assert.doesNotMatch(message, /#988/);
+});
+
+test("#988 is claimed only when every write was issued, answered and answered 2xx", () => {
+  const message = describeCommitFailure({
+    expected: "2 nodes",
+    timeoutMs: 15000,
+    outcome: { kind: "graph", nodes: 1, edges: 0 },
+    autosave: ALL_SETTLED_CLEAN,
+  });
+
+  assert.match(message, /Every autosave write for this flow answered 2xx/);
+  assert.match(message, /#988/);
+});
+
+test("a failed write outranks an in-flight one — it is the concrete cause", () => {
+  const message = describeCommitFailure({
+    expected: "2 nodes",
+    timeoutMs: 15000,
+    outcome: { kind: "graph", nodes: 1, edges: 0 },
+    autosave: {
+      failures: ["PATCH /api/v1/flows/abc → 503 Service Unavailable"],
+      issued: 3,
+      settled: 1,
+    },
+  });
+
+  assert.match(message, /503 Service Unavailable/);
+  assert.doesNotMatch(message, /#988/);
+});

--- a/tests/helpers/flows/graph-commit-failure.ts
+++ b/tests/helpers/flows/graph-commit-failure.ts
@@ -1,0 +1,126 @@
+/**
+ * The failure text of `setup-playground.ts`'s graph-commit gate.
+ *
+ * Split out of the helper so the wording is a pure function with assertions on
+ * its output rather than a template literal nobody can test (#1695).
+ *
+ * The gate gives up for four disjoint reasons and, until #1695, printed one
+ * sentence for all of them — the one blaming the autosave-overtake race of
+ * #988. That was measured wrong in both directions on a healthy 1.13.0.dev5
+ * image: `docker pause` at t=7.5s produced the "stale graph" wording and the
+ * same freeze at t=8.0s produced the "no successful read" wording, 500ms apart,
+ * with no product defect in either. The daily then read the product-shaped
+ * sentence and auto-removed `@stable` from a test that was never measured.
+ *
+ * So the wording is load-bearing twice over: a human triaging the daily reads
+ * it, and so does `classifyInfraError` (`scripts/lib/infra-signatures.ts`),
+ * which `remove-stable-from-failures.ts` uses to decide whether a hard failure
+ * costs a test its tag. Both directions are pinned in the sibling unit test —
+ * the transport wordings must carry the real error so they classify as infra,
+ * and the stale-graph wording must NOT, or a genuine #988 recurrence would
+ * exempt itself.
+ */
+
+/** What the commit gate's probes actually observed before the budget expired. */
+export type CommitProbeOutcome =
+  /** No probe ever completed — every request threw, or the first one outlived the budget. */
+  | { kind: "no-read" }
+  /** The last completed probe answered a non-2xx status. */
+  | { kind: "http-error"; status: number; statusText: string }
+  /** The last completed probe answered 2xx with a body that would not parse. */
+  | { kind: "unreadable-body"; detail: string }
+  /** The last completed probe returned a graph — this is the only stale-read case. */
+  | { kind: "graph"; nodes: number; edges: number };
+
+import type { AutosaveEvidence } from "./watch-autosave-writes";
+
+export interface CommitFailureInput {
+  /** What the gate was waiting for, e.g. "2 nodes" — phrased by the caller. */
+  expected: string;
+  /** The budget that expired, in milliseconds. */
+  timeoutMs: number;
+  outcome: CommitProbeOutcome;
+  /**
+   * Text of the last error a probe request threw, when one was captured. Never
+   * synthesised: with nothing captured the message says so instead, because a
+   * fabricated transport signature would exempt the failure from the `@stable`
+   * removal on no evidence at all.
+   */
+  transportError?: string;
+  /**
+   * What the wire says about this flow's autosave. REQUIRED, and required as a
+   * three-state record rather than a failure list, because the caller's natural
+   * shortcut — no failures, therefore every write landed — is precisely the
+   * false verdict this function exists to stop (#1012, #1695). Only
+   * `issued > 0 && settled === issued && failures.length === 0` licenses the
+   * #988 reading.
+   */
+  autosave: AutosaveEvidence;
+}
+
+/** The prefix every variant keeps — triage and `git grep` both key on it. */
+const PREFIX = "setupPlayground: a canvas edit never reached the database";
+
+export function describeCommitFailure(input: CommitFailureInput): string {
+  const { expected, timeoutMs, outcome } = input;
+  const head = `${PREFIX} — expected ${expected}, `;
+  const { failures, issued, settled } = input.autosave;
+  const inFlight = Math.max(0, issued - settled);
+
+  switch (outcome.kind) {
+    case "no-read":
+      return (
+        head +
+        `no read of GET /api/v1/flows/{id} completed within ${timeoutMs}ms. ` +
+        `This is the instance, not the flow: ${input.transportError ?? "the request never returned"}`
+      );
+
+    case "http-error":
+      return (
+        head +
+        `the last read answered GET /api/v1/flows/{id} → ${outcome.status} ${outcome.statusText} ` +
+        `within ${timeoutMs}ms. This is the instance, not the flow.`
+      );
+
+    case "unreadable-body":
+      return (
+        head +
+        `the last read answered 2xx within ${timeoutMs}ms but its body could not be parsed: ` +
+        `${outcome.detail}. This is the instance, not the flow.`
+      );
+
+    case "graph": {
+      const seen = `last saw ${outcome.nodes} node(s), ${outcome.edges} edge(s) after ${timeoutMs}ms.`;
+      // A write that FAILED explains the lag on its own, and is the most
+      // actionable thing we know, so it outranks the counts.
+      if (failures.length > 0) {
+        return (
+          head +
+          `${seen} The autosave write never landed: ${failures.join("; ")} — the graph is behind ` +
+          `because the write FAILED, not because a stale one overtook it.`
+        );
+      }
+      // Issued and unanswered is the wedge shape: the instance took the write
+      // and never came back. #988 needs two writes that both COMPLETED.
+      if (inFlight > 0) {
+        return (
+          head +
+          `${seen} ${inFlight} autosave write(s) for this flow were still in flight when the budget ` +
+          `expired — the instance never answered them, so this is not the overtake race.`
+        );
+      }
+      if (issued === 0) {
+        return (
+          head +
+          `${seen} No autosave write was issued for this flow at all — the canvas edit never left ` +
+          `the browser, so nothing was there to commit.`
+        );
+      }
+      return (
+        head +
+        `${seen} Every autosave write for this flow answered 2xx, so the usual cause is a stale ` +
+        `autosave PATCH committed after a newer one, which rolls the graph back for good (#988).`
+      );
+    }
+  }
+}

--- a/tests/helpers/flows/setup-playground.ts
+++ b/tests/helpers/flows/setup-playground.ts
@@ -4,7 +4,15 @@ import { adjustScreenView } from "../ui/adjust-screen-view";
 import { getAuthToken } from "../auth/get-auth-token";
 import { zoomOut } from "../ui/zoom-out";
 import { deleteFlow } from "./delete-flow";
+import {
+  describeCommitFailure,
+  type CommitProbeOutcome,
+} from "./graph-commit-failure";
 import { PERMISSIONS_GATE_TIMEOUT_MS } from "./permissions-gate";
+import {
+  watchAutosaveWrites,
+  type AutosaveWatcher,
+} from "./watch-autosave-writes";
 
 /** Empty graph payload — what the SPA posts when the "Blank Flow" card is picked. */
 const BLANK_FLOW_DATA = {
@@ -89,6 +97,20 @@ async function createBlankFlow(
 }
 
 /**
+ * A single probe's own budget, deliberately far below the gate's.
+ *
+ * Without it the read inherits the APIRequestContext default (30s) — longer
+ * than the whole gate — so a wedged backend produced ONE probe that
+ * `raceAgainstDeadline` cut mid-flight, discarding the error with it
+ * (playwright-core `utils/isomorphic/timeoutRunner.js`). The gate then reported
+ * "no successful read" with nothing to attribute it to. Bounded, the probe
+ * rejects on its own with `apiRequestContext.get: Timeout 5000ms exceeded`,
+ * which is both readable by a human and matched by `classifyInfraError`
+ * (#1695).
+ */
+const PROBE_TIMEOUT_MS = 5000;
+
+/**
  * Blocks until the persisted graph satisfies `expectation.matches`.
  *
  * Exists to serialise our canvas edits against the SPA's debounced autosave
@@ -106,6 +128,15 @@ async function createBlankFlow(
  * which says neither what was awaited nor how far the graph got — the same mute
  * failure this helper was rewritten to stop producing. So the last observed
  * state is captured on every probe and reported when the budget runs out.
+ *
+ * WHICH state it reports is load-bearing, and used not to be (#1695): the gate
+ * can expire for four disjoint reasons and printed one #988-shaped sentence for
+ * all of them. Freezing a healthy 1.13.0.dev5 backend at t=7.5s produced the
+ * stale-graph wording and the same freeze at t=8.0s produced "no successful
+ * read" — 500ms apart, no product defect in either — and the daily read the
+ * product-shaped sentence and auto-removed a `@stable` tag on it. The outcome
+ * is therefore tracked explicitly and the wording composed by
+ * `describeCommitFailure`, which has assertions on its output.
  */
 async function waitForGraphPersisted(
   page: Page,
@@ -115,32 +146,68 @@ async function waitForGraphPersisted(
     expected: string;
     matches: (data: { nodes?: unknown[]; edges?: unknown[] }) => boolean;
   },
+  autosave: AutosaveWatcher,
   // Deliberately tighter than the UI gates above: this polls a local API, so a
   // budget that stretches toward the 5-minute test timeout only delays the real
   // error. If the write has not landed in 15s it is not slow, it is lost.
   timeoutMs = 15000,
 ): Promise<void> {
-  const options = authorization
-    ? { headers: { Authorization: authorization } }
-    : undefined;
-  let lastSeen = "no successful read";
+  const options = {
+    ...(authorization ? { headers: { Authorization: authorization } } : {}),
+    timeout: PROBE_TIMEOUT_MS,
+  };
+  // Stays `no-read` until a probe actually comes back with a response — which
+  // is what makes that value mean "the instance never answered", instead of
+  // doubling as the label for a probe the deadline cut short.
+  let outcome: CommitProbeOutcome = { kind: "no-read" };
+  let transportError: string | undefined;
 
   try {
     await expect(async () => {
-      const res = await page.request.get(`/api/v1/flows/${flowId}`, options);
+      let res;
+      try {
+        res = await page.request.get(`/api/v1/flows/${flowId}`, options);
+      } catch (err) {
+        // Keep the REAL error: it is the only thing that tells a wedge from a
+        // product defect, and the exemption in
+        // `scripts/remove-stable-from-failures.ts` matches on it.
+        transportError = err instanceof Error ? err.message : String(err);
+        throw err;
+      }
       if (!res.ok()) {
-        lastSeen = `GET /api/v1/flows/{id} → ${res.status()} ${res.statusText()}`;
+        outcome = {
+          kind: "http-error",
+          status: res.status(),
+          statusText: res.statusText(),
+        };
       }
       expect(res.ok()).toBe(true);
-      const data = (await res.json())?.data ?? {};
-      lastSeen = `${data.nodes?.length ?? 0} node(s), ${data.edges?.length ?? 0} edge(s)`;
+      let data: { nodes?: unknown[]; edges?: unknown[] };
+      try {
+        data = (await res.json())?.data ?? {};
+      } catch (err) {
+        outcome = {
+          kind: "unreadable-body",
+          detail: err instanceof Error ? err.message : String(err),
+        };
+        throw err;
+      }
+      outcome = {
+        kind: "graph",
+        nodes: data.nodes?.length ?? 0,
+        edges: data.edges?.length ?? 0,
+      };
       expect(expectation.matches(data)).toBe(true);
     }).toPass({ timeout: timeoutMs, intervals: [250, 500, 1000] });
   } catch {
     throw new Error(
-      `setupPlayground: a canvas edit never reached the database — expected ${expectation.expected}, ` +
-        `last saw ${lastSeen} after ${timeoutMs}ms. The usual cause is a stale autosave PATCH ` +
-        `committed after a newer one, which rolls the graph back for good (#988).`,
+      describeCommitFailure({
+        expected: expectation.expected,
+        timeoutMs,
+        outcome,
+        transportError,
+        autosave: autosave.evidence(),
+      }),
     );
   }
 }
@@ -168,6 +235,11 @@ export async function setupPlayground(page: Page): Promise<string> {
     name: flowName,
     authorization,
   } = await createBlankFlow(page);
+
+  // Attached before the first canvas edit and detached in `finally`: a stale
+  // graph read cannot say WHY it is stale, and the wire is the only place the
+  // answer exists (#1695).
+  const autosave = watchAutosaveWrites(page, flowId);
 
   try {
     await page.goto(`/flow/${flowId}`);
@@ -231,6 +303,7 @@ export async function setupPlayground(page: Page): Promise<string> {
       flowId,
       authorization,
       { expected: "1 node", matches: (data) => (data.nodes?.length ?? 0) === 1 },
+      autosave,
     );
 
     await zoomOut(page, 2);
@@ -257,6 +330,7 @@ export async function setupPlayground(page: Page): Promise<string> {
       flowId,
       authorization,
       { expected: "2 nodes", matches: (data) => (data.nodes?.length ?? 0) === 2 },
+      autosave,
     );
 
     await page
@@ -277,6 +351,7 @@ export async function setupPlayground(page: Page): Promise<string> {
       flowId,
       authorization,
       { expected: "1 edge", matches: (data) => (data.edges?.length ?? 0) >= 1 },
+      autosave,
     );
   } catch (err) {
     // Best-effort rollback of the created flow — swallow so the original
@@ -289,6 +364,10 @@ export async function setupPlayground(page: Page): Promise<string> {
       authorization ? { headers: { Authorization: authorization } } : undefined,
     ).catch(() => {});
     throw err;
+  } finally {
+    // 24 specs go through this helper, several of them more than once per test;
+    // a listener left attached would keep firing for the rest of the worker.
+    autosave.dispose();
   }
 
   return flowId;

--- a/tests/helpers/flows/watch-autosave-writes.test.ts
+++ b/tests/helpers/flows/watch-autosave-writes.test.ts
@@ -1,0 +1,227 @@
+// Unit tests for watchAutosaveWrites (issue #1695).
+// Run with: npm run test:units
+//
+// What this watcher exists to answer cannot be observed from the graph itself:
+// when the persisted flow is behind the canvas, "the write failed" and "the
+// write succeeded and an older one was committed after it" (#988) leave the
+// SAME database row. Only the wire tells them apart, and the daily's own
+// artifacts are the sole record of it — so a missed or mis-attributed write is
+// invisible on a green run and is exactly what made #1695 read as a product
+// defect. Hence assertions on which writes are recorded, per flow, rather than
+// an E2E run that could only ever show the happy path.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Page } from "@playwright/test";
+import { watchAutosaveWrites } from "./watch-autosave-writes";
+
+const FLOW = "11111111-2222-3333-4444-555555555555";
+const OTHER = "99999999-8888-7777-6666-555555555555";
+const BASE = "http://localhost:7860";
+
+type Handler = (event: unknown) => void;
+
+/** A Page stand-in exposing only the two events the watcher listens on. */
+function fakePage() {
+  const handlers = new Map<string, Set<Handler>>();
+  const page = {
+    on(event: string, handler: Handler) {
+      if (!handlers.has(event)) handlers.set(event, new Set());
+      handlers.get(event)!.add(handler);
+    },
+    off(event: string, handler: Handler) {
+      handlers.get(event)?.delete(handler);
+    },
+  };
+  const emit = (event: string, payload: unknown) => {
+    for (const handler of handlers.get(event) ?? []) handler(payload);
+  };
+  return {
+    page: page as unknown as Page,
+    get listeners() {
+      return [...handlers.values()].reduce((n, set) => n + set.size, 0);
+    },
+    failed(method: string, url: string, errorText: string) {
+      emit("requestfailed", {
+        method: () => method,
+        url: () => url,
+        failure: () => ({ errorText }),
+      });
+    },
+    requested(method: string, url: string) {
+      emit("request", { method: () => method, url: () => url });
+    },
+    responded(method: string, url: string, status: number, statusText: string) {
+      emit("response", {
+        status: () => status,
+        statusText: () => statusText,
+        ok: () => status >= 200 && status < 300,
+        request: () => ({ method: () => method, url: () => url }),
+      });
+    },
+  };
+}
+
+test("records an autosave PATCH that never reached the backend", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.failed("PATCH", `${BASE}/api/v1/flows/${FLOW}`, "net::ERR_CONNECTION_RESET");
+
+  assert.deepEqual(watcher.evidence().failures, [
+    `PATCH /api/v1/flows/${FLOW} → net::ERR_CONNECTION_RESET`,
+  ]);
+});
+
+test("records an autosave PATCH answered with a non-2xx status", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.responded("PATCH", `${BASE}/api/v1/flows/${FLOW}`, 500, "Internal Server Error");
+
+  assert.deepEqual(watcher.evidence().failures, [
+    `PATCH /api/v1/flows/${FLOW} → 500 Internal Server Error`,
+  ]);
+});
+
+test("a successful autosave is not a failure", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.responded("PATCH", `${BASE}/api/v1/flows/${FLOW}`, 200, "OK");
+
+  assert.deepEqual(watcher.evidence().failures, []);
+});
+
+test("a failed write for ANOTHER flow is ignored", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.failed("PATCH", `${BASE}/api/v1/flows/${OTHER}`, "net::ERR_CONNECTION_RESET");
+  fake.responded("PATCH", `${BASE}/api/v1/flows/${OTHER}`, 500, "Internal Server Error");
+
+  assert.deepEqual(
+    watcher.evidence().failures,
+    [],
+    "workers share a backend — attributing another flow's write here would blame this flow for a neighbour's outage",
+  );
+});
+
+test("only writes count — the cleanup DELETE and the gate's own GET are not autosaves", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.responded("GET", `${BASE}/api/v1/flows/${FLOW}`, 502, "Bad Gateway");
+  fake.failed("DELETE", `${BASE}/api/v1/flows/${FLOW}`, "net::ERR_CONNECTION_RESET");
+
+  assert.deepEqual(watcher.evidence().failures, []);
+});
+
+test("a query string on the write URL does not hide it", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.responded("PATCH", `${BASE}/api/v1/flows/${FLOW}?flow_id=${FLOW}`, 503, "Service Unavailable");
+
+  assert.deepEqual(watcher.evidence().failures, [
+    `PATCH /api/v1/flows/${FLOW} → 503 Service Unavailable`,
+  ]);
+});
+
+test("failures are reported oldest first and the array cannot be mutated from outside", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.responded("PATCH", `${BASE}/api/v1/flows/${FLOW}`, 500, "Internal Server Error");
+  fake.failed("PATCH", `${BASE}/api/v1/flows/${FLOW}`, "socket hang up");
+
+  const snapshot = watcher.evidence().failures;
+  assert.deepEqual(snapshot, [
+    `PATCH /api/v1/flows/${FLOW} → 500 Internal Server Error`,
+    `PATCH /api/v1/flows/${FLOW} → socket hang up`,
+  ]);
+
+  snapshot.push("not a real failure");
+  assert.equal(watcher.evidence().failures.length, 2);
+});
+
+test("dispose() detaches both listeners and stops recording", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+  assert.equal(fake.listeners, 3, "one request, one response and one requestfailed listener");
+
+  watcher.dispose();
+  assert.equal(fake.listeners, 0);
+
+  fake.failed("PATCH", `${BASE}/api/v1/flows/${FLOW}`, "socket hang up");
+  assert.deepEqual(
+    watcher.evidence().failures,
+    [],
+    "24 specs go through this helper — a listener left attached leaks into every later test in the worker",
+  );
+});
+
+test("dispose() is safe to call twice", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  watcher.dispose();
+  watcher.dispose();
+
+  assert.equal(fake.listeners, 0);
+});
+
+// --- the in-flight distinction (#1695) ----------------------------------
+//
+// The first version of this watcher reported only failures, and the caller read
+// "no failures" as "every write answered 2xx". A frozen backend refutes that:
+// the PATCH is ISSUED and then hangs, so it neither fails nor answers, and the
+// gate went on to blame #988 — a race between two writes that had both
+// completed — for a wedge in which none had. Absence of failure is three states,
+// not two, and only one of them is evidence for #988.
+
+test("a write that was issued and never answered is counted as in flight", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.requested("PATCH", `${BASE}/api/v1/flows/${FLOW}`);
+
+  const evidence = watcher.evidence();
+  assert.deepEqual(evidence.failures, []);
+  assert.equal(evidence.issued, 1);
+  assert.equal(evidence.settled, 0);
+});
+
+test("a write that answered is settled, not in flight", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.requested("PATCH", `${BASE}/api/v1/flows/${FLOW}`);
+  fake.responded("PATCH", `${BASE}/api/v1/flows/${FLOW}`, 200, "OK");
+
+  const evidence = watcher.evidence();
+  assert.equal(evidence.issued, 1);
+  assert.equal(evidence.settled, 1);
+});
+
+test("a write that failed is settled too — it is not still pending", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.requested("PATCH", `${BASE}/api/v1/flows/${FLOW}`);
+  fake.failed("PATCH", `${BASE}/api/v1/flows/${FLOW}`, "socket hang up");
+
+  const evidence = watcher.evidence();
+  assert.equal(evidence.issued, 1);
+  assert.equal(evidence.settled, 1);
+  assert.equal(evidence.failures.length, 1);
+});
+
+test("a flow with no autosave at all reports zero issued", () => {
+  const fake = fakePage();
+  const watcher = watchAutosaveWrites(fake.page, FLOW);
+
+  fake.requested("GET", `${BASE}/api/v1/flows/${FLOW}`);
+  fake.requested("PATCH", `${BASE}/api/v1/flows/${OTHER}`);
+
+  assert.equal(watcher.evidence().issued, 0);
+});

--- a/tests/helpers/flows/watch-autosave-writes.ts
+++ b/tests/helpers/flows/watch-autosave-writes.ts
@@ -1,0 +1,103 @@
+import type { Page, Request, Response } from "@playwright/test";
+
+/**
+ * Records the autosave writes for ONE flow that did not succeed.
+ *
+ * Exists because the persisted graph cannot tell you why it is behind (#1695).
+ * When `setup-playground.ts`'s commit gate expires on a stale read, two very
+ * different causes leave the same database row: the write FAILED (the instance
+ * — a wedge, a restart, a 5xx), or every write answered 2xx and an older one
+ * was committed after a newer one (#988, the autosave-overtake race). Only the
+ * wire distinguishes them, and the failure text is the only record that
+ * survives into the daily's artifacts.
+ *
+ * Scoped to a single flow id on purpose: workers share one backend, so a
+ * neighbour's failing write is not evidence about this flow.
+ */
+
+/** Langflow's autosave is a whole-graph PATCH of the flow (see setup-playground.ts). */
+const AUTOSAVE_METHOD = "PATCH";
+
+/** `pathname`, never the raw URL — autosave gained a `?flow_id=` query once already (#1644). */
+function pathnameOf(url: string): string {
+  try {
+    return new URL(url, "http://localhost").pathname;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * What the wire says about this flow's autosave, at one moment.
+ *
+ * `failures` alone is not enough, and reading its emptiness as "every write
+ * answered 2xx" is how a frozen backend got blamed on #988 (#1695): a write
+ * against a wedged instance is ISSUED and then hangs, so it neither fails nor
+ * answers. Absence of failure is three states — nothing issued, something still
+ * in flight, everything settled cleanly — and only the last is evidence for the
+ * overtake race.
+ */
+export interface AutosaveEvidence {
+  /** Writes that failed or answered non-2xx, oldest first. */
+  failures: string[];
+  /** Writes started for this flow. */
+  issued: number;
+  /** Writes that reached an outcome — an answer of any status, or a failure. */
+  settled: number;
+}
+
+export interface AutosaveWatcher {
+  /** A snapshot. A copy — callers cannot mutate the record. */
+  evidence(): AutosaveEvidence;
+  /** Detaches every listener. Idempotent. */
+  dispose(): void;
+}
+
+export function watchAutosaveWrites(page: Page, flowId: string): AutosaveWatcher {
+  const path = `/api/v1/flows/${flowId}`;
+  const recorded: string[] = [];
+  let issued = 0;
+  let settled = 0;
+
+  const isAutosave = (method: string, url: string): boolean =>
+    method.toUpperCase() === AUTOSAVE_METHOD && pathnameOf(url) === path;
+
+  const onRequest = (request: Request) => {
+    if (!isAutosave(request.method(), request.url())) return;
+    issued += 1;
+  };
+
+  const onRequestFailed = (request: Request) => {
+    if (!isAutosave(request.method(), request.url())) return;
+    settled += 1;
+    recorded.push(
+      `${AUTOSAVE_METHOD} ${path} → ${request.failure()?.errorText ?? "request failed"}`,
+    );
+  };
+
+  const onResponse = (response: Response) => {
+    const request = response.request();
+    if (!isAutosave(request.method(), request.url())) return;
+    settled += 1;
+    if (response.ok()) return;
+    recorded.push(
+      `${AUTOSAVE_METHOD} ${path} → ${response.status()} ${response.statusText()}`,
+    );
+  };
+
+  page.on("request", onRequest);
+  page.on("requestfailed", onRequestFailed);
+  page.on("response", onResponse);
+
+  let disposed = false;
+  return {
+    evidence: () => ({ failures: [...recorded], issued, settled }),
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      page.off("request", onRequest);
+      page.off("requestfailed", onRequestFailed);
+      page.off("response", onResponse);
+    },
+  };
+}

--- a/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
@@ -14,8 +14,15 @@ import { deleteFlow } from "../../../../helpers/flows/delete-flow";
  *   session-selector.tsx — data-testid="session-{id}-checkbox" (dynamic)
  */
 
-test.describe.configure({ mode: "serial" });
-
+// No `mode: "serial"` on purpose (#1695). The three tests share nothing — each
+// builds its own flow through `setupPlayground`, creates its own sessions and
+// deletes its flow in `afterEach` — and serial mode made a failure in the first
+// one mark the other two `skipped` and restart the group on retry. On daily run
+// 33756085604 that spent the whole file's retry budget without ever measuring
+// them: the second test failed on its ONLY executed attempt (the daily then
+// auto-removed its `@stable`) and the third never ran at all, three attempts to
+// three skips. The daily's sharded lane sets `PW_SHARD_FILE_LEVEL=1`
+// (`fullyParallel: false`), so the file still runs one test at a time there.
 test.describe("Playground – Bulk Session Operations", () => {
   let createdFlowId: string | null = null;
 
@@ -65,7 +72,7 @@ test.describe("Playground – Bulk Session Operations", () => {
 
   test(
     "select-all-checkbox must select all non-default sessions",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
         createdFlowId = await setupPlayground(page);


### PR DESCRIPTION
**Closes #1695.**

## Problem

Three playground specs on shard 4 of daily run [33756085604](https://github.com/oriontech-me/langflow-e2e/actions/runs/33756085604) (2026-09-03) aborted in `setupPlayground` before their bodies ran, reporting that a canvas edit never reached the database. One hard failure — whose `@stable` the workflow auto-removed — and two flakes. The message named #988 (`setupPlayground is not concurrency-safe`, closed).

**Verdict: `transient-saturation` on all rows. Not #988, and not a recurrence of it.**

Reading the run's own artifacts per attempt adds two facts the issue does not carry: `playground-bulk-delete.spec.ts:115` was `skipped` on **all three** attempts — a third victim of the serial-mode collateral — and `:30`'s intermediate attempt died on `apiRequestContext.get: Timeout 20000ms exceeded → GET /api/v1/auto_login`, the canonical infra signature. A healthy pass of this family costs 22 s; the attempts in that window cost 45–116 s and the one that eventually passed cost 109 s.

| Spec:line | a0 | a1 | a2 |
|---|---|---|---|
| `playground-bulk-delete.spec.ts:30` | failed 47 s — `no successful read` | failed 116 s — `auto_login` timeout | passed 109 s |
| `playground-bulk-delete.spec.ts:66` | **skipped** | **skipped** | failed 45 s — `last saw 1 node(s), 0 edge(s)` |
| `playground-bulk-delete.spec.ts:115` | **skipped** | **skipped** | **skipped** |
| `playground-input-text-prefill.spec.ts:120` | failed 55 s — `no successful read` | passed 22 s | — |

Three independent lines of evidence:

**Baseline.** `repro-run` on the unmodified specs against a healthy nightly `1.13.0.dev5`, `--retries=0 --workers=1`: **`0/10 failed (0%), 0 voided`**. The defect never reproduces while the backend answers.

**Deterministic wedge.** `docker pause` on that same healthy image (container alive, event loop blocked — the #922/#927 state) reproduced **both** failure messages, selected only by when the freeze lands:

| Freeze at | Message (pre-fix) |
|---|---|
| `t=7.5s` | `expected 1 node, last saw 0 node(s), 0 edge(s)` — the hard failure's shape |
| `t=8.0s` | `expected 1 node, last saw no successful read` — the flakes' shape |

500 ms of timing decides which sentence prints, and both cited #988. The message shape carried no product-vs-environment information at all.

**Structural.** `lastSeen` was initialised to the literal `"no successful read"` and reassigned on every path where a response object exists, so that string is unreachable while the backend answers. `raceAgainstDeadline` (`playwright-core/lib/utils/isomorphic/timeoutRunner.js:41`) cuts a hung probe mid-flight, and the probe inherited the 30 s `APIRequestContext` default — longer than the gate's own 15 s budget. The `catch` had no binding, so the real error went with it. `classifyInfraError` matches **anywhere** in the message (`scripts/lib/infra-signatures.ts:118`), so the discarded error was precisely what the #1031 exemption needed.

## Fix

**Attribution — `tests/helpers/flows/graph-commit-failure.ts` (new, pure).** One wording per outcome: no read completed / non-2xx / unparseable 2xx body / graph read. Only the last can cite #988. Split out of the helper so the wording is a function with assertions on its output rather than a template literal — the load-bearing test runs each composed message back through `classifyInfraError`, the exact predicate `remove-stable-from-failures.ts` uses.

**Bounded probe — `setup-playground.ts`.** `PROBE_TIMEOUT_MS = 5000` inside the 15 s budget, so a wedged backend makes the probe reject on its own with a real, matchable error instead of being cut mid-flight; `catch {}` → `catch (err)`; the outcome is tracked in four states.

**Autosave evidence — `tests/helpers/flows/watch-autosave-writes.ts` (new).** A stale graph cannot say why it is stale: a write that FAILED and a write that answered 2xx and was overtaken (#988) leave the same database row. The watcher reads the wire, scoped to this flow's id only — workers share a backend, so a neighbour's failing write is not evidence here.

The first cut of this reported only failures, and the caller read their absence as "every write answered 2xx". **The wedge refuted that during verification**: a frozen backend leaves the PATCH *issued and unanswered*, so it neither fails nor answers, and the gate went on to blame #988 — a race between two writes that had both completed — for an instance in which none had. Absence of failure is three states, not two; `autosave` is now a required field of the input so the shortcut cannot come back through the type.

**Serial collateral — `playground-bulk-delete.spec.ts`.** `test.describe.configure({ mode: "serial" })` removed. The three tests share nothing: each builds its own flow through `setupPlayground`, creates its own sessions and deletes its flow in `afterEach`. Serial mode made a failure in the first test mark the other two `skipped` and restart the group on retry — which on this run spent the whole file's retry budget without ever measuring them. The daily's sharded lane sets `PW_SHARD_FILE_LEVEL=1` (`fullyParallel: false`), so the file still runs one test at a time there; what changes is only that a failure no longer suppresses its file-mates.

**`@stable` restored** on `"select-all-checkbox must select all non-default sessions"` (auto-removed by `d85ddb4e`). The removal rested on an attempt whose attempts 0 and 1 never existed, on a shard measured 32.4 % unreachable, with a message reproducible on a healthy image by freezing the backend; the pre-fix baseline is 0/10 clean.

### Rejected alternatives

- **Widening the gate's budget or adding a retry.** The gate is not too tight — the backend was not answering. A longer wait would have converted a legible failure into a slower one.
- **Synthesising a transport token in the in-flight wording** so the `@stable` exemption would match it. That is gaming the gate, not attributing a cause: an in-flight write is reported as such, and left unmatched.
- **Fixing `scripts/remove-stable-from-failures.ts` here.** The attempt-selection gap — the exemption reads only the *last* attempt, so an intermittent wedge un-exempts its own collateral — is #1589's subject and is cross-linked below, not absorbed into this diff.

## Scope note

No assertion in any spec was weakened, loosened, or re-scoped; the three bulk-delete tests assert exactly what they asserted before. On a healthy backend the helper's behaviour is unchanged — the bounded probe only bites where a read takes longer than 5 s, which is already pathological for a local `GET /api/v1/flows/{id}`, and everything else added is on the failure path.

## Verification of the fix against the same wedge

| Freeze at | Message (post-fix) | `classifyInfraError` |
|---|---|---|
| `t=7.5s` / `t=8.0s` | `… last saw 0 node(s), 0 edge(s) … 1 autosave write(s) for this flow were still in flight when the budget expired — the instance never answered them, so this is not the overtake race.` | `null` |
| `t=8.5s` | `… no read of GET /api/v1/flows/{id} completed within 15000ms. This is the instance, not the flow: apiRequestContext.get: Timeout 5000ms exceeded.` | **`api-request-timeout`** |

None cites #988. The daily's exact failure would now read as infrastructure.

## Validation (nightly 1.13.0.dev5, `--retries=0 --workers=1`)

```
nightly: instance=1.13.0.dev5 latest=1.13.0.dev5
run 1..3/3 playground-bulk-delete.spec.ts:        clean expected=3 unexpected=0 flaky=0 backendErrors=false skipped=0
run 1..3/3 playground-input-text-prefill.spec.ts: clean expected=3 unexpected=0 flaky=0 backendErrors=false skipped=0
typecheck=0 lint=0
```

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- `npm run test:units` ✅ **1094 pass / 0 fail** (+25 new: 12 in `graph-commit-failure.test.ts`, 13 in `watch-autosave-writes.test.ts`)
- Pre-fix baseline ✅ `0/10 failed, 0 voided`
- 3 clean `--retries=0` runs per touched spec ✅ · zero `🚨 Backend Error` ✅
- Force-fail ✅ all 3 tests, each verified red then reverted (`FF coverage: complete`, `no FF-MUTATION markers in diff`, `final green run after reverts ✓`):
  - `selecting an individual session checkbox must reveal the bulk-delete-button` — final assert inverted to `toBeHidden()` → `unexpected=1`
  - `select-all-checkbox must select all non-default sessions` — selected-state assert inverted (`.text-status-red` expected `toBeHidden()`) → `unexpected=1`
  - `bulk-delete-button must remove all selected sessions from the sidebar` — post-delete count relaxed to `totalBefore`, so a bulk delete removing nothing would pass → `unexpected=1`
- Blast-radius sanity: `setupPlayground` is imported by 24 specs; two further consumers (`playground-session-nav`, `playground-history-persist`) run clean — `expected=3 unexpected=0 flaky=0 skipped=0`
- Orphan audit: **0** `E2E Playground` flows left on the instance

Validation ran against a dedicated fresh-nightly container on port 7896; the shared `langflow-e2e-runner` on 7860 was left untouched.

Pre-existing and unrelated: `scripts/lib/tmp-dir.test.mjs` → *"a directory the sweep cannot remove costs a leak"* fails identically on clean `origin/main` (1233/1235 both with and without this branch) — the fixture is removable on this host, so the test skips its own premise.

## Cross-links

- **#1589** — the infra-signature exemption reads only the last attempt, so an intermittent wedge un-exempts its own collateral. That is what let the `@stable` removal through here: the final attempt carried a product-shaped signature. Deliberately not fixed in this PR.
- **#988** — closed, and this is not a recurrence. The wording that named it is now reserved for the case where every autosave write was issued, answered, and answered 2xx.
