### PR TITLE
docs(cleanAllFlows): repair the two references that were wrong before the helper was retired

### DIFF
--- a/.claude/skills/langflow-e2e-issues/references/triage-verdicts.md
+++ b/.claude/skills/langflow-e2e-issues/references/triage-verdicts.md
@@ -88,12 +88,25 @@ Route by the verdict:
   start-time overlap in the report JSON. (Real case: #553 — 3/3 failing
   attempts had a `memory-history-regression` test starting inside the
   failure window; its `loadTemplateByName` → `cleanAllFlows` was the wiper.)
-  **Hunt wipers TRANSITIVELY** — a spec-level grep for `cleanAllFlows` misses
-  indirection: in #520 the wiper was `model-provider-model-toggle` via
-  `SimpleAgentTemplatePage.load()` → `loadTemplateByName` → `cleanAllFlows`
-  (a POM hop that hid a 15-spec / 11-`@stable` wiper family). Grep the POMs
-  and helpers a suspect imports, not just the spec body. Same class, roles
-  swap freely: #553's wiper (memory-history) was #520's victim.
+  **Hunt wipers TRANSITIVELY** — the wiper can sit one POM or helper hop away
+  from the spec body, so a spec-level grep misses it. Grep the POMs and
+  helpers a suspect imports, not just the spec, and grep for the BEHAVIOUR
+  rather than for a helper name: **any delete that is not id-scoped**, reached
+  through such a hop — a sweep over `GET /api/v1/flows/`, a delete-by-name or
+  by shared display name, a "clean everything first" pre-step in a POM
+  `load()`. **Historical incidents**, kept because the class recurs and NOT as
+  a chain to reproduce: in #520 the wiper was `model-provider-model-toggle`
+  via `SimpleAgentTemplatePage.load()` → `loadTemplateByName` → a global
+  pre-cleanup (a POM hop that hid a 15-spec / 11-`@stable` wiper family), and
+  #553's wiper was `memory-history` through the same `loadTemplateByName`.
+  **Neither chain resolves today**: the #553 fix removed that pre-cleanup and
+  `tests/helpers/flows/load-template-by-name.ts` records the removal in its
+  own docblock ("Deliberately NO pre-cleanup of existing flows: this helper
+  used to call `cleanAllFlows` first"), and #1772 then retired the helper
+  itself — so that name has **no live call site and no definition** anywhere in
+  the tree: grepping it today returns only prose warning against it. Hunt the
+  shape, not the name. Same class, roles swap freely: #553's wiper
+  (memory-history) was #520's victim.
   GitHub quirk: a `Fixes #NNN` EDITED into an open PR's body may not
   auto-close that issue on merge — verify both issues' state post-merge and
   close manually with a reference comment if needed.

--- a/docs/core-functionality/playground/playground-clear-history.md
+++ b/docs/core-functionality/playground/playground-clear-history.md
@@ -73,7 +73,7 @@ These are distinct operations: Default sessions expose "Clear chat"; user-create
 ## Preconditions *(optional)*
 
 - Langflow running and reachable at `PLAYWRIGHT_BASE_URL`
-- No pre-existing flows required; the setup creates a flow per test and `cleanAllFlows` removes it in `afterEach`
+- No pre-existing flows required; the setup creates a flow per test and `afterEach` deletes that one flow by id with `deleteFlow` — id-scoped, never a global sweep (see Notes)
 - No LLM or API key needed: ChatInput → ChatOutput acts as a synchronous echo
 
 ---
@@ -90,9 +90,15 @@ These are distinct operations: Default sessions expose "Clear chat"; user-create
 
 - Tests run in `serial` mode because Test 2 asserts a session **count** in the
   playground sidebar, which a concurrent sibling on the same flow would perturb.
-  Cleanup is id-scoped — this file never calls `cleanAllFlows`, so it cannot
-  delete a parallel worker's flow (#465/#515). The earlier note claiming
-  `cleanAllFlows` was the reason for serial mode was stale.
+  Cleanup is id-scoped — `afterEach` deletes only the flow the test created,
+  with `deleteFlow` and an explicit bearer, so it cannot delete a parallel
+  worker's flow (#465/#515). Two earlier notes claimed `cleanAllFlows`: one
+  here as the reason for serial mode, one in Preconditions as the `afterEach`
+  mechanism. Both were stale, and the first correction landed **here only** —
+  a one-site fix for a two-site claim, which left the Preconditions copy
+  contradicting this paragraph in the same file. Sweep the whole file when
+  retracting a claim about the file. (#1772 has since retired the helper
+  outright, so the name has no implementation to go looking for.)
 - **Sidebar entry race (#1063).** Both tests previously built the flow through the
   home page → "New Flow" → templates modal → `blank-flow` path, and flaked because
   `FlowPage` mounts the whole `FlowSidebarComponent` inside a `display: none`


### PR DESCRIPTION
Closes #1774.

Off-wave **follow-up** — the exception issue for the two references #1771 deliberately scoped out of itself (*"they get their own review rather than riding along"*). Both were already wrong **before** `cleanAllFlows` was retired, so neither rode along with PR #1772.

**Docs-only.** No `.spec.ts`, no helper, no workflow.

## 1. `docs/core-functionality/playground/playground-clear-history.md` — a file that contradicted itself

Preconditions said `cleanAllFlows` removed the flow in `afterEach`; the Notes paragraph twelve lines later said the file never calls it and cleanup is id-scoped. Notes was right: `playground-clear-history.spec.ts:4` imports `deleteFlow`, and `test.afterEach` deletes the one flow the test created, by id, with an explicit `getAuthToken` bearer (an unheadered `DELETE` 401s under `AUTO_LOGIN` and silently leaks the flow — the spec comments on it in place).

**The irony is preserved rather than quietly completed.** That Notes paragraph exists *because* an earlier stale `cleanAllFlows` claim was corrected there — and the correction was a one-site fix for a two-site claim, retracting the copy in front of it and leaving the Preconditions copy alive. The note now says so, and says to sweep the whole file when retracting a claim about the file. This repo keeps retractions.

Swept for a third copy by name **and** by claim (`afterEach` / `cleanup` / `removes it` / `deleteFlow` / `id-scoped`): there is none. Lines 30 and 105 already described id-scoped cleanup correctly.

## 2. `.claude/skills/langflow-e2e-issues/references/triage-verdicts.md` — a rule kept, its target repaired

The **CROSS-WORKER DESTRUCTIVE CLEANUP** bullet told a future triage agent to hunt wipers transitively and handed it `SimpleAgentTemplatePage.load()` → `loadTemplateByName` → `cleanAllFlows` as the #520 example.

The **POM hop is real and still resolves** (`tests/pages/SimpleAgentTemplatePage.ts:96`). Only the terminal link is gone: `load-template-by-name.ts` has zero references to `clean-all-flows` and records the removal in its own docblock in the past tense (*"used to call `cleanAllFlows` first"*, #553), and #1772 then retired the helper — so the name has **no live call site and no definition anywhere in the tree**. An agent following the instruction literally greps a name that returns only prose warning against it.

So the **instruction is kept** — grep the POMs and helpers a suspect imports, not just the spec body — and only its target changes: from a helper **name** to a **behaviour that still resolves**, namely any delete that is not id-scoped reached through a POM/helper hop (a sweep over `GET /api/v1/flows/`, a delete-by-name or by shared display name, a *"clean everything first"* pre-step in a POM `load()`).

The #520 and #553 chains are **relabelled as historical incidents, not deleted** — the class recurs, so the record is worth having; the chain is not reproducible, so it is marked as such.

## Out of scope, deliberately

The ~54 files mentioning the bare `cleanAllFlows` name. Those are pedagogical (*"never a global `cleanAllFlows`"*), #1772's commit message records that they stay, and `authoring-conventions.md` already carries the note that the name has no implementation behind it.

## Validation

```
npm run typecheck                        ✓
npm run validate:specs                   ✓ exit 0
npm run check:checklist-coverage         ✓ every @stable and documented spec referenced by a Part II bullet
node scripts/check-checklist-guard.mjs   ✓ no auto-generated block edited
```

And the gate that could actually fail here — the PR lane's **`Spec-doc dependency paths`** job. A spec doc is touched, and a dependency path in a doc **the PR changed** fails where a pre-existing one only warns, so it was run against a real blobless `langflow-ai/langflow` clone at `origin/main` + `release-1.13.0` + `release-1.12.2` (the two lines `--mode=release-ref` derives), diff-scoped to this PR's two files:

```
Resolved 591 dependency path(s) from 294 doc(s) against origin/main (12459 tree entries)
and the release line(s) origin/release-1.13.0 (12508), origin/release-1.12.2 (12459); 1 doc(s) exempt.
Every dependency path resolves on at least one of the refs above.
→ 0 ::error::, 0 ::notice::
```

Worth knowing for anyone re-running it: **locally, with no upstream clone, this guard is not a verdict.** It falls back to resolving against *this* repo's HEAD (1264 tree entries, zero `src/`) and reports all 591 paths as missing.

## Note on the SHA

The retirement reaches `main` as **`79de9015`** (squash of PR #1772, closing #1771). `5f28b90e` is the pre-squash branch commit and is reachable only from `claude/frosty-lamport-01e80f` — so a worktree cut before the merge still has `clean-all-flows.ts` on disk while `main` does not. This branch is rebased onto `origin/main` (`491bb2a0`), where the helper has no definition at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
