### PR TITLE
test(flows): quarantine publish-flow "publish then unpublish to revoke access" (#1760)

### DIFF
--- a/tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts
@@ -10,9 +10,17 @@ const FLOW_BASE = {
   is_component: false,
 };
 
-test(
+// Quarantined at triage (2026-09-08 daily, umbrella #1757): after the flow is
+// unpublished, `access_type` still reads back as "PUBLIC" where the test expects
+// "PRIVATE". Recurrent on two consecutive dailies, and byte-identical on both
+// (2026-09-07, 2026-09-08) — same expected/received pair, failing on attempt 0 and
+// passing on attempt 1. Not wedge collateral: 2026-09-07 was a clean daily (0 hard
+// failures, 306 s of total measured downtime against this run's 1644 s), and the
+// failure is a concrete wrong value at 8.9 s / 12.5 s, not a timeout. Lifting the
+// quarantine (remove test.fixme + restore @stable) is a deliverable of #1760.
+test.fixme(
   "user can publish a flow and access it via shareable URL, then unpublish to revoke access",
-  { tag: ["@release", "@workspace", "@playground", "@stable"] },
+  { tag: ["@release", "@workspace", "@playground"] },
   async ({ page, browser, request }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
Quarantines one `@stable` test as **prevention**, at triage of the 2026-09-08 daily (umbrella #1757). Tracked by #1760 — this PR does **not** fix it, and does not close that issue: lifting the quarantine is #1760's own deliverable.

## What fails

`tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts:13` — "user can publish a flow and access it via shareable URL, then unpublish to revoke access". After the unpublish, `access_type` reads back as `"PUBLIC"` where the test expects `"PRIVATE"`.

Recurrent on **two consecutive dailies**, and byte-identical on both — same expected/received pair, failing on attempt 0 and passing on attempt 1 (2026-09-07: 8.95 s then 14.83 s; 2026-09-08: 12.55 s then 25.31 s). The stored `error_signature` is the generic `expect(received).toBe(expected)`, which cannot establish same-cause recurrence on its own (#1626); the expected/received pair read out of each run's `results.json` is what establishes it here.

## Why it is not wedge collateral

2026-09-08 was a heavily wedged run (20 outages / 27.4 min, 4 of 4 shards), but **2026-09-07 was a clean daily** — 0 hard failures, 6 flakes, 306 s of total measured downtime across all four shards against this run's 1 644 s — and the failure reproduced identically there. It is also a concrete wrong value reached in 8.9 s / 12.5 s, not a timeout, and neither occurrence carries an `infra_signature`.

## Scope: the API sibling keeps `@stable`

The same file's "publish flow via API toggles access_type between PUBLIC and PRIVATE" asserts the same `PUBLIC`↔`PRIVATE` transition through the API and **passed on both days**. It is deliberately left tagged, so the endpoint stays covered while the UI path is quarantined — and the contrast is itself a lead recorded on #1760.

## Why both edits

Per `CONTRIBUTING.md` and the triage skill's quarantine mechanism, the two go together:

- **`@stable` removed** — stops it running in `daily-stable.yml`, and stops `QA-CHECKLIST.md` Phase 0 counting a quarantined test as validated.
- **`test.fixme` added** — the `pr-validation.yml` impacted-specs gate selects specs by **file diff**, not by tag, so tag removal alone would leave this PR itself red on the very file it edits (#871).

## Checks run locally

- `npm run typecheck` — clean
- `npx eslint` on the changed file — clean
- `npm run check:checklist-coverage` — passes (the Part II bullet still references the spec)
- `npx playwright test --list --grep @stable` on the file — the quarantined test is gone from the selection; the API sibling still lists

`QA-CHECKLIST.md` is intentionally untouched: the generated blocks are regenerated on merge to `main` by `update-coverage-summary.yml`.

Refs #1757
