### PR TITLE
test(llm-agents): restore @stable on the invalid-tool-name test (#1629)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-tool-name-validation.md
+++ b/docs/core-functionality/llm-agents/agent-tool-name-validation.md
@@ -1,6 +1,6 @@
 # Agent tool name — invalid name blocks execution with a clear error
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.13.x
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts
@@ -197,7 +197,7 @@ for (const { label, options, skipReason } of targets) {
   test.describe(`Agent Tool Name Validation [${label}]`, () => {
     test(
       "an invalid tool name blocks execution with a clear message",
-      { tag: ["@regression", "@agents", "@playground"] },
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
       async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(


### PR DESCRIPTION
**Closes #1629.**

## Problem

`@stable` was auto-removed from `agent-tool-name-validation.spec.ts:198` ("an invalid tool name blocks execution with a clear message") in `22f7f0d8`, after the test burned all three attempts on daily run [33205785035](https://github.com/oriontech-me/langflow-e2e/actions/runs/33205785035) (2026-08-28). **The removal was a false positive of the attempt-selection rule tracked in #1589 — not a spec defect.**

That run is an unusually clean case, because it carries **both outcomes of the rule, on the same run, from the same first cause**. It had exactly 2 hard failures (536 expected / 2 unexpected / 8 flaky) and both failed attempt 0 with a *byte-identical* error pair — the #751/#1072 credential-settle guard, which names its own cause:

```
verdict        read-failed
waited         20.0s over 0 read(s)
last read err  apiRequestContext.get: Timeout 20000ms exceeded.
   -> GET http://localhost:7860/api/v1/auto_login
"Treat the read error above as the finding (a wedged or recycling backend, #1077), not the binding."
```

Running this repo's own `classifyInfraError()` (`scripts/lib/infra-signatures.mjs`) per attempt, over each attempt's joined errors (mirroring `lastFailureError`'s dedup):

| Spec:line | a0 | a1 | a2 | rule today | union of all attempts |
|---|---|---|---|---|---|
| `agent-context-id-isolation.spec.ts:557` | **EXEMPT** `api-request-timeout` ← *read* | `skipped` | `skipped` | **EXEMPT** → tag kept | EXEMPT |
| `agent-tool-name-validation.spec.ts:198` | **EXEMPT** `api-request-timeout` | `null` | `null` ← *read* | **ATTRIBUTABLE** → tag removed | **EXEMPT** |

`lastFailureError` picks the last attempt that is neither `passed` nor `skipped`. For the first spec, a1/a2 were *skipped*, so it landed on a0 and the transport signature exempted it — the removal commit says so in its own message: `1 further hard failure(s) kept @stable as non-attributable wedge collateral (#1031)`. For this test, a1/a2 also **ran and failed** with non-exempt signatures, so it landed on a2 (`locator.click: Timeout` on `provider-item-Google Generative AI`). **Same first cause, opposite outcome, decided purely by whether the retries executed.**

The narrowing point: the pattern that would have exempted it — `api-request-timeout` — **already exists** in `infra-signature-patterns.json`. This failure needed no new pattern, only a different attempt selection.

Corroborating: of the run's 8 flakes, 5 carry the same transport class — including `agent-component-regression.spec.ts:97` flaking on the **identical** #751 guard error and recovering, and `agent-max-iterations.spec.ts:296` flaking on the **identical** `locator.click: Timeout` signature and recovering. The removed test is the only one of the group that happened to burn all three attempts. Run-level context on #1077: 10 outages / 14 min of measured unreachable backend across 3 of 4 shards, shard 2 at a 33.1 % down-share, per-attempt probe-failure ratios 81 % / 58 % / 26 %. Sub-threshold day (2 hard failures), so the mass-failure guard did not trip — the scenario #1589 names as the one where the rule decides the outcome.

## Fix

Restore `@stable` on the tag array at line 198, and bump the spec doc's `Last validated` to the cycle it was re-validated on. The spec file is now **byte-identical to its pre-`22f7f0d8` state** (blob back to `629f9ddb`).

The issue named three paths and all three were investigated independently:

- **Environment / wedge collateral** — confirmed, per the table above.
- **Test / wait strategy — already fixed, before this issue was worked.** The issue's directive 2 points at `setup-google.ts:23` as a bare click with no readiness gate, and the artifact's stack trace confirms that is what ran on 08-28. But #1648/#1650 replaced that exact line with `waitForProviderRow` on **2026-08-31 — three days after the run** — and that helper measured 20 attempts of this class over 12 spec files in the 08-04→08-31 dailies (Google 9, `0 of 20` getting past `waiting for <locator>`), reached the same wedged-backend verdict, and explicitly refuses to raise the budget. So the directive targets code that no longer exists.
- **Product (Langflow) regression — refuted.** On a fresh `1.13.0.dev6` nightly, `GET /api/v1/models?purpose=configure` returns 9 providers with `Google Generative AI` present and its display name unchanged, so attempt 2 was `waitForProviderRow`'s `PROVIDER_LIST_STALLED` branch and not `PROVIDER_ABSENT`. The Google key is funded (a direct `generateContent` on `gemini-3.5-flash` returns HTTP 200).

**Rejected alternatives.** Raising the provider-row timeout — `provider-list-state.ts` argues against it by design ("Raising them would hide the stall this module exists to name"). Adding a readiness gate to `setup-google.ts` — already there since #1648. Any assertion or selector change — the test is green and deterministic on a healthy backend; the failure was the instance, so weakening the spec would remove real coverage.

## Scope note

No assertion, selector, timeout, wait or scope changed — the diff is 2 lines. The sibling `causal control — a valid custom tool name executes normally` (line 229), which only skipped as a knock-on of this failure, keeps its own `@stable` and is confirmed passing. Nothing was quarantined by this issue, so there is no `test.fixme` to lift.

`QA-CHECKLIST.md` is deliberately untouched: the manual Part II bullet (line 498) already references the spec and is `[x]`, and the `Phase 0 — Validated` block that the auto-removal edited is generated and regenerates on merge — editing it would fail the guard (#741).

## Validation (nightly 1.13.0.dev6, `--retries=0`, `--workers=1`)

Run on a dedicated fresh container (`1.13.0.dev6`, image identical to `langflowai/langflow-nightly:latest`; the pipeline's own check reports `instance=1.13.0.dev6 latest=1.13.0.dev6`), provider pinned to **google** to mirror the failing run's target.

- typecheck ✅ (`tsc --noEmit`, exit 0) · eslint ✅ (0 errors) · anti-pattern checklist ✅
- **Pre-fix baseline on the unmodified spec: `0/10 failed (0%), 0 voided`**, 49–57 s per run — the defect does not reproduce against a healthy backend, which is what an environment verdict predicts. Because the baseline never reproduced, the mechanism is proven by re-running the repo's own classifier over the archived run (the table above) rather than by reproduction.
- 3/3 clean validation runs: `expected=2 unexpected=0 flaky=0 backendErrors=false skipped=0` each. `skipped=0` matters — it rules out a green all-skip (#1593).
- force-fail ✅ **both** `test()` calls in the file, each targeting its own validation criterion rather than just breaking a matcher:
  - *invalid tool name* — renamed the tool to the **valid** name so the provider accepts the function name and no invalid-name error is ever surfaced → failed as expected (`unexpected=1`).
  - *causal control* — renamed the tool to the **invalid** name so the provider rejects it: no agent answer, the `/hello/i` bubble assertion fails, the `toHaveCount(0)` absence assertion fails, and the fixture's flow-error monitor fires because that test deliberately does not call `allowFlowErrors()` → failed as expected (`unexpected=1`).
  - Both reverted; `grep -c FF-MUTATION` = 0 in the diff; final green run after the reverts ✅
- zero `🚨 Backend Error` ✅ (asserted from the runner's own `backendErrors=false`, captured on stdout)
- **Flow cleanup audited** (repo rule): 26 flows on the instance before and after, the single `Simple Agent` carrying the **default** URL tool name `fetch_content` rather than `invalid_tool_name!!` or `fetch_content_renamed` — 32 flows created across the 17 runs, **0 orphans**.

`--trace=on` was not used: it hangs the UI on this spec family locally (Colima); traces were left at the config's `retain-on-failure`.

## Follow-ups (filed separately, not folded in here)

Neither was needed for this failure — attempt 0 was already exemptible by an existing pattern — and both are `qa-infra` concerns about the attribution mechanism rather than this spec:

- **All five** provider-list verdicts from #1648 (`stalled`, `errored`, `filtered`, `absent`, `unreached`) classify `null` against `infra-signature-patterns.json`. #1648 stated its goal as words "a human **and `infra_signature`** can both read" and shipped only the human half — so a day on which *every* attempt stalls on the provider list would remove `@stable` again, under a message that reads "This is an INSTANCE stall". Two of the five (`filtered`, `absent`) must stay attributable, so the fix cannot sweep all five.
- `open-new-flow-templates-modal.ts:106` — where attempt 1 died — reports a bare `expect(received).toBe(expected) // Object.is equality` and names neither of the two observables it was racing. Distinct from #1549 (a different helper, and the opposite defect: an over-confident verdict) and from #1626, which owns the signature *collision*; measured evidence for #1626 has been added there instead (22 recorded failures across 15 distinct specs share that one signature).

Recorded on #1589, whose branch decision this run is evidence for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
