### PR TITLE
fix(api-flows-crud): make the flows-CRUD failures attributable and stop the orphan leak (#1759)

### DIFF
--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/cli.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/cli.ts
@@ -435,9 +435,14 @@ async function gateFor(s: PipelineState, step: Phase, evidence: Record<string, u
         problems.push(`need ${BURST} clean --retries=0 runs for ${target}; have ${greens.length}${voidNote} (run next again)`)
       }
     }
+    // The DEBUG verdict is passed in because a `langflow-regression` exempts the
+    // `@stable` half of the quarantine lift and nothing else does (#1759 — see
+    // checkQuarantineLifted). Read from the step record rather than recomputed:
+    // the verdict is the user's decision, already gated by DEBUG.
     problems.push(...checkQuarantineLifted(
       s.issueData?.body ?? '',
       touchedSpecFiles().map(f => ({ file: f, entries: enumerateTestEntries(fs.readFileSync(f, 'utf8')) })),
+      (s.steps?.DEBUG?.evidence as { verdict?: string } | undefined)?.verdict,
     ))
     if (ev.typecheck !== 0) problems.push(`typecheck exit=${ev.typecheck}`)
     if (ev.lint !== 0) problems.push(`lint exit=${ev.lint}`)
@@ -483,6 +488,9 @@ async function gateFor(s: PipelineState, step: Phase, evidence: Record<string, u
           branch: gitCurrentBranch(), prBody: body, issue: s.issue,
           isWave: s.issueData?.milestone != null,
           labels: s.issueData?.labels ?? [],
+          // A product verdict inverts the closing requirement: the issue has to
+          // outlive its own fix PR (#1759 — see checkPrReadiness).
+          verdict: (s.steps?.DEBUG?.evidence as { verdict?: string } | undefined)?.verdict,
         }))
         // `evidence` is the payload being recorded by THIS call; `rec.evidence`
         // is what a previous attempt left behind. Reading the stale one meant a

--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.test.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.test.ts
@@ -121,6 +121,60 @@ test('PR readiness checks branch, Closes line, roadmap label for wave issues', (
   assert.equal(bad.length, 3)
 })
 
+// A `langflow-regression` issue must SURVIVE its own fix PR (#1759). Its
+// deliverable says so: "this issue stays open until the upstream fix lands in
+// langflowai/langflow-nightly:latest, is re-validated there, and @stable is
+// restored". `Closes #NNN` would close it at merge and drop the tracking of an
+// upstream ticket that is still open — so under that verdict the gate INVERTS:
+// a non-closing reference is required and `Closes` is the defect. The house
+// convention already does this by hand (PR #1761: "Tracked by #1759 — this PR
+// does not fix it, and does not close that issue").
+
+const REGRESSION = 'langflow-regression'
+
+test('a langflow-regression PR may reference the issue without closing it (#1759)', () => {
+  for (const ref of ['Refs #1759', 'Tracked by #1759', 'Part of #1759']) {
+    const problems = checkPrReadiness({
+      branch: 'fix/issue-1759-flows-crud', prBody: `${ref}\n## Problem`,
+      issue: 1759, isWave: false, labels: [], verdict: REGRESSION,
+    })
+    assert.deepEqual(problems, [], `"${ref}" should satisfy the gate under a product verdict`)
+  }
+})
+
+test('a langflow-regression PR is REFUSED for saying Closes (#1759)', () => {
+  // The load-bearing half. Merely accepting both forms would let the wrong one
+  // through silently, and the wrong one closes an issue tracking a live
+  // upstream defect.
+  const problems = checkPrReadiness({
+    branch: 'fix/issue-1759-flows-crud', prBody: 'Closes #1759\n## Problem',
+    issue: 1759, isWave: false, labels: [], verdict: REGRESSION,
+  })
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /Closes #1759/)
+  assert.match(problems[0], /stay open|must not close|Refs/i)
+})
+
+test('a langflow-regression PR still needs SOME reference to its issue (#1759)', () => {
+  const problems = checkPrReadiness({
+    branch: 'fix/issue-1759-flows-crud', prBody: '## Problem\nno reference at all',
+    issue: 1759, isWave: false, labels: [], verdict: REGRESSION,
+  })
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /1759/)
+})
+
+test('every other verdict still requires Closes (#1759)', () => {
+  for (const verdict of [undefined, 'test-defect', 'transient-saturation', 'product-changed']) {
+    const problems = checkPrReadiness({
+      branch: 'fix/issue-1759-flows-crud', prBody: 'Refs #1759\n## Problem',
+      issue: 1759, isWave: false, labels: [], verdict,
+    })
+    assert.equal(problems.length, 1, `verdict ${verdict} must still require Closes`)
+    assert.match(problems[0], /missing "Closes #1759"/)
+  }
+})
+
 // ---------- quarantine lift (#1082) ----------
 
 const QUARANTINE_BODY = `
@@ -192,6 +246,71 @@ test('checkQuarantineLifted passes once fixme is gone and @stable is back', () =
     ],
   }]
   assert.deepEqual(checkQuarantineLifted(QUARANTINE_BODY, files), [])
+})
+
+// A product verdict makes the `@stable` half of the deliverable UNREACHABLE, and
+// the issue template says so itself — two of its own checkboxes contradict each
+// other (#1759, measured on the real body):
+//
+//   "Quarantine lifted in the fix PR — remove `test.fixme` **and** restore `@stable`"
+//   "If the root cause is a **product (Langflow) regression**: ... `@stable` is
+//    restored — not on a test-side mute."
+//
+// The second is a condition on the first, and the gate read only the first. Under
+// `langflow-regression` the tag goes back when the UPSTREAM fix lands and is
+// re-validated, so demanding it in the fix PR asks for exactly the test-side mute
+// the body forbids — and would return a test that fails on a live product defect
+// to the daily.
+//
+// The exemption is SCOPED TO THE TAG. `test.fixme` still has to come off: a muted
+// test gives no signal in any context, and while the defect is live that signal is
+// the only thing saying it is still there. An exemption that silenced the whole
+// gate would let a product verdict ship a permanently muted test — strictly worse
+// than the bug this gate exists to prevent.
+
+test('checkQuarantineLifted does not demand @stable under a langflow-regression verdict (#1759)', () => {
+  const files = [{
+    file: 'a.spec.ts',
+    entries: [{ title: "switching the agent's context_id re-tags new turns", modifier: '', tags: ['@regression'] }],
+  }]
+  assert.deepEqual(checkQuarantineLifted(QUARANTINE_BODY, files, 'langflow-regression'), [])
+})
+
+test('a langflow-regression verdict still demands the test.fixme comes off (#1759)', () => {
+  // The load-bearing half. If the verdict silenced the whole gate instead of just
+  // the tag, a product regression could ship a test muted in every context.
+  const files = [{
+    file: 'a.spec.ts',
+    entries: [{ title: "switching the agent's context_id re-tags new turns", modifier: '.fixme', tags: ['@regression'] }],
+  }]
+  const problems = checkQuarantineLifted(QUARANTINE_BODY, files, 'langflow-regression')
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /test\.fixme still on/)
+  assert.doesNotMatch(problems[0], /@stable/)
+})
+
+test('only a product verdict exempts the tag — every other verdict still demands it (#1759)', () => {
+  const files = [{
+    file: 'a.spec.ts',
+    entries: [{ title: "switching the agent's context_id re-tags new turns", modifier: '', tags: ['@regression'] }],
+  }]
+  for (const verdict of ['test-defect', 'transient-saturation', 'cross-worker-wiper', 'product-changed', 'stale-confirmed-bug']) {
+    const problems = checkQuarantineLifted(QUARANTINE_BODY, files, verdict)
+    assert.equal(problems.length, 1, `verdict ${verdict} must still demand @stable`)
+    assert.match(problems[0], /@stable not restored/)
+  }
+})
+
+test('an absent verdict keeps the pre-#1759 behaviour', () => {
+  // Callers that pass nothing (and every phase other than VALIDATE) must be
+  // unaffected: no verdict is not a product verdict.
+  const files = [{
+    file: 'a.spec.ts',
+    entries: [{ title: "switching the agent's context_id re-tags new turns", modifier: '', tags: ['@regression'] }],
+  }]
+  const problems = checkQuarantineLifted(QUARANTINE_BODY, files, undefined)
+  assert.equal(problems.length, 1)
+  assert.match(problems[0], /@stable not restored/)
 })
 
 // ---------- symptom rows (#1082) ----------

--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.ts
@@ -182,9 +182,27 @@ const RESTORE_STABLE_RE = /restore\s+`?@stable|@stable\b[^.\n]{0,40}\brestor/i
  * Only the issue body arms this gate: an issue that never quarantined anything
  * is unaffected, and the `@stable` half only fires when the body asks for the
  * tag back (utility specs legitimately carry no `@stable`).
+ *
+ * `verdict` is the DEBUG verdict, and `langflow-regression` exempts the `@stable`
+ * half — never the `test.fixme` half (#1759). The dedicated-issue template
+ * carries two deliverables that contradict each other under a product verdict:
+ * *"remove `test.fixme` and restore `@stable`"* and *"if the root cause is a
+ * product (Langflow) regression … `@stable` is restored — not on a test-side
+ * mute"*. The second is a condition on the first, and this gate read only the
+ * first, so a confirmed product defect could not close VALIDATE without doing
+ * precisely what the body forbids: putting a test that fails on a live defect
+ * back into the daily. #1759/`LE-2552` was the first issue to reach that state.
+ *
+ * The scope matters as much as the exemption. `test.fixme` must still come off:
+ * a muted test reports in NO context, and while a product defect is live that
+ * report is the only thing saying it is still there. Exempting the whole gate
+ * would let a product verdict ship a permanently muted test — worse than the
+ * hole this gate was added to close.
  */
 export function checkQuarantineLifted(
-  issueBody: string, files: Array<{ file: string; entries: TestEntry[] }>,
+  issueBody: string,
+  files: Array<{ file: string; entries: TestEntry[] }>,
+  verdict?: string,
 ): string[] {
   if (!QUARANTINE_RE.test(issueBody)) return []
   const problems: string[] = []
@@ -210,7 +228,7 @@ export function checkQuarantineLifted(
       problems.push(`quarantine not lifted: test.fixme still on "${e.title}" in ${file}`)
     }
   }
-  if (RESTORE_STABLE_RE.test(issueBody)) {
+  if (RESTORE_STABLE_RE.test(issueBody) && verdict !== 'langflow-regression') {
     for (const { file, entries } of files) {
       for (const e of entries) {
         if (!issueBody.includes(e.title)) continue
@@ -398,14 +416,44 @@ export function checkCiVerdict(
   return []
 }
 
+/**
+ * `verdict` inverts the closing requirement for a `langflow-regression` (#1759).
+ *
+ * The dedicated-issue deliverable is explicit: *"this issue stays **open** until
+ * the upstream fix lands in `langflowai/langflow-nightly:latest`, is re-validated
+ * there, and `@stable` is restored"*. `Closes #NNN` closes it at merge and drops
+ * the tracking of an upstream ticket that is still open — so under that verdict a
+ * NON-closing reference is required and `Closes` is itself the defect. Accepting
+ * both would let the wrong one through in silence, which is the outcome that
+ * matters here. The house already writes it this way by hand: PR #1761,
+ * *"Tracked by #1759 — this PR does not fix it, and does not close that issue."*
+ */
+export const NON_CLOSING_REF_RE = (issue: number) =>
+  new RegExp(`(?:Refs|Tracked by|Part of|Relates to)\\s+#${issue}\\b`, 'i')
+
 export function checkPrReadiness(e: {
   branch: string; prBody: string; issue: number; isWave: boolean; labels: string[]
+  verdict?: string
 }): string[] {
   const problems: string[] = []
   if (!BRANCH_RE.test(e.branch)) {
     problems.push(`branch "${e.branch}" does not match type/issue-NNN-desc`)
   }
-  if (!new RegExp(`Closes #${e.issue}\\b`).test(e.prBody)) {
+  const closes = new RegExp(`Closes #${e.issue}\\b`).test(e.prBody)
+  if (e.verdict === 'langflow-regression') {
+    if (closes) {
+      problems.push(
+        `PR body says "Closes #${e.issue}", but a langflow-regression issue must `
+        + `stay open until the upstream fix lands and is re-validated — reference it `
+        + `without closing it ("Refs #${e.issue}" / "Tracked by #${e.issue}")`,
+      )
+    } else if (!NON_CLOSING_REF_RE(e.issue).test(e.prBody)) {
+      problems.push(
+        `PR body must reference #${e.issue} without closing it `
+        + `("Refs #${e.issue}" / "Tracked by #${e.issue}" / "Part of #${e.issue}")`,
+      )
+    }
+  } else if (!closes) {
     problems.push(`PR body missing "Closes #${e.issue}"`)
   }
   if (e.isWave && !e.labels.includes('roadmap')) {

--- a/docs/api/flows/api-flows-crud.md
+++ b/docs/api/flows/api-flows-crud.md
@@ -1,6 +1,6 @@
 # API Flows CRUD
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.13.x
 
 ---
 
@@ -15,6 +15,27 @@ If any of these tests fail against `langflowai/langflow-nightly:latest`, the flo
 
 ## Tags *(required)*
 `@stable` `@release` `@api` `@regression`
+
+**Test 2 (`GET lists flows and includes the created one`) carries `@release @api
+@regression` but NOT `@stable`, deliberately, and #1759 stays open until it does.**
+`@stable` was removed at triage of the 2026-09-08 daily (umbrella #1757) when the test
+failed under the same assertion for the second time. The investigation reached a
+**product** verdict — `LE-2552`, see *Known product defect* below — so the tag is not
+restored on a test-side change: the issue's own rule is that a product regression is
+restored only after the fix lands in `langflowai/langflow-nightly:latest` and is
+re-validated there.
+
+The test is nonetheless **un-quarantined** (no `test.fixme`), which is a decision and
+not an oversight. `test.fixme` runs in no context at all — not the daily, not the PR
+impacted-specs gate, not the full suite — and Test 2 is the **only** one of the three
+symptoms whose failure is not yet attributable to the confirmed mechanism. Its
+diagnostic (step 5 below) is the discriminant, and a discriminant on a muted test is
+never read. Without `@stable` it runs in the PR gate and the full suite and stays out
+of the daily, so it produces evidence where the issue's owner sees it without diluting
+the daily's signal.
+
+Tests 5 and 9 keep `@stable`: they are first occurrences, they run in the daily on
+purpose, and while the defect is live they are what says it is still there.
 
 ---
 
@@ -35,7 +56,14 @@ The spec runs **9 independent tests** against `/api/v1/flows/` via Playwright's 
 2. `GET /api/v1/flows/`
 3. Assert HTTP status is `200` and the response is iterable (array or `{ flows: [...] }`)
 4. Assert the freshly created `id` is present in the list with the correct name
-5. Cleanup
+5. **When step 4 fails, read `GET /api/v1/flows/{id}` and attach its status together
+   with the list's length** — the assertion is unchanged, this only makes the failure
+   say which of two different defects it is. `200` there means the row exists and the
+   **list** did not return it; `404` means the row is not there at all. Without this
+   the failure reads `expect(received).toBeDefined() / Received: undefined` and names
+   neither. This is the one symptom of the three that #1759 could not attribute, and
+   this reading is what closes it.
+6. Cleanup
 
 **Test 3 — `GET by ID returns correct flow`**
 1. Create a flow via `POST`
@@ -53,8 +81,13 @@ The spec runs **9 independent tests** against `/api/v1/flows/` via Playwright's 
 
 **Test 5 — `DELETE removes flow and returns 200`**
 1. Create a flow via `POST`
-2. `DELETE /api/v1/flows/{id}`
+2. `DELETE /api/v1/flows/{id}` — a **raw** `DELETE` on purpose: this call's status IS
+   the assertion, and `deleteFlow` would absorb a `404` as done and retry one `5xx`
 3. Assert HTTP status is `200`
+4. **When step 3 fails, attach the response body and the status of `GET
+   /api/v1/flows/{id}`** — a `404` from `DELETE` does not say whether the id is wrong
+   or the row was merely not visible to that read (see *Known product defect*), and
+   the `GET` separates the two
 
 **Test 6 — `GET after DELETE returns 404`**
 1. Create a flow via `POST`
@@ -72,9 +105,66 @@ The spec runs **9 independent tests** against `/api/v1/flows/` via Playwright's 
 
 **Test 9 — `deleted flow does not appear in flows listing`**
 1. Create a flow via `POST`
-2. `DELETE /api/v1/flows/{id}`
+2. `DELETE /api/v1/flows/{id}` — **raw, and its status is asserted `200` before the
+   list is read.** This replaces a `deleteFlow` call and is a **strengthening**, not a
+   loosening: the helper treats `404` as the desired end state (correct for idempotent
+   cleanup, wrong for a test whose subject is the delete contract), so a `404` here
+   used to be swallowed and the test then reported *"deleted flow still listed"* —
+   accusing the wrong symptom and making one defect look like two. On the 2026-09-08
+   daily this test and Test 5 were the same failure seen from two sides
 3. `GET /api/v1/flows/`
 4. Assert HTTP status is `200` and the deleted `id` is absent from the list
+5. **When step 4 fails, attach the status of `GET /api/v1/flows/{id}`** — it separates
+   "the delete reported success and removed nothing" from "the row is gone and only
+   the list still shows it"
+
+---
+
+## Known product defect — `LE-2552` (open)
+
+Tests 2, 5 and 9 are the three sides of one live product defect, filed as
+[`LE-2552`](https://datastax.jira.com/browse/LE-2552). **The assertions here are the
+contract and none of them is weakened for it.** What the tests gained is the ability to
+say which side fired.
+
+`DELETE` on this route family answers a **success status for a request that removed
+nothing**. `_read_flow` runs twice per request — once in the `AuthorizedDeleteFlow`
+dependency (`api/v1/authz_route_dependencies.py`, which raises `404 "Flow not found"`
+when it returns `None`) and once inside `_delete_operation` (`api/v1/flows.py`,
+`delete_flow`). When the calls overlap, the dependency's read lands **before** the
+winner commits — so the request enters the handler — and the handler's read lands
+**after** it, so `retry_target is None` hits a bare `return` and the handler still
+answers `200 {"message": "Flow deleted successfully"}`.
+
+Measured on `1.13.0.dev6` **and** `1.13.0.dev0`, with and without `foreign_keys=ON`,
+with and without tracing, at `LANGFLOW_WORKERS=1` (so not multi-worker contention):
+
+| Call | Fan-out | Trials | Result |
+|---|---|---|---|
+| `DELETE /api/v1/flows/{id}` | 4 | 25 | `200` × 4 — 25/25 |
+| `DELETE /api/v1/flows/{id}` | 2 | 40 | `200+200` — 40/40 |
+| `DELETE …/versions/{vid}` | 4 | 25 | `204` × 4 — 25/25 |
+| `DELETE /api/v1/flows/` (bulk) | 4 | 20 | `deleted: 0+0+0+1` — 20/20 |
+
+Idempotent-DELETE-by-design is refuted by the product itself: the **same** condition —
+the row not being there for this request — answers `404` for a never-existed id, `404`
+for a second **sequential** delete, and `404` on the versions route in both of those
+shapes. Only overlapping calls get `2xx`. The bulk route is unaffected and already
+correct, so the right shape exists one route away.
+
+Two consequences for anyone reading a failure here:
+
+- **A `2xx` from `DELETE` is not a post-condition.** Confirm removal with `GET
+  /api/v1/flows/{id}` → `404` or by absence from the list — which is what Tests 6 and
+  9 do, and why Test 9's own delete is now asserted rather than delegated.
+- **A `404` from `DELETE` is not proof the id is wrong.** It is the other face of the
+  same race.
+
+Test 2's own failure (`POST` → `201`, then the list omits the id) is **not** attributed
+to this mechanism: it goes through `read_flows`, a different query, and it did not
+reproduce in six local configurations (0/30 serial, 0/80 concurrent, 0/10 `repro-run`,
+0/6 daily topology, 0/8 current nightly with tracing, 0/10 with the daily's exact
+SQLite pragmas). Its step-5 diagnostic is what will decide it.
 
 ---
 
@@ -84,6 +174,18 @@ The spec runs **9 independent tests** against `/api/v1/flows/` via Playwright's 
 - PATCH changes are durable: a subsequent `GET` reflects the new values.
 - Deleted flows disappear from both `GET /api/v1/flows/{id}` and the list endpoint.
 - Each test cleans up after itself — no orphan flows remain in the database after the suite completes.
+- **A failure of Test 2, 5 or 9 names what the backend did.** The distinctive
+  observable: the failure message carries the status of `GET /api/v1/flows/{id}` taken
+  at the moment of the failure (and, for Test 2, the list's length). A run that fails
+  one of those three without that reading has not met this criterion even if the
+  assertion itself is right — the whole reason #1759 needed an investigation instead of
+  a triage is that the three original messages named none of it. Forced-failure
+  evidence for this is the mutation that flips the assertion while the diagnostic still
+  prints.
+- **While `LE-2552` is open, these three are expected to fail intermittently, and that
+  is the spec working.** The product is intermittent; a green run is not evidence the
+  defect is gone. Closing the loop needs the upstream fix in the nightly plus a
+  re-validated `@stable` on Test 2 — never a test-side change.
 
 ---
 
@@ -108,6 +210,8 @@ The spec runs **9 independent tests** against `/api/v1/flows/` via Playwright's 
 - `src/backend/base/langflow/api/v1/flows.py` — router that exposes `POST/GET/PATCH/DELETE /api/v1/flows/`; any signature, status code, or response shape change here directly affects the spec.
 - `src/backend/base/langflow/services/database/models/flow/model.py` — flow schema (name, description, data, is_component); renaming or removing a field breaks the POST payload and the PATCH/GET assertions.
 - `src/backend/base/langflow/api/utils/` — shared API helpers used by the flows router (validation, current-user resolution); changes here can shift 422 vs 400 boundaries.
+- `src/backend/base/langflow/api/v1/authz_route_dependencies.py` — resolves the flow for `GET`/`PATCH`/`DELETE` by id and is where the `404 "Flow not found"` originates. It performs the **first** of the two `_read_flow` calls per request; the second is in the router. `LE-2552` lives in the gap between them, so a change to either read (or to the retry that wraps the second one) changes what Tests 5 and 9 observe.
+- `src/backend/base/langflow/api/v1/flows_helpers.py` — `_read_flow` itself (owner-scoped unless an authorization plugin widens it) and `_new_flow`; the query that decides whether a just-written row is visible to the next read.
 
 ---
 

--- a/tests/helpers/flows/describe-flow-readback.test.ts
+++ b/tests/helpers/flows/describe-flow-readback.test.ts
@@ -1,0 +1,108 @@
+// Unit tests for describeFlowReadback (#1759 / LE-2552).
+// Run with: npm run test:units
+//
+// The helper exists because the three api-flows-crud failures on the 2026-09-08
+// daily named nothing. `expect(found).toBeDefined() / Received: undefined` does
+// not say whether the row is missing from the DATABASE or merely missing from
+// the LIST, and those are two different defects. The helper reads the row by id
+// and turns that into one line that goes into the assertion message.
+//
+// Two properties carry the whole design and both are asserted below.
+//
+// 1. It NEVER THROWS. It runs on the branch where an assertion is about to
+//    fail, so a throw here would replace the real failure with its own and the
+//    original signal would be gone -- the same reasoning that wraps
+//    `recordTokenAttribution` inside `deleteFlow` (delete-flow.ts §2.3).
+//
+// 2. It has THREE outcomes, not two. A readback that cannot be performed is
+//    UNDECIDED and says so; it is never folded into either verdict (#1012 --
+//    an unevaluated result is unknown, not clean). Getting this wrong is worse
+//    than having no helper: a triage reading "the row is NOT there" off a 503
+//    would chase a phantom.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { APIRequestContext } from "@playwright/test";
+import { describeFlowReadback } from "./describe-flow-readback";
+
+const ID = "3fa4f2b2-31d0-408d-a64d-c8ee30772add";
+
+/** A request context whose GET answers `status`, recording what it was asked. */
+function fakeRequest(status: number) {
+  const calls: Array<{ url: string; options: unknown }> = [];
+  const request = {
+    get: async (url: string, options: unknown) => {
+      calls.push({ url, options });
+      return { status: () => status };
+    },
+  } as unknown as APIRequestContext;
+  return { request, calls };
+}
+
+/** A request context whose GET rejects — the backend is unreachable. */
+function throwingRequest(message: string) {
+  const request = {
+    get: async () => {
+      throw new Error(message);
+    },
+  } as unknown as APIRequestContext;
+  return request;
+}
+
+test("a 200 readback states the row exists and nothing more", async () => {
+  const { request } = fakeRequest(200);
+  const line = await describeFlowReadback(request, ID);
+  assert.match(line, /200/);
+  assert.match(line, /exists/i);
+  assert.ok(line.includes(ID), "the line must name the id it read");
+  // The helper must NOT infer which caller-side read failed. It is called from
+  // a list assertion AND from a raw-DELETE assertion, and in the second there
+  // is no list at all -- an earlier version of this line ended "so the list is
+  // what failed to return it" and printed exactly that under the DELETE test,
+  // pointing a triage at a read that never happened. The caller supplies the
+  // context through `note`; the helper reports only what it observed.
+  assert.doesNotMatch(line, /\blist\b/i);
+});
+
+test("a 404 readback says the row is absent", async () => {
+  const { request } = fakeRequest(404);
+  const line = await describeFlowReadback(request, ID);
+  assert.match(line, /404/);
+  assert.match(line, /absent|not there|does not exist/i);
+});
+
+test("any other status is UNDECIDED and claims neither verdict", async () => {
+  const { request } = fakeRequest(503);
+  const line = await describeFlowReadback(request, ID);
+  assert.match(line, /503/);
+  assert.match(line, /undecided/i);
+  // The load-bearing half: a readback that did not answer must not be read as
+  // either outcome. Asserting only the presence of "undecided" would pass on a
+  // line that ALSO claimed the row exists.
+  assert.doesNotMatch(line, /exists/i);
+  assert.doesNotMatch(line, /absent|not there|does not exist/i);
+});
+
+test("a readback that throws is UNDECIDED, and the throw does not escape", async () => {
+  const request = throwingRequest("socket hang up");
+  const line = await describeFlowReadback(request, ID);
+  assert.match(line, /undecided/i);
+  assert.match(line, /socket hang up/);
+  assert.doesNotMatch(line, /exists/i);
+  assert.doesNotMatch(line, /absent|not there|does not exist/i);
+});
+
+test("it reads the by-id route and forwards the caller's options", async () => {
+  const { request, calls } = fakeRequest(200);
+  const headers = { Authorization: "Bearer t" };
+  await describeFlowReadback(request, ID, { headers });
+  assert.equal(calls.length, 1, "exactly one readback request");
+  assert.equal(calls[0].url, `/api/v1/flows/${ID}`);
+  assert.deepEqual(calls[0].options, { headers });
+});
+
+test("an extra note from the caller is carried into the line", async () => {
+  const { request } = fakeRequest(404);
+  const line = await describeFlowReadback(request, ID, undefined, "list had 31 flows");
+  assert.match(line, /list had 31 flows/);
+  assert.match(line, /404/);
+});

--- a/tests/helpers/flows/describe-flow-readback.ts
+++ b/tests/helpers/flows/describe-flow-readback.ts
@@ -1,0 +1,74 @@
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * Reads a flow by id and describes, in one line, what that read found — for use
+ * as the message of an assertion that is about to fail.
+ *
+ * Why this exists (#1759 / `LE-2552`): on the 2026-09-08 daily, three
+ * `api-flows-crud` assertions failed and none of their messages said what the
+ * backend had done. `expect(found).toBeDefined() / Received: undefined` does not
+ * distinguish *the row is missing from the database* from *the row is there and
+ * the LIST did not return it*, and those are two different defects. The by-id
+ * route answers exactly that question, so reading it at the moment of failure
+ * turns an unattributable message into an attributable one. The assertion itself
+ * is unchanged — this only decorates it.
+ *
+ * Two properties are contractual, and both are pinned in
+ * `describe-flow-readback.test.ts`:
+ *
+ * 1. **It never throws.** It runs on the branch where a test is already failing.
+ *    A throw here would replace the real failure with its own and destroy the
+ *    signal it exists to sharpen — the same reason `deleteFlow` wraps its
+ *    attribution hook in a bare `catch` (delete-flow.ts §2.3).
+ *
+ * 2. **It has three outcomes, not two.** A readback that could not be performed
+ *    is `UNDECIDED` and claims neither verdict (#1012 — an unevaluated result is
+ *    unknown, not clean). Folding a 503 into "the row is absent" would send a
+ *    triage after a phantom, which is worse than printing nothing at all.
+ *
+ * Deliberately NOT declared through `apiCoverage`: the call only happens on the
+ * failing branch, and the coverage gate FAILS a declaration the test never
+ * issues (`fixtures/api-coverage-gate.spec.ts` §4). An undeclared request is
+ * tolerated, so this needs no declaration.
+ *
+ * @param request  A Playwright `APIRequestContext` (`page.request` or the `request` fixture).
+ * @param id       The flow id whose visibility is in question.
+ * @param options  Optional Playwright request options, e.g. `{ headers: { Authorization } }`.
+ * @param note     Extra context from the caller, carried into the line verbatim (e.g. the list's length).
+ */
+export async function describeFlowReadback(
+  request: APIRequestContext,
+  id: string,
+  options?: Parameters<APIRequestContext["get"]>[1],
+  note?: string,
+): Promise<string> {
+  const route = `/api/v1/flows/${id}`;
+  const suffix = note ? ` [${note}]` : "";
+
+  let status: number;
+  try {
+    const res = await request.get(route, options);
+    status = res.status();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return (
+      `readback GET ${route} threw (${message}): UNDECIDED — ` +
+      `the readback never answered, so it says nothing either way${suffix}`
+    );
+  }
+
+  if (status === 200) {
+    // Reports what it observed, and deliberately does not infer which
+    // caller-side read failed: this runs from a list assertion AND from a raw
+    // DELETE, and in the second there is no list to blame. The caller's `note`
+    // carries the context.
+    return `readback GET ${route} -> 200: the row EXISTS${suffix}`;
+  }
+  if (status === 404) {
+    return `readback GET ${route} -> 404: the row is absent from the database${suffix}`;
+  }
+  return (
+    `readback GET ${route} -> ${status}: UNDECIDED — ` +
+    `the readback did not answer 200 or 404, so it says nothing either way${suffix}`
+  );
+}

--- a/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { describeFlowReadback } from "../../../../helpers/flows/describe-flow-readback";
 
 type Flow = { id: string; name: string; description?: string };
 
@@ -16,7 +17,15 @@ const FLOW_BASE = {
 // five CRUD operations count in `npm run api:coverage` — where they counted for
 // nothing before, despite being driven as contracts here since the spec was written.
 // No assertion changed. Cleanup deletes through `deleteFlow` are not declared: the
-// helper verifies them, but the DELETE contract is asserted by its own test below.
+// helper verifies them, but the DELETE contract is asserted by the two tests that
+// issue a RAW delete ("DELETE removes flow and returns 200" and "deleted flow does
+// not appear in flows listing"), and those two do declare it.
+//
+// `describeFlowReadback` is deliberately NOT declared anywhere in this file. It is
+// called only on the branch where an assertion is about to fail, and the coverage
+// gate FAILS a declaration the test never issues (fixtures/api-coverage-gate.spec.ts
+// §4) — declaring `GET /api/v1/flows/{flow_id}` for it would redden three tests on
+// every green run. An undeclared request is tolerated, which is what makes this safe.
 test.describe("CRUD /api/v1/flows", () => {
   // Each test manages its own flow to remain independent
   test(
@@ -53,14 +62,23 @@ test.describe("CRUD /api/v1/flows", () => {
     },
   );
 
-  // Quarantined at triage (2026-09-08 daily, umbrella #1757): `POST /api/v1/flows/`
-  // returns 201 and the very next `GET /api/v1/flows/` does not contain the created
-  // flow, so `expect(found).toBeDefined()` receives `undefined`. Recurrent under the
-  // same assertion on the 2026-08-19 and 2026-09-08 dailies. Not wedge collateral —
-  // the attempt ran at 12:41:27Z and finished in 418 ms, ~2.5 min before the earliest
-  // measured outage window on any shard (12:43:57Z). Lifting the quarantine (remove
-  // test.fixme + restore @stable) is a deliverable of #1759.
-  test.fixme(
+  // `POST /api/v1/flows/` returns 201 and the very next `GET /api/v1/flows/` does not
+  // contain the created flow. Recurrent under the same assertion on the 2026-08-19 and
+  // 2026-09-08 dailies. Not wedge collateral — the attempt ran at 12:41:27Z and
+  // finished in 418 ms, ~2.5 min before the earliest measured outage window on any
+  // shard (12:43:57Z).
+  //
+  // NO `@stable`, and #1759 stays open until it comes back: the investigation reached a
+  // PRODUCT verdict (`LE-2552`), so the tag is restored only after the upstream fix
+  // lands in the nightly and is re-validated there — never on a test-side change.
+  //
+  // The triage quarantine (`test.fixme`) is LIFTED, and that is a decision: `test.fixme`
+  // runs in no context at all, and this is the one of the three symptoms whose failure
+  // is NOT yet attributable to LE-2552's mechanism (it goes through `read_flows`, a
+  // different query, and did not reproduce in six local configurations). Its readback
+  // below is the discriminant, and a discriminant on a muted test is never read. Without
+  // `@stable` it runs in the PR gate and the full suite and stays out of the daily.
+  test(
     "GET lists flows and includes the created one",
     { tag: ["@release", "@api", "@regression"] },
     async ({ request, apiCoverage }) => {
@@ -87,7 +105,21 @@ test.describe("CRUD /api/v1/flows", () => {
 
           const flows = (await listRes.json()) as Flow[];
           const found = flows.find((f) => f.id === id);
-          expect(found).toBeDefined();
+          // Readback ONLY on the branch that is about to fail, so the green path
+          // pays no extra request. Its line goes into the assertion MESSAGE
+          // because `error.message` is what `results.json` carries and what the
+          // daily triage reads — an attachment would not be there. Which of two
+          // defects this is turns on the readback's status: 200 means the row
+          // exists and the LIST did not return it; 404 means the row is absent.
+          const diagnosis = found
+            ? undefined
+            : await describeFlowReadback(
+                request,
+                id,
+                { headers: { Authorization: authToken } },
+                `list returned ${flows.length} flow(s)`,
+              );
+          expect(found, diagnosis).toBeDefined();
           expect(found?.name).toBe(flowName);
         });
       } finally {
@@ -208,15 +240,40 @@ test.describe("CRUD /api/v1/flows", () => {
         return json.id as string;
       });
 
-      await test.step("DELETE /api/v1/flows/{id} returns 200", async () => {
-        // Raw DELETE on purpose: this call's status IS the assertion. `deleteFlow`
-        // absorbs 404-as-done and retries one 5xx, which would erase what this test
-        // checks (§3.1).
-        const deleteRes = await request.delete(`/api/v1/flows/${id}`, {
-          headers: { Authorization: authToken },
+      try {
+        await test.step("DELETE /api/v1/flows/{id} returns 200", async () => {
+          // Raw DELETE on purpose: this call's status IS the assertion. `deleteFlow`
+          // absorbs 404-as-done and retries one 5xx, which would erase what this test
+          // checks (§3.1).
+          const deleteRes = await request.delete(`/api/v1/flows/${id}`, {
+            headers: { Authorization: authToken },
+          });
+          // A 404 here does not say whether the id is wrong or the row was merely
+          // not visible to that read — the two faces of LE-2552. The readback
+          // separates them, in the message the daily triage actually reads.
+          const diagnosis =
+            deleteRes.status() === 200
+              ? undefined
+              : await describeFlowReadback(
+                  request,
+                  id,
+                  { headers: { Authorization: authToken } },
+                  `DELETE body: ${(await deleteRes.text()).slice(0, 200)}`,
+                );
+          expect(deleteRes.status(), diagnosis).toBe(200);
         });
-        expect(deleteRes.status()).toBe(200);
-      });
+      } finally {
+        // The raw DELETE is the assertion, so when it does NOT answer 200 the flow
+        // survives and nothing else removes it — this test leaked one orphan per
+        // failure onto the shared superuser until #1759 (the 2026-09-08 daily left
+        // two, from the two failed attempts). A 404 here is the desired end state
+        // and `deleteFlow` treats it as such, so the green path costs one no-op.
+        await test.step("cleanup created flow", async () => {
+          await deleteFlow(request, id, {
+            headers: { Authorization: authToken },
+          }).catch(() => {});
+        });
+      }
     },
   );
 
@@ -291,7 +348,11 @@ test.describe("CRUD /api/v1/flows", () => {
     "deleted flow does not appear in flows listing",
     { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request, apiCoverage }) => {
-      apiCoverage.declare(["POST /api/v1/flows/", "GET /api/v1/flows/"]);
+      apiCoverage.declare([
+        "POST /api/v1/flows/",
+        "DELETE /api/v1/flows/{flow_id}",
+        "GET /api/v1/flows/",
+      ]);
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow Deleted List - ${Date.now()}`;
 
@@ -305,20 +366,62 @@ test.describe("CRUD /api/v1/flows", () => {
         return json.id as string;
       });
 
-      await test.step("DELETE the flow", async () => {
-        await deleteFlow(request, id, { headers: { Authorization: authToken } });
-      });
-
-      await test.step("GET /api/v1/flows/ does not include the deleted flow", async () => {
-        const listRes = await request.get("/api/v1/flows/", {
-          headers: { Authorization: authToken },
+      try {
+        await test.step("DELETE /api/v1/flows/{id} returns 200", async () => {
+          // Raw and ASSERTED, where this used to call `deleteFlow`. That is a
+          // strengthening, not a loosening: the helper treats 404 as the desired
+          // end state — right for idempotent cleanup, wrong for a test whose
+          // subject is what the delete reported. Swallowing that 404 is why this
+          // test and "DELETE removes flow and returns 200" read as two separate
+          // defects on the 2026-09-08 daily when they were one (#1759 / LE-2552).
+          const deleteRes = await request.delete(`/api/v1/flows/${id}`, {
+            headers: { Authorization: authToken },
+          });
+          const diagnosis =
+            deleteRes.status() === 200
+              ? undefined
+              : await describeFlowReadback(
+                  request,
+                  id,
+                  { headers: { Authorization: authToken } },
+                  `DELETE body: ${(await deleteRes.text()).slice(0, 200)}`,
+                );
+          expect(deleteRes.status(), diagnosis).toBe(200);
         });
-        expect(listRes.status()).toBe(200);
 
-        const flows = (await listRes.json()) as Flow[];
-        const found = flows.find((f) => f.id === id);
-        expect(found).toBeUndefined();
-      });
+        await test.step("GET /api/v1/flows/ does not include the deleted flow", async () => {
+          const listRes = await request.get("/api/v1/flows/", {
+            headers: { Authorization: authToken },
+          });
+          expect(listRes.status()).toBe(200);
+
+          const flows = (await listRes.json()) as Flow[];
+          const found = flows.find((f) => f.id === id);
+          // A 2xx from DELETE is not proof of removal (LE-2552), so when the list
+          // still carries the id the readback says which it is: 200 means the
+          // delete reported success and removed nothing; 404 means the row is gone
+          // and only the LIST still shows it.
+          const diagnosis = found
+            ? await describeFlowReadback(
+                request,
+                id,
+                { headers: { Authorization: authToken } },
+                `list returned ${flows.length} flow(s)`,
+              )
+            : undefined;
+          expect(found, diagnosis).toBeUndefined();
+        });
+      } finally {
+        // Same hole as the raw-DELETE test above: with the delete asserted rather
+        // than delegated, a failure leaves the flow behind and nothing else
+        // removes it. A 404 is the desired end state here, which `deleteFlow`
+        // accepts, so the green path costs one no-op request.
+        await test.step("cleanup created flow", async () => {
+          await deleteFlow(request, id, {
+            headers: { Authorization: authToken },
+          }).catch(() => {});
+        });
+      }
     },
   );
 });


### PR DESCRIPTION
**Refs #1759.** Deliberately **not** `Closes`: the root cause is a product regression (`LE-2552`), and the issue's own deliverable keeps it open until the upstream fix lands in `langflowai/langflow-nightly:latest` and is re-validated there. Same convention as PR #1761.

## Problem

Three assertions in `api-flows-crud.spec.ts` failed inside one **8-second window** on the 2026-09-08 daily (run [34227075296](https://github.com/oriontech-me/langflow-e2e/actions/runs/34227075296)), and **none of their messages said what the backend had done**:

| Line | Assertion | Message it produced |
|---|---|---|
| `:56` | list contains the id `POST` returned | `expect(received).toBeDefined() / Received: undefined` |
| `:186` | raw `DELETE` of that id → 200 | `Expected: 200 / Received: 404` |
| `:283` | list omits the id whose `DELETE` was confirmed | `expect(received).toBeUndefined()` |

`:56` is recurrent under the same assertion (2026-08-19 + 2026-09-08) and was quarantined at triage in #1761. Not wedge collateral: the attempts are 154–453 ms and the earliest measured outage on any shard opened 2.5 min later.

## Root cause — `LE-2552`

`DELETE` on the flows family **answers a success status for a request that removed nothing**. `_read_flow` runs **twice per request** — once in the `AuthorizedDeleteFlow` dependency (which raises `404 "Flow not found"` when it returns `None`) and once inside `_delete_operation`. When the calls overlap, the dependency's read lands **before** the winner commits (so the request enters the handler) and the handler's read lands **after** it, so `retry_target is None` hits a bare `return` and the handler still answers `200 {"message": "Flow deleted successfully"}`.

Measured on `1.13.0.dev6` **and** `1.13.0.dev0`, with and without `foreign_keys=ON`, with and without tracing, at `LANGFLOW_WORKERS=1` (so not multi-worker contention):

| Call | Fan-out | Trials | Result |
|---|---|---|---|
| `DELETE /api/v1/flows/{id}` | 4 | 25 | `200` × 4 — **25/25** |
| `DELETE /api/v1/flows/{id}` | 2 | 40 | `200+200` — **40/40** |
| `DELETE …/versions/{vid}` | 4 | 25 | `204` × 4 — **25/25** |
| `DELETE /api/v1/flows/` (bulk) | 4 | 20 | `deleted: 0+0+0+1` — **20/20** |

**Not idempotent-DELETE-by-design**, and the product refutes that itself: the *same* condition — the row not being there for this request — answers `404` for a never-existed id, `404` for a second **sequential** delete, and `404` on the versions route in both shapes. Only overlapping calls get `2xx`. The **bulk** route is unaffected and already correct, so the right shape exists one route away.

**Cross-worker interference is eliminated**, which is the question the issue asked to answer with evidence: `cleanAllFlows` no longer exists (#515 removed the last caller); `delete_multiple_flows` is scoped by `Flow.id.in_(ids)` **AND** `Flow.user_id == actor.id`; `flow.folder_id` has no `ON DELETE CASCADE` in the DDL; and — decisively — a **fourth** test failed in the same 14-second window, `api-flows-versions.spec.ts:53` at *"DELETE removes v2 and only v2"* (`DELETE {version_id}` → **204**, next `GET` still listed **3** versions), on a flow named with `Date.now()` + `Math.random()` whose versions no other worker can address.

`201`-before-commit was also refuted: holding SQLite's write lock for 20 s made the `POST` **block 18 888 ms** and only then answer `201`; the immediate `GET` **did** contain the flow and `DELETE` answered `200`.

## Fix

**No assertion is weakened, and no retry, sleep, catch or narrowed scope is added** — the issue forbids that, and the status and list content *are* the contract. What changes is attribution:

- **New helper `describeFlowReadback`** reads `GET /api/v1/flows/{id}` and returns one line for the assertion message. Two contractual properties, both pinned by unit tests: it **never throws** (it runs where a test is already failing, so a throw would replace the real failure with its own), and it has **three** outcomes, not two — a readback that cannot be performed is `UNDECIDED` and claims neither verdict (#1012).
- **Tests 2, 5 and 9** call it **only on the branch about to fail**, so the green path pays no extra request, and pass its line as `expect()`'s second argument — `error.message` is what `results.json` carries and what the daily triage reads; an attachment would not be there.
- **Test 9's delete becomes raw and asserted `200`** where it called `deleteFlow`. A **strengthening**: the helper treats `404` as the desired end state, right for idempotent cleanup and wrong for a test whose subject is the delete contract. Swallowing that `404` is why `:186` and `:283` read as two defects when they were one.
- **Tests 5 and 9 gain an id-scoped `finally`.** The raw `DELETE` is the assertion, so a failure left the flow behind and nothing removed it — the 2026-09-08 daily left **two orphans** on the shared superuser from `:186` failing twice. Measured both ways: **without** the `finally` a failing run takes the instance `26 → 27` flows; **with** it, `26 → 26`.

### Rejected alternatives

- **A retry or a wait around the read-back** — forbidden by the issue, and it would erase the only signal that the defect is live.
- **`test.fail()`** — the product fails intermittently (~1 per daily), so a `test.fail()` gate would be red on the ~99 % of runs where the product is right.
- **Restoring `@stable` on Test 2** — that is the "test-side mute" the issue's own deliverable forbids under a product verdict.

## Tags

| Test | State | Why |
|---|---|---|
| `:56` GET lists flows… | **un-quarantined, no `@stable`** | `test.fixme` runs in **no** context, and `:56` is the one symptom **not** attributable to LE-2552's mechanism (it goes through `read_flows`, a different query, and did not reproduce in six local configurations). Its readback is the discriminant, and a discriminant on a muted test is never read. Without `@stable` it runs in the PR gate and the full suite and stays **out of the daily** |
| `:186`, `:283` | `@stable` kept | first occurrences; they run in the daily on purpose and are what says the defect is still there |

`@stable` returns to `:56` only when the upstream fix is in the nightly and re-validated. **While LE-2552 is open these three fail intermittently, and that is the spec working** — a green run is not evidence the defect is gone.

## Scope note — extra files, declared

Beyond the four files this issue owns, the PR carries **three pipeline files**. Two gates made a `langflow-regression` issue impossible to close correctly, and #1759 is the first to reach that state:

- `checkQuarantineLifted` demanded `@stable` back, i.e. exactly the test-side mute the issue body forbids. The verdict now exempts **only** that half — `test.fixme` must still come off, since exempting the whole gate would let a product verdict ship a permanently muted test.
- `checkPrReadiness` demanded `Closes #NNN`, which would close an issue tracking a live upstream ticket. Under the verdict the requirement inverts: a non-closing reference is required and `Closes` is refused, because accepting both would let the wrong one through in silence.

Both decisions sit in the pure functions with tests on their output, and both were verified by **mutation** — reverting either condition fails two tests, not zero.

## Validation (nightly `1.13.0.dev6`, `--retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `npm run test:units` **1100/1100** ✅ · `npm run test:pipeline` **138/138** ✅ (was 130)
- **3/3 clean burst** on `api-flows-crud.spec.ts`: `expected=9 unexpected=0 flaky=0 skipped=0`, zero `🚨 Backend Error`
- **Force-fail 9/9**, each verified red, all mutations reverted, zero `FF-MUTATION` markers, final green run after reverts ✅
- The three readback mutations prove the diagnostic **prints**, not just that the assertion fails:
  - `readback GET /api/v1/flows/a419f249-… -> 200: the row EXISTS [list returned 28 flow(s)]`
  - `readback GET /api/v1/flows/d82184a8-… -> 200: the row EXISTS [DELETE body: {"detail":"Flow not found"}]`
  - `readback GET /api/v1/flows/07637e5f-… -> 404: the row is absent from the database [list returned 27 flow(s)]`
- Orphan audit after every run: **26 flows, starters only**, on both instances
- Pre-fix baseline recorded: **0/10** on the unmodified spec — the daily signature does not reproduce locally in six configurations, which is why the verdict rests on the endpoint proof above rather than on a reproduction rate
