### PR TITLE
test(api): quarantine api-flows-crud "GET lists flows and includes the created one" (#1759)

### DIFF
--- a/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
@@ -53,9 +53,16 @@ test.describe("CRUD /api/v1/flows", () => {
     },
   );
 
-  test(
+  // Quarantined at triage (2026-09-08 daily, umbrella #1757): `POST /api/v1/flows/`
+  // returns 201 and the very next `GET /api/v1/flows/` does not contain the created
+  // flow, so `expect(found).toBeDefined()` receives `undefined`. Recurrent under the
+  // same assertion on the 2026-08-19 and 2026-09-08 dailies. Not wedge collateral —
+  // the attempt ran at 12:41:27Z and finished in 418 ms, ~2.5 min before the earliest
+  // measured outage window on any shard (12:43:57Z). Lifting the quarantine (remove
+  // test.fixme + restore @stable) is a deliverable of #1759.
+  test.fixme(
     "GET lists flows and includes the created one",
-    { tag: ["@stable", "@release", "@api", "@regression"] },
+    { tag: ["@release", "@api", "@regression"] },
     async ({ request, apiCoverage }) => {
       apiCoverage.declare(["POST /api/v1/flows/", "GET /api/v1/flows/"]);
       const authToken = await getAuthToken(request);


### PR DESCRIPTION
Quarantines one `@stable` test as **prevention**, at triage of the 2026-09-08 daily (umbrella #1757). Tracked by #1759 — this PR does **not** fix it, and does not close that issue: lifting the quarantine is #1759's own deliverable.

## What fails

`tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts:56` — "GET lists flows and includes the created one". `POST /api/v1/flows/` returns `201` with an id, and the very next `GET /api/v1/flows/` does not contain that flow, so `expect(found).toBeDefined()` receives `undefined`.

Recurrent under the **same assertion** on the 2026-08-19 and 2026-09-08 dailies (`toBeDefined()` appears exactly once in that test), which meets the flake criterion in `CONTRIBUTING.md`.

## Why it is not wedge collateral

Worth stating explicitly, because the 2026-09-08 run measured 20 outages / 27.4 min of unreachable backend across 4 of 4 shards. The attempt ran at `12:41:27.215Z` and failed in **418 ms** — roughly **2.5 minutes before** the earliest measured outage window on any shard (`12:43:57Z`), with all four liveness recorders up and answering from `12:41:11Z`. A millisecond-scale wrong result is also not the 20–30 s timeout shape a wedge produces, and the entry carries no `infra_signature`.

## Why both edits

Per `CONTRIBUTING.md` and the triage skill's quarantine mechanism, the two go together:

- **`@stable` removed** — stops it running in `daily-stable.yml`, and stops `QA-CHECKLIST.md` Phase 0 counting a quarantined test as validated.
- **`test.fixme` added** — the `pr-validation.yml` impacted-specs gate selects specs by **file diff**, not by tag, so tag removal alone would leave this PR itself red on the very file it edits (#871).

## Checks run locally

- `npm run typecheck` — clean
- `npx eslint` on the changed file — clean
- `npm run check:checklist-coverage` — passes (the Part II bullet still references the spec)
- `npx playwright test --list --grep @stable` on the file — the quarantined test is gone from the selection; the file's other 8 `@stable` tests still list

`QA-CHECKLIST.md` is intentionally untouched: the generated blocks are regenerated on merge to `main` by `update-coverage-summary.yml`.

Refs #1757
