### PR TITLE
fix(pipeline): classify dedicated [Daily #N] issues by title, not by the word "triage" (#1751)

### DIFF
--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/classify.test.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/classify.test.ts
@@ -14,6 +14,44 @@ test('daily-failure without triage wording → dedicated fix', () => {
   assert.equal(r.type, 'fix')
 })
 
+// The real dedicated body ALWAYS carries the word "triage" — it is the first
+// line of the mandatory template — so the wording rule alone routed every
+// dedicated issue to the triage spine. Regression for #1302.
+const DEDICATED_BODY = 'Spun out of daily-failure triage #1296 (run [30997773754](...), 2026-08-05).\n\nThe day\'s triage verdict is that it was not environmental.'
+
+test('dedicated "[Daily #N]" title → fix, even though the body says "triage"', () => {
+  const r = classify({
+    title: '[Daily #1296] ollama-provider — the flow produces no chat message within 180 s',
+    labels: ['daily-failure', 'area:model-providers'],
+    body: DEDICATED_BODY,
+  })
+  assert.equal(r.type, 'fix')
+  assert.match(r.reason, /\[Daily #N\]/)
+})
+
+test('umbrella "[Daily Failure]" title → triage, even with no "triage" wording', () => {
+  const r = classify({
+    title: '[Daily Failure] @stable tests failed on 2026-08-05 (langflowai/langflow-nightly:latest)',
+    labels: ['daily-failure', 'needs-triage'],
+    body: '5 tests failed. See the run.',
+  })
+  assert.equal(r.type, 'daily-failure-triage')
+  assert.match(r.reason, /umbrella/)
+})
+
+test('the dedicated title is a PREFIX match, so a mention of one is not one', () => {
+  // Anchored on purpose. Unanchor it and this issue — which only REFERS to a
+  // dedicated issue — is read as dedicated and routed to `fix`, when the
+  // wording fallback is what should decide it.
+  const r = classify({
+    title: 'Follow-up to [Daily #744] — the helper needs id-scoped cleanup',
+    labels: ['daily-failure'],
+    body: 'Came out of triage; not a failure of its own.',
+  })
+  assert.equal(r.type, 'daily-failure-triage')
+  assert.match(r.reason, /no title contract match/)
+})
+
 test('community label → community', () => {
   assert.equal(classify({ ...base, title: 'Playground crash', labels: ['community', 'high'] }).type, 'community')
 })

--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/classify.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/classify.ts
@@ -2,14 +2,36 @@ import type { IssueType } from './types.ts'
 
 export interface ClassifyInput { title: string; labels: string[]; body: string }
 
+/** Dedicated daily-failure issue, e.g. "[Daily #1296] ollama-provider — ...". */
+export const DEDICATED_DAILY_TITLE = /^\s*\[daily\s*#\d+\]/
+/** Umbrella opened by daily-stable.yml, e.g. "[Daily Failure] @stable tests failed on ...". */
+export const UMBRELLA_DAILY_TITLE = /^\s*\[daily\s+failure\]/
+
 export function classify(i: ClassifyInput): { type: IssueType | null; reason: string } {
   const hay = (i.title + '\n' + i.body).toLowerCase()
   const title = i.title.toLowerCase()
   const labels = i.labels.map(l => l.toLowerCase())
 
   if (labels.includes('daily-failure')) {
+    // The title contract is read FIRST, because the "triage" wording cannot
+    // separate the two kinds: the dedicated-issue template's mandatory first
+    // line is "Spun out of daily-failure triage #<umbrella>"
+    // (langflow-e2e-triage/references/issue-templates.md), so EVERY dedicated
+    // issue carries the word and every one of them used to route to the triage
+    // spine — which dispatches sub-issues for a failure that already has a
+    // dedicated issue. Both titles are machine-written and stable:
+    // `scripts/create-failure-issue.mjs` opens the umbrella as
+    // "[Daily Failure] ..." and the triage skill opens each dedicated issue as
+    // "[Daily #<umbrella>] ...".
+    if (DEDICATED_DAILY_TITLE.test(title)) {
+      return { type: 'fix', reason: 'label daily-failure + "[Daily #N]" dedicated-issue title' }
+    }
+    if (UMBRELLA_DAILY_TITLE.test(title)) {
+      return { type: 'daily-failure-triage', reason: 'label daily-failure + "[Daily Failure]" umbrella title' }
+    }
+    // Neither title form — a hand-opened issue. Fall back to the wording.
     if (/triage/.test(hay)) {
-      return { type: 'daily-failure-triage', reason: 'label daily-failure + "triage" wording' }
+      return { type: 'daily-failure-triage', reason: 'label daily-failure + "triage" wording (no title contract match)' }
     }
     return { type: 'fix', reason: 'label daily-failure, dedicated issue (no "triage" wording)' }
   }

--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/cli.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/cli.ts
@@ -19,6 +19,7 @@ import {
   checkSpecDoc, checkQaDiff, checkForceFailCoverage, checkNoMutationMarkers,
   checkPrReadiness, checkQuarantineLifted, checkDebugEvidence, checkBranchPurity,
   checkCiVerdict, symptomsOwnedElsewhere, checkFinalGreenCoverage, finalGreenTargets,
+  resolveClassification,
 } from './gates.ts'
 import { summarizeRunArtifact } from './artifacts.ts'
 import { instructionFor } from './instructions.ts'
@@ -372,11 +373,9 @@ async function gateFor(s: PipelineState, step: Phase, evidence: Record<string, u
   const rec = s.steps[step]
 
   if (step === 'CLASSIFY') {
-    if (!s.type && typeof evidence.type === 'string') {
-      if (typeof evidence.justification !== 'string') problems.push('claude classification needs justification')
-      else setType(s, evidence.type as never, 'claude', evidence.justification)
-    }
-    if (!s.type && !evidence.type) problems.push('no type: heuristic failed and none supplied')
+    const decision = resolveClassification(s.type, evidence)
+    if (decision.set) setType(s, decision.set.type, 'claude', decision.set.justification)
+    problems.push(...decision.problems)
   }
 
   if (step === 'SPECIFY' && s.type === 'file-watcher') {

--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.test.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.test.ts
@@ -5,7 +5,7 @@ import {
   checkNoMutationMarkers, checkPrReadiness, BRANCH_RE,
   checkQuarantineLifted, extractSymptomRows, checkSymptomCoverage,
   symptomsOwnedElsewhere, checkDebugEvidence, checkBranchPurity, checkCiVerdict,
-  checkFinalGreenCoverage, finalGreenTargets,
+  checkFinalGreenCoverage, finalGreenTargets, resolveClassification,
 } from './gates.ts'
 import type { RunRecord } from './types.ts'
 
@@ -439,4 +439,64 @@ test('finalGreenTargets re-runs a file whose only record executed nothing', () =
   assert.deepEqual(
     finalGreenTargets(['a.spec.ts'], [empty('a.spec.ts')]).targets,
     ['a.spec.ts'])
+})
+
+// ---------------------------------------------------------------------------
+// resolveClassification — CLASSIFY gate decision (#1302)
+// ---------------------------------------------------------------------------
+
+test('resolveClassification records Claude\'s type when the heuristic found none', () => {
+  const d = resolveClassification(undefined, { type: 'fix', justification: 'dedicated daily issue' })
+  assert.deepEqual(d.problems, [])
+  assert.deepEqual(d.set, { type: 'fix', justification: 'dedicated daily issue' })
+})
+
+test('resolveClassification OVERRIDES a wrong heuristic and names what it replaced', () => {
+  const d = resolveClassification('daily-failure-triage', {
+    type: 'fix', justification: '[Daily #1296] is the dedicated title, not the umbrella',
+  })
+  assert.deepEqual(d.problems, [])
+  assert.equal(d.set?.type, 'fix')
+  assert.match(d.set!.justification, /overrides heuristic "daily-failure-triage"/)
+  assert.match(d.set!.justification, /dedicated title/)
+})
+
+test('resolveClassification treats a matching type as a confirmation, rewriting nothing', () => {
+  const d = resolveClassification('fix', { type: 'fix', justification: 'agreed' })
+  assert.deepEqual(d.problems, [])
+  assert.equal(d.set, undefined)
+})
+
+test('resolveClassification refuses an unknown type instead of casting it', () => {
+  const d = resolveClassification('fix', { type: 'flake-fix', justification: 'typo' })
+  assert.equal(d.set, undefined)
+  assert.equal(d.problems.length, 1)
+  assert.match(d.problems[0], /not a known issue type/)
+  assert.match(d.problems[0], /validate-promote/)
+})
+
+test('resolveClassification refuses a non-string type', () => {
+  const d = resolveClassification(undefined, { type: 7, justification: 'x' })
+  assert.equal(d.set, undefined)
+  assert.match(d.problems[0], /not a known issue type/)
+})
+
+test('resolveClassification requires a non-empty justification, override included', () => {
+  for (const justification of [undefined, '', '   ']) {
+    const d = resolveClassification('daily-failure-triage', { type: 'fix', justification })
+    assert.equal(d.set, undefined, `justification ${JSON.stringify(justification)} must not set a type`)
+    assert.deepEqual(d.problems, ['claude classification needs justification'])
+  }
+})
+
+test('resolveClassification passes a plain confirmation through untouched', () => {
+  const d = resolveClassification('new-spec', { confirmed: true } as Record<string, unknown>)
+  assert.deepEqual(d.problems, [])
+  assert.equal(d.set, undefined)
+})
+
+test('resolveClassification still fails when no heuristic ran and nothing was supplied', () => {
+  const d = resolveClassification(undefined, {})
+  assert.equal(d.set, undefined)
+  assert.deepEqual(d.problems, ['no type: heuristic failed and none supplied'])
 })

--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.ts
@@ -1,6 +1,48 @@
-import type { FFEntry, ReproRate, RunRecord, TestEntry } from './types.ts'
-import { VERDICTS } from './types.ts'
+import type { FFEntry, IssueType, ReproRate, RunRecord, TestEntry } from './types.ts'
+import { ISSUE_TYPES, VERDICTS } from './types.ts'
 import { countsAsClean } from './runners.ts'
+
+export interface ClassificationDecision {
+  /** What to record, or undefined when nothing changes (a plain confirmation). */
+  set?: { type: IssueType; justification: string }
+  problems: string[]
+}
+
+/**
+ * Decides what the CLASSIFY gate records, given the heuristic's verdict and the
+ * evidence Claude supplied. Pure so the override path is testable — it used to
+ * live inside `gateFor` as `if (!s.type && typeof evidence.type === 'string')`,
+ * which had two defects: a WRONG heuristic could not be corrected at all (the
+ * guard only fired when no type was set), and the supplied string was cast with
+ * `as never`, so a typo set an unknown type that `spineFor` then read as BASE.
+ */
+export function resolveClassification(
+  current: IssueType | undefined,
+  evidence: { type?: unknown; justification?: unknown },
+): ClassificationDecision {
+  const problems: string[] = []
+  const supplied = evidence.type
+
+  if (supplied === undefined) {
+    if (!current) problems.push('no type: heuristic failed and none supplied')
+    return { problems }
+  }
+  if (typeof supplied !== 'string' || !ISSUE_TYPES.includes(supplied as IssueType)) {
+    problems.push(`evidence.type ${JSON.stringify(supplied)} is not a known issue type (${ISSUE_TYPES.join(', ')})`)
+    return { problems }
+  }
+  const type = supplied as IssueType
+  const justification = typeof evidence.justification === 'string' ? evidence.justification.trim() : ''
+  if (!justification) {
+    problems.push('claude classification needs justification')
+    return { problems }
+  }
+  // Same type as the heuristic: a confirmation, nothing to rewrite.
+  if (current === type) return { problems }
+  // An override is auditable in the state file, so it names what it replaced.
+  const note = current ? `overrides heuristic "${current}": ${justification}` : justification
+  return { set: { type, justification: note }, problems }
+}
 
 export const SPEC_DOC_SECTIONS = [
   'What this test validates', 'Tags', 'Validation criterion', 'External dependencies',

--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/instructions.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/instructions.ts
@@ -20,8 +20,11 @@ export function instructionFor(s: PipelineState): string {
         s.type
           ? `Heuristic classification: ${s.type} (${s.classification?.justification}). Confirm it with the user.`
           : `No heuristic matched. Classify the issue yourself using the 6-type table in the langflow-e2e-issues skill and record a justification.`,
+        s.type
+          ? `If the heuristic is WRONG, do NOT confirm it — complete with {"type":"<correct type>","justification":"<why>"} instead; that overrides it and is recorded as such.`
+          : '',
         done('CLASSIFY', s.type ? '{"confirmed":true}' : '{"type":"<type>","justification":"<why>"}'),
-      ].join('\n')
+      ].filter(Boolean).join('\n')
 
     case 'SPECIFY': {
       if (s.type === 'file-watcher') {

--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/types.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/types.ts
@@ -1,10 +1,16 @@
-export type IssueType =
-  | 'new-spec'
-  | 'validate-promote'
-  | 'daily-failure-triage'
-  | 'fix'
-  | 'community'
-  | 'file-watcher'
+// Runtime list, not a bare type union: the CLASSIFY gate accepts a type from
+// Claude and used to cast it with `as never`, so a typo set an unknown type and
+// `spineFor` silently fell through to BASE.
+export const ISSUE_TYPES = [
+  'new-spec',
+  'validate-promote',
+  'daily-failure-triage',
+  'fix',
+  'community',
+  'file-watcher',
+] as const
+
+export type IssueType = typeof ISSUE_TYPES[number]
 
 export type Phase =
   | 'INTAKE' | 'CLASSIFY' | 'SPECIFY' | 'PLAN' | 'DEBUG' | 'IMPLEMENT'


### PR DESCRIPTION
Closes #1751.

Found while driving #1302 through the deterministic pipeline. `next 1302` printed:

```
— issue #1302 · phase CLASSIFY · type daily-failure-triage —
heuristic: daily-failure-triage (label daily-failure + "triage" wording)
```

#1302 is a **dedicated** daily-failure issue with a confirmed root cause and a merged fix. The triage spine is `INTAKE → CLASSIFY → DISPATCH → DISPATCHED`, whose whole job is to fan out one dedicated issue per failure — so the pipeline was about to re-file the issue it was standing in.

## Defect 1 — the wording rule can never separate the two kinds

`classify.ts` searched title + body for "triage":

```ts
if (labels.includes('daily-failure')) {
  if (/triage/.test(hay)) return { type: 'daily-failure-triage', ... }
  return { type: 'fix', ... }
}
```

The **mandatory first line** of the dedicated-issue template (`langflow-e2e-triage/references/issue-templates.md:53`) is:

```
Spun out of daily-failure triage #<umbrella> (run [<run_id>](<run_url>), <date>).
```

So every dedicated issue carries the word, and every one of them misroutes. The mirror case fails too: the umbrella's per-test body (`scripts/create-failure-issue.mjs`) need not contain "triage" at all, and such an umbrella classified as `fix`.

The discriminator that works is the title contract `CLAUDE.md` already names, and both sides of it are machine-written: `create-failure-issue.mjs:206-211` opens the umbrella as `[Daily Failure] …`, and the triage skill opens each dedicated issue as `[Daily #<umbrella>] …` (`issue-templates.md:41`). The title is now read first; the wording survives as the fallback for a hand-opened issue.

Both regexes are **anchored on purpose** — a title that merely *mentions* `[Daily #744]` (a follow-up, say) is not a dedicated issue and must fall through to the wording.

## Defect 2 — a wrong heuristic could not be corrected

```ts
if (!s.type && typeof evidence.type === 'string') { … setType(s, evidence.type as never, …) }
```

The guard only fired when the heuristic had found nothing, so `complete 1302 CLASSIFY --evidence-json '{"type":"fix","justification":"…"}'` was silently ignored, and there is no `--type` flag. The instruction said *"Confirm it with the user"* while offering no way to record a disagreement — #1302 had to be aborted for it.

The same line cast the string with `as never`, so a typo (`"flake-fix"`) would set an unknown type that `spineFor` reads as the BASE spine: a wrong process, silently.

## The fix

- `types.ts` exports `ISSUE_TYPES` as a runtime list, so a supplied type is **validated** rather than cast.
- The gate decision moves into a pure `resolveClassification()` in `gates.ts` — per this skill's own rule that the decision belongs in a tested pure function, not in the phase block. It allows an override, requires a justification for one, records what it replaced (`overrides heuristic "daily-failure-triage": …`), and treats a matching type as a plain confirmation that rewrites nothing.
- `instructions.ts` tells the reader the override exists, instead of only asking for confirmation.

## Validation

```
npm run test:pipeline    119 -> 130 tests, 0 failed
tsc -p (pipeline)        clean
```

**Force-fails — 4 mutations, each reverting one half of the fix, each shown red:**

| Mutation | Result |
|---|---|
| `classify.ts` back to wording-only | **3 red** — dedicated-title, umbrella-title, and the anchoring pin |
| `DEDICATED_DAILY_TITLE` unanchored | **1 red** — the anchoring pin |
| gate back to set-only-when-unset | **3 red** — override, unknown-type, justification-required |
| type validation replaced by a blind cast | **2 red** — unknown type, non-string type |

One test written for this PR **passed against the pre-fix code** and was rewritten rather than kept: its two cases used bodies where the old and new rules agree, so it discriminated nothing. It is now an anchoring pin, which the second mutation above catches. A test engineered to always pass is worse than no test.

End-to-end check on the real issue: `classify()` on #1302's actual title, labels and body now returns `{ type: 'fix', reason: 'label daily-failure + "[Daily #N]" dedicated-issue title' }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
