### PR TITLE
test(llm-agents): fix agent-tool-inspection's no-op UI assert and promote it to @stable

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -498,7 +498,7 @@
 - [x] Tool with invalid name — validation prevents execution with clear message → `core-functionality/llm-agents/agent-tool-name-validation.spec.ts`
 
 #### 6.5 Output and Reasoning
-- [-] Inspect tools used by Agent in Playground → `llm-agents/agent-tool-inspection.spec.ts` (UI chip names the tool + persisted `tool_use` input/output; `@stable` gated on the clean baseline #818, per #827)
+- [x] Inspect tools used by Agent in Playground → `llm-agents/agent-tool-inspection.spec.ts` (completed tool step names the tool + persisted `tool_use` input/output; **`@stable` since #1451**. Both gates it carried closed on 2026-07-30 — the flaky cluster #773 and the clean non-guarded baseline #818, per #827 — and the promotion was not a tag flip: the forced-failure pass found layer 1 asserting the canvas nodes' `tools_metadata` field through the Playground modal, i.e. the tools ATTACHED to the agent rather than the ones it USED, and it passed on a run with no tool call at all. Rewritten onto `tool-status-done`, then 6 clean whole-file runs on 1.12.1 / `gpt-4o-mini` with five forced failures)
 - [x] Agent returns output in structured JSON format (output_schema) → `agent-structured-output.spec.ts`
 - [-] Agent returns output in correctly rendered Markdown → `llm-agents/agent-markdown-output.spec.ts`
 - [x] Agent Instructions (system prompt) is respected in the model response → `agent-system-prompt.spec.ts`

--- a/docs/core-functionality/llm-agents/agent-tool-inspection.md
+++ b/docs/core-functionality/llm-agents/agent-tool-inspection.md
@@ -17,8 +17,10 @@ for agent tool usage — if they break, tool calls become a black box.
 **Two layers, both asserted:**
 
 1. **UI (which tool) —** the Playground renders a **completed tool step** for
-   the call — a `tool-status-done` marker in a row naming the tool
-   (`FETCH CONTENT`) with its duration. This is the operator's at-a-glance
+   the call — a `tool-status-done` marker in a row naming the tool. The
+   accordion trigger reads `FETCH CONTENT` plus the duration; the status dot's
+   own parent, which is what the spec asserts on, is the title cell and carries
+   the NAME alone. This is the operator's at-a-glance
    "tools used" surface on the message, and it exists only because the agent
    actually invoked the tool.
 2. **Payload (what it did) —** the run's persisted `tool_use` content block
@@ -58,8 +60,9 @@ for agent tool usage — if they break, tool calls become a black box.
 > caught it. On the same runs `tool-status-done` is **0**, and on a real call it
 > is exactly **1**, inside a row reading `FETCH CONTENT 834ms`
 > (`ToolCallCard.tsx`). `mcp-client-agent.spec.ts` asserts the same two test
-> ids and its doc states the same premise as *"Proof #1"* — reported separately,
-> not fixed here.
+> ids and its doc states the same premise as *"Proof #1"*; its comment also
+> repeats the wrong-accordion belief corrected below. Deliberately **not** fixed
+> here — different spec — and **no issue tracks it yet**.
 
 Distinct from existing coverage: `agent-multi-tool-selection` asserts WHICH
 tool the agent picks and the ORDER of a two-tool sequence; `mcp-client-agent`
@@ -91,12 +94,21 @@ Evidence, on `1.12.1` with `MODEL_TEST_PROVIDER=openai MODEL_TEST_ID=gpt-4o-mini
   at layer 1 (*"Playground must show a COMPLETED tool step"*) where before it
   reached the payload layer.
 - **Backend-error audit:** one advisory across the six runs, a
-  `404 {"detail":"Flow not found"}` on `GET /api/v1/flows/{id}` — the known
-  teardown race where the editor polls a flow `afterEach` has just deleted, not
-  a product failure. An earlier pre-fix run also logged one
-  `500 {"detail":"Could not update the flow."}` on an autosave `PATCH`, seen
-  once in five and not reproduced in the six post-fix runs; it is recorded here
-  rather than dismissed, since an HTTP error never fails a test (#1084).
+  `404 {"detail":"Flow not found"}` on `GET /api/v1/flows/{id}`, and **none at
+  all** in the three runs after the follow-up fix. It **matches the shape** of
+  the teardown race recorded in #1023 (fixed for project-management by #1103) —
+  a still-mounted editor polling a flow the `afterEach` has just deleted by id,
+  and this spec does leave the editor mounted. Recorded as matching that shape
+  rather than as a confirmed instance: it was seen once and nothing here
+  measured the polling that would attribute it. An earlier pre-fix run also
+  logged one `500 {"detail":"Could not update the flow."}` on an autosave
+  `PATCH`, seen once in five and not reproduced since. Both are recorded rather
+  than dismissed, since an HTTP error never fails a test (#1084).
+- **CONTRIBUTING step 4 (`--debug` walkthrough) was NOT run**, and is stated
+  here rather than left to be assumed from the other four: it drives an
+  interactive inspector, and what it would have shown — which element each
+  assertion resolves to — was obtained instead by dumping the live DOM at the
+  assertion point, which is what found the layer-1 false positive.
 
 **What is NOT covered by that evidence:** only `openai` was measured locally —
 the Anthropic key is drained (`credit balance is too low`) and google was not
@@ -131,12 +143,15 @@ public `httpbin.org`; the go-httpbin path is CI's (#1128).
    `https://httpbin.org/json` — same env convention as
    `agent-multi-tool-selection`).
 4. Open the Playground (`playground-btn-flow-io`), send, wait for the run to
-   finish (Stop button hidden). No "expand the Steps accordion" step: the tool
-   card `collapses to header-only once the producer attaches a duration`
-   (`ToolCallCard.tsx`), so the trigger row carrying the status dot and the tool
-   name is always rendered — only the args/result body collapses. The spec
-   carried such a helper, inherited from 1.11; it was measured dead on 1.12.1
-   (it matches zero rows) and removed.
+   finish (Stop button hidden), then best-effort expand the "Steps"/"Finished"
+   accordion. That expand matches **zero rows on 1.12.1** and is kept anyway,
+   because why it matches nothing is a property of the **producer**:
+   `ContentBlockDisplay.tsx` renders GROUPED blocks behind an `isExpanded` gate
+   that starts closed — on that branch the tool cards are not in the DOM until
+   the chevron is clicked — while FLAT items render above it ungated, and the
+   file states which one we get ("The agent emits tool_use items flat (not
+   inside a group)"). The branch the helper guards is live product code, so it
+   stays.
 5. **UI inspection assert:** a completed tool step is visible
    (`tool-status-done`), and the row that carries it names `fetch_content` —
    the Playground names the URL tool the agent used. Asserted in two steps on
@@ -164,11 +179,13 @@ public `httpbin.org`; the go-httpbin path is CI's (#1128).
 
 - The Playground renders a completed tool step (`tool-status-done`) whose row
   names `fetch_content` after the run (UI names the tool actually used).
-  `done` is not the only terminal status — `toolStatus.ts` derives
-  `error | done | running` and `error` wins over a duration — so a tool that was
-  called and FAILED renders no `tool-status-done` and this assertion fails. That
-  is correct for this spec, which goes on to assert the fetched payload, and the
-  failure message names BOTH causes rather than claiming no tool was invoked.
+  `done` is not the only status this can be missing for — `toolStatus.ts`
+  derives `error | done | running`, `error` wins over a duration, and a grouped
+  `tool_use` sits behind the collapsed Steps accordion — so a call that FAILED,
+  one that never RESOLVED, and one rendered on the grouped branch all fail this
+  assertion. Failing is correct for this spec, which goes on to assert the
+  fetched payload; the failure message names all four causes rather than
+  claiming no tool was invoked (#884).
 - The run's persisted `fetch_content` `tool_use` block carries `tool_input`
   with the prompt's exact URL AND `output` containing `Sample Slide Show`
   (the input and output are captured for inspection).
@@ -219,8 +236,8 @@ cleanup and the flow count grows.
 - Which tool the agent selects among several / multi-tool ordering (covered by
   `agent-multi-tool-selection`).
 - MCP tools in the Playground (covered by `mcp-client-agent` — whose own
-  tool-indicator assertion carries the premise corrected here, reported
-  separately rather than fixed in this PR).
+  tool-indicator assertion carries the premise corrected here; a separate spec,
+  deliberately not fixed in this PR, and not yet tracked by an issue).
 - The `button_open_actions` per-message actions button (message-level actions,
   not tool inspection).
 - Duration-value correctness (`duration` is captured but timing is

--- a/docs/core-functionality/llm-agents/agent-tool-inspection.md
+++ b/docs/core-functionality/llm-agents/agent-tool-inspection.md
@@ -62,7 +62,10 @@ for agent tool usage — if they break, tool calls become a black box.
 > (`ToolCallCard.tsx`). `mcp-client-agent.spec.ts` asserts the same two test
 > ids and its doc states the same premise as *"Proof #1"*; its comment also
 > repeats the wrong-accordion belief corrected below. Deliberately **not** fixed
-> here — different spec — and **no issue tracks it yet**.
+> here — different spec — and tracked by **#1793**, which also records the one
+> thing this PR could not measure: whether the MCPTools node's `tools_metadata`
+> actually carries an `echo` entry, i.e. whether its Proof #2 is a no-op or only
+> unsound in premise.
 
 Distinct from existing coverage: `agent-multi-tool-selection` asserts WHICH
 tool the agent picks and the ORDER of a two-tool sequence; `mcp-client-agent`
@@ -237,7 +240,7 @@ cleanup and the flow count grows.
   `agent-multi-tool-selection`).
 - MCP tools in the Playground (covered by `mcp-client-agent` — whose own
   tool-indicator assertion carries the premise corrected here; a separate spec,
-  deliberately not fixed in this PR, and not yet tracked by an issue).
+  deliberately not fixed in this PR, tracked by #1793).
 - The `button_open_actions` per-message actions button (message-level actions,
   not tool inspection).
 - Duration-value correctness (`duration` is captured but timing is

--- a/docs/core-functionality/llm-agents/agent-tool-inspection.md
+++ b/docs/core-functionality/llm-agents/agent-tool-inspection.md
@@ -131,7 +131,12 @@ public `httpbin.org`; the go-httpbin path is CI's (#1128).
    `https://httpbin.org/json` — same env convention as
    `agent-multi-tool-selection`).
 4. Open the Playground (`playground-btn-flow-io`), send, wait for the run to
-   finish (Stop button hidden).
+   finish (Stop button hidden). No "expand the Steps accordion" step: the tool
+   card `collapses to header-only once the producer attaches a duration`
+   (`ToolCallCard.tsx`), so the trigger row carrying the status dot and the tool
+   name is always rendered — only the args/result body collapses. The spec
+   carried such a helper, inherited from 1.11; it was measured dead on 1.12.1
+   (it matches zero rows) and removed.
 5. **UI inspection assert:** a completed tool step is visible
    (`tool-status-done`), and the row that carries it names `fetch_content` —
    the Playground names the URL tool the agent used. Asserted in two steps on
@@ -159,6 +164,11 @@ public `httpbin.org`; the go-httpbin path is CI's (#1128).
 
 - The Playground renders a completed tool step (`tool-status-done`) whose row
   names `fetch_content` after the run (UI names the tool actually used).
+  `done` is not the only terminal status — `toolStatus.ts` derives
+  `error | done | running` and `error` wins over a duration — so a tool that was
+  called and FAILED renders no `tool-status-done` and this assertion fails. That
+  is correct for this spec, which goes on to assert the fetched payload, and the
+  failure message names BOTH causes rather than claiming no tool was invoked.
 - The run's persisted `fetch_content` `tool_use` block carries `tool_input`
   with the prompt's exact URL AND `output` containing `Sample Slide Show`
   (the input and output are captured for inspection).

--- a/docs/core-functionality/llm-agents/agent-tool-inspection.md
+++ b/docs/core-functionality/llm-agents/agent-tool-inspection.md
@@ -1,6 +1,6 @@
 # Agent tool inspection — Playground names the tool used and captures its input/output
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.12.x (promotion measured on 1.12.1)
 
 ---
 
@@ -16,10 +16,11 @@ for agent tool usage — if they break, tool calls become a black box.
 
 **Two layers, both asserted:**
 
-1. **UI (which tool) —** the Playground renders a `div-tools_tools_metadata`
-   row containing a `tool_<name>` chip (e.g. `tool_fetch_content`, label
-   `FETCH_CONTENT`) naming the tool the agent used. This is the operator's
-   at-a-glance "tools used" surface on the message.
+1. **UI (which tool) —** the Playground renders a **completed tool step** for
+   the call — a `tool-status-done` marker in a row naming the tool
+   (`FETCH CONTENT`) with its duration. This is the operator's at-a-glance
+   "tools used" surface on the message, and it exists only because the agent
+   actually invoked the tool.
 2. **Payload (what it did) —** the run's persisted `tool_use` content block
    (monitor API, nonce-keyed) carries `name`, `tool_input` (the exact
    arguments — here the URL from the prompt), `output` (the tool's result),
@@ -29,14 +30,36 @@ for agent tool usage — if they break, tool calls become a black box.
 > tool call surfaced as a `.cursor-pointer` accordion row reading "Called tool
 > <NAME>" that **expanded inline** to show `Input:` and `Output:` JSON in the
 > DOM. On 1.12 that expandable accordion is **gone** (scouted live on
-> `1.12.0.dev0`): the Playground now shows a compact `div-tools_tools_metadata`
-> row of `tool_<name>` chips (label only, no inline Input/Output expansion —
-> same surface `mcp-client-agent` asserts for MCP tools, #894). The tool call's
-> input/output payload is no longer rendered as expandable UI; it lives in the
-> persisted `content_blocks` (`tool_use` with `tool_input` + `output`), which is
-> what any inspection reads from. This spec therefore asserts the chip (UI) plus
-> the persisted payload (monitor API) — deterministic and faithful to the 1.12
-> product, rather than driving a DOM accordion that no longer exists.
+> `1.12.0.dev0`): the Playground now shows a compact per-call step naming the
+> tool and its duration. The tool call's input/output payload is no longer
+> rendered as expandable UI; it lives in the persisted `content_blocks`
+> (`tool_use` with `tool_input` + `output`), which is what any inspection reads
+> from. This spec therefore asserts the completed step (UI) plus the persisted
+> payload (monitor API) — deterministic and faithful to the 1.12 product,
+> rather than driving a DOM accordion that no longer exists.
+
+> **Why not `div-tools_tools_metadata` / `tool_<name>` (#1451).** Until the
+> promotion below, layer 1 asserted those two test ids with an unscoped
+> `.last()`, on the stated premise that *"the block only exists after a real
+> tool call, so a hallucinated text-only answer has no chip"*. **That premise is
+> false and the assertion was a no-op.** They are the `tools_metadata` **field
+> of the URL and Web Search nodes on the canvas** —
+> `aria-labelledby="node-URLComponent-…-field-tools_metadata-label"`, with the
+> node's `button_open_actions` gear inside — and the canvas stays mounted
+> **behind** the Playground modal, so an unscoped locator matches it. Playwright
+> visibility is a non-empty bounding box, not "on top", so being behind a modal
+> does not hide it. They list the tools **attached** to the agent, not the ones
+> it used, and they exist before any run.
+>
+> Measured on `1.12.1`: an agent instructed never to call a tool, answering
+> `4` to *"What is 2+2?"*, still renders **2** metadata blocks and **both**
+> chips (`tool_fetch_content`, `tool_perform_search`) with **no** `tool_use`
+> block persisted — and the old layer 1 **passed**. Only the payload layer
+> caught it. On the same runs `tool-status-done` is **0**, and on a real call it
+> is exactly **1**, inside a row reading `FETCH CONTENT 834ms`
+> (`ToolCallCard.tsx`). `mcp-client-agent.spec.ts` asserts the same two test
+> ids and its doc states the same premise as *"Proof #1"* — reported separately,
+> not fixed here.
 
 Distinct from existing coverage: `agent-multi-tool-selection` asserts WHICH
 tool the agent picks and the ORDER of a two-tool sequence; `mcp-client-agent`
@@ -47,10 +70,38 @@ asserts the chip exists for MCP tools. Neither asserts the tool call's
 
 ## Tags *(required)*
 
-`@regression` `@agents` `@playground`
+`@stable` `@regression` `@agents` `@playground`
 
-No `@stable` at creation — this area is in the current flaky cluster (#773);
-promotion is gated on the clean non-guarded baseline (#818), per issue #827.
+**Promoted in #1451.** The spec shipped without `@stable` under two gates that
+have both been closed since 2026-07-30 — the flaky cluster #773 and the clean
+non-guarded baseline #818, per #827 — and the justification then outlived its
+reason silently for two weeks, which is what #1451 was raised about.
+
+Promotion was **not** a tag flip: the forced-failure pass found layer 1 to be a
+false positive (see the `#1451` note above) and it was rewritten first.
+Evidence, on `1.12.1` with `MODEL_TEST_PROVIDER=openai MODEL_TEST_ID=gpt-4o-mini
+--workers=1 --retries=0`:
+
+- **6 clean whole-file runs** of the rewritten spec (5 plain + 1 `--trace=on`),
+  15.0–17.8 s each.
+- **Five forced failures, each re-executed against the committed fix**, and each
+  failing on its own assertion: a wrong tool name in the step (layer 1), a wrong
+  URL in `tool_input`, an impossible title in `output`, a wrong causal anchor,
+  and the premise itself — an agent told never to call a tool, which now fails
+  at layer 1 (*"Playground must show a COMPLETED tool step"*) where before it
+  reached the payload layer.
+- **Backend-error audit:** one advisory across the six runs, a
+  `404 {"detail":"Flow not found"}` on `GET /api/v1/flows/{id}` — the known
+  teardown race where the editor polls a flow `afterEach` has just deleted, not
+  a product failure. An earlier pre-fix run also logged one
+  `500 {"detail":"Could not update the flow."}` on an autosave `PATCH`, seen
+  once in five and not reproduced in the six post-fix runs; it is recorded here
+  rather than dismissed, since an HTTP error never fails a test (#1084).
+
+**What is NOT covered by that evidence:** only `openai` was measured locally —
+the Anthropic key is drained (`credit balance is too low`) and google was not
+exercised, so both rest on the daily's own rotation (#1185). And the run used
+public `httpbin.org`; the go-httpbin path is CI's (#1128).
 
 ---
 
@@ -81,9 +132,11 @@ promotion is gated on the clean non-guarded baseline (#818), per issue #827.
    `agent-multi-tool-selection`).
 4. Open the Playground (`playground-btn-flow-io`), send, wait for the run to
    finish (Stop button hidden).
-5. **UI inspection assert:** the `div-tools_tools_metadata` row is visible and
-   contains a `tool_fetch_content` chip — the Playground names the URL tool the
-   agent used.
+5. **UI inspection assert:** a completed tool step is visible
+   (`tool-status-done`), and the row that carries it names `fetch_content` —
+   the Playground names the URL tool the agent used. Asserted in two steps on
+   purpose: "the agent invoked no tool at all" and "it invoked a different
+   tool" are different failures and must not report the same message.
 6. **Payload inspection assert (API):** poll `GET /api/v1/monitor/messages` —
    nonce-keyed session lookup (same technique as `agent-multi-tool-selection`);
    locate the `fetch_content` `tool_use` block and assert:
@@ -104,8 +157,8 @@ promotion is gated on the clean non-guarded baseline (#818), per issue #827.
 
 ## Validation criterion *(required)*
 
-- The Playground renders a `div-tools_tools_metadata` row with a
-  `tool_fetch_content` chip after the run (UI names the tool used).
+- The Playground renders a completed tool step (`tool-status-done`) whose row
+  names `fetch_content` after the run (UI names the tool actually used).
 - The run's persisted `fetch_content` `tool_use` block carries `tool_input`
   with the prompt's exact URL AND `output` containing `Sample Slide Show`
   (the input and output are captured for inspection).
@@ -122,11 +175,22 @@ promotion is gated on the clean non-guarded baseline (#818), per issue #827.
   is the real arguments the agent passed, not a static chip label.
 - **Nonce-keyed session lookup** — monitor messages persist across flow wipes;
   the per-run nonce pins the API assertions to THIS run.
-- **Force-failure checks** (CONTRIBUTING §2): M1 — assert a bogus chip testid
-  (`tool_nonexistent`) ⇒ the UI assert must fail; M2 — assert an impossible
-  title in `output` (`Sample Slide Show XYZ`) ⇒ the payload assert must fail
-  against the real captured output; M3 — assert a wrong URL in `tool_input`
-  ⇒ the input assert must fail.
+- **Assert an element only an invocation creates** — `tool-status-done` is
+  rendered per tool CALL, so layer 1 cannot pass on a run where the agent
+  answered from memory. The test ids it replaced could, and did (see the
+  `#1451` note above): that is the difference between asserting the tools the
+  agent HAS and the tools it USED.
+- **Force-failure checks** (CONTRIBUTING §3), all five executed against the
+  committed spec and all five red: **M1** — the step must name
+  `perform_search` ⇒ layer 1 fails *"The tool named in the Playground step must
+  be fetch_content"*; **M2** — a wrong URL as the `tool_input` needle ⇒ the
+  payload assert fails against the real captured input; **M3** — an impossible
+  title as the `output` regex ⇒ the payload assert fails against the real
+  captured output; **M4** — an impossible causal anchor ⇒ the final-answer
+  assert fails; **M5** — the premise: the system prompt forbids tool use and the
+  task is answerable from memory (*"What is 2+2?"*) ⇒ layer 1 fails, *no tool
+  step exists*. M5 is the one that matters: it is the mutation the previous
+  layer 1 survived.
 
 ---
 
@@ -144,7 +208,9 @@ cleanup and the flow count grows.
 
 - Which tool the agent selects among several / multi-tool ordering (covered by
   `agent-multi-tool-selection`).
-- MCP-tool chips (covered by `mcp-client-agent`).
+- MCP tools in the Playground (covered by `mcp-client-agent` — whose own
+  tool-indicator assertion carries the premise corrected here, reported
+  separately rather than fixed in this PR).
 - The `button_open_actions` per-message actions button (message-level actions,
   not tool inspection).
 - Duration-value correctness (`duration` is captured but timing is
@@ -162,9 +228,10 @@ cleanup and the flow count grows.
   daily self-hosts go-httpbin and exports `ECHO_BASE_URL`; its `/json` serves
   the identical slideshow, keeping the output assert deterministic (same
   convention + SSRF-allowlist note as `agent-multi-tool-selection`).
-- `src/frontend/src/components/core/chatComponents/` — renders the
-  `div-tools_tools_metadata` row and `tool_<name>` chips (the 1.12 tool-usage
-  surface).
+- `src/frontend/src/components/core/chatComponents/ToolCallCard.tsx` — renders
+  the per-call step: `data-testid={`tool-status-${status}`}` beside the tool
+  title, inside an accordion row. This is the 1.12 tool-USAGE surface, and it is
+  rendered only for a call the agent made.
 - `GET /api/v1/monitor/messages` — persisted `content_blocks[].contents[]`
   `tool_use` entries carrying `name`, `tool_input`, `output`, `duration`.
 - `tests/helpers/provider-setup/data/models.json` + `providers.json`

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
@@ -51,7 +51,7 @@ import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targ
  * `tool_use` block persisted — the old layer 1 passed. `tool-status-done` is 0
  * on that run and exactly 1 on a real call. `mcp-client-agent.spec.ts` asserts
  * the same two test ids and its comment carries the same premise; that is a
- * separate spec and is deliberately NOT fixed here. No issue tracks it yet.
+ * separate spec and is deliberately NOT fixed here — tracked by #1793.
  *
  * Distinct from siblings: `agent-multi-tool-selection` asserts WHICH tool and
  * the ORDER of a sequence; `mcp-client-agent` asserts a tool indicator for MCP

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
@@ -20,9 +20,9 @@ import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targ
  * Playground"). After a tool-using run, the operator must be able to inspect
  * what the agent did — this spec asserts BOTH layers of that surface:
  *
- *   1. UI (which tool) — the Playground renders a `div-tools_tools_metadata`
- *      row with a `tool_<name>` chip (here `tool_fetch_content`, label
- *      "FETCH_CONTENT") naming the tool the agent called.
+ *   1. UI (which tool) — the Playground renders a COMPLETED step for the call
+ *      (`tool-status-done`) in a row naming the tool, here "FETCH CONTENT"
+ *      followed by its duration.
  *   2. Payload (what it did) — the run's persisted `tool_use` content block
  *      (monitor API, nonce-keyed) carries `tool_input` (the exact arguments,
  *      here the prompt's URL) and `output` (the tool result, the deterministic
@@ -30,17 +30,32 @@ import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targ
  *
  * 1.12 rendering note: through ~1.11 the tool call surfaced as a
  * `.cursor-pointer` "Called tool" accordion that expanded inline to Input/Output
- * JSON; on 1.12 that accordion is gone (scouted live on 1.12.0.dev0). The chips
- * name the tool; the input/output payload lives only in `content_blocks`, which
- * is what any inspection reads from — so this spec asserts the chip (UI) + the
+ * JSON; on 1.12 that accordion is gone (scouted live on 1.12.0.dev0). The
+ * input/output payload lives only in `content_blocks`, which is what any
+ * inspection reads from — so this spec asserts the completed step (UI) + the
  * persisted payload (API), not a DOM accordion that no longer exists (#894 found
  * the same drift for the MCP-tool indicator).
  *
+ * WHY NOT `div-tools_tools_metadata` / `tool_<name>` (#1451). Until this
+ * revision layer 1 asserted those two test ids, on the stated premise that "the
+ * block only exists after a real tool call, so a hallucinated text-only answer
+ * has no chip". That premise is FALSE, and the assertion was a no-op: they are
+ * the `tools_metadata` FIELD of the URL and Web Search NODES on the canvas
+ * (`aria-labelledby="node-URLComponent-…-field-tools_metadata-label"`), which
+ * stays mounted BEHIND the Playground modal and is therefore matched by an
+ * unscoped `.last()`. They list the tools ATTACHED to the agent, not the ones it
+ * used, and they exist before any run. Measured on 1.12.1: an agent told never
+ * to call a tool, answering "4" to "what is 2+2", still renders 2 metadata
+ * blocks and BOTH chips (`tool_fetch_content`, `tool_perform_search`) with no
+ * `tool_use` block persisted — the old layer 1 passed. `tool-status-done` is 0
+ * on that run and exactly 1 on a real call. `mcp-client-agent.spec.ts` asserts
+ * the same two test ids and carries the same premise in its doc — reported
+ * separately, not fixed here.
+ *
  * Distinct from siblings: `agent-multi-tool-selection` asserts WHICH tool and
- * the ORDER of a sequence; `mcp-client-agent` asserts the chip for MCP tools.
- * Neither asserts the tool call's INPUT arguments are captured — this spec's
- * subject. Gated: no @stable at creation (flaky cluster #773; promotion gated
- * on the clean baseline #818, per #827).
+ * the ORDER of a sequence; `mcp-client-agent` asserts a tool indicator for MCP
+ * tools. Neither asserts the tool call's INPUT arguments are captured — this
+ * spec's subject.
  */
 
 if (!process.env.CI) {
@@ -54,6 +69,10 @@ const HTTPBIN_BASE = (
 ).replace(/\/$/, "");
 const FETCH_URL = `${HTTPBIN_BASE}/json`;
 const URL_TOOL = "fetch_content";
+// The completed step renders the tool name as a display label ("FETCH CONTENT"),
+// so match it tolerantly: uppercased-with-spaces and the raw `fetch_content`
+// spelling both satisfy this, and neither is hardcoded away from URL_TOOL.
+const TOOL_STEP_LABEL = new RegExp(URL_TOOL.replace(/_/g, "[\\s_]"), "i");
 const EXPECTED_TITLE = /Sample Slide Show/i;
 const SYSTEM_PROMPT =
   "For every user question you MUST call exactly one tool to obtain the answer - " +
@@ -141,12 +160,11 @@ async function openPlaygroundAndSend(page: Page, task: string): Promise<void> {
   await waitForAgentToFinish(page);
 }
 
-// The Playground renders the tools-metadata block inside a collapsed
-// "Steps"/"Finished" accordion by default (chat-message.tsx, hideHeader=false —
-// chevron click required to reveal it). Best-effort expand every such row so the
-// `div-tools_tools_metadata` / `tool_<name>` chips become visible; if already
-// expanded the click is a no-op. Mirrors mcp-client-agent.spec.ts (proven on
-// 1.12) — the chevron trigger is a `.cursor-pointer` in the header row.
+// The Playground renders the per-run steps inside a collapsed "Steps"/"Finished"
+// accordion by default (chat-message.tsx, hideHeader=false — chevron click
+// required to reveal it). Best-effort expand every such row so the completed
+// tool step becomes visible; if already expanded the click is a no-op — the
+// chevron trigger is a `.cursor-pointer` in the header row.
 async function expandAgentSteps(page: Page): Promise<void> {
   await page.evaluate(() => {
     const rows = Array.from(
@@ -232,7 +250,7 @@ for (const { label, options, skipReason } of targets) {
   test.describe(`Agent Tool Inspection [${label}]`, () => {
     test(
       "Playground names the tool used and captures its input/output",
-      { tag: ["@regression", "@agents", "@playground"] },
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
       async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(
@@ -255,19 +273,23 @@ for (const { label, options, skipReason } of targets) {
           await openPlaygroundAndSend(page, task);
         });
 
-        await test.step("UI inspection: the tools-used row names the URL tool", async () => {
-          // Reveal the collapsed Steps accordion, then assert the tools-metadata
-          // block + the URL-tool chip (unscoped `.last()`, mirroring the proven
-          // mcp-client-agent assertions — the block only exists after a real tool
-          // call, so a hallucinated text-only answer has no chip).
+        await test.step("UI inspection: the completed step names the URL tool", async () => {
+          // Reveal the collapsed Steps accordion, then assert a COMPLETED tool
+          // step. `tool-status-done` is the only element in the Playground that
+          // an actual invocation creates: measured on 1.12.1, a run where the
+          // agent answered from memory renders ZERO of them, and a run that
+          // called the tool renders exactly one, in a row reading
+          // "FETCH CONTENT 834ms". Its parent carries the tool NAME without the
+          // duration, which is what the second assertion reads.
           await expandAgentSteps(page);
+          const completedToolSteps = page.getByTestId("tool-status-done").locator("xpath=..");
           await expect(
-            page.getByTestId("div-tools_tools_metadata").last(),
-            "Playground must show a tool-usage block — agent answered without invoking any tool",
+            completedToolSteps.first(),
+            "Playground must show a COMPLETED tool step — agent answered without invoking any tool",
           ).toBeVisible({ timeout: 120000 });
           await expect(
-            page.getByTestId(`tool_${URL_TOOL}`).last(),
-            `The tool named in the Playground must be ${URL_TOOL}`,
+            completedToolSteps.filter({ hasText: TOOL_STEP_LABEL }).first(),
+            `The tool named in the Playground step must be ${URL_TOOL}`,
           ).toBeVisible({ timeout: 5000 });
         });
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
@@ -160,25 +160,14 @@ async function openPlaygroundAndSend(page: Page, task: string): Promise<void> {
   await waitForAgentToFinish(page);
 }
 
-// The Playground renders the per-run steps inside a collapsed "Steps"/"Finished"
-// accordion by default (chat-message.tsx, hideHeader=false — chevron click
-// required to reveal it). Best-effort expand every such row so the completed
-// tool step becomes visible; if already expanded the click is a no-op — the
-// chevron trigger is a `.cursor-pointer` in the header row.
-async function expandAgentSteps(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const rows = Array.from(
-      document.querySelectorAll<HTMLElement>("div.flex.items-center.justify-between"),
-    ).filter((row) => {
-      const text = row.textContent ?? "";
-      return text.includes("Finished") || text.includes("Steps");
-    });
-    for (const row of rows) {
-      row.querySelector<HTMLElement>(".cursor-pointer")?.click();
-    }
-  });
-}
-
+// NOTE — there is deliberately no "expand the Steps accordion" helper here.
+// The spec carried one (a best-effort click on every `.cursor-pointer` inside a
+// row reading "Finished"/"Steps"), inherited from the 1.11 surface, and it was
+// dead: measured on 1.12.1 it finds ZERO such rows, and `tool-status-done` is
+// already visible before it runs. `ToolCallCard.tsx` says why — the card
+// "collapses to header-only once the producer attaches a duration", so the
+// TRIGGER row carrying the status dot and the tool name is always rendered and
+// only the args/result BODY collapses. Removing the call: 2 runs, 2 passes.
 // Payload inspection (§6.5): the persisted `tool_use` block for THIS run
 // (nonce-keyed) must carry `tool_input` containing `inputNeedle` (the prompt's
 // exact URL — proves the captured input is the real arguments) AND `output`
@@ -274,18 +263,27 @@ for (const { label, options, skipReason } of targets) {
         });
 
         await test.step("UI inspection: the completed step names the URL tool", async () => {
-          // Reveal the collapsed Steps accordion, then assert a COMPLETED tool
-          // step. `tool-status-done` is the only element in the Playground that
-          // an actual invocation creates: measured on 1.12.1, a run where the
-          // agent answered from memory renders ZERO of them, and a run that
-          // called the tool renders exactly one, in a row reading
-          // "FETCH CONTENT 834ms". Its parent carries the tool NAME without the
-          // duration, which is what the second assertion reads.
-          await expandAgentSteps(page);
+          // Assert a COMPLETED tool step. `tool-status-done` is the only element
+          // in the Playground that an actual invocation creates: measured on
+          // 1.12.1, a run where the agent answered from memory renders ZERO of
+          // them, and a run that called the tool renders exactly one, in a row
+          // reading "FETCH CONTENT 834ms". Its parent is the title cell, whose
+          // text is the tool NAME alone (no duration) — that is what the second
+          // assertion reads.
+          //
+          // `done` is not the only terminal status: `toolStatus.ts` derives
+          // `error` (which WINS over a duration) | `done` | `running`, so a tool
+          // that was called and FAILED renders `tool-status-error` and no
+          // `tool-status-done`. This spec requires a successful call — it goes
+          // on to assert the fetched payload — so failing there is right, but
+          // the message must not then claim no tool was invoked (#884: a wrong
+          // attribution costs more than a missing one).
           const completedToolSteps = page.getByTestId("tool-status-done").locator("xpath=..");
           await expect(
             completedToolSteps.first(),
-            "Playground must show a COMPLETED tool step — agent answered without invoking any tool",
+            "Playground must show a COMPLETED tool step (`tool-status-done`) — " +
+              "either the agent invoked no tool at all, or the call it made " +
+              "errored (`tool-status-error`, which wins over a duration)",
           ).toBeVisible({ timeout: 120000 });
           await expect(
             completedToolSteps.filter({ hasText: TOOL_STEP_LABEL }).first(),

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
@@ -21,8 +21,9 @@ import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targ
  * what the agent did — this spec asserts BOTH layers of that surface:
  *
  *   1. UI (which tool) — the Playground renders a COMPLETED step for the call
- *      (`tool-status-done`) in a row naming the tool, here "FETCH CONTENT"
- *      followed by its duration.
+ *      (`tool-status-done`). The accordion trigger reads "FETCH CONTENT" plus
+ *      the duration; the dot's own parent, asserted here, is the title cell
+ *      and carries the name alone.
  *   2. Payload (what it did) — the run's persisted `tool_use` content block
  *      (monitor API, nonce-keyed) carries `tool_input` (the exact arguments,
  *      here the prompt's URL) and `output` (the tool result, the deterministic
@@ -49,8 +50,8 @@ import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targ
  * blocks and BOTH chips (`tool_fetch_content`, `tool_perform_search`) with no
  * `tool_use` block persisted — the old layer 1 passed. `tool-status-done` is 0
  * on that run and exactly 1 on a real call. `mcp-client-agent.spec.ts` asserts
- * the same two test ids and carries the same premise in its doc — reported
- * separately, not fixed here.
+ * the same two test ids and its comment carries the same premise; that is a
+ * separate spec and is deliberately NOT fixed here. No issue tracks it yet.
  *
  * Distinct from siblings: `agent-multi-tool-selection` asserts WHICH tool and
  * the ORDER of a sequence; `mcp-client-agent` asserts a tool indicator for MCP
@@ -160,14 +161,40 @@ async function openPlaygroundAndSend(page: Page, task: string): Promise<void> {
   await waitForAgentToFinish(page);
 }
 
-// NOTE — there is deliberately no "expand the Steps accordion" helper here.
-// The spec carried one (a best-effort click on every `.cursor-pointer` inside a
-// row reading "Finished"/"Steps"), inherited from the 1.11 surface, and it was
-// dead: measured on 1.12.1 it finds ZERO such rows, and `tool-status-done` is
-// already visible before it runs. `ToolCallCard.tsx` says why — the card
-// "collapses to header-only once the producer attaches a duration", so the
-// TRIGGER row carrying the status dot and the tool name is always rendered and
-// only the args/result BODY collapses. Removing the call: 2 runs, 2 passes.
+// Best-effort expand of the "Steps"/"Finished" accordion. Measured on 1.12.1 it
+// matches ZERO rows and `tool-status-done` is already visible before it runs —
+// yet it is kept, because WHY it matches nothing is a property of the PRODUCER,
+// not of the surface, and the branch it guards is live product code.
+//
+// `ContentBlockDisplay.tsx` splits a message's content two ways. GROUPED blocks
+// render inside `{(hideHeader || isExpanded) && <Accordion …>}`, behind a header
+// (`{!hideHeader && …}`, and neither call site passes `hideHeader`, which
+// defaults to false) whose title is "Steps"/"Finished" and whose `.cursor-pointer`
+// chevron toggles `isExpanded` — initialised to `false`. On that branch the tool
+// cards are NOT IN THE DOM until the chevron is clicked, and this helper's
+// selector matches that row exactly. FLAT items take the other path
+// (`looseItems`), rendered above it with no header gate at all, and the file
+// says which one we get: "The agent emits tool_use items flat (not inside a
+// group), so they get their own ToolCallCard wrapper".
+//
+// So the helper is dead only for as long as the agent keeps emitting flat. An
+// earlier revision of this spec deleted it and justified that with
+// `ToolCallCard.tsx`'s "collapses to header-only once the producer attaches a
+// duration" — the WRONG mechanism: that comment is about the per-card accordion
+// holding the args/result body, not about the Steps accordion this targets.
+async function expandAgentSteps(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const rows = Array.from(
+      document.querySelectorAll<HTMLElement>("div.flex.items-center.justify-between"),
+    ).filter((row) => {
+      const text = row.textContent ?? "";
+      return text.includes("Finished") || text.includes("Steps");
+    });
+    for (const row of rows) {
+      row.querySelector<HTMLElement>(".cursor-pointer")?.click();
+    }
+  });
+}
 // Payload inspection (§6.5): the persisted `tool_use` block for THIS run
 // (nonce-keyed) must carry `tool_input` containing `inputNeedle` (the prompt's
 // exact URL — proves the captured input is the real arguments) AND `output`
@@ -263,7 +290,8 @@ for (const { label, options, skipReason } of targets) {
         });
 
         await test.step("UI inspection: the completed step names the URL tool", async () => {
-          // Assert a COMPLETED tool step. `tool-status-done` is the only element
+          // Expand first (a no-op today — see `expandAgentSteps`), then assert a
+          // COMPLETED tool step. `tool-status-done` is the only element
           // in the Playground that an actual invocation creates: measured on
           // 1.12.1, a run where the agent answered from memory renders ZERO of
           // them, and a run that called the tool renders exactly one, in a row
@@ -271,19 +299,24 @@ for (const { label, options, skipReason } of targets) {
           // text is the tool NAME alone (no duration) — that is what the second
           // assertion reads.
           //
-          // `done` is not the only terminal status: `toolStatus.ts` derives
-          // `error` (which WINS over a duration) | `done` | `running`, so a tool
-          // that was called and FAILED renders `tool-status-error` and no
-          // `tool-status-done`. This spec requires a successful call — it goes
-          // on to assert the fetched payload — so failing there is right, but
-          // the message must not then claim no tool was invoked (#884: a wrong
-          // attribution costs more than a missing one).
+          // `done` is not the only status this can be missing for, and the
+          // message has to say so or it misattributes (#884). `toolStatus.ts`
+          // derives `error` (which WINS over a duration) | `done` | `running`,
+          // so a call that FAILED renders `tool-status-error` and one that never
+          // resolved renders `tool-status-running` — both are invocations. And a
+          // grouped `tool_use` would be behind the collapsed Steps accordion the
+          // helper above exists for. This spec requires a SUCCESSFUL call — it
+          // goes on to assert the fetched payload — so failing here is right in
+          // every one of those cases; only the wording has to distinguish them.
+          await expandAgentSteps(page);
           const completedToolSteps = page.getByTestId("tool-status-done").locator("xpath=..");
           await expect(
             completedToolSteps.first(),
-            "Playground must show a COMPLETED tool step (`tool-status-done`) — " +
-              "either the agent invoked no tool at all, or the call it made " +
-              "errored (`tool-status-error`, which wins over a duration)",
+            "Playground must show a COMPLETED tool step (`tool-status-done`). " +
+              "Either the agent invoked no tool at all, or the call it made " +
+              "errored (`tool-status-error`, which wins over a duration), or it " +
+              "never resolved (`tool-status-running`, no duration attached), or " +
+              "the card is inside a collapsed Steps/Finished group accordion",
           ).toBeVisible({ timeout: 120000 });
           await expect(
             completedToolSteps.filter({ hasText: TOOL_STEP_LABEL }).first(),


### PR DESCRIPTION
Closes #1451.

## What this changes

`agent-tool-inspection` shipped without `@stable` under two gates that **both closed on
2026-07-30** — the flaky cluster #773 and the clean non-guarded baseline #818, per #827 —
and the justification then sat in `QA-CHECKLIST.md` and in the spec doc for two weeks
after its reason was gone. That silent expiry is what #1451 was raised about.

**The promotion is not a tag flip.** The forced-failure pass found layer 1 to be a false
positive, so it is rewritten first.

## Layer 1 was a no-op (commit 1)

The spec asserted `div-tools_tools_metadata` plus a `tool_<name>` chip with an unscoped
`.last()`, on the stated premise that *"the block only exists after a real tool call, so a
hallucinated text-only answer has no chip"*. **That premise is false.** Those two test ids
are the `tools_metadata` **field of the URL and Web Search nodes on the canvas** —
`aria-labelledby="node-URLComponent-…-field-tools_metadata-label"`, with the node's
`button_open_actions` gear inside — and the canvas stays mounted **behind** the Playground
modal. Playwright visibility is a non-empty bounding box, not "on top", so being behind a
modal does not hide it. They list the tools **attached** to the agent and exist before any
run.

Measured on `1.12.1`: an agent instructed never to call a tool, answering `4` to *"What is
2+2?"*, still renders **2** metadata blocks and **both** chips (`tool_fetch_content`,
`tool_perform_search`) with **no** `tool_use` block persisted — **and the old layer 1
passed.** Only the payload layer caught it. On the same run `tool-status-done` is **0**;
on a real call it is exactly **1**, in a row reading `FETCH CONTENT 834ms`
(`ToolCallCard.tsx`). Layer 1 now asserts that element and reads the tool name off its
parent.

## Two defects found reviewing commits 1–2 against the source (commit 3)

Both were mine, both found by checking the Langflow source rather than the diff:

- **`expandAgentSteps` was dead code carrying a false claim.** Its comment said the
  Playground hides the steps in a collapsed accordion needing a chevron click. Measured on
  1.12.1 it matches **zero** rows, and `tool-status-done` is already visible before it
  runs. `ToolCallCard.tsx` says why — the card *"collapses to header-only once the producer
  attaches a duration"*, so the trigger row with the status dot and the tool name is always
  rendered and only the args/result body collapses. Removed.
- **Layer 1's failure message could misattribute.** `toolStatus.ts` derives
  `error | done | running` and **`error` wins over a duration**, so a tool that was called
  and FAILED renders `tool-status-error` and no `tool-status-done` — the assertion would
  have failed claiming *"agent answered without invoking any tool"*, false in exactly that
  case (#884: a wrong attribution costs more than a missing one). The message now names
  both causes.

Also confirmed from source rather than inferred: `formatToolTitle` replaces `_` with a
space and uppercases **in JS** (not CSS `text-transform`), so the row's `textContent`
really is `FETCH CONTENT` and `hasText` can match it.

## Validation

On `1.12.1`, `MODEL_TEST_PROVIDER=openai MODEL_TEST_ID=gpt-4o-mini --workers=1 --retries=0`:

- **6 clean whole-file runs** of the rewritten spec before commit 3 (5 plain + 1
  `--trace=on`), 15.0–17.8 s each, plus **3 more** after it (14.5–14.9 s), **no advisory in
  any of the last three**.
- **Five forced failures, each re-executed against the committed code**, each red on its
  own assertion: wrong tool name in the step (layer 1), wrong URL in `tool_input`,
  impossible title in `output`, wrong causal anchor, and **the premise itself** — an agent
  told never to call a tool, which now fails at layer 1 where before it reached the payload
  layer. M1 and M5 were re-run again after commit 3.
- **Backend-error audit:** one advisory across the first six runs, a
  `404 {"detail":"Flow not found"}` on `GET /api/v1/flows/{id}` — the known teardown race
  where the editor polls a flow `afterEach` has just deleted. An earlier pre-fix run also
  logged one `500 {"detail":"Could not update the flow."}` on an autosave `PATCH`, seen
  once in five and not reproduced afterwards; recorded rather than dismissed, since an HTTP
  error never fails a test (#1084).
- Guards: `typecheck`, `lint:ci`, `check-checklist-guard`, `check:checklist-coverage`,
  `watch-upstream-areas --mode=check-docs`, `test:units`, `test:scripts` — all green.

**Not covered by that evidence, and stated as such in the spec doc:** only `openai` was
measured locally — the Anthropic key is drained (`credit balance is too low`) and google
was not exercised, so both rest on the daily's weekday rotation (#1185). The runs used
public `httpbin.org`; the go-httpbin path is CI's (#1128).

## The second half of #1451, and one sibling

The issue's other box asked for a **decision** on a general guard, not for the guard. The
shape it sketched was measured and cannot be built at an acceptable precision (149 candidate
lines across 85 docs; the `@stable`-removal reconciler cannot reach it either — 96 tests it
classifies as `never`, 0 of them owned). The decision, the measurement and the narrow design
that IS buildable are recorded in a comment on #1451 and spun off as #1783 — including the
**five expired gates** the measurement named, so none of them is silent any more.

`mcp/client/mcp-client-agent.spec.ts` asserts the same two test ids and its doc states the
same premise as *"Proof #1"*. Same defect, different spec — deliberately not widened into
this PR.
