### PR TITLE
Fold a spec that ran under different targets into one entry, and leave the conclusion to the reader

### DIFF
--- a/scripts/compare-lane-verdicts.test.mjs
+++ b/scripts/compare-lane-verdicts.test.mjs
@@ -283,12 +283,38 @@ test("specKey drops the parameterization that testKey keeps", () => {
   assert.equal(specKey(paramFail("google")), specKey(paramFail("anthropic")));
 });
 
-test("paramProvider reads all three label shapes the corpus carries", () => {
+test("paramProvider reads the label shapes the corpus actually carries", () => {
+  // Counted, not assumed: 97 param-carrying entries over both series, 8 distinct
+  // labels, all `provider / model` except one `provider:openai (fallback)`. An earlier
+  // comment here claimed a bare `google` was one of the shapes — it appears ZERO times.
   assert.equal(paramProvider("google / gemini-3.5-flash"), "google");
-  assert.equal(paramProvider("google"), "google");
   assert.equal(paramProvider("provider:openai (fallback)"), "openai");
+  assert.equal(paramProvider("google"), "google"); // tolerated, not a documented input
   assert.equal(paramProvider(null), null);
   assert.equal(paramProvider(""), null);
+  // Names a MODEL, so it names no provider. Returning the whole string as one rendered
+  // `providers DIFFER (Actions openai, VM model:gpt-4o-mini)` — the overclaim again.
+  assert.equal(paramProvider("model:gpt-4o-mini"), null);
+});
+
+test("a side that names no provider is not reported as the SAME provider", () => {
+  // `providersDiffer` is false for two different reasons — equal, or one side unnamed —
+  // and the render collapsed both into "SAME provider (X)", printing `VM [no target]`
+  // and `SAME provider (google)` on adjacent lines over a row that never said google.
+  // It is also the only line in the block that touches cause.
+  const result = oneEach(
+    paramFail("google / gemini-3.5-flash", { error_signature: "Error: same" }),
+    paramFail(undefined, { error_signature: "Error: same" }),
+  );
+  const d = result.divergences[0];
+  assert.equal(d.crossTarget.providersKnown, false);
+  assert.equal(d.crossTarget.providersDiffer, false);
+  const text = renderReport(result);
+  assert.match(text, /one side does not name a provider \(Actions google, VM —\)/);
+  assert.match(text, /cannot be told from these two rows/);
+  assert.doesNotMatch(text, /SAME provider/);
+  // The --json surface was already right; the text has to agree with it.
+  assert.deepEqual(d.providers, { ci: "google", vm: null });
 });
 
 test("the same spec under two targets is ONE entry, not two one-sided ones", () => {
@@ -339,34 +365,49 @@ test("the fold NEVER stamps the head of the report, whatever it found", () => {
   }
 });
 
-test("a folded pair ranks WITH its severity, never above a genuine two-lane red", () => {
-  // Ranking the fold first was the promotion the cold review caught: a pair that
-  // hard-failed on one lane and flaked on the other outranked a real one-sided red.
-  const other = fail({ test: "traces are listed", file: "tests-automations/regression/api/monitor/api-monitor-traces.spec.ts" });
+test("a folded pair ranks below BOTH one-sided failures, not just one of them", () => {
+  // Half-pinned before: `-1` was caught but `0.5` — above `ci-only-failed`, which the
+  // docblock says it must never outrank — passed, because the fixture had no
+  // `ci-only-*` entry at all. Both sides now appear.
+  const vmOnly = fail({ test: "traces are listed", file: "tests-automations/regression/api/monitor/api-monitor-traces.spec.ts" });
+  const ciOnly = fail({ test: "a flow publishes", file: "tests-automations/regression/flow-functionality/publish-flow.spec.ts" });
   const result = compare(
     row("daily-stable", {
-      failures: [paramFail("google", { error_signature: "Error: same" })],
-      totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 },
+      failures: [ciOnly, paramFail("google", { error_signature: "Error: same" })],
+      totals: { passed: 8, failed: 2, flaky: 0, skipped: 2 },
     }),
     row("daily-stable-vm", {
-      failures: [other],
+      failures: [vmOnly],
       flaky: [paramFail("anthropic", { error_signature: "Error: same" })],
       totals: { passed: 8, failed: 1, flaky: 1, skipped: 2 },
     }),
   );
   assert.deepEqual(
     result.divergences.map((d) => d.kind),
-    ["vm-only-failed", "cross-target-failed"],
+    ["vm-only-failed", "ci-only-failed", "cross-target-failed"],
   );
 });
 
-test("a pair that only flaked on both targets is a flake, and ranks with the flakes", () => {
-  const result = oneEach(
-    paramFail("google", { error_signature: "Error: boom" }),
-    paramFail("anthropic", { error_signature: "Error: boom" }),
-    { passed: 9, failed: 0, flaky: 1, skipped: 2 },
+test("a flaky pair ranks with the flakes, below every hard failure", () => {
+  // The old fixture had exactly one divergence, so `divergences[0]` was that pair at
+  // ANY rank — `-99`, first in the whole report above every red, passed the test whose
+  // title said "ranks with the flakes".
+  const red = fail({ test: "traces are listed", file: "tests-automations/regression/api/monitor/api-monitor-traces.spec.ts" });
+  const result = compare(
+    row("daily-stable", {
+      flaky: [paramFail("google", { error_signature: "Error: boom" })],
+      totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 },
+    }),
+    row("daily-stable-vm", {
+      failures: [red],
+      flaky: [paramFail("anthropic", { error_signature: "Error: boom" })],
+      totals: { passed: 8, failed: 1, flaky: 1, skipped: 2 },
+    }),
   );
-  assert.equal(result.divergences[0].kind, "cross-target-flaky");
+  assert.deepEqual(
+    result.divergences.map((d) => d.kind),
+    ["vm-only-failed", "cross-target-flaky"],
+  );
   assert.match(renderReport(result), /a retry passed on both/);
 });
 
@@ -410,6 +451,37 @@ test("a locator assertion is a shell too - it is the suite's most frequent signa
   assert.equal(isGenericSignature("Error: expect(received).not.toBeNull()"), true);
   // Still not a shell: it names its own cause.
   assert.equal(isGenericSignature("Error: setupPlayground: a canvas edit never reached the database"), false);
+});
+
+test("the shell rule sees THROUGH the ANSI the rows actually carry", () => {
+  // Restored: the rewrite deleted this and nothing replaced it, leaving the only reason
+  // the shell caveat ever fires on real data unpinned. Counted over both series: 262 of
+  // 696 signatures are assertion shells and ALL 262 are ANSI-wrapped, so an
+  // un-normalized rule recognises exactly zero of them.
+  const esc = String.fromCharCode(27);
+  const wrapped = `Error: ${esc}[2mexpect(${esc}[22m${esc}[31mreceived${esc}[39m${esc}[2m).${esc}[22mtoBe${esc}[2m(${esc}[22mexpected)`;
+  assert.equal(isGenericSignature(wrapped), true);
+  assert.equal(isGenericSignature(`Error: ${esc}[2mexpect(locator).toBeVisible() failed`), true);
+});
+
+test("each lane's line carries THAT lane's status and signature", () => {
+  // Both were mirrorable without failing a test: every fixture gave the two sides the
+  // same signature, and the mixed-severity test that asserted the two statuses was
+  // deleted in the rewrite. "Both statuses printed" is named as a fact the entry
+  // renders, so it has to be pinned.
+  const result = compare(
+    row("daily-stable", {
+      failures: [paramFail("google", { error_signature: "Error: only Actions saw this" })],
+      totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 },
+    }),
+    row("daily-stable-vm", {
+      flaky: [paramFail("anthropic", { error_signature: "Error: only the VM saw this" })],
+      totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 },
+    }),
+  );
+  const text = renderReport(result);
+  assert.match(text, /Actions \[google\] failed: Error: only Actions saw this/);
+  assert.match(text, /VM\s+\[anthropic\] flaky: Error: only the VM saw this/);
 });
 
 test("'unknown' is the absence of a signature, so it never makes a pair agree", () => {

--- a/scripts/compare-lane-verdicts.test.mjs
+++ b/scripts/compare-lane-verdicts.test.mjs
@@ -34,6 +34,7 @@ import {
   testKey,
   specKey,
   isGenericSignature,
+  comparableSignature,
   selectRuns,
   indexOutcomes,
   compareRuns,
@@ -342,6 +343,37 @@ test("an ANSI-wrapped assertion shell is still recognised as a shell", () => {
   // every real row through as if it carried a cause.
   const wrapped = "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22mexpected)";
   assert.equal(isGenericSignature(wrapped), true);
+});
+
+test("'unknown' is the absence of a signature, so it never makes a pair agree", () => {
+  // `append-weekly-history.mjs` writes `unknown` when a failure carries no message,
+  // and its own comment says triage already clustered unrelated specs by matching on
+  // it. 15 of the 764 signatures in reports/daily-history.jsonl are `unknown`, so two
+  // message-less failures of one spec used to fold as the report's strongest claim.
+  const result = compare(
+    row("daily-stable", { failures: [paramFail("google", { error_signature: "unknown" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+    row("daily-stable-vm", { failures: [paramFail("anthropic", { error_signature: "unknown" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  );
+  assert.equal(result.divergences[0].kind, "cross-provider-differs");
+  assert.equal(result.divergences[0].crossProvider.signaturesMatch, false);
+  assert.equal(comparableSignature("unknown"), null);
+  assert.doesNotMatch(renderReport(result), /FAILED the same way/);
+});
+
+test("colorization on one lane only does not split one cause into two", () => {
+  // 255 of the 764 rows carry SGR escapes, and the colorization is environment-derived
+  // — nothing here sets FORCE_COLOR/NO_COLOR and supports-color keys on
+  // GITHUB_ACTIONS, which the VM does not have. Comparing raw strings would invert the
+  // fold into the very false negative it exists to remove.
+  const esc = String.fromCharCode(27);
+  const colorized = `Error: ${esc}[2mexpect(received)${esc}[22m.toBe(expected)`;
+  const plain = "Error: expect(received).toBe(expected)";
+  assert.equal(comparableSignature(colorized), plain);
+  const result = compare(
+    row("daily-stable", { failures: [paramFail("google", { error_signature: colorized })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+    row("daily-stable-vm", { failures: [paramFail("anthropic", { error_signature: plain })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  );
+  assert.equal(result.divergences[0].crossProvider.signaturesMatch, true);
 });
 
 test("a pair that only FLAKED on both providers is never stamped as a failure (Copilot, PR 1767)", () => {

--- a/scripts/compare-lane-verdicts.test.mjs
+++ b/scripts/compare-lane-verdicts.test.mjs
@@ -35,6 +35,7 @@ import {
   specKey,
   isGenericSignature,
   comparableSignature,
+  paramProvider,
   selectRuns,
   indexOutcomes,
   compareRuns,
@@ -249,237 +250,225 @@ test("VM-only failures sort above Actions-only ones, because they are the lane u
 });
 
 // ---------------------------------------------------------------------------
-// The provider split (#1766)
+// The target split (#1766)
 // ---------------------------------------------------------------------------
-// What these protect. The day's provider is resolved at RUN TIME, so the two lanes can
-// pin different ones on the same morning — on 2026-09-08 Actions landed on google and
-// the VM on anthropic, because the shared Anthropic balance drained between the two
-// runs. Keyed with the param, one spec then becomes two identities and a failure BOTH
-// lanes saw is reported as two one-sided differences: a false negative in the one class
-// this comparator exists to find. That morning the report printed
-// `Flaky on BOTH lanes: 0` while holding the evidence of a spec that flaked on both.
+// What these protect. The day's target is resolved at RUN TIME, so the two lanes can
+// run one spec under different targets on the same morning — on 2026-09-08 Actions
+// landed on google/gemini-3.5-flash and the VM on anthropic/claude-haiku-4-5, and a
+// smoke that afternoon settled google/gemini-2.5-flash against the Actions lane's
+// google/gemini-3.5-flash. Keyed with the target, one spec becomes two identities and a
+// failure BOTH lanes saw is reported as two one-sided differences: that morning the
+// report printed `Flaky on BOTH lanes: 0` while holding exactly that evidence.
 //
-// The second thing they protect is the reading of the fold. Agreement across two
-// providers eliminates the provider as the cause. DISAGREEMENT establishes nothing —
-// the implication runs one way only — and a bucket that reads as "provider-specific,
-// dismissed" would turn this file into a way of losing defects.
+// The SECOND thing they protect is that the fold does not conclude. Three review rounds
+// found sixteen defects here and every one was a claim the row could not support:
+// "different providers" over a shared provider, "the provider is eliminated" over an
+// assertion shell, over a failure the harness could not attribute, and over a hard
+// failure paired with a retry. So the tests below pin the ABSENCE of those claims as
+// hard as they pin the fold itself.
 
 const paramFail = (param, over = {}) =>
   fail({ test: "agent interaction suite", file: "tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts", param, ...over });
+
+const oneEach = (ciOver, vmOver, ciTotals = { passed: 9, failed: 1, flaky: 0, skipped: 2 }, vmTotals = ciTotals) => {
+  const key = (t) => (t.failed ? "failures" : "flaky");
+  return compare(
+    row("daily-stable", { [key(ciTotals)]: [ciOver], totals: ciTotals }),
+    row("daily-stable-vm", { [key(vmTotals)]: [vmOver], totals: vmTotals }),
+  );
+};
 
 test("specKey drops the parameterization that testKey keeps", () => {
   assert.notEqual(testKey(paramFail("google")), testKey(paramFail("anthropic")));
   assert.equal(specKey(paramFail("google")), specKey(paramFail("anthropic")));
 });
 
-test("the same spec failing on two providers is ONE cross-provider entry, not two one-sided ones", () => {
-  const result = compare(
-    row("daily-stable", {
-      failures: [paramFail("google / gemini-3.5-flash", { error_signature: "Error: the agent never answered" })],
-      totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 },
-    }),
-    row("daily-stable-vm", {
-      failures: [paramFail("anthropic / claude-haiku-4-5", { error_signature: "Error: the agent never answered" })],
-      totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 },
-    }),
+test("paramProvider reads all three label shapes the corpus carries", () => {
+  assert.equal(paramProvider("google / gemini-3.5-flash"), "google");
+  assert.equal(paramProvider("google"), "google");
+  assert.equal(paramProvider("provider:openai (fallback)"), "openai");
+  assert.equal(paramProvider(null), null);
+  assert.equal(paramProvider(""), null);
+});
+
+test("the same spec under two targets is ONE entry, not two one-sided ones", () => {
+  const result = oneEach(
+    paramFail("google / gemini-3.5-flash", { error_signature: "Error: the agent never answered" }),
+    paramFail("anthropic / claude-haiku-4-5", { error_signature: "Error: the agent never answered" }),
   );
   assert.equal(result.divergences.length, 1);
   const d = result.divergences[0];
-  assert.equal(d.kind, "cross-provider-failed");
+  assert.equal(d.kind, "cross-target-failed");
   assert.deepEqual(d.params, { ci: "google / gemini-3.5-flash", vm: "anthropic / claude-haiku-4-5" });
-  assert.equal(d.crossProvider.signaturesMatch, true);
-  // The name carries no param: the entry IS the pair, and naming one side would read
-  // as the other side being absent.
+  assert.equal(d.crossTarget.signaturesMatch, true);
+  assert.equal(d.crossTarget.providersDiffer, true);
+  // The name carries no target: the entry IS the pair.
   assert.doesNotMatch(d.name, /gemini|claude/);
 });
 
-test("cross-provider agreement is stamped at the head, where it cannot be scrolled past", () => {
-  const result = compare(
-    row("daily-stable", { failures: [paramFail("google", { error_signature: "Error: X" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-    row("daily-stable-vm", { failures: [paramFail("openai", { error_signature: "Error: X" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+test("two models of the SAME provider are not reported as different providers", () => {
+  // The load-bearing defect the cold review found: the only comparison was string
+  // inequality of the whole label, and every claim built on it said "providers". Nine
+  // specs in the series have been recorded under two different google models, and a
+  // 2026-09-08 smoke settled gemini-2.5-flash while the Actions lane pinned 3.5.
+  const result = oneEach(
+    paramFail("google / gemini-3.5-flash", { error_signature: "Error: the agent never answered" }),
+    paramFail("google / gemini-2.5-flash", { error_signature: "Error: the agent never answered" }),
   );
+  const d = result.divergences[0];
+  assert.equal(d.crossTarget.providersDiffer, false);
   const text = renderReport(result);
-  assert.match(text, /FAILED the same way on both lanes under DIFFERENT providers/);
-  assert.match(text, /provider is eliminated as the cause/);
-  // Ranked first: the strongest statement of the day leads the list.
-  assert.equal(result.divergences[0].kind, "cross-provider-failed");
+  assert.match(text, /SAME provider \(google\), different target — the provider is NOT ruled out/);
+  assert.doesNotMatch(text, /providers DIFFER/);
 });
 
-test("different signatures across providers are INCONCLUSIVE, never 'provider-specific'", () => {
-  const result = compare(
-    row("daily-stable", { flaky: [paramFail("google", { error_signature: "Error: MODEL_TOGGLE_WRITE_STALLED" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
-    row("daily-stable-vm", { flaky: [paramFail("anthropic", { error_signature: "Error: credential never settled" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
-  );
-  assert.equal(result.divergences.length, 1);
-  assert.equal(result.divergences[0].kind, "cross-provider-differs");
-  const text = renderReport(result);
-  assert.match(text, /INCONCLUSIVE/);
-  assert.match(text, /do NOT establish that the provider is the cause/);
-  // The head stamp belongs to agreement only — an inconclusive pair must not be
-  // promoted into "the product".
-  assert.doesNotMatch(text, /FAILED the same way on both lanes/);
+test("the fold NEVER stamps the head of the report, whatever it found", () => {
+  // The stamp is the surface that cannot be qualified, and three rounds found it
+  // asserting what the entry beneath it declined to assert. There is no longer one.
+  for (const [ciSig, vmSig] of [
+    ["Error: a real cause", "Error: a real cause"],
+    ["Error: expect(locator).toBeVisible() failed", "Error: expect(locator).toBeVisible() failed"],
+    ["Error: one thing", "Error: another thing"],
+  ]) {
+    const text = renderReport(
+      oneEach(paramFail("google", { error_signature: ciSig }), paramFail("anthropic", { error_signature: vmSig })),
+    );
+    assert.doesNotMatch(text, /^!!/m, `stamped for ${ciSig} / ${vmSig}`);
+    assert.doesNotMatch(text, /eliminated as the cause/);
+    assert.doesNotMatch(text, /they are the product/);
+  }
 });
 
-test("a shared signature that is only an assertion shell is a LEAD, not a confirmation", () => {
-  const shell = "Error: expect(received).toBe(expected) // Object.is equality";
-  assert.equal(isGenericSignature(shell), true);
-  assert.equal(isGenericSignature("Error: expect(received).not.toBeNull()"), true);
-  // Carries a cause of its own, so it is not a shell.
-  assert.equal(isGenericSignature("Error: Agent credential never settled (#751 guard)"), false);
-
+test("a folded pair ranks WITH its severity, never above a genuine two-lane red", () => {
+  // Ranking the fold first was the promotion the cold review caught: a pair that
+  // hard-failed on one lane and flaked on the other outranked a real one-sided red.
+  const other = fail({ test: "traces are listed", file: "tests-automations/regression/api/monitor/api-monitor-traces.spec.ts" });
   const result = compare(
-    row("daily-stable", { failures: [paramFail("google", { error_signature: shell })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-    row("daily-stable-vm", { failures: [paramFail("openai", { error_signature: shell })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+    row("daily-stable", {
+      failures: [paramFail("google", { error_signature: "Error: same" })],
+      totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 },
+    }),
+    row("daily-stable-vm", {
+      failures: [other],
+      flaky: [paramFail("anthropic", { error_signature: "Error: same" })],
+      totals: { passed: 8, failed: 1, flaky: 1, skipped: 2 },
+    }),
   );
-  assert.equal(result.divergences[0].crossProvider.generic, true);
+  assert.deepEqual(
+    result.divergences.map((d) => d.kind),
+    ["vm-only-failed", "cross-target-failed"],
+  );
+});
+
+test("a pair that only flaked on both targets is a flake, and ranks with the flakes", () => {
+  const result = oneEach(
+    paramFail("google", { error_signature: "Error: boom" }),
+    paramFail("anthropic", { error_signature: "Error: boom" }),
+    { passed: 9, failed: 0, flaky: 1, skipped: 2 },
+  );
+  assert.equal(result.divergences[0].kind, "cross-target-flaky");
+  assert.match(renderReport(result), /a retry passed on both/);
+});
+
+test("an infra_signature on ONE side names that side, and does not claim both", () => {
+  // It is an OR, and one-sided is the ordinary case (2026-09-07: one on Actions against
+  // five on the VM). The old text asserted "both sides" and "either lane", contradicting
+  // the per-lane narrowing printed directly above it on the same screen.
+  const result = oneEach(
+    paramFail("google", { error_signature: "Error: same" }),
+    paramFail("anthropic", { error_signature: "Error: same", infra_signature: "api-request-timeout" }),
+  );
+  const d = result.divergences[0];
+  assert.equal(d.crossTarget.infraCi, false);
+  assert.equal(d.crossTarget.infraVm, true);
   const text = renderReport(result);
-  assert.match(text, /LEAD, not a confirmation \(#1626\)/);
-  assert.match(text, /expected\/received pair/);
+  assert.match(text, /an infra_signature is present on the VM:/);
+  // Specific to the infra line: the KIND_LABEL legitimately says "on both lanes",
+  // which is what makes a broad assertion here useless.
+  assert.doesNotMatch(text, /present on both lanes/);
+  assert.doesNotMatch(text, /present on Actions/);
+});
+
+test("an assertion shell says it names no cause, and claims nothing further", () => {
+  const shell = "Error: expect(locator).toBeVisible() failed";
+  const result = oneEach(
+    paramFail("google", { error_signature: shell }),
+    paramFail("anthropic", { error_signature: shell }),
+  );
+  assert.equal(result.divergences[0].crossTarget.generic, true);
+  const text = renderReport(result);
+  assert.match(text, /signatures match, but the shared one is an assertion shell: it names no cause/);
+  assert.doesNotMatch(text, /LEAD/);
 });
 
 test("a locator assertion is a shell too - it is the suite's most frequent signature", () => {
   // Requiring `expect(received)` covered the minority: measured over both series,
   // `expect(locator)` shells are 158 of 764 signatures against 97, and
-  // `expect(locator).toBeVisible() failed` alone is 115. A pair agreeing only on "some
-  // locator was not visible" was taking the head stamp with no caveat.
+  // `expect(locator).toBeVisible() failed` alone is 115.
   assert.equal(isGenericSignature("Error: expect(locator).toBeVisible() failed"), true);
   assert.equal(isGenericSignature("Error: expect(locator).toHaveCount(expected) failed"), true);
-  assert.equal(isGenericSignature("Error: expect(locator).toHaveAttribute(expected) failed"), true);
+  assert.equal(isGenericSignature("Error: expect(received).not.toBeNull()"), true);
   // Still not a shell: it names its own cause.
   assert.equal(isGenericSignature("Error: setupPlayground: a canvas edit never reached the database"), false);
 });
 
-test("an ANSI-wrapped assertion shell is still recognised as a shell", () => {
-  // The rows carry raw escapes: the shells in reports/daily-history.jsonl look like
-  // `Error: \u001b[2mexpect(\u001b[22m…`. Matching the plain string only would let
-  // every real row through as if it carried a cause.
-  const wrapped = "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22mexpected)";
-  assert.equal(isGenericSignature(wrapped), true);
-});
-
 test("'unknown' is the absence of a signature, so it never makes a pair agree", () => {
-  // `append-weekly-history.mjs` writes `unknown` when a failure carries no message,
-  // and its own comment says triage already clustered unrelated specs by matching on
-  // it. 15 of the 764 signatures in reports/daily-history.jsonl are `unknown`, so two
-  // message-less failures of one spec used to fold as the report's strongest claim.
-  const result = compare(
-    row("daily-stable", { failures: [paramFail("google", { error_signature: "unknown" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-    row("daily-stable-vm", { failures: [paramFail("anthropic", { error_signature: "unknown" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  // `append-weekly-history.mjs` writes `unknown` when a failure carries no message, and
+  // its own comment says triage already clustered unrelated specs by matching on it.
+  // 15 of the 764 signatures in reports/daily-history.jsonl are `unknown`.
+  const result = oneEach(
+    paramFail("google", { error_signature: "unknown" }),
+    paramFail("anthropic", { error_signature: "unknown" }),
   );
-  assert.equal(result.divergences[0].kind, "cross-provider-differs");
-  assert.equal(result.divergences[0].crossProvider.signaturesMatch, false);
+  assert.equal(result.divergences[0].crossTarget.signaturesMatch, false);
   assert.equal(comparableSignature("unknown"), null);
-  assert.doesNotMatch(renderReport(result), /FAILED the same way/);
+  assert.match(renderReport(result), /signatures do NOT match \(or one is absent\)/);
 });
 
 test("colorization on one lane only does not split one cause into two", () => {
-  // 255 of the 764 rows carry SGR escapes, and the colorization is environment-derived
-  // — nothing here sets FORCE_COLOR/NO_COLOR and supports-color keys on
-  // GITHUB_ACTIONS, which the VM does not have. Comparing raw strings would invert the
-  // fold into the very false negative it exists to remove.
+  // 255 of the 764 rows carry SGR escapes, and the colorization is environment-derived —
+  // nothing here sets FORCE_COLOR/NO_COLOR and supports-color keys on GITHUB_ACTIONS,
+  // which the VM does not have.
   const esc = String.fromCharCode(27);
   const colorized = `Error: ${esc}[2mexpect(received)${esc}[22m.toBe(expected)`;
   const plain = "Error: expect(received).toBe(expected)";
   assert.equal(comparableSignature(colorized), plain);
-  const result = compare(
-    row("daily-stable", { failures: [paramFail("google", { error_signature: colorized })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-    row("daily-stable-vm", { failures: [paramFail("anthropic", { error_signature: plain })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  const result = oneEach(
+    paramFail("google", { error_signature: colorized }),
+    paramFail("anthropic", { error_signature: plain }),
   );
-  assert.equal(result.divergences[0].crossProvider.signaturesMatch, true);
+  assert.equal(result.divergences[0].crossTarget.signaturesMatch, true);
 });
 
-test("a pair that only FLAKED on both providers is never stamped as a failure (Copilot, PR 1767)", () => {
-  // The stamp used to say "failed the SAME way … they are the product" over two
-  // retries that passed. This file already split `agreed` into failed/flaky because
-  // one heading over both makes a reader at 09:00 count a retry as a hard failure;
-  // the fold reintroduced exactly that, one layer up. Reproduced before fixing.
-  const result = compare(
-    row("daily-stable", { flaky: [paramFail("google", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
-    row("daily-stable-vm", { flaky: [paramFail("anthropic", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
+test("the two BOTH-lanes tallies keep their meaning, and the pairs get a line of their own", () => {
+  // Adding pairs to those tallies is how an infra pair and a shell pair ended up
+  // counted under "the product, not the environment". Leaving them uncounted is how a
+  // day whose only finding was a pair ended with two zeroes and no mention of it.
+  const result = oneEach(
+    paramFail("google", { error_signature: "Error: same", infra_signature: "api-request-timeout" }),
+    paramFail("anthropic", { error_signature: "Error: same", infra_signature: "api-request-timeout" }),
   );
-  assert.equal(result.divergences.length, 1);
-  assert.equal(result.divergences[0].kind, "cross-provider-flaky");
   const text = renderReport(result);
-  assert.doesNotMatch(text, /FAILED the same way/);
-  assert.match(text, /flaked the same way on both lanes under DIFFERENT providers/);
-  assert.match(text, /not a hard failure/);
+  assert.match(text, /Failed on BOTH lanes \(the product, not the environment\): 0\n/);
+  assert.match(text, /Same spec, DIFFERENT targets \(counted in neither tally above\): 1/);
+  assert.match(text, /agent-component-regression/);
 });
 
-test("a pair that failed on one lane and flaked on the other counts as a hard failure", () => {
-  // Mixed severity reaches the fold — both kinds are one-sided entries — and the side
-  // that failed is what decides. Silence about it would be the same overclaim pointed
-  // the other way: a real red ranked among the retries.
-  const result = compare(
-    row("daily-stable", { failures: [paramFail("google", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-    row("daily-stable-vm", { flaky: [paramFail("anthropic", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
-  );
-  assert.equal(result.divergences[0].kind, "cross-provider-failed");
-  const text = renderReport(result);
-  assert.match(text, /FAILED the same way/);
-  // Both statuses printed: the reader has to be able to see it was mixed.
-  assert.match(text, /Actions \[google\] failed:/);
-  assert.match(text, /VM\s+\[anthropic\] flaky:/);
+test("a day with no folded pair says zero, not nothing", () => {
+  const text = renderReport(compare(row("daily-stable"), row("daily-stable-vm")));
+  assert.match(text, /Same spec, DIFFERENT targets \(counted in neither tally above\): 0/);
 });
 
-test("the folded entry carries the tags of BOTH sides, not the CI side's empty array (Copilot, PR 1767)", () => {
+test("the folded entry carries the tags of BOTH sides, not the CI side's empty array", () => {
   // `??` falls through on null, not on `[]`, so a CI entry tagged `[]` erased tags the
   // VM entry had. The lanes can sit one commit apart, which is how the two sides come
   // to disagree about tags at all — PR 1745 restored `@stable` to four specs between
   // two runs — and `--json` consumers filter on this field.
-  const result = compare(
-    row("daily-stable", { failures: [paramFail("google", { error_signature: "Error: X", tags: [] })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-    row("daily-stable-vm", { failures: [paramFail("anthropic", { error_signature: "Error: X", tags: ["stable", "agents"] })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  const result = oneEach(
+    paramFail("google", { error_signature: "Error: X", tags: [] }),
+    paramFail("anthropic", { error_signature: "Error: X", tags: ["stable", "agents"] }),
   );
   assert.deepEqual(result.divergences[0].tags, ["stable", "agents"]);
-});
-
-test("a shell pair is listed but NEVER headlined: the stamp cannot outrank the entry", () => {
-  // The stamp exists so it cannot be scrolled past, so it must not promote what the
-  // body refuses. It used to print "they are the product" above an entry whose own
-  // text read "a LEAD, not a confirmation".
-  const shell = "Error: expect(locator).toBeVisible() failed";
-  const result = compare(
-    row("daily-stable", { failures: [paramFail("google", { error_signature: shell })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-    row("daily-stable-vm", { failures: [paramFail("anthropic", { error_signature: shell })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-  );
-  assert.equal(result.divergences[0].crossProvider.confirmable, false);
-  const text = renderReport(result);
-  assert.doesNotMatch(text, /they are the product/);
-  assert.match(text, /cannot carry the claim/);
-  assert.match(text, /LEAD, not a confirmation/);
-});
-
-test("a pair both lanes could not attribute to the spec is not the product either", () => {
-  // compareRuns already warns that an infra_signature means the harness could not
-  // reach the backend. 42 of the 764 entries carry one, and the same timeout string is
-  // 37 occurrences — a wedged container on one lane plus a blip on the other was
-  // taking rank 0 and the "product" stamp.
-  const sig = "TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.";
-  const result = compare(
-    row("daily-stable", { failures: [paramFail("google", { error_signature: sig, infra_signature: "api-request-timeout" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-    row("daily-stable-vm", { failures: [paramFail("anthropic", { error_signature: sig, infra_signature: "api-request-timeout" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-  );
-  const d = result.divergences[0];
-  assert.equal(d.crossProvider.infra, true);
-  assert.equal(d.crossProvider.confirmable, false);
-  const text = renderReport(result);
-  assert.doesNotMatch(text, /they are the product/);
-  assert.match(text, /could not reach the backend/);
-});
-
-test("the foot-of-report tallies count the cross-provider pairs too", () => {
-  // Those two lines are read as the day's product-defect tally. A day whose only
-  // finding was a cross-provider pair used to end with `Flaky on BOTH lanes: 0` —
-  // the PR's own complaint, still true for anyone reading the tally.
-  const result = compare(
-    row("daily-stable", { flaky: [paramFail("google", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
-    row("daily-stable-vm", { flaky: [paramFail("anthropic", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
-  );
-  const text = renderReport(result);
-  assert.match(text, /Flaky on BOTH lanes[^\n]*: 0 \(\+1 as cross-provider pair\(s\), listed above\)/);
-  // And a day with none of them keeps the line clean.
-  const plain = compare(row("daily-stable"), row("daily-stable-vm"));
-  assert.match(renderReport(plain), /Flaky on BOTH lanes[^\n]*: 0\n/);
 });
 
 test("three one-sided entries for one spec do NOT fold: which pairs with which is a guess", () => {
@@ -491,7 +480,7 @@ test("three one-sided entries for one spec do NOT fold: which pairs with which i
     row("daily-stable-vm", { failures: [paramFail("anthropic")], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
   );
   assert.equal(result.divergences.length, 3);
-  assert.equal(result.divergences.filter((d) => d.kind.startsWith("cross-provider")).length, 0);
+  assert.equal(result.divergences.filter((d) => d.kind.startsWith("cross-target")).length, 0);
 });
 
 test("two one-sided entries from the SAME lane are not a pair", () => {
@@ -506,20 +495,18 @@ test("two one-sided entries from the SAME lane are not a pair", () => {
   assert.deepEqual(result.divergences.map((d) => d.kind), ["ci-only-failed", "ci-only-failed"]);
 });
 
-test("a spec parameterized on one lane only still folds, and the report names the empty side", () => {
-  // Real shape: the VM's catalog was frozen empty, so its variant carries no param
-  // while the Actions one does. Refusing to fold here would report the same spec twice.
-  const result = compare(
-    row("daily-stable", { failures: [paramFail("google", { error_signature: "Error: X" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
-    row("daily-stable-vm", { failures: [paramFail(undefined, { error_signature: "Error: X" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+test("a spec targeted on one lane only still folds, and the report names the empty side", () => {
+  const result = oneEach(
+    paramFail("google", { error_signature: "Error: X" }),
+    paramFail(undefined, { error_signature: "Error: X" }),
   );
   assert.equal(result.divergences.length, 1);
-  assert.equal(result.divergences[0].kind, "cross-provider-failed");
-  assert.match(renderReport(result), /VM\s+\[no param\]/);
+  assert.equal(result.divergences[0].kind, "cross-target-failed");
+  assert.match(renderReport(result), /VM\s+\[no target\]/);
 });
 
 test("pairing leaves an unparameterized one-sided failure alone", () => {
-  // The traces family carries no param, and the VM fails all of it every day while
+  // The traces family carries no target, and the VM fails all of it every day while
   // Actions passes it. Folding anything there would erase divergence nº 4.
   const result = compare(
     row("daily-stable"),

--- a/scripts/compare-lane-verdicts.test.mjs
+++ b/scripts/compare-lane-verdicts.test.mjs
@@ -433,6 +433,40 @@ test("the folded entry carries the tags of BOTH sides, not the CI side's empty a
   assert.deepEqual(result.divergences[0].tags, ["stable", "agents"]);
 });
 
+test("a shell pair is listed but NEVER headlined: the stamp cannot outrank the entry", () => {
+  // The stamp exists so it cannot be scrolled past, so it must not promote what the
+  // body refuses. It used to print "they are the product" above an entry whose own
+  // text read "a LEAD, not a confirmation".
+  const shell = "Error: expect(locator).toBeVisible() failed";
+  const result = compare(
+    row("daily-stable", { failures: [paramFail("google", { error_signature: shell })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+    row("daily-stable-vm", { failures: [paramFail("anthropic", { error_signature: shell })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  );
+  assert.equal(result.divergences[0].crossProvider.confirmable, false);
+  const text = renderReport(result);
+  assert.doesNotMatch(text, /they are the product/);
+  assert.match(text, /cannot carry the claim/);
+  assert.match(text, /LEAD, not a confirmation/);
+});
+
+test("a pair both lanes could not attribute to the spec is not the product either", () => {
+  // compareRuns already warns that an infra_signature means the harness could not
+  // reach the backend. 42 of the 764 entries carry one, and the same timeout string is
+  // 37 occurrences — a wedged container on one lane plus a blip on the other was
+  // taking rank 0 and the "product" stamp.
+  const sig = "TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.";
+  const result = compare(
+    row("daily-stable", { failures: [paramFail("google", { error_signature: sig, infra_signature: "api-request-timeout" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+    row("daily-stable-vm", { failures: [paramFail("anthropic", { error_signature: sig, infra_signature: "api-request-timeout" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  );
+  const d = result.divergences[0];
+  assert.equal(d.crossProvider.infra, true);
+  assert.equal(d.crossProvider.confirmable, false);
+  const text = renderReport(result);
+  assert.doesNotMatch(text, /they are the product/);
+  assert.match(text, /could not reach the backend/);
+});
+
 test("three one-sided entries for one spec do NOT fold: which pairs with which is a guess", () => {
   const result = compare(
     row("daily-stable", {

--- a/scripts/compare-lane-verdicts.test.mjs
+++ b/scripts/compare-lane-verdicts.test.mjs
@@ -467,6 +467,21 @@ test("a pair both lanes could not attribute to the spec is not the product eithe
   assert.match(text, /could not reach the backend/);
 });
 
+test("the foot-of-report tallies count the cross-provider pairs too", () => {
+  // Those two lines are read as the day's product-defect tally. A day whose only
+  // finding was a cross-provider pair used to end with `Flaky on BOTH lanes: 0` —
+  // the PR's own complaint, still true for anyone reading the tally.
+  const result = compare(
+    row("daily-stable", { flaky: [paramFail("google", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
+    row("daily-stable-vm", { flaky: [paramFail("anthropic", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
+  );
+  const text = renderReport(result);
+  assert.match(text, /Flaky on BOTH lanes[^\n]*: 0 \(\+1 as cross-provider pair\(s\), listed above\)/);
+  // And a day with none of them keeps the line clean.
+  const plain = compare(row("daily-stable"), row("daily-stable-vm"));
+  assert.match(renderReport(plain), /Flaky on BOTH lanes[^\n]*: 0\n/);
+});
+
 test("three one-sided entries for one spec do NOT fold: which pairs with which is a guess", () => {
   const result = compare(
     row("daily-stable", {

--- a/scripts/compare-lane-verdicts.test.mjs
+++ b/scripts/compare-lane-verdicts.test.mjs
@@ -344,6 +344,18 @@ test("an ANSI-wrapped assertion shell is still recognised as a shell", () => {
   assert.equal(isGenericSignature(wrapped), true);
 });
 
+test("the folded entry carries the tags of BOTH sides, not the CI side's empty array (Copilot, PR 1767)", () => {
+  // `??` falls through on null, not on `[]`, so a CI entry tagged `[]` erased tags the
+  // VM entry had. The lanes can sit one commit apart, which is how the two sides come
+  // to disagree about tags at all — PR 1745 restored `@stable` to four specs between
+  // two runs — and `--json` consumers filter on this field.
+  const result = compare(
+    row("daily-stable", { failures: [paramFail("google", { error_signature: "Error: X", tags: [] })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+    row("daily-stable-vm", { failures: [paramFail("anthropic", { error_signature: "Error: X", tags: ["stable", "agents"] })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  );
+  assert.deepEqual(result.divergences[0].tags, ["stable", "agents"]);
+});
+
 test("three one-sided entries for one spec do NOT fold: which pairs with which is a guess", () => {
   const result = compare(
     row("daily-stable", {

--- a/scripts/compare-lane-verdicts.test.mjs
+++ b/scripts/compare-lane-verdicts.test.mjs
@@ -32,6 +32,8 @@ import {
   parseHistory,
   mergeEntries,
   testKey,
+  specKey,
+  isGenericSignature,
   selectRuns,
   indexOutcomes,
   compareRuns,
@@ -243,6 +245,150 @@ test("VM-only failures sort above Actions-only ones, because they are the lane u
     result.divergences.map((d) => d.kind),
     ["vm-only-failed", "ci-only-failed"],
   );
+});
+
+// ---------------------------------------------------------------------------
+// The provider split (#1766)
+// ---------------------------------------------------------------------------
+// What these protect. The day's provider is resolved at RUN TIME, so the two lanes can
+// pin different ones on the same morning — on 2026-09-08 Actions landed on google and
+// the VM on anthropic, because the shared Anthropic balance drained between the two
+// runs. Keyed with the param, one spec then becomes two identities and a failure BOTH
+// lanes saw is reported as two one-sided differences: a false negative in the one class
+// this comparator exists to find. That morning the report printed
+// `Flaky on BOTH lanes: 0` while holding the evidence of a spec that flaked on both.
+//
+// The second thing they protect is the reading of the fold. Agreement across two
+// providers eliminates the provider as the cause. DISAGREEMENT establishes nothing —
+// the implication runs one way only — and a bucket that reads as "provider-specific,
+// dismissed" would turn this file into a way of losing defects.
+
+const paramFail = (param, over = {}) =>
+  fail({ test: "agent interaction suite", file: "tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts", param, ...over });
+
+test("specKey drops the parameterization that testKey keeps", () => {
+  assert.notEqual(testKey(paramFail("google")), testKey(paramFail("anthropic")));
+  assert.equal(specKey(paramFail("google")), specKey(paramFail("anthropic")));
+});
+
+test("the same spec failing on two providers is ONE cross-provider entry, not two one-sided ones", () => {
+  const result = compare(
+    row("daily-stable", {
+      failures: [paramFail("google / gemini-3.5-flash", { error_signature: "Error: the agent never answered" })],
+      totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 },
+    }),
+    row("daily-stable-vm", {
+      failures: [paramFail("anthropic / claude-haiku-4-5", { error_signature: "Error: the agent never answered" })],
+      totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 },
+    }),
+  );
+  assert.equal(result.divergences.length, 1);
+  const d = result.divergences[0];
+  assert.equal(d.kind, "cross-provider-agreed");
+  assert.deepEqual(d.params, { ci: "google / gemini-3.5-flash", vm: "anthropic / claude-haiku-4-5" });
+  assert.equal(d.crossProvider.signaturesMatch, true);
+  // The name carries no param: the entry IS the pair, and naming one side would read
+  // as the other side being absent.
+  assert.doesNotMatch(d.name, /gemini|claude/);
+});
+
+test("cross-provider agreement is stamped at the head, where it cannot be scrolled past", () => {
+  const result = compare(
+    row("daily-stable", { failures: [paramFail("google", { error_signature: "Error: X" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+    row("daily-stable-vm", { failures: [paramFail("openai", { error_signature: "Error: X" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  );
+  const text = renderReport(result);
+  assert.match(text, /failed the SAME way on both lanes under DIFFERENT providers/);
+  assert.match(text, /provider is eliminated as the cause/);
+  // Ranked first: the strongest statement of the day leads the list.
+  assert.equal(result.divergences[0].kind, "cross-provider-agreed");
+});
+
+test("different signatures across providers are INCONCLUSIVE, never 'provider-specific'", () => {
+  const result = compare(
+    row("daily-stable", { flaky: [paramFail("google", { error_signature: "Error: MODEL_TOGGLE_WRITE_STALLED" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
+    row("daily-stable-vm", { flaky: [paramFail("anthropic", { error_signature: "Error: credential never settled" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
+  );
+  assert.equal(result.divergences.length, 1);
+  assert.equal(result.divergences[0].kind, "cross-provider-differs");
+  const text = renderReport(result);
+  assert.match(text, /INCONCLUSIVE/);
+  assert.match(text, /do NOT establish that the provider is the cause/);
+  // The head stamp belongs to agreement only — an inconclusive pair must not be
+  // promoted into "the product".
+  assert.doesNotMatch(text, /failed the SAME way on both lanes/);
+});
+
+test("a shared signature that is only an assertion shell is a LEAD, not a confirmation", () => {
+  const shell = "Error: expect(received).toBe(expected) // Object.is equality";
+  assert.equal(isGenericSignature(shell), true);
+  assert.equal(isGenericSignature("Error: expect(received).not.toBeNull()"), true);
+  // Carries a cause of its own, so it is not a shell.
+  assert.equal(isGenericSignature("Error: Agent credential never settled (#751 guard)"), false);
+
+  const result = compare(
+    row("daily-stable", { failures: [paramFail("google", { error_signature: shell })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+    row("daily-stable-vm", { failures: [paramFail("openai", { error_signature: shell })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  );
+  assert.equal(result.divergences[0].crossProvider.generic, true);
+  const text = renderReport(result);
+  assert.match(text, /LEAD, not a confirmation \(#1626\)/);
+  assert.match(text, /expected\/received pair/);
+});
+
+test("an ANSI-wrapped assertion shell is still recognised as a shell", () => {
+  // The rows carry raw escapes: the shells in reports/daily-history.jsonl look like
+  // `Error: \u001b[2mexpect(\u001b[22m…`. Matching the plain string only would let
+  // every real row through as if it carried a cause.
+  const wrapped = "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22mexpected)";
+  assert.equal(isGenericSignature(wrapped), true);
+});
+
+test("three one-sided entries for one spec do NOT fold: which pairs with which is a guess", () => {
+  const result = compare(
+    row("daily-stable", {
+      failures: [paramFail("google"), paramFail("openai")],
+      totals: { passed: 8, failed: 2, flaky: 0, skipped: 2 },
+    }),
+    row("daily-stable-vm", { failures: [paramFail("anthropic")], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  );
+  assert.equal(result.divergences.length, 3);
+  assert.equal(result.divergences.filter((d) => d.kind.startsWith("cross-provider")).length, 0);
+});
+
+test("two one-sided entries from the SAME lane are not a pair", () => {
+  const result = compare(
+    row("daily-stable", {
+      failures: [paramFail("google"), paramFail("openai")],
+      totals: { passed: 8, failed: 2, flaky: 0, skipped: 2 },
+    }),
+    row("daily-stable-vm"),
+  );
+  assert.equal(result.divergences.length, 2);
+  assert.deepEqual(result.divergences.map((d) => d.kind), ["ci-only-failed", "ci-only-failed"]);
+});
+
+test("a spec parameterized on one lane only still folds, and the report names the empty side", () => {
+  // Real shape: the VM's catalog was frozen empty, so its variant carries no param
+  // while the Actions one does. Refusing to fold here would report the same spec twice.
+  const result = compare(
+    row("daily-stable", { failures: [paramFail("google", { error_signature: "Error: X" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+    row("daily-stable-vm", { failures: [paramFail(undefined, { error_signature: "Error: X" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  );
+  assert.equal(result.divergences.length, 1);
+  assert.equal(result.divergences[0].kind, "cross-provider-agreed");
+  assert.match(renderReport(result), /VM\s+\[no param\]/);
+});
+
+test("pairing leaves an unparameterized one-sided failure alone", () => {
+  // The traces family carries no param, and the VM fails all of it every day while
+  // Actions passes it. Folding anything there would erase divergence nº 4.
+  const result = compare(
+    row("daily-stable"),
+    row("daily-stable-vm", { failures: [fail()], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+  );
+  assert.equal(result.divergences.length, 1);
+  assert.equal(result.divergences[0].kind, "vm-only-failed");
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/compare-lane-verdicts.test.mjs
+++ b/scripts/compare-lane-verdicts.test.mjs
@@ -284,7 +284,7 @@ test("the same spec failing on two providers is ONE cross-provider entry, not tw
   );
   assert.equal(result.divergences.length, 1);
   const d = result.divergences[0];
-  assert.equal(d.kind, "cross-provider-agreed");
+  assert.equal(d.kind, "cross-provider-failed");
   assert.deepEqual(d.params, { ci: "google / gemini-3.5-flash", vm: "anthropic / claude-haiku-4-5" });
   assert.equal(d.crossProvider.signaturesMatch, true);
   // The name carries no param: the entry IS the pair, and naming one side would read
@@ -298,10 +298,10 @@ test("cross-provider agreement is stamped at the head, where it cannot be scroll
     row("daily-stable-vm", { failures: [paramFail("openai", { error_signature: "Error: X" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
   );
   const text = renderReport(result);
-  assert.match(text, /failed the SAME way on both lanes under DIFFERENT providers/);
+  assert.match(text, /FAILED the same way on both lanes under DIFFERENT providers/);
   assert.match(text, /provider is eliminated as the cause/);
   // Ranked first: the strongest statement of the day leads the list.
-  assert.equal(result.divergences[0].kind, "cross-provider-agreed");
+  assert.equal(result.divergences[0].kind, "cross-provider-failed");
 });
 
 test("different signatures across providers are INCONCLUSIVE, never 'provider-specific'", () => {
@@ -316,7 +316,7 @@ test("different signatures across providers are INCONCLUSIVE, never 'provider-sp
   assert.match(text, /do NOT establish that the provider is the cause/);
   // The head stamp belongs to agreement only — an inconclusive pair must not be
   // promoted into "the product".
-  assert.doesNotMatch(text, /failed the SAME way on both lanes/);
+  assert.doesNotMatch(text, /FAILED the same way on both lanes/);
 });
 
 test("a shared signature that is only an assertion shell is a LEAD, not a confirmation", () => {
@@ -342,6 +342,39 @@ test("an ANSI-wrapped assertion shell is still recognised as a shell", () => {
   // every real row through as if it carried a cause.
   const wrapped = "Error: \u001b[2mexpect(\u001b[22m\u001b[31mreceived\u001b[39m\u001b[2m).\u001b[22mtoBe\u001b[2m(\u001b[22mexpected)";
   assert.equal(isGenericSignature(wrapped), true);
+});
+
+test("a pair that only FLAKED on both providers is never stamped as a failure (Copilot, PR 1767)", () => {
+  // The stamp used to say "failed the SAME way … they are the product" over two
+  // retries that passed. This file already split `agreed` into failed/flaky because
+  // one heading over both makes a reader at 09:00 count a retry as a hard failure;
+  // the fold reintroduced exactly that, one layer up. Reproduced before fixing.
+  const result = compare(
+    row("daily-stable", { flaky: [paramFail("google", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
+    row("daily-stable-vm", { flaky: [paramFail("anthropic", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
+  );
+  assert.equal(result.divergences.length, 1);
+  assert.equal(result.divergences[0].kind, "cross-provider-flaky");
+  const text = renderReport(result);
+  assert.doesNotMatch(text, /FAILED the same way/);
+  assert.match(text, /flaked the same way on both lanes under DIFFERENT providers/);
+  assert.match(text, /not a hard failure/);
+});
+
+test("a pair that failed on one lane and flaked on the other counts as a hard failure", () => {
+  // Mixed severity reaches the fold — both kinds are one-sided entries — and the side
+  // that failed is what decides. Silence about it would be the same overclaim pointed
+  // the other way: a real red ranked among the retries.
+  const result = compare(
+    row("daily-stable", { failures: [paramFail("google", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
+    row("daily-stable-vm", { flaky: [paramFail("anthropic", { error_signature: "Error: boom" })], totals: { passed: 9, failed: 0, flaky: 1, skipped: 2 } }),
+  );
+  assert.equal(result.divergences[0].kind, "cross-provider-failed");
+  const text = renderReport(result);
+  assert.match(text, /FAILED the same way/);
+  // Both statuses printed: the reader has to be able to see it was mixed.
+  assert.match(text, /Actions \[google\] failed:/);
+  assert.match(text, /VM\s+\[anthropic\] flaky:/);
 });
 
 test("the folded entry carries the tags of BOTH sides, not the CI side's empty array (Copilot, PR 1767)", () => {
@@ -388,7 +421,7 @@ test("a spec parameterized on one lane only still folds, and the report names th
     row("daily-stable-vm", { failures: [paramFail(undefined, { error_signature: "Error: X" })], totals: { passed: 9, failed: 1, flaky: 0, skipped: 2 } }),
   );
   assert.equal(result.divergences.length, 1);
-  assert.equal(result.divergences[0].kind, "cross-provider-agreed");
+  assert.equal(result.divergences[0].kind, "cross-provider-failed");
   assert.match(renderReport(result), /VM\s+\[no param\]/);
 });
 

--- a/scripts/compare-lane-verdicts.test.mjs
+++ b/scripts/compare-lane-verdicts.test.mjs
@@ -337,6 +337,18 @@ test("a shared signature that is only an assertion shell is a LEAD, not a confir
   assert.match(text, /expected\/received pair/);
 });
 
+test("a locator assertion is a shell too - it is the suite's most frequent signature", () => {
+  // Requiring `expect(received)` covered the minority: measured over both series,
+  // `expect(locator)` shells are 158 of 764 signatures against 97, and
+  // `expect(locator).toBeVisible() failed` alone is 115. A pair agreeing only on "some
+  // locator was not visible" was taking the head stamp with no caveat.
+  assert.equal(isGenericSignature("Error: expect(locator).toBeVisible() failed"), true);
+  assert.equal(isGenericSignature("Error: expect(locator).toHaveCount(expected) failed"), true);
+  assert.equal(isGenericSignature("Error: expect(locator).toHaveAttribute(expected) failed"), true);
+  // Still not a shell: it names its own cause.
+  assert.equal(isGenericSignature("Error: setupPlayground: a canvas edit never reached the database"), false);
+});
+
 test("an ANSI-wrapped assertion shell is still recognised as a shell", () => {
   // The rows carry raw escapes: the shells in reports/daily-history.jsonl look like
   // `Error: \u001b[2mexpect(\u001b[22m…`. Matching the plain string only would let

--- a/scripts/lib/lane-verdict-diff.mjs
+++ b/scripts/lib/lane-verdict-diff.mjs
@@ -238,6 +238,16 @@ export function pairCrossProvider(divergences) {
     const vmErr = comparableSignature(vm.vm?.error);
     const signaturesMatch = Boolean(ciErr) && ciErr === vmErr;
     const generic = signaturesMatch && isGenericSignature(ciErr);
+    // `compareRuns` already warns that a failure carrying an infra_signature means the
+    // harness could not reach the backend, "so they are not attributable to the spec
+    // that reported them". Two of those with one signature — the same timeout string
+    // is 37 occurrences, and 42 of 764 entries carry an infra_signature — folded to
+    // rank 0 and were headlined as the product: a wedged container on one lane plus a
+    // network blip on the other, sold as the strongest claim in the report.
+    const infra = Boolean(ci.ci?.infra || vm.vm?.infra);
+    // What the head stamp is allowed to promote: a match that names a cause AND is
+    // attributable to the spec. Everything else is listed, never headlined.
+    const confirmable = signaturesMatch && !generic && !infra;
 
     folded.add(ci);
     folded.add(vm);
@@ -261,7 +271,7 @@ export function pairCrossProvider(divergences) {
         : hardFailure(ci.ci, vm.vm)
           ? "cross-provider-failed"
           : "cross-provider-flaky",
-      crossProvider: { signaturesMatch, generic },
+      crossProvider: { signaturesMatch, generic, infra, confirmable },
     });
   }
 
@@ -586,11 +596,23 @@ export function renderReport(result, { sources = [] } = {}) {
   // make cannot live only inside a list a reader scrolls.
   const crossFailed = divergences.filter((d) => d.kind === "cross-provider-failed");
   const crossFlaky = divergences.filter((d) => d.kind === "cross-provider-flaky");
-  if (crossFailed.length) {
+  // The stamp exists so it CANNOT be scrolled past, which is exactly why it must not
+  // promote what the entry below it refuses: an unfiltered count headlined "the
+  // product" over a pair whose own body said "a LEAD, not a confirmation".
+  const headlined = crossFailed.filter((d) => d.crossProvider?.confirmable);
+  const qualified = crossFailed.filter((d) => !d.crossProvider?.confirmable);
+  if (headlined.length) {
     L.push(
       "",
-      `!! ${crossFailed.length} spec(s) FAILED the same way on both lanes under DIFFERENT providers.`,
+      `!! ${headlined.length} spec(s) FAILED the same way on both lanes under DIFFERENT providers.`,
       "   The provider is eliminated as the cause for those - read them first, they are the product.",
+    );
+  }
+  if (qualified.length) {
+    L.push(
+      "",
+      `!! ${qualified.length} more cross-provider pair(s) agree on a signature that cannot carry the claim -`,
+      "   an assertion shell, or a failure the harness could not attribute to the spec. Listed, not headlined.",
     );
   }
   // Its own line, and it never says "failed": both lanes retried and passed. Worth the
@@ -643,6 +665,11 @@ export function renderReport(result, { sources = [] } = {}) {
           L.push(
             "      the shared signature is an assertion shell, so this is a LEAD, not a confirmation (#1626):",
             "      read the expected/received pair out of each run's results.json before calling it one cause.",
+          );
+        } else if (d.crossProvider?.infra) {
+          L.push(
+            "      both sides carry an infra_signature: the harness could not reach the backend, so the",
+            "      shared signature is not attributable to this spec on either lane (see the narrowing above).",
           );
         } else if (d.crossProvider?.signaturesMatch) {
           L.push("      the provider is eliminated as the cause: it reproduced on both.");

--- a/scripts/lib/lane-verdict-diff.mjs
+++ b/scripts/lib/lane-verdict-diff.mjs
@@ -183,16 +183,33 @@ export function isGenericSignature(signature) {
  * cross-provider entry.
  *
  * Only an exact pair folds — one entry from each lane. Three or more one-sided entries
- * for one spec means a lane ran two parameterizations of it, and which pairs with which
- * is then a guess; the honest outcome is to leave them alone rather than invent a
+ * for one spec means SOME lane ran more than one parameterization, and which pairs with
+ * which is then a guess; the honest outcome is to leave them alone rather than invent a
  * pairing the row cannot support.
  *
- * The fold does NOT decide whether the provider was the cause. It produces two kinds:
+ * Exactly two is not a guarantee of the scheduled shape, and the limit is stated rather
+ * than assumed. On a run with the day's provider pinned, two entries ARE the two lanes'
+ * one variant each. Under `ALL_MODELS=true` or an explicit `MODEL_TEST_PROVIDER`,
+ * `resolveTestTargets` returns several targets, so two entries can also be both lanes
+ * failing a DIFFERENT variant — and folding then describes one pair where there were
+ * two findings. Nothing here can tell those apart: the row does not carry which
+ * provider the lane pinned, which is the field #1731 has to land before this can be
+ * checked. What the fold guarantees meanwhile is that nothing is lost — both params and
+ * both signatures are printed on the entry — and the two are ranked as INCONCLUSIVE,
+ * which is what two unexplained one-sided findings deserve anyway.
  *
- *  - `cross-provider-agreed`   same signature on both providers. The provider is
- *                              eliminated as the cause: this is the product. Ranked
- *                              first, because it is the strongest thing this file can
- *                              say and it must not be scrolled past.
+ * The fold does NOT decide whether the provider was the cause. It produces three kinds:
+ *
+ *  - `cross-provider-failed`   same signature, hard failure on at least one lane. The
+ *                              provider is eliminated as the cause: this is the
+ *                              product. Ranked first, and the only kind the head stamp
+ *                              promotes — and only when the match is CONFIRMABLE: not
+ *                              an assertion shell, and not a failure the harness could
+ *                              not attribute to the spec.
+ *  - `cross-provider-flaky`    same signature, but a retry passed on both. Never called
+ *                              a failure: this file already split `agreed` into
+ *                              failed/flaky because one heading over both makes a
+ *                              reader at 09:00 count a retry as a red.
  *  - `cross-provider-differs`  different signatures. INCONCLUSIVE, and the label says
  *                              so. The implication only runs one way — a
  *                              provider-independent cause makes both lanes break, but
@@ -693,9 +710,16 @@ export function renderReport(result, { sources = [] } = {}) {
   // "looks right while being wrong" shape this file is written against.
   const agreedFailed = agreed.filter((a) => a.kind === "agreed-failed");
   const agreedFlaky = agreed.filter((a) => a.kind === "agreed-flaky");
-  L.push("", `Failed on BOTH lanes (the product, not the environment): ${agreedFailed.length}`);
+  // The cross-provider pairs are counted HERE too, not only in the list above. These
+  // two lines are read as the day's product-defect tally, and leaving the pairs out of
+  // them would keep the very complaint this change was written against alive: a day
+  // whose only finding is a cross-provider pair ended with `Flaky on BOTH lanes: 0`.
+  const crossF = divergences.filter((d) => d.kind === "cross-provider-failed").length;
+  const crossK = divergences.filter((d) => d.kind === "cross-provider-flaky").length;
+  const alsoCross = (n) => (n ? ` (+${n} as cross-provider pair(s), listed above)` : "");
+  L.push("", `Failed on BOTH lanes (the product, not the environment): ${agreedFailed.length}${alsoCross(crossF)}`);
   for (const a of agreedFailed) L.push(`  ${a.name}`);
-  L.push("", `Flaky on BOTH lanes (unstable in both, not a lane difference): ${agreedFlaky.length}`);
+  L.push("", `Flaky on BOTH lanes (unstable in both, not a lane difference): ${agreedFlaky.length}${alsoCross(crossK)}`);
   for (const a of agreedFlaky) L.push(`  ${a.name}`);
 
   L.push(

--- a/scripts/lib/lane-verdict-diff.mjs
+++ b/scripts/lib/lane-verdict-diff.mjs
@@ -88,6 +88,129 @@ export function describeTest(entry) {
 }
 
 /**
+ * The identity of a SPEC across the two lanes, with the parameterization dropped.
+ *
+ * `testKey` is right for the diff and wrong for one question. The day's provider is
+ * resolved AT RUN TIME by `select-daily-model-target.mjs`, which walks forward from the
+ * weekday's slot past whatever `collect-models` probed inactive. So the two lanes can
+ * pin DIFFERENT providers on the same morning — and did on 2026-09-08: Actions landed
+ * on google and the VM on anthropic, because the shared Anthropic balance drained
+ * between 08:04 and 12:41. Every provider-parametrized spec then carries a different
+ * `param` on each side, keys as two identities, and lands in the report as two
+ * one-sided differences.
+ *
+ * That is a FALSE NEGATIVE in the class this comparator exists to find. On that day the
+ * `agent-component-regression` suite flaked on BOTH lanes and the report printed
+ * `Flaky on BOTH lanes: 0`. It held the evidence and could not say it.
+ *
+ * And the pairing is worth more than a corrected count: a failure that reproduces on
+ * gemini AND on claude has ELIMINATED the provider as its cause, by construction.
+ * Cross-provider agreement is STRONGER evidence of a product defect than agreement on
+ * one provider — and the rotation already buys it, at no extra cost.
+ */
+export function specKey(entry) {
+  // Same separator, same reason as testKey: joined with nothing, a file ending in a
+  // title's first characters could collide with another pair.
+  return [entry?.file ?? "", entry?.test ?? ""].join("\u0001");
+}
+
+/**
+ * Does this signature carry a cause, or is it an assertion shell?
+ *
+ * `expect(received).toBe(expected)` is the most generic string this suite produces and
+ * establishes NOTHING about same-causeness on its own (#1626). Triage settles recurrence
+ * by reading the expected/received pair out of `results.json`; a history row carries
+ * only the signature. So a match between two shells is a LEAD and has to say so — #1759,
+ * filed the same week, rests its entire "why these are one cause" section on the pair
+ * and explicitly not on the signature.
+ *
+ * Deliberately narrow: an `Error: expect(...)` prefix and nothing else. Anything with a
+ * message of its own — the guards naming #751, the tracing precondition, a timeout
+ * naming its URL — carries a cause and is not a shell.
+ */
+export function isGenericSignature(signature) {
+  if (!signature) return false;
+  const bare = String(signature)
+    .replace(/\u001b\[[0-9;]*m/g, "")
+    .trim();
+  return /^Error:\s*expect\(received\)\s*\.\s*(not\s*\.\s*)?[A-Za-z]+\s*\(/.test(bare);
+}
+
+/**
+ * Fold one-sided differences that are the SAME spec on different providers into one
+ * cross-provider entry.
+ *
+ * Only an exact pair folds — one entry from each lane. Three or more one-sided entries
+ * for one spec means a lane ran two parameterizations of it, and which pairs with which
+ * is then a guess; the honest outcome is to leave them alone rather than invent a
+ * pairing the row cannot support.
+ *
+ * The fold does NOT decide whether the provider was the cause. It produces two kinds:
+ *
+ *  - `cross-provider-agreed`   same signature on both providers. The provider is
+ *                              eliminated as the cause: this is the product. Ranked
+ *                              first, because it is the strongest thing this file can
+ *                              say and it must not be scrolled past.
+ *  - `cross-provider-differs`  different signatures. INCONCLUSIVE, and the label says
+ *                              so. The implication only runs one way — a
+ *                              provider-independent cause makes both lanes break, but
+ *                              a provider-DEPENDENT surface does not follow from
+ *                              disagreement: providers differ in latency, tool-call
+ *                              format and response shape, so a genuine Langflow defect
+ *                              can surface on one and not the other. Reading this
+ *                              bucket as "provider-specific, dismissed" would turn the
+ *                              instrument into a way of losing defects.
+ */
+export function pairCrossProvider(divergences) {
+  const ONE_SIDED = /^(ci|vm)-only-(failed|flaky)$/;
+  const groups = new Map();
+  for (const d of divergences) {
+    if (!ONE_SIDED.test(d.kind)) continue;
+    const k = specKey(d);
+    if (!groups.has(k)) groups.set(k, []);
+    groups.get(k).push(d);
+  }
+
+  const folded = new Set();
+  const pairs = [];
+  for (const group of groups.values()) {
+    if (group.length !== 2) continue;
+    const ci = group.find((d) => d.kind.startsWith("ci-"));
+    const vm = group.find((d) => d.kind.startsWith("vm-"));
+    if (!ci || !vm) continue; // both from the same lane: not a pair
+    const ciParam = ci.param ?? null;
+    const vmParam = vm.param ?? null;
+    // Identical params cannot key differently, so reaching here with both null would
+    // mean the exact diff already had them as one entry.
+    if (ciParam === vmParam) continue;
+    if (!ciParam && !vmParam) continue;
+
+    const ciErr = ci.ci?.error ?? null;
+    const vmErr = vm.vm?.error ?? null;
+    const signaturesMatch = Boolean(ciErr) && Boolean(vmErr) && ciErr === vmErr;
+    const generic = signaturesMatch && isGenericSignature(ciErr);
+
+    folded.add(ci);
+    folded.add(vm);
+    pairs.push({
+      key: specKey(ci),
+      name: describeTest({ file: ci.file, test: ci.test }),
+      file: ci.file ?? null,
+      test: ci.test ?? null,
+      param: null,
+      params: { ci: ciParam, vm: vmParam },
+      tags: ci.tags ?? vm.tags ?? [],
+      ci: ci.ci,
+      vm: vm.vm,
+      kind: signaturesMatch ? "cross-provider-agreed" : "cross-provider-differs",
+      crossProvider: { signaturesMatch, generic },
+    });
+  }
+
+  return [...divergences.filter((d) => !folded.has(d)), ...pairs];
+}
+
+/**
  * Merge several history files into one entry list.
  *
  * THE TWO LANES DO NOT SHARE A FILE, and assuming they did was a real defect.
@@ -339,12 +462,20 @@ export function compareRuns({
     divergences.push({ ...common, kind: `${only}-only-${status}` });
   }
 
+  // Fold the provider-split pairs BEFORE ranking, so the strongest entry the day can
+  // produce is ranked as what it is instead of as two one-sided flakes.
+  const paired = pairCrossProvider(divergences);
+  divergences.length = 0;
+  divergences.push(...paired);
+
   const rank = {
-    "vm-only-failed": 0,
-    "ci-only-failed": 1,
-    "severity-differs": 2,
-    "vm-only-flaky": 3,
-    "ci-only-flaky": 4,
+    "cross-provider-agreed": 0,
+    "vm-only-failed": 1,
+    "ci-only-failed": 2,
+    "severity-differs": 3,
+    "cross-provider-differs": 4,
+    "vm-only-flaky": 5,
+    "ci-only-flaky": 6,
   };
   divergences.sort((a, b) => (rank[a.kind] ?? 9) - (rank[b.kind] ?? 9) || a.name.localeCompare(b.name));
   agreed.sort((a, b) => a.name.localeCompare(b.name));
@@ -353,6 +484,8 @@ export function compareRuns({
 }
 
 const KIND_LABEL = {
+  "cross-provider-agreed": "SAME signature on both lanes, on DIFFERENT providers (the product, not the provider)",
+  "cross-provider-differs": "same spec on both lanes, different providers AND different signatures (inconclusive)",
   "vm-only-failed": "FAILED on the VM only",
   "ci-only-failed": "FAILED on Actions only",
   "severity-differs": "failed on one lane, flaky on the other",
@@ -387,6 +520,17 @@ export function renderReport(result, { sources = [] } = {}) {
     );
   }
 
+  // Same reasoning as the version stamp above: the strongest statement the day can
+  // make cannot live only inside a list a reader scrolls.
+  const crossAgreed = divergences.filter((d) => d.kind === "cross-provider-agreed");
+  if (crossAgreed.length) {
+    L.push(
+      "",
+      `!! ${crossAgreed.length} spec(s) failed the SAME way on both lanes under DIFFERENT providers.`,
+      "   The provider is eliminated as the cause for those - read them first, they are the product.",
+    );
+  }
+
   const pushWarnings = () => {
     if (!warnings.length) return;
     L.push("", "Narrowed by:");
@@ -417,6 +561,27 @@ export function renderReport(result, { sources = [] } = {}) {
         L.push(`  ${KIND_LABEL[kind] ?? kind}:`);
       }
       L.push(`    ${d.name}`);
+      if (d.kind.startsWith("cross-provider")) {
+        // Both sides always, and the provider named on each: the whole content of the
+        // entry is that these two runs are the same spec under different providers.
+        L.push(`      Actions [${d.params.ci ?? "no param"}] ${d.ci?.status ?? "?"}: ${d.ci?.error ?? "(no signature)"}`);
+        L.push(`      VM      [${d.params.vm ?? "no param"}] ${d.vm?.status ?? "?"}: ${d.vm?.error ?? "(no signature)"}`);
+        if (d.crossProvider?.generic) {
+          L.push(
+            "      the shared signature is an assertion shell, so this is a LEAD, not a confirmation (#1626):",
+            "      read the expected/received pair out of each run's results.json before calling it one cause.",
+          );
+        } else if (d.crossProvider?.signaturesMatch) {
+          L.push("      the provider is eliminated as the cause: it reproduced on both.");
+        } else {
+          L.push(
+            "      INCONCLUSIVE - different signatures do NOT establish that the provider is the cause;",
+            "      providers differ in latency, tool-call format and response shape, so one Langflow defect",
+            "      can surface on one and not the other.",
+          );
+        }
+        continue;
+      }
       const err = d.vm?.error ?? d.ci?.error;
       if (err) L.push(`      ${err}`);
       if (d.kind === "severity-differs") L.push(`      Actions: ${d.ci.status} | VM: ${d.vm.status}`);

--- a/scripts/lib/lane-verdict-diff.mjs
+++ b/scripts/lib/lane-verdict-diff.mjs
@@ -163,7 +163,19 @@ export function comparableSignature(signature) {
 export function isGenericSignature(signature) {
   const bare = comparableSignature(signature);
   if (!bare) return false;
-  return /^Error:\s*expect\(received\)\s*\.\s*(not\s*\.\s*)?[A-Za-z]+\s*\(/.test(bare);
+  // ANY subject, not just `received`. Requiring `expect(received)` covered the
+  // MINORITY: measured over both series, `expect(locator)` shells are 158 of 764
+  // signatures against 97 for `expect(received)`, and `expect(locator).toBeVisible()
+  // failed` alone is 115 — the single most frequent signature the suite produces. A
+  // pair agreeing only on "some locator was not visible" was taking the head stamp
+  // with no LEAD caveat, which is the false confidence this guard exists to prevent,
+  // on the dominant shell class of an e2e suite.
+  //
+  // Checked against the corpus rather than reasoned: of the 115 DISTINCT signatures in
+  // the two series, this matches 21 and every one of them is a bare matcher; nothing
+  // carrying a message of its own matches, and no signature starting with `expect(`
+  // escapes it.
+  return /^Error:\s*expect\([^)]*\)\s*\.\s*(not\s*\.\s*)?[A-Za-z]+\s*\(/.test(bare);
 }
 
 /**

--- a/scripts/lib/lane-verdict-diff.mjs
+++ b/scripts/lib/lane-verdict-diff.mjs
@@ -114,6 +114,38 @@ export function specKey(entry) {
   return [entry?.file ?? "", entry?.test ?? ""].join("\u0001");
 }
 
+/** SGR escapes, as an escape rather than the literal byte — same rule as the key's separator. */
+const ANSI = /\u001b\[[0-9;]*m/g;
+
+/**
+ * The comparable form of a signature, or `null` when there is nothing to compare.
+ *
+ * Two strings that LOOK present must not be compared, and both were reachable:
+ *
+ *  - **`"unknown"`.** It is what `append-weekly-history.mjs` records when a failure
+ *    carries no message at all (`firstFailedSignature || "unknown"`), and that file's
+ *    own comment already says what it is: *"`unknown` is not a signature but the
+ *    absence of one: triage's recurrence rule matches on it, so message-less failures
+ *    clustered together across unrelated specs"*. It fixed that for its own selection;
+ *    comparing it here reintroduced it one file over. **15 of the 764 signatures in
+ *    `reports/daily-history.jsonl` are `unknown`** — two message-less failures of one
+ *    spec folded to `cross-provider-failed`, rank 0, headlined as the product.
+ *  - **the SGR escapes.** 255 of those 764 rows carry them, and the colorization is
+ *    environment-derived: nothing in this repo sets `FORCE_COLOR` or `NO_COLOR`, and
+ *    supports-color keys on `GITHUB_ACTIONS`, which the VM does not have. Comparing
+ *    raw strings would make one failure, colorized on one lane and plain on the other,
+ *    read as two different causes — the exact false negative this pairing exists to
+ *    remove. Both series carry escapes at the same rate today, so this is a latent
+ *    inversion rather than an observed one; normalizing costs nothing and removes it.
+ */
+export function comparableSignature(signature) {
+  const bare = String(signature ?? "")
+    .replace(ANSI, "")
+    .trim();
+  if (!bare || bare === "unknown") return null;
+  return bare;
+}
+
 /**
  * Does this signature carry a cause, or is it an assertion shell?
  *
@@ -129,10 +161,8 @@ export function specKey(entry) {
  * naming its URL — carries a cause and is not a shell.
  */
 export function isGenericSignature(signature) {
-  if (!signature) return false;
-  const bare = String(signature)
-    .replace(/\u001b\[[0-9;]*m/g, "")
-    .trim();
+  const bare = comparableSignature(signature);
+  if (!bare) return false;
   return /^Error:\s*expect\(received\)\s*\.\s*(not\s*\.\s*)?[A-Za-z]+\s*\(/.test(bare);
 }
 
@@ -191,9 +221,10 @@ export function pairCrossProvider(divergences) {
     if (ciParam === vmParam) continue;
     if (!ciParam && !vmParam) continue;
 
-    const ciErr = ci.ci?.error ?? null;
-    const vmErr = vm.vm?.error ?? null;
-    const signaturesMatch = Boolean(ciErr) && Boolean(vmErr) && ciErr === vmErr;
+    // Normalized on BOTH sides before the equality, never raw: see comparableSignature.
+    const ciErr = comparableSignature(ci.ci?.error);
+    const vmErr = comparableSignature(vm.vm?.error);
+    const signaturesMatch = Boolean(ciErr) && ciErr === vmErr;
     const generic = signaturesMatch && isGenericSignature(ciErr);
 
     folded.add(ci);

--- a/scripts/lib/lane-verdict-diff.mjs
+++ b/scripts/lib/lane-verdict-diff.mjs
@@ -199,7 +199,12 @@ export function pairCrossProvider(divergences) {
       test: ci.test ?? null,
       param: null,
       params: { ci: ciParam, vm: vmParam },
-      tags: ci.tags ?? vm.tags ?? [],
+      // The UNION, not the CI side. `??` falls through on null and not on `[]`, so a
+      // CI entry tagged `[]` used to erase tags the VM entry had — and the lanes can
+      // sit one commit apart, which is exactly how the two sides come to disagree
+      // about tags (PR 1745 restored `@stable` to four specs between two runs). This
+      // entry claims to describe the pair, and `--json` consumers filter on it.
+      tags: [...new Set([...(ci.tags ?? []), ...(vm.tags ?? [])])],
       ci: ci.ci,
       vm: vm.vm,
       kind: signaturesMatch ? "cross-provider-agreed" : "cross-provider-differs",

--- a/scripts/lib/lane-verdict-diff.mjs
+++ b/scripts/lib/lane-verdict-diff.mjs
@@ -171,6 +171,12 @@ export function pairCrossProvider(divergences) {
     groups.get(k).push(d);
   }
 
+  // A flake both lanes saw is NOT a failure both lanes saw. This file already split
+  // `agreed` into `agreed-failed`/`agreed-flaky` for that reason — one heading over
+  // both makes a reader at 09:00 count a retry as a hard failure — and the fold has
+  // to carry the same distinction or it reintroduces it one layer up.
+  const hardFailure = (a, b) => a?.status === "failed" || b?.status === "failed";
+
   const folded = new Set();
   const pairs = [];
   for (const group of groups.values()) {
@@ -207,7 +213,11 @@ export function pairCrossProvider(divergences) {
       tags: [...new Set([...(ci.tags ?? []), ...(vm.tags ?? [])])],
       ci: ci.ci,
       vm: vm.vm,
-      kind: signaturesMatch ? "cross-provider-agreed" : "cross-provider-differs",
+      kind: !signaturesMatch
+        ? "cross-provider-differs"
+        : hardFailure(ci.ci, vm.vm)
+          ? "cross-provider-failed"
+          : "cross-provider-flaky",
       crossProvider: { signaturesMatch, generic },
     });
   }
@@ -474,13 +484,16 @@ export function compareRuns({
   divergences.push(...paired);
 
   const rank = {
-    "cross-provider-agreed": 0,
+    "cross-provider-failed": 0,
     "vm-only-failed": 1,
     "ci-only-failed": 2,
     "severity-differs": 3,
     "cross-provider-differs": 4,
-    "vm-only-flaky": 5,
-    "ci-only-flaky": 6,
+    // Above the one-lane flakes — a flake reproduced on two providers says more than
+    // one lane's flake — and below every hard failure, which is the point.
+    "cross-provider-flaky": 5,
+    "vm-only-flaky": 6,
+    "ci-only-flaky": 7,
   };
   divergences.sort((a, b) => (rank[a.kind] ?? 9) - (rank[b.kind] ?? 9) || a.name.localeCompare(b.name));
   agreed.sort((a, b) => a.name.localeCompare(b.name));
@@ -489,8 +502,9 @@ export function compareRuns({
 }
 
 const KIND_LABEL = {
-  "cross-provider-agreed": "SAME signature on both lanes, on DIFFERENT providers (the product, not the provider)",
+  "cross-provider-failed": "SAME signature on both lanes, DIFFERENT providers, hard failure on at least one (the product, not the provider)",
   "cross-provider-differs": "same spec on both lanes, different providers AND different signatures (inconclusive)",
+  "cross-provider-flaky": "SAME signature on both lanes, DIFFERENT providers, but a RETRY passed on both (not a hard failure)",
   "vm-only-failed": "FAILED on the VM only",
   "ci-only-failed": "FAILED on Actions only",
   "severity-differs": "failed on one lane, flaky on the other",
@@ -527,12 +541,23 @@ export function renderReport(result, { sources = [] } = {}) {
 
   // Same reasoning as the version stamp above: the strongest statement the day can
   // make cannot live only inside a list a reader scrolls.
-  const crossAgreed = divergences.filter((d) => d.kind === "cross-provider-agreed");
-  if (crossAgreed.length) {
+  const crossFailed = divergences.filter((d) => d.kind === "cross-provider-failed");
+  const crossFlaky = divergences.filter((d) => d.kind === "cross-provider-flaky");
+  if (crossFailed.length) {
     L.push(
       "",
-      `!! ${crossAgreed.length} spec(s) failed the SAME way on both lanes under DIFFERENT providers.`,
+      `!! ${crossFailed.length} spec(s) FAILED the same way on both lanes under DIFFERENT providers.`,
       "   The provider is eliminated as the cause for those - read them first, they are the product.",
+    );
+  }
+  // Its own line, and it never says "failed": both lanes retried and passed. Worth the
+  // head because reproducing on two providers rules the provider out of the flake -
+  // not worth the word that would send triage looking for a red.
+  if (crossFlaky.length) {
+    L.push(
+      "",
+      `!! ${crossFlaky.length} spec(s) flaked the same way on both lanes under DIFFERENT providers.`,
+      "   A retry passed on both, so this is not a hard failure - but the provider is not the cause either.",
     );
   }
 

--- a/scripts/lib/lane-verdict-diff.mjs
+++ b/scripts/lib/lane-verdict-diff.mjs
@@ -129,7 +129,8 @@ const ANSI = /\u001b\[[0-9;]*m/g;
  *    clustered together across unrelated specs"*. It fixed that for its own selection;
  *    comparing it here reintroduced it one file over. **15 of the 764 signatures in
  *    `reports/daily-history.jsonl` are `unknown`** — two message-less failures of one
- *    spec folded to `cross-provider-failed`, rank 0, headlined as the product.
+ *    spec folded as a matching pair and was headlined as the product, back when the
+ *    fold still drew conclusions.
  *  - **the SGR escapes.** 255 of those 764 rows carry them, and the colorization is
  *    environment-derived: nothing in this repo sets `FORCE_COLOR` or `NO_COLOR`, and
  *    supports-color keys on `GITHUB_ACTIONS`, which the VM does not have. Comparing
@@ -179,48 +180,76 @@ export function isGenericSignature(signature) {
 }
 
 /**
- * Fold one-sided differences that are the SAME spec on different providers into one
- * cross-provider entry.
+ * The provider named by a `param` label, or `null` when the label does not name one.
+ *
+ * The labels are written by `select-daily-model-target.mjs` and by the specs' own
+ * target resolution, and the corpus carries three shapes: `google / gemini-3.5-flash`,
+ * a bare `google`, and `provider:openai (fallback)` — the last from
+ * `test-targets.ts` when the catalog was frozen empty.
+ *
+ * It exists because comparing the WHOLE label answers a different question than the
+ * one the report was asking. Two labels differ whenever the MODEL differs, and the
+ * model differs routinely: google shows four distinct labels across the series, nine
+ * specs have been recorded under two different google models, and one 2026-09-08 smoke
+ * on the VM settled `gemini-2.5-flash` while the Actions lane of the same morning
+ * pinned `gemini-3.5-flash` — same provider, same catalog size, different key. Every
+ * conclusion this file used to draw from a fold said "different providers"; on those
+ * pairs it was false.
+ */
+export function paramProvider(param) {
+  const bare = String(param ?? "").trim();
+  if (!bare) return null;
+  const fallback = bare.match(/^provider:([A-Za-z0-9_-]+)/);
+  if (fallback) return fallback[1];
+  const head = bare.split("/")[0].trim();
+  return head || null;
+}
+
+/**
+ * Fold one-sided differences that are the SAME spec under different targets into one
+ * entry.
  *
  * Only an exact pair folds — one entry from each lane. Three or more one-sided entries
- * for one spec means SOME lane ran more than one parameterization, and which pairs with
- * which is then a guess; the honest outcome is to leave them alone rather than invent a
- * pairing the row cannot support.
+ * for one spec means some lane ran more than one parameterization, and which pairs with
+ * which is then a guess; the honest outcome is to leave them alone.
  *
- * Exactly two is not a guarantee of the scheduled shape, and the limit is stated rather
- * than assumed. On a run with the day's provider pinned, two entries ARE the two lanes'
- * one variant each. Under `ALL_MODELS=true` or an explicit `MODEL_TEST_PROVIDER`,
- * `resolveTestTargets` returns several targets, so two entries can also be both lanes
- * failing a DIFFERENT variant — and folding then describes one pair where there were
- * two findings. Nothing here can tell those apart: the row does not carry which
- * provider the lane pinned, which is the field #1731 has to land before this can be
- * checked. What the fold guarantees meanwhile is that nothing is lost — both params and
- * both signatures are printed on the entry — and the two are ranked as INCONCLUSIVE,
- * which is what two unexplained one-sided findings deserve anyway.
+ * ## What the fold establishes, and what it does not
  *
- * The fold does NOT decide whether the provider was the cause. It produces three kinds:
+ * It establishes ONE thing: these two lines are the same spec, and the report should
+ * show them side by side instead of as two unrelated one-sided differences. That was a
+ * real false negative — on 2026-09-08 `agent-component-regression` was in both lanes'
+ * lists and the report printed `Flaky on BOTH lanes: 0`.
  *
- *  - `cross-provider-failed`   same signature, hard failure on at least one lane. The
- *                              provider is eliminated as the cause: this is the
- *                              product. Ranked first, and the only kind the head stamp
- *                              promotes — and only when the match is CONFIRMABLE: not
- *                              an assertion shell, and not a failure the harness could
- *                              not attribute to the spec.
- *  - `cross-provider-flaky`    same signature, but a retry passed on both. Never called
- *                              a failure: this file already split `agreed` into
- *                              failed/flaky because one heading over both makes a
- *                              reader at 09:00 count a retry as a red.
- *  - `cross-provider-differs`  different signatures. INCONCLUSIVE, and the label says
- *                              so. The implication only runs one way — a
- *                              provider-independent cause makes both lanes break, but
- *                              a provider-DEPENDENT surface does not follow from
- *                              disagreement: providers differ in latency, tool-call
- *                              format and response shape, so a genuine Langflow defect
- *                              can surface on one and not the other. Reading this
- *                              bucket as "provider-specific, dismissed" would turn the
- *                              instrument into a way of losing defects.
+ * It establishes NOTHING about cause, and this file stopped claiming otherwise. Three
+ * review rounds found sixteen defects in this function and every one was in what the
+ * fold CLAIMED, none in the folding: the report asserted "the provider is eliminated
+ * as the cause" over pairs that shared a provider, over signatures that were assertion
+ * shells, over failures the harness could not attribute to the spec, and over a hard
+ * failure paired with a retry. The pattern is the design, not the wording: the claim
+ * needs facts the row does not carry — which provider the lane PINNED, and whether the
+ * lane ran one variant or several.
+ *
+ * So the entry now reports and the reader concludes. It carries the facts —
+ * `providersDiffer`, `signaturesMatch`, `generic`, `infra`, both targets, both statuses
+ * and both signatures — and the report prints them without a verdict, a ranking above
+ * the one-sided failures, or a head stamp.
+ *
+ * **The conclusion is deferred, not abandoned.** "A failure reproducing on gemini AND
+ * on claude has eliminated the provider" is a sound inference; it is simply not
+ * checkable from a row that never says which provider was pinned. When that field
+ * lands (it waits on #1731, whose matrix-output path would otherwise record the
+ * provider of whichever shard finished last), the claim can come back as something the
+ * file can verify rather than assume.
+ *
+ * Two kinds, split by severity only, because a retry that passed is not a red — the
+ * distinction `agreed-failed`/`agreed-flaky` already exists in this file for the same
+ * reason:
+ *
+ *  - `cross-target-failed`  hard failure on at least one lane. Ranked with the
+ *                           one-sided failures, never above them.
+ *  - `cross-target-flaky`   both lanes retried and passed. Ranked with the flakes.
  */
-export function pairCrossProvider(divergences) {
+export function pairCrossTarget(divergences) {
   const ONE_SIDED = /^(ci|vm)-only-(failed|flaky)$/;
   const groups = new Map();
   for (const d of divergences) {
@@ -229,12 +258,6 @@ export function pairCrossProvider(divergences) {
     if (!groups.has(k)) groups.set(k, []);
     groups.get(k).push(d);
   }
-
-  // A flake both lanes saw is NOT a failure both lanes saw. This file already split
-  // `agreed` into `agreed-failed`/`agreed-flaky` for that reason — one heading over
-  // both makes a reader at 09:00 count a retry as a hard failure — and the fold has
-  // to carry the same distinction or it reintroduces it one layer up.
-  const hardFailure = (a, b) => a?.status === "failed" || b?.status === "failed";
 
   const folded = new Set();
   const pairs = [];
@@ -245,50 +268,57 @@ export function pairCrossProvider(divergences) {
     if (!ci || !vm) continue; // both from the same lane: not a pair
     const ciParam = ci.param ?? null;
     const vmParam = vm.param ?? null;
-    // Identical params cannot key differently, so reaching here with both null would
-    // mean the exact diff already had them as one entry.
+    // Identical labels cannot key differently, so this is defensive only: the exact
+    // diff would already have had them as one entry.
     if (ciParam === vmParam) continue;
-    if (!ciParam && !vmParam) continue;
 
     // Normalized on BOTH sides before the equality, never raw: see comparableSignature.
     const ciErr = comparableSignature(ci.ci?.error);
     const vmErr = comparableSignature(vm.vm?.error);
     const signaturesMatch = Boolean(ciErr) && ciErr === vmErr;
     const generic = signaturesMatch && isGenericSignature(ciErr);
-    // `compareRuns` already warns that a failure carrying an infra_signature means the
-    // harness could not reach the backend, "so they are not attributable to the spec
-    // that reported them". Two of those with one signature — the same timeout string
-    // is 37 occurrences, and 42 of 764 entries carry an infra_signature — folded to
-    // rank 0 and were headlined as the product: a wedged container on one lane plus a
-    // network blip on the other, sold as the strongest claim in the report.
-    const infra = Boolean(ci.ci?.infra || vm.vm?.infra);
-    // What the head stamp is allowed to promote: a match that names a cause AND is
-    // attributable to the spec. Everything else is listed, never headlined.
-    const confirmable = signaturesMatch && !generic && !infra;
+    // OR, and the rendered text names WHICH side rather than asserting both: one-sided
+    // is the ordinary case (2026-09-07: one on Actions against five on the VM), and the
+    // narrowing block printed above the list already reports the per-lane counts.
+    const infraCi = Boolean(ci.ci?.infra);
+    const infraVm = Boolean(vm.vm?.infra);
+    // A FACT about the two labels, not a licence to conclude anything from it.
+    const ciProvider = paramProvider(ciParam);
+    const vmProvider = paramProvider(vmParam);
+    const providersDiffer = Boolean(ciProvider) && Boolean(vmProvider) && ciProvider !== vmProvider;
 
     folded.add(ci);
     folded.add(vm);
     pairs.push({
+      // NOTE for `--json` consumers: a folded row is shaped differently from every
+      // other divergence. `key` is a 2-segment specKey (not the 3-segment testKey),
+      // `param` is null because there are two, and the labels live in `params`.
       key: specKey(ci),
       name: describeTest({ file: ci.file, test: ci.test }),
       file: ci.file ?? null,
       test: ci.test ?? null,
       param: null,
       params: { ci: ciParam, vm: vmParam },
+      providers: { ci: ciProvider, vm: vmProvider },
       // The UNION, not the CI side. `??` falls through on null and not on `[]`, so a
       // CI entry tagged `[]` used to erase tags the VM entry had — and the lanes can
       // sit one commit apart, which is exactly how the two sides come to disagree
       // about tags (PR 1745 restored `@stable` to four specs between two runs). This
-      // entry claims to describe the pair, and `--json` consumers filter on it.
+      // entry describes the pair, and `--json` consumers filter on it.
       tags: [...new Set([...(ci.tags ?? []), ...(vm.tags ?? [])])],
       ci: ci.ci,
       vm: vm.vm,
-      kind: !signaturesMatch
-        ? "cross-provider-differs"
-        : hardFailure(ci.ci, vm.vm)
-          ? "cross-provider-failed"
-          : "cross-provider-flaky",
-      crossProvider: { signaturesMatch, generic, infra, confirmable },
+      kind:
+        ci.ci?.status === "failed" || vm.vm?.status === "failed"
+          ? "cross-target-failed"
+          : "cross-target-flaky",
+      crossTarget: {
+        signaturesMatch,
+        generic,
+        infraCi,
+        infraVm,
+        providersDiffer,
+      },
     });
   }
 
@@ -549,21 +579,21 @@ export function compareRuns({
 
   // Fold the provider-split pairs BEFORE ranking, so the strongest entry the day can
   // produce is ranked as what it is instead of as two one-sided flakes.
-  const paired = pairCrossProvider(divergences);
+  const paired = pairCrossTarget(divergences);
   divergences.length = 0;
   divergences.push(...paired);
 
+  // A folded pair ranks WITH the severity it has, never above it. Ranking it first was
+  // the promotion the cold review caught: a pair that hard-failed on one lane and
+  // flaked on the other outranked a genuine two-lane red.
   const rank = {
-    "cross-provider-failed": 0,
-    "vm-only-failed": 1,
-    "ci-only-failed": 2,
+    "vm-only-failed": 0,
+    "ci-only-failed": 1,
+    "cross-target-failed": 2,
     "severity-differs": 3,
-    "cross-provider-differs": 4,
-    // Above the one-lane flakes — a flake reproduced on two providers says more than
-    // one lane's flake — and below every hard failure, which is the point.
-    "cross-provider-flaky": 5,
-    "vm-only-flaky": 6,
-    "ci-only-flaky": 7,
+    "vm-only-flaky": 4,
+    "ci-only-flaky": 5,
+    "cross-target-flaky": 6,
   };
   divergences.sort((a, b) => (rank[a.kind] ?? 9) - (rank[b.kind] ?? 9) || a.name.localeCompare(b.name));
   agreed.sort((a, b) => a.name.localeCompare(b.name));
@@ -572,9 +602,8 @@ export function compareRuns({
 }
 
 const KIND_LABEL = {
-  "cross-provider-failed": "SAME signature on both lanes, DIFFERENT providers, hard failure on at least one (the product, not the provider)",
-  "cross-provider-differs": "same spec on both lanes, different providers AND different signatures (inconclusive)",
-  "cross-provider-flaky": "SAME signature on both lanes, DIFFERENT providers, but a RETRY passed on both (not a hard failure)",
+  "cross-target-failed": "same spec on both lanes under DIFFERENT targets, hard failure on at least one lane",
+  "cross-target-flaky": "same spec on both lanes under DIFFERENT targets, a retry passed on both",
   "vm-only-failed": "FAILED on the VM only",
   "ci-only-failed": "FAILED on Actions only",
   "severity-differs": "failed on one lane, flaky on the other",
@@ -609,39 +638,11 @@ export function renderReport(result, { sources = [] } = {}) {
     );
   }
 
-  // Same reasoning as the version stamp above: the strongest statement the day can
-  // make cannot live only inside a list a reader scrolls.
-  const crossFailed = divergences.filter((d) => d.kind === "cross-provider-failed");
-  const crossFlaky = divergences.filter((d) => d.kind === "cross-provider-flaky");
-  // The stamp exists so it CANNOT be scrolled past, which is exactly why it must not
-  // promote what the entry below it refuses: an unfiltered count headlined "the
-  // product" over a pair whose own body said "a LEAD, not a confirmation".
-  const headlined = crossFailed.filter((d) => d.crossProvider?.confirmable);
-  const qualified = crossFailed.filter((d) => !d.crossProvider?.confirmable);
-  if (headlined.length) {
-    L.push(
-      "",
-      `!! ${headlined.length} spec(s) FAILED the same way on both lanes under DIFFERENT providers.`,
-      "   The provider is eliminated as the cause for those - read them first, they are the product.",
-    );
-  }
-  if (qualified.length) {
-    L.push(
-      "",
-      `!! ${qualified.length} more cross-provider pair(s) agree on a signature that cannot carry the claim -`,
-      "   an assertion shell, or a failure the harness could not attribute to the spec. Listed, not headlined.",
-    );
-  }
-  // Its own line, and it never says "failed": both lanes retried and passed. Worth the
-  // head because reproducing on two providers rules the provider out of the flake -
-  // not worth the word that would send triage looking for a red.
-  if (crossFlaky.length) {
-    L.push(
-      "",
-      `!! ${crossFlaky.length} spec(s) flaked the same way on both lanes under DIFFERENT providers.`,
-      "   A retry passed on both, so this is not a hard failure - but the provider is not the cause either.",
-    );
-  }
+  // NO head stamp for the folded pairs, deliberately. The version mismatch earns one
+  // because it is a fact about the run; a fold is an observation whose meaning depends
+  // on facts the row does not carry, and a stamp is exactly the surface that cannot be
+  // qualified. Three rounds of review found the stamp asserting what the entry beneath
+  // it declined to assert.
 
   const pushWarnings = () => {
     if (!warnings.length) return;
@@ -673,29 +674,32 @@ export function renderReport(result, { sources = [] } = {}) {
         L.push(`  ${KIND_LABEL[kind] ?? kind}:`);
       }
       L.push(`    ${d.name}`);
-      if (d.kind.startsWith("cross-provider")) {
-        // Both sides always, and the provider named on each: the whole content of the
-        // entry is that these two runs are the same spec under different providers.
-        L.push(`      Actions [${d.params.ci ?? "no param"}] ${d.ci?.status ?? "?"}: ${d.ci?.error ?? "(no signature)"}`);
-        L.push(`      VM      [${d.params.vm ?? "no param"}] ${d.vm?.status ?? "?"}: ${d.vm?.error ?? "(no signature)"}`);
-        if (d.crossProvider?.generic) {
+      if (d.kind.startsWith("cross-target")) {
+        // Facts only, every one of them read off the two rows: both targets, both
+        // statuses, both signatures, and what the two labels have in common. No line
+        // here concludes anything about cause — see pairCrossTarget's docblock for why
+        // this file stopped trying.
+        const x = d.crossTarget ?? {};
+        L.push(`      Actions [${d.params.ci ?? "no target"}] ${d.ci?.status ?? "?"}: ${d.ci?.error ?? "(no signature)"}`);
+        L.push(`      VM      [${d.params.vm ?? "no target"}] ${d.vm?.status ?? "?"}: ${d.vm?.error ?? "(no signature)"}`);
+        L.push(
+          x.providersDiffer
+            ? `      providers DIFFER (Actions ${d.providers?.ci}, VM ${d.providers?.vm})`
+            : `      SAME provider (${d.providers?.ci ?? d.providers?.vm ?? "unnamed"}), different target — the provider is NOT ruled out`,
+        );
+        if (x.signaturesMatch) {
           L.push(
-            "      the shared signature is an assertion shell, so this is a LEAD, not a confirmation (#1626):",
-            "      read the expected/received pair out of each run's results.json before calling it one cause.",
+            x.generic
+              ? "      signatures match, but the shared one is an assertion shell: it names no cause (#1626)"
+              : "      signatures match",
           );
-        } else if (d.crossProvider?.infra) {
-          L.push(
-            "      both sides carry an infra_signature: the harness could not reach the backend, so the",
-            "      shared signature is not attributable to this spec on either lane (see the narrowing above).",
-          );
-        } else if (d.crossProvider?.signaturesMatch) {
-          L.push("      the provider is eliminated as the cause: it reproduced on both.");
         } else {
-          L.push(
-            "      INCONCLUSIVE - different signatures do NOT establish that the provider is the cause;",
-            "      providers differ in latency, tool-call format and response shape, so one Langflow defect",
-            "      can surface on one and not the other.",
-          );
+          L.push("      signatures do NOT match (or one is absent)");
+        }
+        if (x.infraCi || x.infraVm) {
+          const which = x.infraCi && x.infraVm ? "both lanes" : x.infraCi ? "Actions" : "the VM";
+          L.push(`      an infra_signature is present on ${which}: the harness could not reach the backend there,`);
+          L.push("      so that side's signature is not attributable to this spec (see the narrowing above)");
         }
         continue;
       }
@@ -710,17 +714,22 @@ export function renderReport(result, { sources = [] } = {}) {
   // "looks right while being wrong" shape this file is written against.
   const agreedFailed = agreed.filter((a) => a.kind === "agreed-failed");
   const agreedFlaky = agreed.filter((a) => a.kind === "agreed-flaky");
-  // The cross-provider pairs are counted HERE too, not only in the list above. These
-  // two lines are read as the day's product-defect tally, and leaving the pairs out of
-  // them would keep the very complaint this change was written against alive: a day
-  // whose only finding is a cross-provider pair ended with `Flaky on BOTH lanes: 0`.
-  const crossF = divergences.filter((d) => d.kind === "cross-provider-failed").length;
-  const crossK = divergences.filter((d) => d.kind === "cross-provider-flaky").length;
-  const alsoCross = (n) => (n ? ` (+${n} as cross-provider pair(s), listed above)` : "");
-  L.push("", `Failed on BOTH lanes (the product, not the environment): ${agreedFailed.length}${alsoCross(crossF)}`);
+  L.push("", `Failed on BOTH lanes (the product, not the environment): ${agreedFailed.length}`);
   for (const a of agreedFailed) L.push(`  ${a.name}`);
-  L.push("", `Flaky on BOTH lanes (unstable in both, not a lane difference): ${agreedFlaky.length}${alsoCross(crossK)}`);
+  L.push("", `Flaky on BOTH lanes (unstable in both, not a lane difference): ${agreedFlaky.length}`);
   for (const a of agreedFlaky) L.push(`  ${a.name}`);
+
+  // A line of their own rather than a `+N` on the two above. Those two tallies mean
+  // "the same test id, on both lanes" and adding pairs to them was how an infra pair
+  // and an assertion-shell pair ended up counted under "the product, not the
+  // environment". But the count cannot be absent either: a day whose only finding is a
+  // pair used to end with two zeroes and no mention of it.
+  const crossPairs = divergences.filter((d) => d.kind.startsWith("cross-target"));
+  L.push(
+    "",
+    `Same spec, DIFFERENT targets (counted in neither tally above): ${crossPairs.length}`,
+  );
+  for (const d of crossPairs) L.push(`  ${d.name}`);
 
   L.push(
     "",

--- a/scripts/lib/lane-verdict-diff.mjs
+++ b/scripts/lib/lane-verdict-diff.mjs
@@ -103,10 +103,13 @@ export function describeTest(entry) {
  * `agent-component-regression` suite flaked on BOTH lanes and the report printed
  * `Flaky on BOTH lanes: 0`. It held the evidence and could not say it.
  *
- * And the pairing is worth more than a corrected count: a failure that reproduces on
- * gemini AND on claude has ELIMINATED the provider as its cause, by construction.
- * Cross-provider agreement is STRONGER evidence of a product defect than agreement on
- * one provider — and the rotation already buys it, at no extra cost.
+ * What the pairing does NOT buy is a conclusion. This docblock used to argue that a
+ * failure reproducing on gemini and on claude "has ELIMINATED the provider as its
+ * cause, by construction" — and that argument outlived the code, which stopped drawing
+ * it. The inference is sound and unverifiable here, for the reason `pairCrossTarget`
+ * gives: the row never records which provider the lane PINNED, so the file cannot tell
+ * a two-provider pair from a two-model pair without being told. Read that docblock
+ * before reintroducing a claim on this one's authority.
  */
 export function specKey(entry) {
   // Same separator, same reason as testKey: joined with nothing, a file ending in a
@@ -182,10 +185,21 @@ export function isGenericSignature(signature) {
 /**
  * The provider named by a `param` label, or `null` when the label does not name one.
  *
- * The labels are written by `select-daily-model-target.mjs` and by the specs' own
- * target resolution, and the corpus carries three shapes: `google / gemini-3.5-flash`,
- * a bare `google`, and `provider:openai (fallback)` — the last from
- * `test-targets.ts` when the catalog was frozen empty.
+ * The labels are written by `select-daily-model-target.mjs` and by the specs' own target
+ * resolution. Counted over both series — 97 param-carrying entries, 8 distinct labels —
+ * every one is `provider / model` (`google / gemini-3.5-flash` 55, `openai / gpt-4o-mini`
+ * 13, `google / gemini-2.5-flash` 12, `google / gemini-flash-latest` 7,
+ * `anthropic / claude-haiku-4-5` 6, `anthropic / claude-sonnet-5` 2, `google / default` 1)
+ * except one `provider:openai (fallback)`, which `test-targets.ts` emits when the
+ * catalog was frozen empty. An earlier version of this comment claimed a bare `google`
+ * was one of the shapes; it appears ZERO times, and no `label:` in `test-targets.ts` can
+ * produce it. The bare branch below stays as tolerance, not as a documented input.
+ *
+ * `model:<id>` — `test-targets.ts` emits it when the target model is absent from the
+ * catalog — names no provider, and returning its whole string as one was the same
+ * overclaim this file spent three reviews removing: against `openai / gpt-4o-mini` it
+ * rendered `providers DIFFER (Actions openai, VM model:gpt-4o-mini)`. It answers `null`,
+ * which routes the pair to "cannot be told from these two rows".
  *
  * It exists because comparing the WHOLE label answers a different question than the
  * one the report was asking. Two labels differ whenever the MODEL differs, and the
@@ -201,6 +215,7 @@ export function paramProvider(param) {
   if (!bare) return null;
   const fallback = bare.match(/^provider:([A-Za-z0-9_-]+)/);
   if (fallback) return fallback[1];
+  if (/^model:/.test(bare)) return null;
   const head = bare.split("/")[0].trim();
   return head || null;
 }
@@ -282,10 +297,15 @@ export function pairCrossTarget(divergences) {
     // narrowing block printed above the list already reports the per-lane counts.
     const infraCi = Boolean(ci.ci?.infra);
     const infraVm = Boolean(vm.vm?.infra);
-    // A FACT about the two labels, not a licence to conclude anything from it.
+    // FACTS about the two labels, not a licence to conclude anything from them. THREE
+    // states, not two: `providersDiffer` is false both when the providers are equal and
+    // when a side names none, and the render used to collapse those into "SAME
+    // provider" — printing `VM [no target]` and `SAME provider (google)` on adjacent
+    // lines, over a row that never said it ran google.
     const ciProvider = paramProvider(ciParam);
     const vmProvider = paramProvider(vmParam);
-    const providersDiffer = Boolean(ciProvider) && Boolean(vmProvider) && ciProvider !== vmProvider;
+    const providersKnown = Boolean(ciProvider) && Boolean(vmProvider);
+    const providersDiffer = providersKnown && ciProvider !== vmProvider;
 
     folded.add(ci);
     folded.add(vm);
@@ -317,6 +337,7 @@ export function pairCrossTarget(divergences) {
         generic,
         infraCi,
         infraVm,
+        providersKnown,
         providersDiffer,
       },
     });
@@ -682,11 +703,19 @@ export function renderReport(result, { sources = [] } = {}) {
         const x = d.crossTarget ?? {};
         L.push(`      Actions [${d.params.ci ?? "no target"}] ${d.ci?.status ?? "?"}: ${d.ci?.error ?? "(no signature)"}`);
         L.push(`      VM      [${d.params.vm ?? "no target"}] ${d.vm?.status ?? "?"}: ${d.vm?.error ?? "(no signature)"}`);
-        L.push(
-          x.providersDiffer
-            ? `      providers DIFFER (Actions ${d.providers?.ci}, VM ${d.providers?.vm})`
-            : `      SAME provider (${d.providers?.ci ?? d.providers?.vm ?? "unnamed"}), different target — the provider is NOT ruled out`,
-        );
+        if (!x.providersKnown) {
+          // The honest third state. Saying "same" here would assert a provider for a
+          // row that never named one, and this is the only line in the block that
+          // touches cause at all.
+          L.push(
+            `      one side does not name a provider (Actions ${d.providers?.ci ?? "—"}, VM ${d.providers?.vm ?? "—"}):`,
+            "      whether the provider differs cannot be told from these two rows",
+          );
+        } else if (x.providersDiffer) {
+          L.push(`      providers DIFFER (Actions ${d.providers?.ci}, VM ${d.providers?.vm})`);
+        } else {
+          L.push(`      SAME provider (${d.providers?.ci}), different target — the provider is NOT ruled out`);
+        }
         if (x.signaturesMatch) {
           L.push(
             x.generic


### PR DESCRIPTION
Closes #1766.

The comparator keyed a test on `file + title + param`. Each lane picks the day's target at run time, so one spec can run under different targets on each lane — and it then keyed as two identities and landed in the report as two one-sided differences.

## The false negative it fixes

On 2026-09-08 Actions pinned **google / gemini-3.5-flash** (the Anthropic balance drained between the two runs, so the rotation advanced past Tuesday's slot) and the VM pinned **anthropic / claude-haiku-4-5**. `agent-component-regression :: agent interaction suite` flaked on **both** lanes, and the report said:

```
  flaky on the VM only:    … [anthropic / claude-haiku-4-5]
  flaky on Actions only:   … [google / gemini-3.5-flash]

Flaky on BOTH lanes (unstable in both, not a lane difference): 0
```

Against the same two rows, this branch now says:

```
  same spec on both lanes under DIFFERENT targets, a retry passed on both:
    …agent-component-regression.spec.ts :: agent interaction suite
      Actions [google / gemini-3.5-flash] flaky: Error: MODEL_TOGGLE_WRITE_STALLED: …
      VM      [anthropic / claude-haiku-4-5] flaky: Error: Agent credential never settled …
      providers DIFFER (Actions google, VM anthropic)
      signatures do NOT match (or one is absent)

Same spec, DIFFERENT targets (counted in neither tally above): 1
```

Divergences for the day go 30 → 29, and the one that moved is the one that was being counted twice.

## Four review rounds, twenty defects, all in the same place

The fold survived every round unchanged. **Every finding was in what the fold CLAIMED, none in the folding.** The first version ranked a match first, stamped the head of the report and called it "the product, not the provider". Each round I added a guard, and the next round found the new guard overclaiming:

| round | what it caught |
|---|---|
| Copilot | the stamp said "**failed** the same way" over a pair both lanes retried and passed; the folded entry took the CI side's empty `tags` over the VM's |
| forked review | `"unknown"` — the string `append-weekly-history.mjs` writes for a message-less failure — counted as a matching signature (15 of 764); the shell rule required `expect(received)` and so missed `expect(locator)`, which is 158 of 764 against 97; the stamp promoted pairs whose own body said "a LEAD, not a confirmation"; two `infra_signature` failures were headlined as "the product" (42 of 764 carry one) |
| cold read | **the only comparison was string inequality of the whole label, while every conclusion said "providers"** — and models differ routinely: google carries four labels across the series, nine specs have two google models, and a smoke that afternoon settled `gemini-2.5-flash` on the VM against the Actions lane's `gemini-3.5-flash`. Plus: `confirmable` gated the stamp and was ignored by the foot tally added one commit later; `infra` was an OR whose text asserted "both sides"; a failed+flaky pair was headlined "FAILED the same way"; and on the only day that ever produced the motivating artefact the report still ended `Flaky on BOTH lanes: 0` |
| cold read of the cut | `providersDiffer` is false both when the providers are EQUAL and when one side names none, and the render collapsed those into "SAME provider (google)" right under a `VM [no target]` line — over a row that never said google, on an input one of my own tests already exercised. `specKey`'s docblock still argued for the removed conclusion. `paramProvider`'s docblock enumerated a label shape that appears **zero** times and omitted `model:<id>`, which it returned whole as a provider name. Three properties were unpinned — including the ANSI strip whose only test the rewrite **deleted**, though 262 of 696 shells are ANSI-wrapped and the un-normalized rule recognises none |

Four rounds in the same place is the design speaking, not the wording — and the fourth read the cut itself, the commit written *after* I concluded my own failure mode was overclaiming, and found me doing it again in three docblocks and a render branch. **The claims need facts the row does not carry** — which provider the lane pinned, and whether it ran one variant or several. One docblock sentence of mine even claimed a mitigation ("ambiguous pairs are ranked INCONCLUSIVE") that the code never implemented; I wrote it without checking and repeated it in this body.

## So the fold reports and the reader concludes

- `pairCrossProvider` → **`pairCrossTarget`**: a fold is a difference of *target*, and only sometimes of provider. `paramProvider()` reads the label shapes the corpus actually carries — counted: 97 param entries, 8 labels, all `provider / model` bar one `provider:openai (fallback)` — and answers `null` for `model:<id>`, which names no provider. The entry reports **three** states, not two: providers differ; same provider, and so **not** ruled out; or one side names none and it **cannot be told from these two rows**.
- **No head stamp, at all.** It is the one surface that cannot be qualified.
- **Two kinds, split by severity only**, each ranked *with* its severity and never above it. No `differs` kind: whether the signatures match is a field and a line, not a verdict.
- **The two BOTH-lanes tallies keep their meaning**; the pairs get a line of their own that says it counts in neither.
- The entry prints both targets, both statuses, both signatures, which providers, whether the signatures match, whether the shared one is an assertion shell, and **which lane** carries an `infra_signature`. Nothing about cause.

**The inference is deferred, not abandoned.** "It reproduced on gemini and on claude, so the provider is eliminated" is sound — it is just not checkable from a row that never says which provider was pinned. When that field lands (it waits on #1731, whose matrix-output path would otherwise record the provider of whichever shard finished last) the claim can come back as something this file verifies instead of assumes.

## How it was checked

- **Against the real rows of 2026-09-08**, not a fixture: the output above is that run. 2026-09-07 also re-checked — 20 divergences, no fold, the traces family untouched.
- `npm run test:scripts` → **1256 pass / 0 fail** (1 pre-existing skip).
- **Mutation, one per property.** Every mutant the two cold reads named as surviving now fails: forcing `providersDiffer` and `providersKnown` true, widening `infra` to an OR of both sides, both rank promotions (`0.5` above `ci-only-failed`, `-99` for the flaky kind), the un-normalized shell rule, the VM line mirroring the Actions side's status and signature, `model:` as a provider name, and dropping the pairs line.
- **Against the corpus rather than by reasoning:** of the 115 distinct signatures in the two series the shell rule matches 21, every one a bare matcher; nothing message-bearing matches and nothing starting with `expect(` escapes. Every cited count re-derived: `unknown` 15/764, SGR escapes 255/764, `infra_signature` 42/764.
- `npx eslint` clean on both files.

## Deliberately out of scope

Recording the day's **pinned provider** on the row — which is also what would let the deferred claim return — needs the value to reach the merge job, and in `daily-stable.yml` that path is a matrix job output: the shape #1731 describes, where the last shard to write wins. For a provider that degrades worse than for a version: if a balance drains mid-run, shard 1 pins one provider and shard 4 another, and the row records whichever finished last. It should ride the #1731 fix rather than copy the defective path.

The fold needs none of it: `param` is already on every failure and flaky entry of the row.
