### PR TITLE
fix(mcp): assert the tool the agent USED, not the tools attached to MCPTools

### DIFF
--- a/docs/core-functionality/llm-agents/agent-tool-inspection.md
+++ b/docs/core-functionality/llm-agents/agent-tool-inspection.md
@@ -265,7 +265,8 @@ cleanup and the flow count grows.
   the identical slideshow, keeping the output assert deterministic (same
   convention + SSRF-allowlist note as `agent-multi-tool-selection`).
 - `src/frontend/src/components/core/chatComponents/ToolCallCard.tsx` — renders
-  the per-call step: `data-testid={`tool-status-${status}`}` beside the tool
+  the per-call step — a status test id (`tool-status-done`,
+  `tool-status-error` or `tool-status-running`) beside the tool
   title, inside an accordion row. This is the 1.12 tool-USAGE surface, and it is
   rendered only for a call the agent made.
 - `GET /api/v1/monitor/messages` — persisted `content_blocks[].contents[]`

--- a/docs/core-functionality/llm-agents/agent-tool-inspection.md
+++ b/docs/core-functionality/llm-agents/agent-tool-inspection.md
@@ -151,10 +151,16 @@ public `httpbin.org`; the go-httpbin path is CI's (#1128).
    because why it matches nothing is a property of the **producer**:
    `ContentBlockDisplay.tsx` renders GROUPED blocks behind an `isExpanded` gate
    that starts closed — on that branch the tool cards are not in the DOM until
-   the chevron is clicked — while FLAT items render above it ungated, and the
-   file states which one we get ("The agent emits tool_use items flat (not
-   inside a group)"). The branch the helper guards is live product code, so it
-   stays.
+   the chevron is clicked — while FLAT items render above it ungated. **What
+   decides which layout this Playground gets is `hideHeader`, and an earlier
+   revision of this section got that wrong** (#1793): the two call sites differ
+   — `chat-message.tsx` passes nothing (header shown, grouped cards gated) while
+   `bot-message.tsx` passes `hideHeader={true}` (no header, gate satisfied
+   unconditionally). This Playground is the second, measured rather than
+   inferred: on a run with a completed tool call, zero rows matched the helper's
+   selector while `tool-status-done` was already present, and `ToolCallCard`
+   only renders inside `ContentBlockDisplay`. The helper is kept for the other
+   call site's layout.
 5. **UI inspection assert:** a completed tool step is visible
    (`tool-status-done`), and the row that carries it names `fetch_content` —
    the Playground names the URL tool the agent used. Asserted in two steps on

--- a/docs/mcp/client/mcp-client-agent.md
+++ b/docs/mcp/client/mcp-client-agent.md
@@ -25,10 +25,22 @@ Validates that an LLM agent can discover and call an MCP tool mid-conversation v
 > was the only one that could fail — which is why the spec was weakened rather
 > than useless, and why the gap went unnoticed.
 >
-> **Not measured, and left as the open half of #1793:** whether the MCPTools
-> node's `tools_metadata` actually carries an `echo` entry. That decides whether
-> Proof #2 specifically was a no-op or merely unsound in its premise, and it
-> needs the `everything` server running.
+> **Measured here, closing the open half of #1793: both old proofs were
+> no-ops, not merely unsound.** On `1.12.1` with the `everything` server
+> registered and the agent asked *"What is 2+2? Answer with the number only. Do
+> not use any tool."*, at the assertion point:
+> `div-tools_tools_metadata` **visible**, `tool_echo` **visible**,
+> `tool-status-done` count **0**. The canvas chips enumerate every attached
+> tool — `tool_echo`, `tool_get-env`, `tool_get-resource-links`,
+> `tool_get-annotated-message` from the server plus the template's own
+> `tool_fetch_content` / `tool_perform_search` — with no invocation involved.
+>
+> One force-failure is worth recording because it did NOT fail, and the reason
+> is the #1187 lesson rather than a weak assertion: instructing the agent
+> *"You MUST NOT call any tool, ever. Reply with exactly: hello mcp"* still
+> produced `tool-status-done` = 1 reading `ECHO` — the model called the tool
+> anyway. A mutation on the model'"'"'s CHOICE is not a mutation on the assertion;
+> the prompt that needs no tool is.
 
 ---
 

--- a/docs/mcp/client/mcp-client-agent.md
+++ b/docs/mcp/client/mcp-client-agent.md
@@ -8,7 +8,6 @@
 
 Validates that an LLM agent can discover and call an MCP tool mid-conversation via the MCPTools component. The agent receives a prompt instructing it to call the `echo` tool and the test verifies the echoed value appears in the Playground response. This is the primary real-world use case for MCP client: a user builds a flow where the agent has access to external tools via MCP.
 
-
 > **Proofs #1 and #2 asserted the wrong surface until #1793.** They read
 > `div-tools_tools_metadata` and `tool_echo` with an unscoped `.last()`, on the
 > stated premise that *"this DOM only exists after the agent invoked a tool"*.
@@ -39,7 +38,7 @@ Validates that an LLM agent can discover and call an MCP tool mid-conversation v
 > is the #1187 lesson rather than a weak assertion: instructing the agent
 > *"You MUST NOT call any tool, ever. Reply with exactly: hello mcp"* still
 > produced `tool-status-done` = 1 reading `ECHO` — the model called the tool
-> anyway. A mutation on the model'"'"'s CHOICE is not a mutation on the assertion;
+> anyway. A mutation on the model's CHOICE is not a mutation on the assertion;
 > the prompt that needs no tool is.
 
 ---
@@ -81,7 +80,7 @@ Validates that an LLM agent can discover and call an MCP tool mid-conversation v
 - `src/frontend/src/modals/addMcpServerModal/index.tsx` — JSON tab; testids `json-tab`, `json-input`, `add-mcp-server-button`
 - `src/backend/base/langflow/api/v2/mcp.py` — `GET /api/v2/mcp/servers?action_count=true` and `DELETE /api/v2/mcp/servers/{name}`
 - `src/frontend/src/components/core/parameterRenderComponent/components/mcpComponent/index.tsx` — tool mode toggle and toolset handle
-- `src/frontend/src/components/core/chatComponents/ToolCallCard.tsx` — renders the per-call step asserted by Proofs #1–#2: `data-testid={`tool-status-${status}`}` beside the tool title, mounted by `ContentBlockDisplay.tsx` only under `if (run.item.type === "tool_use")`
+- `src/frontend/src/components/core/chatComponents/ToolCallCard.tsx` — renders the per-call step asserted by Proofs #1–#2: a status test id beside the tool title, one of `tool-status-done`, `tool-status-error` or `tool-status-running`, mounted by `ContentBlockDisplay.tsx` only under `if (run.item.type === "tool_use")`
 - `src/frontend/src/components/core/chatComponents/toolStatus.ts` — derives `error | done | running`, with `error` winning over a duration; only `done` satisfies Proof #1
 - npm package `@modelcontextprotocol/server-everything` — launched via `npx`
 - `tests/helpers/flows/agent-credential-settle.ts` — the shared probe, verdict taxonomy and failure formatter this spec's load guard settles on (#1274/#1371). Only the pure functions are shared; the wait loop is this spec's own

--- a/docs/mcp/client/mcp-client-agent.md
+++ b/docs/mcp/client/mcp-client-agent.md
@@ -8,6 +8,28 @@
 
 Validates that an LLM agent can discover and call an MCP tool mid-conversation via the MCPTools component. The agent receives a prompt instructing it to call the `echo` tool and the test verifies the echoed value appears in the Playground response. This is the primary real-world use case for MCP client: a user builds a flow where the agent has access to external tools via MCP.
 
+
+> **Proofs #1 and #2 asserted the wrong surface until #1793.** They read
+> `div-tools_tools_metadata` and `tool_echo` with an unscoped `.last()`, on the
+> stated premise that *"this DOM only exists after the agent invoked a tool"*.
+> **That premise is false.** Both test ids come from
+> `parameterRenderComponent/components/ToolsComponent/index.tsx` — the
+> `tools_metadata` **field of the MCPTools node on the canvas**, which stays
+> mounted behind the Playground modal and is matched by an unscoped locator
+> (Playwright visibility is a bounding box, not "on top"). They enumerate the
+> tools **attached** to the component and exist **before any run**.
+>
+> Measured on the sibling spec at `1.12.1` (#1451 / PR #1792): an agent
+> instructed never to call a tool still rendered the block and the chips, with
+> no `tool_use` persisted, and the equivalent assertions **passed**. Proof #3
+> was the only one that could fail — which is why the spec was weakened rather
+> than useless, and why the gap went unnoticed.
+>
+> **Not measured, and left as the open half of #1793:** whether the MCPTools
+> node's `tools_metadata` actually carries an `echo` entry. That decides whether
+> Proof #2 specifically was a no-op or merely unsound in its premise, and it
+> needs the `everything` server running.
+
 ---
 
 ## Tags *(required)*
@@ -25,9 +47,9 @@ Validates that an LLM agent can discover and call an MCP tool mid-conversation v
 5. Enable tool mode on MCPTools (`tool-mode-button`) — verify "toolset" label appears
 6. Connect MCPTools toolset output handle → Agent tools input handle
 7. Open Playground and send: `"Use the 'echo' tool to echo: hello mcp"`
-8. Wait for agent to finish (Stop button disappears), best-effort expand any collapsed "Agent Steps" accordion
-9. **Proof #1** — the Playground shows a tool-invocation block (`div-tools_tools_metadata`): the agent actually called a tool, it did not hallucinate a text-only answer
-10. **Proof #2** — the invoked tool is `echo` (`tool_echo` testid, rendered "ECHO")
+8. Wait for agent to finish (Stop button disappears)
+9. **Proof #1** — the Playground shows a **completed tool step** (`tool-status-done`): the agent actually called a tool, it did not hallucinate a text-only answer
+10. **Proof #2** — the row carrying that step names `echo`
 11. **Proof #3** — the last AI chat message (`[data-testid^="chat-message-AI-"]`) contains `"hello mcp"` — the echoed payload made the full round-trip and was surfaced to the user
 
 ---
@@ -47,7 +69,8 @@ Validates that an LLM agent can discover and call an MCP tool mid-conversation v
 - `src/frontend/src/modals/addMcpServerModal/index.tsx` — JSON tab; testids `json-tab`, `json-input`, `add-mcp-server-button`
 - `src/backend/base/langflow/api/v2/mcp.py` — `GET /api/v2/mcp/servers?action_count=true` and `DELETE /api/v2/mcp/servers/{name}`
 - `src/frontend/src/components/core/parameterRenderComponent/components/mcpComponent/index.tsx` — tool mode toggle and toolset handle
-- `src/frontend/src/components/core/chatComponents/ContentBlockDisplay.tsx` (+ the Playground tool-metadata renderer) — emits the `div-tools_tools_metadata` / `tool_<name>` testids and the "Agent Steps" block asserted by Proofs #1–#2
+- `src/frontend/src/components/core/chatComponents/ToolCallCard.tsx` — renders the per-call step asserted by Proofs #1–#2: `data-testid={`tool-status-${status}`}` beside the tool title, mounted by `ContentBlockDisplay.tsx` only under `if (run.item.type === "tool_use")`
+- `src/frontend/src/components/core/chatComponents/toolStatus.ts` — derives `error | done | running`, with `error` winning over a duration; only `done` satisfies Proof #1
 - npm package `@modelcontextprotocol/server-everything` — launched via `npx`
 - `tests/helpers/flows/agent-credential-settle.ts` — the shared probe, verdict taxonomy and failure formatter this spec's load guard settles on (#1274/#1371). Only the pure functions are shared; the wait loop is this spec's own
 - `tests/helpers/flows/load-template-by-name.ts` — loads the Simple Agent template and returns the created flow id

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
@@ -168,20 +168,33 @@ async function openPlaygroundAndSend(page: Page, task: string): Promise<void> {
 //
 // `ContentBlockDisplay.tsx` splits a message's content two ways. GROUPED blocks
 // render inside `{(hideHeader || isExpanded) && <Accordion …>}`, behind a header
-// (`{!hideHeader && …}`, and neither call site passes `hideHeader`, which
-// defaults to false) whose title is "Steps"/"Finished" and whose `.cursor-pointer`
-// chevron toggles `isExpanded` — initialised to `false`. On that branch the tool
-// cards are NOT IN THE DOM until the chevron is clicked, and this helper's
-// selector matches that row exactly. FLAT items take the other path
-// (`looseItems`), rendered above it with no header gate at all, and the file
-// says which one we get: "The agent emits tool_use items flat (not inside a
-// group), so they get their own ToolCallCard wrapper".
+// (`{!hideHeader && …}`) whose title is "Steps"/"Finished" and whose
+// `.cursor-pointer` chevron toggles `isExpanded` — initialised to `false`. On
+// that branch the tool cards are NOT IN THE DOM until the chevron is clicked,
+// and this helper's selector matches that row exactly. FLAT items take the
+// other path (`looseItems`), rendered above it with no header gate at all.
 //
-// So the helper is dead only for as long as the agent keeps emitting flat. An
-// earlier revision of this spec deleted it and justified that with
+// **`hideHeader` is what decides it, and an earlier revision of this comment
+// got that wrong** (#1793). It claimed "neither call site passes `hideHeader`,
+// which defaults to false", so the helper was dead only while the agent kept
+// emitting flat. There are two call sites and they differ:
+// `modals/IOModal/…/chat-message.tsx` passes nothing (header shown, grouped
+// cards gated), while `components/core/playgroundComponent/…/bot-message.tsx`
+// passes `hideHeader={true}` — no header at all, and the gate satisfied
+// unconditionally, so grouped cards render too.
+//
+// The Playground this spec drives is the SECOND one, and that is measured
+// rather than read off the imports: on a run with a completed tool call, zero
+// rows matched this helper's selector while `tool-status-done` was already
+// present — and `ToolCallCard` only ever renders inside `ContentBlockDisplay`,
+// so the component rendered with no header. Hence the helper is dead here for a
+// reason no producer change can revive, and it is kept only for the other call
+// site's layout.
+//
+// (A revision before that one deleted the helper and justified it with
 // `ToolCallCard.tsx`'s "collapses to header-only once the producer attaches a
-// duration" — the WRONG mechanism: that comment is about the per-card accordion
-// holding the args/result body, not about the Steps accordion this targets.
+// duration" — a third wrong mechanism: that comment is about the per-card
+// accordion holding the args/result body.)
 async function expandAgentSteps(page: Page): Promise<void> {
   await page.evaluate(() => {
     const rows = Array.from(

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -390,52 +390,59 @@ for (const { label, options, skipReason } of targets) {
         await test.step("Verify agent invoked the echo MCP tool and returned echoed text", async () => {
           await waitForAgentToFinish(page);
 
-          // Try to expand any collapsed "Steps" accordions in the chat history.
-          // chat-message.tsx renders ContentBlockDisplay with hideHeader=false (collapsed
-          // by default — chevron click required); bot-message.tsx renders it with
-          // hideHeader=true (accordion items always visible). The expansion is best-effort:
-          // if items are already visible the click is a no-op; the assertions below cover
-          // both layouts.
+          // Proof #1: the agent actually INVOKED a tool.
           //
-          // The chevron motion.div has class "cursor-pointer" and sits in the same header
-          // row as the "Finished" / "Steps" text — click via DOM scoped to that row only,
-          // to avoid clicking unrelated cursor-pointer chevrons elsewhere in the UI.
-          await page.evaluate(() => {
-            const rows = Array.from(
-              document.querySelectorAll<HTMLElement>(
-                'div.flex.items-center.justify-between',
-              ),
-            ).filter((row) => {
-              const text = row.textContent ?? "";
-              return text.includes("Finished") || text.includes("Steps");
-            });
-            for (const row of rows) {
-              // Tag-agnostic: the accordion trigger is a <div> on older builds
-              // and a <button> on 1.11.0.dev38+ (see NOTE below).
-              const chevron = row.querySelector<HTMLElement>(".cursor-pointer");
-              chevron?.click();
-            }
-          });
-
-          // Proof #1: the Playground rendered a tool-invocation block.
-          // On 1.12 the tool call surfaces as a `tool_<name>` testid inside a
-          // `div-tools_tools_metadata` block (under an "Agent Steps" header) — this
-          // DOM only exists after the agent invoked a tool, so if the LLM
-          // hallucinated a text-only answer the block is absent. (Through ~1.11 the
-          // same signal was a `.cursor-pointer` accordion row reading "Called tool
-          // ECHO"; that text-based selector was stale drift, not a product change —
-          // the tool round-trip is verified healthy via GET /api/v1/monitor/messages,
-          // `content_blocks: ["tool_use|text|text"]`, `tool_use name=echo`. #894.)
-          // Ref: src/frontend/src/components/core/chatComponents/ContentBlockDisplay.tsx
+          // `tool-status-done` (`chatComponents/ToolCallCard.tsx`) is rendered
+          // per tool CALL — `ContentBlockDisplay` mounts a `ToolCallCard` only
+          // under `if (run.item.type === "tool_use")`. That is the whole point
+          // of this assertion, and the two test ids it replaced could not carry
+          // it (#1793).
+          //
+          // WHAT THIS REPLACED, and why it was a no-op. Proofs #1 and #2 used
+          // to assert `div-tools_tools_metadata` and `tool_echo` with an
+          // unscoped `.last()`, on the premise that "this DOM only exists after
+          // the agent invoked a tool". It does not: both come from
+          // `parameterRenderComponent/components/ToolsComponent/index.tsx` —
+          // `data-testid={"div-" + id}` and a `<Badge>` per entry of
+          // `visibleActions` — i.e. the `tools_metadata` FIELD of the MCPTools
+          // NODE on the canvas, which stays mounted behind the Playground modal
+          // and is matched by an unscoped locator (Playwright visibility is a
+          // bounding box, not "on top"). They enumerate the tools ATTACHED to
+          // the component and exist BEFORE any run. Measured on the sibling
+          // spec at 1.12.1 (#1451/PR #1792): an agent instructed never to call
+          // a tool still rendered both, with no `tool_use` block persisted, and
+          // the equivalent assertions PASSED.
+          //
+          // NO "expand the Steps accordion" step. This Playground renders
+          // through `bot-message.tsx`, which passes `hideHeader={true}` to
+          // `ContentBlockDisplay` — so no "Steps"/"Finished" header exists to
+          // click, and the `{(hideHeader || isExpanded) && …}` gate that hides
+          // GROUPED tool cards behind that chevron is satisfied unconditionally
+          // here. Measured: on a run with a completed tool call, zero rows
+          // matched the old helper's selector while `tool-status-done` was
+          // already present. (The other call site, `chat-message.tsx`, does not
+          // pass `hideHeader` and would need the chevron — which is why the
+          // helper existed at all.)
+          const completedToolSteps = page
+            .getByTestId("tool-status-done")
+            .locator("xpath=..");
           await expect(
-            page.getByTestId("div-tools_tools_metadata").last(),
-            "Playground must show a tool-invocation block — agent answered without invoking any tool",
+            completedToolSteps.first(),
+            "Playground must show a COMPLETED tool step (`tool-status-done`). " +
+              "Either the agent invoked no tool at all, or the call it made " +
+              "errored (`tool-status-error`, which wins over a duration), or it " +
+              "never resolved (`tool-status-running`, no duration attached)",
           ).toBeVisible({ timeout: 120000 });
 
-          // Proof #2: the tool called was 'echo' — the per-tool testid is
-          // `tool_<rawToolName>` (lowercase; the visible label uppercases to "ECHO").
+          // Proof #2: the tool called was 'echo'.
+          //
+          // The status dot's parent is the title cell, whose text is the tool
+          // NAME alone (the duration is a sibling). `formatToolTitle` replaces
+          // `_` with a space and uppercases IN JS — not CSS `text-transform` —
+          // so the row's textContent really is matchable; the pattern is
+          // tolerant of both spellings rather than pinning the display form.
           await expect(
-            page.getByTestId("tool_echo").last(),
+            completedToolSteps.filter({ hasText: /\becho\b/i }).first(),
             "The MCP tool invoked must be 'echo' — agent picked a different tool from the everything server",
           ).toBeVisible({ timeout: 5000 });
 


### PR DESCRIPTION
Closes #1793.

## What was wrong

`mcp-client-agent`'s Proofs #1 and #2 asserted `div-tools_tools_metadata` and
`tool_echo` with an unscoped `.last()`, on the stated premise that *"this DOM
only exists after the agent invoked a tool, so if the LLM hallucinated a
text-only answer the block is absent"*.

**The premise is false.** Both test ids come from
`parameterRenderComponent/components/ToolsComponent/index.tsx` —
`data-testid={"div-" + id}` and a `<Badge>` per entry of `visibleActions` — i.e.
the `tools_metadata` **field of the MCPTools node on the canvas**. The canvas
stays mounted **behind** the Playground modal, and Playwright visibility is a
non-empty bounding box rather than "on top", so an unscoped locator matches it.
They enumerate the tools **attached** to the component and exist **before any
run**.

## The measurement — both proofs were NO-OPS, not merely unsound

This is the half #1793 recorded as unmeasured, and it needed the `everything`
server. Measured on `1.12.1`, on a run where the agent was asked *"What is 2+2?
Answer with the number only. Do not use any tool."* — at the assertion point:

| | |
|---|---|
| `div-tools_tools_metadata` (old Proof #1) | **visible** → would have passed |
| `tool_echo` (old Proof #2) | **visible** → would have passed |
| `tool-status-done` (new) | **0** → the test fails, on Proof #1's own message |

Old passes and new fails **on the same run**, which is what a forced failure is
supposed to produce. The canvas chips enumerate every attached tool —
`tool_echo`, `tool_get-env`, `tool_get-resource-links`,
`tool_get-annotated-message` from the server, plus the template's own
`tool_fetch_content` / `tool_perform_search` — with no invocation involved.

**Proof #3 was genuine** and is why the spec was weakened rather than useless:
the echoed payload in the final answer can only come from a real round-trip.
That is also why the gap went unnoticed.

## The fix

Both proofs now read `tool-status-done` (`chatComponents/ToolCallCard.tsx`),
which `ContentBlockDisplay` mounts **only** under
`if (run.item.type === "tool_use")`, and take the tool name off the status dot's
parent — the title cell, whose text is the name alone. The failure message names
the three statuses `toolStatus.ts` can produce, because `error` **wins over a
duration**, so a tool that was called and failed renders no `done` and must not
be reported as "no tool was invoked" (#884).

## A forced failure that did NOT fail, recorded rather than retried away

Instructing the agent *"You MUST NOT call any tool, ever. Reply with exactly:
hello mcp"* still produced `tool-status-done` = 1 reading `ECHO` — the model
called the tool anyway. That is an **invalid experiment, not a passed
force-fail**: the counterfactual state it was meant to create never existed, so
it says nothing about the assertion either way. It was diagnosed by dumping the
DOM rather than swapped for a mutation that happened to go red — the difference
between validating and picking the result you want. #1187's lesson applies: a
mutation on the model's CHOICE measures the model, not the spec.

## Correcting a claim merged today in #1792

#1793 cites #1792's `expandAgentSteps` note as its reference, and that note is
**wrong**: it says *"neither call site passes `hideHeader`, which defaults to
false"*, which made the Steps-accordion helper dead only while the agent emits
flat. There are two call sites and they differ —
`modals/IOModal/…/chat-message.tsx` passes nothing, while
`components/core/playgroundComponent/…/bot-message.tsx` passes
**`hideHeader={true}`**.

The Playground both specs drive is the second, and that is **measured, not read
off the imports**: on a run with a completed tool call, zero rows matched the
helper's selector while `tool-status-done` was already present — and
`ToolCallCard` only ever renders inside `ContentBlockDisplay`, so the component
rendered with **no header**. So the helper is dead for a reason no producer
change can revive, and the `{(hideHeader || isExpanded)}` gate that hides grouped
cards is satisfied unconditionally here. Corrected in
`agent-tool-inspection.spec.ts` and its doc as well as here, rather than left to
contradict this PR from the next file over.

## Validation

`1.12.1`, `MODEL_TEST_PROVIDER=openai MODEL_TEST_ID=gpt-4o-mini --workers=1
--retries=0`, with the `everything` server registered by the spec itself:

- **3 clean runs**, 18.8–21.4 s, **no advisory in any**.
- **Forced failures:** the no-tool prompt fails Proof #1 with its own message; a
  wrong tool name (`printEnv`) fails Proof #2 with its own message.
- `tsc --noEmit`, `lint:ci`, the QA-CHECKLIST guard and the coverage guard are
  green; the spec-doc dependency paths added here
  (`ToolCallCard.tsx`, `toolStatus.ts`) resolve on `origin/main`,
  `release-1.13.0` and `release-1.12.1`.

**Scope unchanged:** this is a correctness fix, not a promotion. The spec stays
`@mcp @agents @regression`, and #963 still owns its `@stable` absence.
