### PR TITLE
Inherited spec triage: the two `@stable` predicates are not equivalent, and the record said they were (#1781)

### DIFF
--- a/docs/triage/inherited-spec-triage-plan.md
+++ b/docs/triage/inherited-spec-triage-plan.md
@@ -4,17 +4,24 @@
 
 **Goal:** Build the tooling that measures the 55 never-validated OSS specs, publishes a per-test triage verdict, and prevents the backlog from regrowing silently.
 
-**Architecture:** One AST parser already exists for `@stable` (`scripts/lib/stable-tests.ts`); it is widened to return *every* tagged declaration, and a pure predicate module derives the backlog and its two tiers from that. Everything else is a thin shell over pure functions: a baseline writer, a `--grep` fragment builder, a report-to-table renderer, and an ownership guard. The measurement itself is **nine** `manual.yml` dispatches — three passes over three shards — whose JSON reports the renderer consumes.
+**Architecture:** One AST parser returns every declared test with the tags that reach it — `collectDeclaredTests()` in `scripts/lib/stable-tests.ts`, which #1746's orphan reconciler landed — and a pure predicate module derives the backlog and its two tiers from that. Everything else is a thin shell over pure functions: a baseline writer, a `--grep` fragment builder, a report-to-table renderer, and an ownership guard. The measurement itself is **nine** `manual.yml` dispatches — three passes over three shards — whose JSON reports the renderer consumes.
 
-> ### ⚠️ Status, 2026-09-09: Tasks 1–6 are IMPLEMENTED; Task 7's runbook has NOT been run
+> This sentence used to read *"one AST parser already exists for `@stable`; it **is widened** to return every tagged declaration"*, which is inverted twice over. Task 1 did widen that parser; #1746 then landed a second answer to the same question in the same file, and the widening was **reverted** in `db7a580e` in favour of consuming upstream's. Nothing of Task 1 shipped — see its own banner below.
+
+> ### ⚠️ Status, 2026-09-09: Task 1 was REVERTED; Tasks 2–6 are IMPLEMENTED; Task 7's runbook has NOT been run
 >
 > The design (`docs/triage/inherited-spec-triage-design.md`) is binding, and the
 > shipped code under `scripts/` is what actually ran. **Tasks 1, 2, 3, 4 and 6
-> carry a per-task superseded note** over their code blocks: each of those five
-> shipped a deviation from the literal block below, every deviation was forced
-> by a measurement or a review, and the reasoning lives in the design plus the
-> functions' own docblocks. The blocks are marked stale rather than rewritten,
-> deliberately — a half-updated code block is worse than one honestly labelled.
+> carry a per-task note** over their code blocks, and the five are not all the
+> same kind of note: **Tasks 2, 3, 4 and 6 each shipped a deviation** from the
+> literal block below, forced by a measurement or a review, with the reasoning
+> in the design plus the functions' own docblocks — while **Task 1 shipped
+> nothing at all.** It was implemented, then reverted in `db7a580e` once #1746
+> landed a second parser for the same question in the same file; every symbol
+> its blocks name is deleted, and a worker following them would re-add the
+> parser that commit removed. The blocks are marked stale rather than
+> rewritten, deliberately — a half-updated code block is worse than one
+> honestly labelled — so read each task's banner before its steps.
 >
 > **Task 7 (the measurement) has NOT been run** — its deliverable
 > `docs/triage/inherited-spec-triage.md` does not exist, and its steps below are
@@ -88,16 +95,39 @@ here because their content is issue A's output.
 
 `scripts/lib/stable-tests.ts` already walks the specs and reads inline `tag:` arrays, but it only ever returns the `@stable` ones. Two parsers that are supposed to agree about what a tag is would be exactly the drift issue #985 was raised about, so the backlog predicate is built on this one — widened, not copied.
 
-> ⚠️ **SUPERSEDED — Task 1 is implemented, and its `CollectTaggedResult` below
-> is missing the field the fix needed.** Widening the walk to five declaration
-> modifiers also widened the **warning** channel, and both consumers of
-> `parseStableTests` are fail-closed on a warning
-> (`scripts/check-checklist-coverage.ts` exits 1 on any), so the first
+> ⚠️ **REVERTED — Task 1 shipped NOTHING. Do not implement the steps below.**
+> It was implemented, and then removed in **`db7a580e`**. #1746 (PR #1754)
+> landed while this branch was in final review and added to the very same file
+> a second answer to the same question — declared tests with the tags that
+> reach them — and two parallel APIs for one question in one file is the #985
+> drift Task 1 was itself justified by. So `scripts/lib/stable-tests.ts` is
+> back to the form `origin/main` has, apart from one additive `DeclaredTest`
+> field (`modifier`), and `scripts/lib/inherited-backlog.ts` (Task 2) consumes
+> upstream's `collectDeclaredTests()` instead. The measurement that decided it:
+> the four-clause predicate evaluated through upstream's parser returns the
+> identical **55 specs / 92 tests**, 0 entering and 0 leaving — the same
+> population from a different walk. Upstream's is also the better parser on two
+> axes this branch had to concede: it RESOLVES describe-level inheritance of
+> `@stable` where this one only warned, and its discriminator admits an
+> untagged declaration while still excluding the in-body `test.skip(cond, msg)`
+> guard.
+>
+> **Every symbol named in this task — `TaggedTest`, `CollectTaggedResult`,
+> `parseTaggedTests`, `collectTaggedTests`, and the `ParseWarning` /
+> `warningDetails` pair — is deleted.** The four exposures of consuming
+> upstream's parser instead, all zero occurrences in the corpus today, are
+> recorded in `scripts/lib/inherited-backlog.ts`'s header, and the one input on
+> which this branch's `isStable` and `parseStableTests` legitimately disagree
+> (a describe-level `@stable`) is recorded on `isStable` itself.
+>
+> Kept as history, because it is why the reverted parser had the shape it did:
+> widening the walk to five declaration modifiers also widened the **warning**
+> channel, and both consumers of `parseStableTests` are fail-closed on a
+> warning (`scripts/check-checklist-coverage.ts` exits 1 on any), so the first
 > `test.skip(..., { tag: SHARED_TAGS })` anyone wrote would have failed every
-> PR — with a remediation that a modified declaration cannot satisfy. A warning
-> now carries the modifier it is about (`ParseWarning` / `warningDetails`), and
-> `parseStableTests` forwards only the ones that bear on the `@stable`
-> population. `warnings: string[]` is unchanged for every existing caller.
+> PR — with a remediation that a modified declaration cannot satisfy. That is a
+> live hazard for anyone who widens that parser again; upstream's avoids it by
+> not admitting those forms at all.
 
 **Files:**
 - Modify: `scripts/lib/stable-tests.ts`
@@ -325,13 +355,25 @@ Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
 > observations fold into one verdict where a green can mask a red). Zero
 > collisions of either class today. See `Backlog.titleCollisions` in
 > `scripts/lib/inherited-backlog.ts`, and the design's §2.
+>
+> **Also superseded by Task 1's revert (`db7a580e`): the input type.** Task 1
+> shipped nothing, so this module consumes `DeclaredTest` /
+> `collectDeclaredTests()` from `scripts/lib/stable-tests.ts` (#1746's parser).
+> Every `TaggedTest` below — the `Produces` signature's `classifyBacklog(all:
+> TaggedTest[], …)` and the `import type { TaggedTest }` in Step 1's fixture —
+> names a deleted type; read `DeclaredTest` for it. The fixture factory also
+> differs from the block below in shape, since `DeclaredTest` carries `stable`
+> / `fixme` / `unparseableTags` and no `modulePath` / `specFile`. Clause 2's
+> predicate is `t.stable && !t.fixme` rather than `modifier === "" &&
+> tags.includes("@stable")`; the two agree on every input except a
+> describe-level `@stable`, which is documented on `isStable`.
 
 **Files:**
 - Create: `scripts/lib/inherited-backlog.ts`
 - Test: `scripts/lib/inherited-backlog.test.ts`
 
 **Interfaces:**
-- Consumes: `TaggedTest`, `collectTaggedTests` from Task 1.
+- Consumes: `DeclaredTest`, `collectDeclaredTests` from `scripts/lib/stable-tests.ts` — #1746's parser, not Task 1's (reverted; see its banner).
 - Produces:
   ```ts
   export const LANE_SELECTORS: readonly string[];

--- a/scripts/lib/inherited-backlog.test.ts
+++ b/scripts/lib/inherited-backlog.test.ts
@@ -19,26 +19,36 @@ import {
 } from "./inherited-backlog";
 import { STABLE_TAG, type DeclaredTest } from "./stable-tests";
 
-// Builds a `DeclaredTest` the way `parseDeclaredTests` would for a
-// declaration whose OWN tag array is exactly `tags` and that inherits
-// nothing from an enclosing `describe` -- inheritance itself is
-// `stable-tests.test.ts`'s concern, not this predicate's. `stable` and
-// `fixme` are derived from `tags` / `modifier` the same way the real parser
-// derives them, so `isStable`'s `test.stable && !test.fixme` sees the exact
-// shape it sees in production.
+// Builds a `DeclaredTest` the way `parseDeclaredTests` would. By default the
+// declaration's OWN tag array is exactly `tags` and it inherits nothing from
+// an enclosing `describe`, so `stable` and `fixme` are derived from `tags` /
+// `modifier` exactly as the real parser derives them and `isStable`'s
+// `test.stable && !test.fixme` sees the shape it sees in production.
+//
+// `stable` is an explicit OVERRIDE for one case the derivation cannot reach:
+// `@stable` on an enclosing `test.describe`, which `collectDeclaredTests()`
+// RESOLVES into `stable: true` with the tag absent from the child's own
+// array. HOW the parser resolves that is `stable-tests.test.ts`'s concern;
+// what `classifyBacklog` does with such a row is nobody's but this file's,
+// and until the override existed no test here could construct one -- so the
+// only semantic change the #1746 reconciliation made to this predicate was
+// unpinned, and reverting it to `tags.includes(STABLE_TAG) && !fixme` passed
+// every test in the repo (the corpus has zero instances). See the tests
+// tagged "inherited @stable" below.
 function t(
   relativePath: string,
   title: string,
   tags: string[],
   line = 1,
   modifier = "",
+  stable = tags.includes(STABLE_TAG),
 ): DeclaredTest {
   return {
     title,
     relativePath,
     line,
     tags,
-    stable: tags.includes(STABLE_TAG),
+    stable,
     fixme: modifier === "fixme" || modifier === "skip",
     modifier,
     unparseableTags: false,
@@ -104,6 +114,46 @@ test("a file with one real @stable test is excluded even when a fixme'd test als
     t("a/x.spec.ts", "plain backlog test", ["@release"], 3),
   ], NO_FACTS);
   assert.equal(b.specs.length, 0);
+});
+
+// ─── inherited @stable -- the one semantic change the #1746 switch made ──────
+//
+// `isStable` reads `DeclaredTest.stable`, which is true when `@stable` REACHES
+// the test: its own `tag` array OR an enclosing `test.describe`'s. The retired
+// parser could only see the first, so these two rows were unconstructible here
+// and the change was invisible: reverting clause 2 and clause 4 to
+// `tags.includes(STABLE_TAG) && !fixme` is behaviourally visible (measured:
+// `stableFiles` goes 1 -> 0 on the second fixture, putting the sibling in
+// scope) yet passed the whole unit lane, the real-suite test and
+// `triage:baseline --check`, because the corpus has zero describe-level
+// `@stable` blocks. Which is precisely the standard `Backlog.titleCollisions`
+// states two docblocks up: a corpus with zero instances cannot pin a guard
+// against them.
+//
+// The divergence from `parseStableTests` here is deliberate and documented on
+// `isStable` itself: that parser WARNS about a describe-level tag (it would be
+// invisible to Phase 0) while this module must treat the test as run by the
+// daily, so not never-validated debt.
+
+test("clause 2: a test inheriting @stable from its describe is not backlog debt", () => {
+  const b = classifyBacklog(
+    [t("a/x.spec.ts", "inherits stable", ["@release"], 10, "", /* stable */ true)],
+    NO_FACTS,
+  );
+  assert.equal(b.specs.length, 0, "an inherited-@stable test is run by the daily");
+  assert.equal(b.testCount, 0);
+});
+
+test("clause 4: a test inheriting @stable exempts its whole file, siblings included", () => {
+  // The file-wide half, which is the consequence that actually moves the
+  // baseline: `stableFiles` is keyed on `isStable`, so the untagged sibling
+  // drops out too.
+  const b = classifyBacklog([
+    t("a/x.spec.ts", "inherits stable", ["@release"], 10, "", /* stable */ true),
+    t("a/x.spec.ts", "sibling with no stable of its own", ["@release"], 20),
+  ], NO_FACTS);
+  assert.deepEqual(b.specs, [], "the describe's tag exempts every test in the file");
+  assert.equal(b.testCount, 0);
 });
 
 test("tier is T1 when the spec has a doc or id-scoped cleanup", () => {
@@ -223,6 +273,32 @@ test("assertNoWarnings only counts declarations that are actually unparseable", 
     () => assertNoWarnings([clean, bad]),
     /reported 1 declaration\(s\)/,
   );
+});
+
+// The documented WIDTH, which was documented and untested: "every declaration
+// across the whole suite, not only the in-scope ones". Every fixture above
+// passes rows the backlog KEEPS, so narrowing the guard to `classifyBacklog`'s
+// output -- or filtering by scope inside `assertNoWarnings` -- would have kept
+// all of them green while dropping the guarantee. These two rows are
+// demonstrably out of scope (clause 3 drops the lane one, clause 2 the stable
+// one), which is exactly why they must still be refused: an unreadable `tag`
+// array is the one thing that could be HIDING the lane tag or the `@stable`
+// the clause reading it depends on.
+test("assertNoWarnings refuses declarations the backlog itself excludes", () => {
+  const lane: DeclaredTest = {
+    ...t("a/x.spec.ts", "enterprise only", ["@enterprise"]),
+    unparseableTags: true,
+  };
+  const stable: DeclaredTest = {
+    ...t("a/y.spec.ts", "already validated", [STABLE_TAG]),
+    unparseableTags: true,
+  };
+  assert.equal(
+    classifyBacklog([lane, stable], NO_FACTS).testCount,
+    0,
+    "fixture is only meaningful while both rows are out of scope",
+  );
+  assert.throws(() => assertNoWarnings([lane, stable]), /reported 2 declaration\(s\)/);
 });
 
 // ─── Invariant over the real suite ───────────────────────────────────────────

--- a/scripts/lib/inherited-backlog.ts
+++ b/scripts/lib/inherited-backlog.ts
@@ -12,20 +12,74 @@
  * this file exists to avoid. The two never disagreed on POPULATION, only on
  * shape: the same four-clause predicate evaluated against this parser's
  * output over the real suite returns the identical 55 specs / 92 tests as the
- * walker it replaced. Two measured exposures of the switch, both zero
- * occurrences today: `collectDeclaredTests()` does not admit `.only` /
- * `.fail` / `.slow` declarations at all (confirmed empty:
- * `grep -rnoE '^\s*test\.(only|fail|slow)\(\s*"' tests/tests-automations/regression`),
- * and it inherits only its OWN three lane tags (`@destructive` / `@enterprise`
- * / `@serving`) from an enclosing `test.describe` -- a describe tagged
- * `@authz` / `@sso` / `@governance` alone would not reach a test's `tags`
- * here. The corpus has zero describes carrying any lane tag at all today, so
- * nothing currently relies on that inheritance either way.
+ * walker it replaced (`db7a580e`).
+ *
+ * FOUR measured exposures of that switch, all zero occurrences today. Two
+ * NARROW the population, in the direction of dropping a declaration:
+ *
+ *  1. `collectDeclaredTests()` does not admit `.only` / `.fail` / `.slow`
+ *     declarations at all -- its matcher is `isPlainTestCall(node) ||
+ *     isSkippedDeclaration(node)`, a bare `test(...)` or the declaring
+ *     `test.fixme` / `test.skip`, where the retired walker's
+ *     `/^test(?:\.(fixme|skip|only|fail|slow))?$/` admitted all five. The
+ *     corpus figure was re-derived BY AST, not by grep: 4 `.fixme`, 6
+ *     `.skip`, ZERO `.only` / `.fail` / `.slow` declaring calls (the design's
+ *     §1 clause 1 records the same three figures). Grep cannot answer this
+ *     question, and the command recorded here before could have returned
+ *     empty while a declaration existed: it anchored on `("`, so
+ *     `test.only('a', ...)`, a template-literal title (a spelling this corpus
+ *     uses for parametrized titles) and a title on the following line all
+ *     escaped it. The over-wide screen is
+ *     `grep -rnE '(^|[^.[:alnum:]_])test\.(only|fail|slow)\s*\(' tests/tests-automations/regression`,
+ *     which prints THREE lines today and not one of them is a declaration:
+ *     two prose mentions inside comments, plus one no-arg `test.fail()`
+ *     MODIFIER called from a test body
+ *     (`api/flows/workflows-v2-job-lifecycle.spec.ts:326`). Nothing but an
+ *     AST separates that last one from a declaration, which is why the AST
+ *     figure is the authority here and the grep only a screen.
+ *  2. an unreadable `tag` array ON one of those three forms therefore no
+ *     longer reaches `assertNoWarnings`'s refusal below: the matcher never
+ *     sees the node, so `unparseableTags` is never set for it and the
+ *     suite-level warning the retired walker raised is simply gone. A
+ *     corollary of (1), spelled out because refusals that stopped refusing
+ *     are this module's own subject.
+ *
+ * Two WIDEN it, in the direction of admitting one:
+ *
+ *  3. a declaration with NO `tag` option at all is now a row, where the
+ *     retired walker required an inline `tag:` array and dropped it -- so a
+ *     future `test("x", async () => {})` joins this backlog silently.
+ *     Arguably the right answer (an untagged test has never carried `@stable`
+ *     either), which is exactly why it is stated here rather than discovered
+ *     from a baseline diff.
+ *  4. `@stable` on an enclosing `test.describe` is RESOLVED into the child
+ *     tests' `stable` field instead of raising a suite-level refusal. What
+ *     that costs the baseline writer's parse-refusal path is recorded in
+ *     `update-inherited-backlog-baseline.ts`'s header; where it lands HERE is
+ *     `isStable` below, and it is the one input on which this module and
+ *     `parseStableTests` legitimately disagree -- see that function's docblock.
+ *
+ * Lane-tag inheritance is narrower than `LANE_SELECTORS`: `collectDeclaredTests()`
+ * inherits only its OWN three lane tags (`@destructive` / `@enterprise` /
+ * `@serving`) from an enclosing `test.describe`, so a describe tagged `@authz`
+ * / `@sso` / `@governance` alone would not reach a test's `tags` here. The
+ * corpus has zero describes carrying any lane tag at all today, so nothing
+ * currently relies on that inheritance either way.
+ *
+ * THE LINT LANE DOES NOT OPEN THIS FILE. `npm run lint` is `eslint tests/`,
+ * so no PR job ever lints anything under `scripts/` -- this module or
+ * `./stable-tests.ts` included. `npm run typecheck` compiles them and
+ * `npm run test:units` runs their tests, but a lint-only defect (a dead
+ * import is an ERROR under this repo's config) is invisible to every gate on
+ * the PR; one shipped in the commit this note was added with. Same shape as
+ * #1593's "typechecked by nothing", and worth stating rather than leaving the
+ * lane looking clean: run `npx eslint scripts/lib/inherited-backlog.ts` by
+ * hand when you change this file.
  */
 import * as fs from "fs";
 import * as path from "path";
 import {
-  REGRESSION_ROOT, REPO_ROOT, STABLE_TAG, type DeclaredTest, collectDeclaredTests,
+  REGRESSION_ROOT, REPO_ROOT, type DeclaredTest, collectDeclaredTests,
 } from "./stable-tests";
 
 /**
@@ -91,17 +145,55 @@ export interface Backlog {
  * `test.skip(...)`).
  *
  * `test.stable` alone is not enough: a `test.fixme("x", { tag: ["@stable"] })`
- * has `stable: true` but runs in no lane whatever its tags claim. This is the
- * SAME rule `parseStableTests` uses (`./stable-tests.ts`, via its
- * `modifier === "" && tags.includes(STABLE_TAG)` filter over the same AST) --
- * `test.stable && !test.fixme` is that predicate's exact equivalent over
- * `DeclaredTest`'s shape, and it is what the QA-CHECKLIST generator and the
- * checklist guard both, transitively, read. Do not simplify this to
- * `test.stable` -- that would give the suite's single most load-bearing tag a
- * second, looser definition inside the one module whose entire justification
- * is that there is only one (Task 2 review, ruling P7). A quarantined
- * declaration belongs in THIS backlog, and the design's PARK outcome is how
- * it exits.
+ * has `stable: true` but runs in no lane whatever its tags claim. Do not
+ * simplify this to `test.stable` -- that would give the suite's single most
+ * load-bearing tag a second, looser definition inside the one module whose
+ * entire justification is that there is only one (Task 2 review, ruling P7).
+ * A quarantined declaration belongs in THIS backlog, and the design's PARK
+ * outcome is how it exits.
+ *
+ * THIS IS NOT `parseStableTests`'s FILTER, and where the two stop agreeing is
+ * the most important sentence in the file -- this module's whole justification
+ * is that there is ONE definition of `@stable`, so the input on which that
+ * stops being literally true has to be written down rather than smoothed over.
+ * (An earlier version of this docblock claimed the two were "exact
+ * equivalents" "over the same AST", citing a `modifier === "" &&
+ * tags.includes(STABLE_TAG)` filter. All three were wrong: that filter was
+ * THIS branch's deleted parser, `parseStableTests` has its own separate walk,
+ * and the equivalence is false on the one input `db7a580e` widened.)
+ *
+ * `parseStableTests` (`./stable-tests.ts`, read transitively by the
+ * QA-CHECKLIST generator and the checklist guard) matches `isPlainTestCall()`
+ * -- a BARE `test(...)`, so `test.fixme` / `test.skip` are not even
+ * candidates -- and then requires `@stable` in that declaration's OWN `tag`
+ * array. It also has its own AST walk (`parseStableTestsInFile`): there are
+ * two walks over the specs now, deliberately, not one shared one. The two
+ * predicates answer different questions:
+ *
+ *   `isStable`         -- does the daily RUN this test? Playwright's
+ *                         `--grep @stable` honours a `test.describe` tag, so
+ *                         a test inheriting it really is in the stable lane.
+ *   `parseStableTests` -- is `@stable` WRITTEN where Phase 0 can see it? That
+ *                         parser is per-`test()` by construction, so a
+ *                         describe-level tag leaves those tests invisible to
+ *                         Phase 0 and to the checklist guard -- a defect, and
+ *                         it warns fail-closed about it (#985).
+ *
+ * So on a describe-level tag they DISAGREE. Measured, on
+ * `test.describe("s", { tag: ["@stable"] }, () => { test("inner", { tag:
+ * ["@release"] }, ...) })`:
+ *
+ *   parseStableTests -> 0 tests, 1 warning
+ *   isStable         -> true
+ *
+ * Both are right for their own question, and the divergence must NOT be
+ * "fixed" in either direction. Such a test IS run by the daily, so its file
+ * is not never-validated debt and clauses 2 and 4 must exclude it (pinned by
+ * a unit test, since the corpus has no instance); the warning is about the
+ * other failure entirely and must keep firing. Every other input agrees: a
+ * plain own-tag `@stable` is stable to both, an untagged declaration to
+ * neither, and a `test.fixme` carrying `@stable` to neither -- the one for
+ * want of a plain-call match, the other for `!fixme`.
  */
 function isStable(test: DeclaredTest): boolean {
   return test.stable && !test.fixme;
@@ -199,7 +291,12 @@ export function specFactsFromDisk(relativePath: string): SpecFacts {
  * an `@stable` tag on that declaration or on another one in the SAME file,
  * either of which would silently flip clause 2 or clause 4's answer -- so it
  * checks every declaration across the whole suite, not only the in-scope
- * ones, the same width `collectTaggedTests()`'s warnings array had.
+ * ones, the same width `collectTaggedTests()`'s warnings array had. That
+ * width is now pinned by a fixture whose unparseable rows are demonstrably
+ * OUT of scope (a lane selector and an `@stable`), because it was documented
+ * and untested: every earlier fixture passed rows the backlog itself keeps,
+ * so narrowing this to `classifyBacklog`'s output -- or filtering by scope in
+ * here -- would have broken the guarantee with nothing failing.
  */
 export function assertNoWarnings(tests: readonly DeclaredTest[]): void {
   const unparseable = tests.filter((t) => t.unparseableTags);

--- a/scripts/update-inherited-backlog-baseline.test.ts
+++ b/scripts/update-inherited-backlog-baseline.test.ts
@@ -18,7 +18,8 @@ import assert from "node:assert/strict";
 import { spawnSync } from "child_process";
 import * as path from "path";
 import { renderBaseline, diffBaseline, formatParseRefusal } from "./update-inherited-backlog-baseline";
-import type { Backlog } from "./lib/inherited-backlog";
+import { assertNoWarnings, type Backlog } from "./lib/inherited-backlog";
+import type { DeclaredTest } from "./lib/stable-tests";
 
 function spec(relativePath: string, tier: "T1" | "T2" = "T2") {
   return {
@@ -86,11 +87,33 @@ test("a missing committed baseline reports every spec as added", () => {
 // -- the same choice Task 2 made for `assertNoWarnings` itself.
 
 test("formatParseRefusal names the failure in the floor's own voice", () => {
-  const msg = formatParseRefusal(new Error("collectBacklog(): collectTaggedTests() reported 1 parse warning(s) (printed above)."));
+  // The input is the message `assertNoWarnings` REALLY throws, taken from the
+  // function itself rather than transcribed. The transcription it replaces
+  // quoted `collectTaggedTests() reported 1 parse warning(s)`, which nothing
+  // can produce since the #1746 reconciliation (`db7a580e`) replaced that
+  // walker's suite-level warnings array with the per-declaration
+  // `DeclaredTest.unparseableTags`. What this pins -- the prefix and the
+  // em-dash join -- was never wrong, but a fixture quoting a message no code
+  // path emits is one stale read away from being taken for the contract, and
+  // a hand-copied literal can go stale again. Deriving it cannot.
+  const bad: DeclaredTest = {
+    title: "one", relativePath: "a/x.spec.ts", line: 1, tags: [],
+    stable: false, fixme: false, modifier: "", unparseableTags: true,
+  };
+  const stderr = console.error;
+  console.error = () => {};   // assertNoWarnings prints the offending lines
+  let thrown = "";
+  try {
+    assertNoWarnings([bad]);
+  } catch (e) {
+    thrown = (e as Error).message;
+  } finally {
+    console.error = stderr;
+  }
+  assert.match(thrown, /^collectBacklog\(\): collectDeclaredTests\(\) reported 1 declaration\(s\)/);
   assert.equal(
-    msg,
-    "[triage-baseline] refusing: the AST parser could not fully read the corpus — " +
-      "collectBacklog(): collectTaggedTests() reported 1 parse warning(s) (printed above).",
+    formatParseRefusal(new Error(thrown)),
+    "[triage-baseline] refusing: the AST parser could not fully read the corpus — " + thrown,
   );
 });
 


### PR DESCRIPTION
Closes #1781

Fixes the eight findings a review raised against `db7a580e` — the reconciliation with #1746 — which reached `main` in #1780 with no independent review, because its author stalled mid-edit and it was finished by hand.

**Nothing here changes behaviour.** The review confirmed the reconciliation itself was the right call, the restoration of `scripts/lib/stable-tests.ts` byte-exact, and every measured number reproducible tuple-for-tuple. What this PR fixes is the *record*, in the two places the record is load-bearing, plus one real test gap.

## The two that matter

**The docblock justifying clause 2 claimed an equivalence that does not hold.** It said `isStable` (`test.stable && !test.fixme`) is the "exact equivalent" of `parseStableTests`'s filter. Measured on `test.describe("s", { tag: ["@stable"] }, () => { test("inner", { tag: ["@release"] }, …) })`:

```
parseStableTests   -> 0 tests, 1 warning
isStable           -> true
```

The divergence is **correct and stays**: Playwright's `--grep "@stable"` really does run an inherited-stable test, so its file is not never-validated debt, while `parseStableTests` warns fail-closed for a different reason (Phase 0 invisibility). The two answer different questions — *"does the daily run this"* versus *"is `@stable` written where Phase 0 can see it"* — and on a describe tag they legitimately disagree. The docblock now says that. It is the module whose whole justification is that there is one definition of `@stable`, so the sentence where that stops being literally true is the most important one in the file.

**The one semantic change the parser switch made was unpinned, and the test factory structurally could not express it.** `t()` derived `stable` from `tags`, so no fixture could construct `stable: true` with `@stable` absent — the inherited case. All 16 tests exercised only the pre-reconciliation semantics, and reverting the predicate survived every test in the repo, the real-suite test and `triage:baseline --check`, because the corpus has zero instances. Now pinned on both halves: the inherited-stable test is out of scope, **and so is its unstable file-mate** (the exemption is file-wide, via `stableFiles`). The reverted-predicate mutation yields 17 pass / **2 fail** — exactly the two new tests, every pre-existing one surviving.

That is this module's own standard, stated two docblocks up about `titleCollisions`: *"pinned by a unit test rather than by the corpus, exactly because a corpus with zero instances cannot pin a guard against them."*

## The rest

- The plan's Architecture line still said the parser "**is widened**"; Task 1's banner named `CollectTaggedResult`, `ParseWarning` and `warningDetails`, **all deleted**, so a worker following it would re-add the parser `db7a580e` removed. Task 1 is now bannered as reverted, with the commit; the header's five-task claim and Task 2's Interfaces block are corrected. Code blocks are marked, not rewritten — the file's existing convention.
- A dead `STABLE_TAG` import is gone. Worth naming why it survived review: `npm run lint` is `eslint tests/`, so CI never opens either changed file, and `npx eslint` on it reported an **error**. Same shape as #1593's "typechecked by nothing" — the lane gap is now recorded where a reader will hit it, and `eslint` was run explicitly on all three changed files here (0 problems).
- The recorded re-verification command missed `test.only('a', …)`, a template literal, and a title on the next line — and the template spelling is live in this corpus. Widened.
- "Two measured exposures" undercounted by two: a declaration with **no `tag` option** is now *in* the population (the widening direction), and an unreadable `tag` array on a `.only`/`.fail`/`.slow` declaration no longer raises the `assertNoWarnings` refusal.
- A stale fixture string quoted a message that can no longer be produced; it is now derived from the message the code formats.
- `assertNoWarnings`'s documented whole-suite width is pinned, so narrowing it to `classifyBacklog`'s output would fail a test rather than silently break the guarantee.

## Verification

```
test:units       1268/1268        typecheck        clean
test:scripts     1 known flake    eslint (explicit, 3 files)   0 problems
                 (scripts/lib/tmp-dir.test.mjs, macOS-only, green in CI)
triage:baseline --check   in sync: 55 spec(s), 92 test(s)
triage:verify             set-exact: 92/92/0/0, shards 31/31/30
#1746's own tests         24/24 and 34/34, behaviourally untouched
scripts/lib/stable-tests.ts   not touched by this PR
```

Parity against `origin/main` holds for every pre-existing consumer: `collectStableTests` 597, `declaredTests` 822, `declaredStable` 597, `declaredFixme` 10, `declaredUnparseable` 0, `declaredCounts` {812, 88, 724}, plus a content hash projected onto upstream's field set.

Those figures are one higher than #1780's because **#1779 added a test declaration while this was in flight** — caught by the parity check flagging four differences, then traced to its cause and re-derived from the new base rather than bumped to match. `declaredStable` stayed 597 and the baseline stayed in sync at 55/92: the new test is non-`@stable`, but its file carries `@stable`, so clause 4 excludes it. The instrument survived `main` moving under it.

## Still not done, and not in scope here

The measurement (Task 7) has not been run — it needs CI and live provider credentials, and its runbook steps are current, not superseded. The ownership guard is #1770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
