### PR TITLE
test(triage): promote 12 measured-green T1 tests to @stable (#1786)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -128,11 +128,11 @@
 
 > `POST /api/v2/workflows` is the run path the product itself uses, and this suite already **observes** it — `tests/fixtures/flow-error-policy.ts` classifies its stream and eight specs trigger it incidentally — but until now nothing **drove it as an API contract**. The submit half was exercised constantly; the read-back half by nothing. Spec doc: `docs/api/flows/workflows-v2-job-lifecycle.md`.
 
-- [-] A batch create with a duplicate name is refused `409 "Name must be unique"` rather than stalling on the SQLite write lock, the body renders no SQL or bound parameters, and the **next write still succeeds** — the last clause is the one that matters: a `409` that left the lock held satisfies every other assertion and is still the defect `langflow-ai/langflow#14634` fixed, because the caller sees a clean conflict and the *next* writer dies with "database is locked" → `api/flows/workflows-v2-job-lifecycle.spec.ts`
-- [-] A batch create with a duplicate `endpoint_name` is refused with its **own** message (`"Endpoint name must be unique"`), asserted as not equal to the name guard's — two guards, one status, so the message is the only thing separating them → `api/flows/workflows-v2-job-lifecycle.spec.ts`
-- [-] A completed `mode=background` run reports the `session_id` it was submitted with, and its outputs, on the **first** status read that says `completed` — asserted as "not the flow id" too, since the flow id is the specific degradation `langflow-ai/langflow#14512` names → `api/flows/workflows-v2-job-lifecycle.spec.ts`
+- [x] A batch create with a duplicate name is refused `409 "Name must be unique"` rather than stalling on the SQLite write lock, the body renders no SQL or bound parameters, and the **next write still succeeds** — the last clause is the one that matters: a `409` that left the lock held satisfies every other assertion and is still the defect `langflow-ai/langflow#14634` fixed, because the caller sees a clean conflict and the *next* writer dies with "database is locked" → `api/flows/workflows-v2-job-lifecycle.spec.ts`
+- [x] A batch create with a duplicate `endpoint_name` is refused with its **own** message (`"Endpoint name must be unique"`), asserted as not equal to the name guard's — two guards, one status, so the message is the only thing separating them → `api/flows/workflows-v2-job-lifecycle.spec.ts`
+- [x] A completed `mode=background` run reports the `session_id` it was submitted with, and its outputs, on the **first** status read that says `completed` — asserted as "not the flow id" too, since the flow id is the specific degradation `langflow-ai/langflow#14512` names → `api/flows/workflows-v2-job-lifecycle.spec.ts`
 - [!] A completed `mode=sync` run answers its own status query with the session and outputs it just returned — **declared failing (`test.fail()`) against a live defect, 15/15 on `1.12.0.dev37`**; it flips to an *unexpected pass* the day upstream fixes it, which is the alarm to remove the annotation: the read-back reports `status: "completed"` alongside `session_id == flow_id` and `outputs: {}`, self-healing in 250–463 ms (median 434, 12/12 cold jobs). #14512's fix is present (its `sync_result_storage_enabled` setting reads `False`, the default) but the flag-off path races the `vertex_build` commit it reconstructs from. Detection depends on issuing the two calls back to back — with assertions interleaved between them the defect went unseen in 1 of 13 runs → `api/flows/workflows-v2-job-lifecycle.spec.ts`
-- [-] Attribution control: the same sync read-back **is** correct once the job's rows settle (≤10 s). Paired with the row above on purpose — that red plus this green is the race; *both* red would be a strictly worse regression, reconstruction unavailable at any time, and without the pair the two would report as one finding → `api/flows/workflows-v2-job-lifecycle.spec.ts`
+- [x] Attribution control: the same sync read-back **is** correct once the job's rows settle (≤10 s). Paired with the row above on purpose — that red plus this green is the race; *both* red would be a strictly worse regression, reconstruction unavailable at any time, and without the pair the two would report as one finding → `api/flows/workflows-v2-job-lifecycle.spec.ts`
 
 #### 1.10 Files API — the whole family, as a contract (1.13)
 
@@ -276,7 +276,7 @@
 #### 2.4 Code Editing
 - [x] Edit Python code of custom component — Check & Save clears the pulse-pink indicator → `core-components/customComponentAdd.spec.ts`
 - [x] Full custom component → `core-components/full-custom-component.spec.ts`
-- [-] `configureCustomComponent` helper compiles code into a node with its declared interface → `core-components/configure-mcp-and-custom-component.spec.ts`
+- [x] `configureCustomComponent` helper compiles code into a node with its declared interface → `core-components/configure-mcp-and-custom-component.spec.ts`
 
 ---
 
@@ -353,8 +353,8 @@
 - [x] Payload inválido (não-JSON) é encapsulado em `{"payload": "..."}` na saída → `core-components/webhook-component-regression.spec.ts`
 - [x] Webhook is a singleton — adding one removes both the Webhook and Chat Input `+` buttons from the sidebar (mutual exclusion) → `core-components/singleton-components.spec.ts`
 - [x] Webhook cannot be duplicated (`Cmd/Ctrl+D`) or copy/pasted (`Cmd/Ctrl+C`+`V`) — blocked with the "components were not pasted" toast → `core-components/singleton-components.spec.ts`
-- [-] Generated cURL includes the `x-api-key` header when webhook auth is enabled (mocked `GET /api/v1/config`, auto-login off) → `core-components/general-bugs-component-webhook-api-key-display.spec.ts`
-- [-] Generated cURL omits `x-api-key` when webhook auth is disabled → `core-components/general-bugs-component-webhook-api-key-display.spec.ts`
+- [x] Generated cURL includes the `x-api-key` header when webhook auth is enabled (mocked `GET /api/v1/config`, auto-login off) → `core-components/general-bugs-component-webhook-api-key-display.spec.ts`
+- [x] Generated cURL omits `x-api-key` when webhook auth is disabled → `core-components/general-bugs-component-webhook-api-key-display.spec.ts`
 
 #### 3.5 Agent (Component)
 - [x] Agent component renders on canvas with title, handles and default fields → `core-components/agent-component-regression.spec.ts`
@@ -616,7 +616,7 @@
 - [x] Direct response → `api/flows/api-build-direct-response.spec.ts`
 - [x] Playground UX (playground-ux) → `playground/playground-ux.spec.ts`
 - [x] Send empty message — send button stays enabled by design (only disabled while a file upload is in progress) → `playground/playground-empty-message-send.spec.ts`
-- [-] Send message while response is in progress — should wait or queue → `playground/playground-send-while-in-progress.spec.ts`
+- [x] Send message while response is in progress — should wait or queue → `playground/playground-send-while-in-progress.spec.ts`
 - [x] Attach image in chat — compact preview appears in input before sending → `core-functionality/playground/playground-output-image.spec.ts`
 - [x] Image rendered in user message bubble after sending → `core-functionality/playground/playground-output-image.spec.ts`
 - [x] Attach non-image file (.txt) in chat — preview tile renders (delete button visible, no `<img>`) → `core-functionality/playground/playground-non-image-attachment.spec.ts`
@@ -629,7 +629,7 @@
 - [x] ChatInput Input Text pre-fills the playground textarea on first open → `core-functionality/playground/playground-input-text-prefill.spec.ts`
 - [x] ChatInput Input Text re-pre-fills the textarea on a new session → `core-functionality/playground/playground-input-text-prefill.spec.ts`
 - [x] Pre-filled Input Text can be sent as the first message of the session → `core-functionality/playground/playground-input-text-prefill.spec.ts`
-- [-] Attach and send an image on a live LLM flow (Basic Prompting) — the image renders in the chat messages → `core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts`
+- [x] Attach and send an image on a live LLM flow (Basic Prompting) — the image renders in the chat messages → `core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts`
 - [-] Custom `sender_name` on Chat Input/Output is applied to a live LLM turn — messages render as `chat-message-<custom name>` after a default-label turn → `core-functionality/llm-agents/chatInputOutputUser-shard-2.spec.ts`
 
 #### 9.2 History and Session
@@ -687,7 +687,7 @@
 - [-] Move flow to another folder
 
 #### 10.2 Folder Navigation
-- [-] Navigate between folders → `core-functionality/project-management/flow-navigation-between-folders.spec.ts`
+- [x] Navigate between folders → `core-functionality/project-management/flow-navigation-between-folders.spec.ts`
 - [-] Search flow by name filters results correctly
 - [-] Folders in navigation sidebar
 
@@ -845,7 +845,7 @@
 - [x] Execute MCP server tool and receive result in flow → `mcp/client/mcp-client-regression.spec.ts`
 - [x] MCP server connection error — unreachable server produces empty tool dropdown → `mcp/client/mcp-client-regression.spec.ts`
 - [x] Configure connection via HTTP form tab → `mcp/client/mcp-client-regression.spec.ts`
-- [-] `configureMcpServer` helper registers an MCP server via the HTTP form → `core-components/configure-mcp-and-custom-component.spec.ts`
+- [x] `configureMcpServer` helper registers an MCP server via the HTTP form → `core-components/configure-mcp-and-custom-component.spec.ts`
 - [x] Execute numeric tool with inputs and verify result → `mcp/client/mcp-client-regression.spec.ts`
 - [x] Duplicate MCP server registration returns 409 Conflict → `mcp/client/mcp-server-registration-status-codes.spec.ts`
 - [x] Deleting a non-existent MCP server returns 404 Not Found → `mcp/client/mcp-server-registration-status-codes.spec.ts`

--- a/docs/api/flows/workflows-v2-job-lifecycle.md
+++ b/docs/api/flows/workflows-v2-job-lifecycle.md
@@ -1,6 +1,6 @@
 # Workflows v2 — the job lifecycle
 
-**Last validated:** Langflow 1.12.0.dev37 — `langflowai/langflow-nightly@sha256:b672ab7e91981c6f1719b2932bfa7e2255324d4cfac18b7fedf0dbf5722761de`, the digest `:latest` resolves to (`docker inspect --format '{{index .RepoDigests 0}}'`); upstream revision `50340f2a4322eca624b7ef5684237d87f863fc1b`.
+**Last validated:** Langflow 1.13.0.dev7 — `langflowai/langflow-nightly@sha256:080f47f85f4788f321b63ce5fc82920ea499407ce0f89d67a93b5dbd54675535`, the digest `:latest` resolves to (`docker inspect --format '{{index .RepoDigests 0}}'`). Same version the nine #1784 measurement dispatches ran against.
 
 ---
 

--- a/docs/core-components/configure-mcp-and-custom-component.md
+++ b/docs/core-components/configure-mcp-and-custom-component.md
@@ -1,6 +1,6 @@
 # Configure an MCP server & Configure a Custom Component — reusable config helpers
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev7`)
 
 ---
 

--- a/docs/core-components/general-bugs-component-webhook-api-key-display.md
+++ b/docs/core-components/general-bugs-component-webhook-api-key-display.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-components/general-bugs-component-webhook-api-key-display.spec.ts`
 
-**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev7`)
 
 ---
 
@@ -15,7 +15,10 @@ includes the `x-api-key` header depends on the instance's webhook-auth config:
    the generated cURL **must** contain `x-api-key` so the user knows an API key
    is required to call the webhook.
 2. **Webhook auth disabled** (`webhook_auth_enable: false`) — the cURL **must
-   not** contain `x-api-key` (no key is needed).
+   not** contain `x-api-key` (no key is needed) — asserted **only after** the
+   value is confirmed to be a generated cURL, because an absent key and an
+   absent cURL are otherwise the same observation. See *The absence needs an
+   anchor* below.
 
 Both cases are driven by mocking `GET /api/v1/config` (and, for case 1, forcing
 `auto_login` off), then reading the generated cURL out of the component's cURL
@@ -63,8 +66,33 @@ component. Every flow the page creates is captured from its
 
 | Case | Criterion |
 |---|---|
-| `webhook_auth_enable: true` | the generated cURL (`text-area-modal` value) contains `x-api-key` |
-| `webhook_auth_enable: false` | the generated cURL does **not** contain `x-api-key` |
+| both | the `text-area-modal` value is a generated cURL — it contains `curl -X POST` |
+| `webhook_auth_enable: true` | that cURL contains `x-api-key` |
+| `webhook_auth_enable: false` | that cURL does **not** contain `x-api-key` |
+
+### The absence needs an anchor
+
+Case 2's criterion used to be *"the generated cURL does not contain
+`x-api-key`"* and nothing more, which is satisfied by the **empty string** —
+`"".includes("x-api-key")` is `false`. A modal that opened without populating,
+or populated with something else entirely, therefore read as a pass: the test
+could be green having verified nothing.
+
+The failure mode is concrete rather than hypothetical. The component declares
+the field as a **placeholder the frontend substitutes** —
+`MultilineInput(name="curl", value="CURL_WEBHOOK")` in
+`lfx/components/input_output/webhook.py` — and the real command is assembled in
+the frontend as `curl -X POST '<endpoint>' …` with the auth header in a
+conditional slot. So if substitution ever fails, the field reads the literal
+`CURL_WEBHOOK`, which contains no `x-api-key` and would have **passed** case 2
+while the feature was broken.
+
+The anchor is therefore `curl -X POST`, asserted in **both** cases before the
+key claim: it is present in every generated command and absent from the
+unsubstituted sentinel (`"CURL_WEBHOOK".includes("curl")` is `false` — the
+sentinel is upper-case). Case 1 needs no anchor of its own for correctness, but
+carries it so the two tests fail the same way when generation breaks, instead of
+one failing on the key and the other passing.
 
 ---
 
@@ -96,6 +124,11 @@ component. Every flow the page creates is captured from its
 
 ## Notes
 
+- 1.13.0.dev7 (2026-09-09, issue #1786): promoted to `@stable`. The measured
+  evidence is 3/3 green across nine `manual.yml` dispatches, recorded in
+  `docs/triage/inherited-spec-triage.md`. The promotion added case 2's payload
+  anchor (above), found by the force-failability audit design §3 requires before
+  a green baseline is trusted — the assertion was green-able on an empty value.
 - dev46 migration (issue #818): removed the dead `enable`/`disableInspectPanel`
   calls (the inspect-panel toggle feature was removed upstream), added the
   `inspector-add-curl` step (the cURL field became advanced), and renamed the

--- a/docs/core-functionality/llm-agents/chatInputOutputUser-shard-0.md
+++ b/docs/core-functionality/llm-agents/chatInputOutputUser-shard-0.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts`
 
-**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev7`)
 
 ---
 

--- a/docs/core-functionality/playground/playground-send-while-in-progress.md
+++ b/docs/core-functionality/playground/playground-send-while-in-progress.md
@@ -1,6 +1,6 @@
 # Playground — send a message while a response is in progress (wait/queue)
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev7`)
 
 ---
 

--- a/docs/core-functionality/project-management/flow-navigation-between-folders.md
+++ b/docs/core-functionality/project-management/flow-navigation-between-folders.md
@@ -1,6 +1,6 @@
 # Project Management – Navigate Between Folders
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev20`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev7`)
 
 ---
 
@@ -45,7 +45,26 @@ list.
 5. Bootstrap the session (`awaitBootstrapTest(page, { skipModal: true })`); assert both folders' sidebar entries are visible.
 6. `clickProject(folderA)` → assert flow **A** name is visible **and** flow **B** name is hidden (`toBeHidden` / `toHaveCount(0)`).
 7. `clickProject(folderB)` → assert flow **B** name is visible **and** flow **A** name is hidden.
-8. **Cleanup (finally):** delete `flowAId`, `flowBId` (id-scoped, ignored if already gone), then folders `folderAId`, `folderBId` via `DELETE /api/v1/projects/{id}`.
+8. **Cleanup (finally):** delete `flowAId`, `flowBId` (id-scoped, ignored if already gone), **plus every flow the PAGE created**, then folders `folderAId`, `folderBId` via `DELETE /api/v1/projects/{id}`.
+
+### The two flows the API-created pair does not account for
+
+Measured on `1.13.0.dev7` while promoting this spec to `@stable` (#1786): a green
+run left the instance **two flows heavier** — one named `New Flow` and a second
+copy of `Basic Prompting` — even though every id this spec creates through
+`request.post` was deleted. They come from `awaitBootstrapTest`, not from the
+API setup, so `flowAId`/`flowBId` never named them and the `finally` could not
+delete what it had never seen. The spec's own docblock claimed id-scoped
+cleanup, which was true of the ids it knew about and false of the instance.
+
+The fix is the pattern the sibling specs already use rather than a new one:
+capture every `POST /api/v1/flows` → `201` **on the page** and delete those ids
+in the same `finally`. The API setup issues its creates through
+`request.post` (a separate `APIRequestContext`), so the page-side capture cannot
+double-count them — the two sets are disjoint by construction.
+
+Never a global sweep: the suite runs `fullyParallel`, so deleting anything this
+run did not create would wipe a concurrent worker's flow.
 
 ---
 

--- a/tests/tests-automations/regression/api/flows/workflows-v2-job-lifecycle.spec.ts
+++ b/tests/tests-automations/regression/api/flows/workflows-v2-job-lifecycle.spec.ts
@@ -145,7 +145,7 @@ test.describe("Workflows v2 — the job lifecycle", () => {
 
   test(
     "batch create refuses a duplicate name with 409, leaks no SQL, and leaves the next write working",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       const base = unique("batch-unique");
       let seededName = "";
@@ -229,7 +229,7 @@ test.describe("Workflows v2 — the job lifecycle", () => {
 
   test(
     "batch create refuses a duplicate endpoint_name with its own message",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       const sharedEndpoint = `ep${Date.now().toString(36)}${Math.random()
         .toString(36)
@@ -254,7 +254,7 @@ test.describe("Workflows v2 — the job lifecycle", () => {
 
   test(
     "a completed background run reports the session it was given",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       const sessionId = unique("bg-session");
       let jobId = "";
@@ -303,7 +303,7 @@ test.describe("Workflows v2 — the job lifecycle", () => {
 
   test(
     "a completed sync run answers its own status query with the session and outputs it returned",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       // DECLARED FAILING, and the declaration is the alarm in both directions.
       //
@@ -380,7 +380,7 @@ test.describe("Workflows v2 — the job lifecycle", () => {
 
   test(
     "attribution control: the sync read-back is correct once the job's rows settle",
-    { tag: ["@api", "@regression"] },
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
       // This test exists to make the previous one's failure attributable, and
       // the pair is the diagnosis: previous red + this green is a race between

--- a/tests/tests-automations/regression/core-components/configure-mcp-and-custom-component.spec.ts
+++ b/tests/tests-automations/regression/core-components/configure-mcp-and-custom-component.spec.ts
@@ -85,7 +85,7 @@ test.afterEach(async ({ request }) => {
 
 test(
   "configureMcpServer registers an MCP server via the HTTP form",
-  { tag: ["@regression", "@mcp"] },
+  { tag: ["@stable", "@regression", "@mcp"] },
   async ({ page, request }) => {
     trackCreatedFlows(page);
 
@@ -135,7 +135,7 @@ test(
 
 test(
   "configureCustomComponent compiles code into a node with its declared interface",
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     trackCreatedFlows(page);
 

--- a/tests/tests-automations/regression/core-components/general-bugs-component-webhook-api-key-display.spec.ts
+++ b/tests/tests-automations/regression/core-components/general-bugs-component-webhook-api-key-display.spec.ts
@@ -43,7 +43,7 @@ test.afterEach(async ({ request }) => {
 
 test(
   "user must be able to see api key in webhook component when auto login is disabled",
-  { tag: ["@release"] },
+  { tag: ["@stable", "@release"] },
   async ({ page }) => {
     trackCreatedFlows(page);
     await page.route("**/api/v1/auto_login", (route) => {
@@ -108,6 +108,17 @@ test(
 
     const curl = await page.getByTestId("text-area-modal").inputValue();
 
+    // Anchor both key claims on the payload existing. The component declares
+    // this field as a placeholder the frontend substitutes --
+    // MultilineInput(name="curl", value="CURL_WEBHOOK") in
+    // lfx/components/input_output/webhook.py -- and the real command is
+    // assembled in the frontend as `curl -X POST '<endpoint>' ...` with the
+    // auth header in a conditional slot. `curl -X POST` is present in every
+    // generated command and absent from the unsubstituted sentinel, so it
+    // separates "no key" from "no cURL at all". Carried here as well as in the
+    // absence test so both fail the same way when generation breaks.
+    expect(curl).toContain("curl -X POST");
+
     expect(curl).toContain("x-api-key");
 
     await page.getByText("Close", { exact: true }).last().click();
@@ -116,7 +127,7 @@ test(
 
 test(
   "user must be able to not see api key in webhook component when auto login is enabled",
-  { tag: ["@release"] },
+  { tag: ["@stable", "@release"] },
   async ({ page }) => {
     trackCreatedFlows(page);
     await page.route("**/api/v1/config", (route) => {
@@ -168,6 +179,13 @@ test(
     await page.getByTestId("button_open_text_area_modal_str_curl").click();
 
     const curl = await page.getByTestId("text-area-modal").inputValue();
+
+    // Without this the assertion below is satisfied by the EMPTY STRING --
+    // "".includes("x-api-key") is false -- so a modal that opened without
+    // populating, or populated with the unsubstituted `CURL_WEBHOOK`
+    // sentinel, read as a pass while cURL generation was broken. See the
+    // sibling test above for the substitution mechanism.
+    expect(curl).toContain("curl -X POST");
 
     expect(curl).not.toContain("x-api-key");
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts
@@ -46,7 +46,7 @@ test.afterEach(async ({ request }) => {
 
 test(
   "user must be able to send an image on chat",
-  { tag: ["@release", "@workspace", "@components"] },
+  { tag: ["@stable", "@release", "@workspace", "@components"] },
   async ({ page }) => {
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-send-while-in-progress.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-send-while-in-progress.spec.ts
@@ -40,7 +40,7 @@ test.describe("Playground — send while a response is in progress", () => {
 
   test(
     "input is locked while a run is in progress and recovers after it completes",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page, request }) => {
       const bearer = await getAuthToken(request);
       flow = await createRunnableChatFlowViaApi(request, { Authorization: bearer });

--- a/tests/tests-automations/regression/core-functionality/project-management/flow-navigation-between-folders.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/flow-navigation-between-folders.spec.ts
@@ -29,10 +29,32 @@ import { MainPage } from "../../../../pages/MainPage";
 
 test(
   "navigating between two folders scopes the listing to each folder's flows",
-  { tag: ["@release", "@workspace", "@mainpage", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@mainpage", "@regression"] },
   async ({ page, request }) => {
     const authToken = await getAuthToken(request);
     const headers = { Authorization: authToken };
+
+    // The API setup below names every flow it creates, but `awaitBootstrapTest`
+    // creates its own -- measured on 1.13.0.dev7: a green run left `New Flow`
+    // and a second `Basic Prompting` behind, ids this test never saw and so
+    // could never delete (#1786). Capture the PAGE's creates too. The setup
+    // issues its own through `request.post`, a separate APIRequestContext, so
+    // the two sets are disjoint and nothing is deleted twice.
+    const pageCreatedFlowIds: string[] = [];
+    page.on("response", (resp) => {
+      if (
+        resp.url().includes("/api/v1/flows") &&
+        resp.request().method() === "POST" &&
+        resp.status() === 201
+      ) {
+        resp
+          .json()
+          .then((body: { id?: string }) => {
+            if (body?.id) pageCreatedFlowIds.push(body.id);
+          })
+          .catch(() => {});
+      }
+    });
     const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const folderAName = `nav-folderA-${stamp}`;
     const folderBName = `nav-folderB-${stamp}`;
@@ -111,6 +133,12 @@ test(
     } finally {
       if (flowAId) await deleteFlow(request, flowAId, { headers });
       if (flowBId) await deleteFlow(request, flowBId, { headers });
+      // Id-scoped, never a global sweep: the suite runs fullyParallel, so
+      // deleting anything this run did not create would wipe a concurrent
+      // worker's flow.
+      for (const id of pageCreatedFlowIds.splice(0)) {
+        await deleteFlow(request, id, { headers }).catch(() => {});
+      }
       // deleteProject retries the 500 the endpoint returns under concurrent
       // writes (#965) — the bare request.delete here resolved on that status and
       // left both folders on the instance permanently.


### PR DESCRIPTION
Closes #1786

Promotes to `@stable` the T1 specs the #1784 triage table measured **3/3 green**. That measurement supplies **one** of the four conditions design §3 requires; this PR adds the other three — a force-fail run per test, the flow-leak audit the table cannot render, and a doc with the four mandatory sections.

**Scope is 6 specs / 12 tests, not the 7 / 13 the issue lists.** `chatInputOutputUser-shard-2` is the only one of the 13 that needs a real model reply and the OpenAI credential has no credit, so it is split into its own issue rather than promoted on top of a red. Detail at the bottom.

## 1. Covered tests

| # | Test | What it validates |
|---|---|---|
| 1 | `batch create refuses a duplicate name with 409, leaks no SQL, and leaves the next write working` | `409` with no SQL or bound parameters in the body, **and the next write still returns 201** — the last clause is the defect `langflow-ai/langflow#14634` fixed: a `409` that left the lock held satisfies everything else while the *next* writer dies on "database is locked" |
| 2 | `batch create refuses a duplicate endpoint_name with its own message` | `409` carrying its **own** message, asserted as not equal to the name guard's — two guards share one status, so the message is the only thing separating them |
| 3 | `a completed background run reports the session it was given` | the submitted `session_id` comes back on the **first** status read that says `completed`, and is not the `flow_id` — the specific degradation `langflow-ai/langflow#14512` names |
| 4 | `a completed sync run answers its own status query with the session and outputs it returned` | **`test.fail()`** — the unweakened contract, which #1575 breaks today. Playwright's `expected` here means *failed as declared*; the day upstream fixes it this goes red asking for the line back |
| 5 | `attribution control: the sync read-back is correct once the job's rows settle` | the same submit + read-back **is** correct once the rows settle (≤10 s). Deliberately not declared failing: it is what stops row 4 from converting a dead instance into a green expected failure |
| 6 | `configureMcpServer registers an MCP server via the HTTP form` | the registration `POST` answers `200` and the server appears in the list |
| 7 | `configureCustomComponent compiles code into a node with its declared interface` | the compiled node renders with its declared title and inputs (`title-My Full Component`, `title-my input`) |
| 8 | `user must be able to see api key in webhook component when auto login is disabled` | with `webhook_auth_enable: true` the generated cURL is a real command **and** carries `x-api-key` |
| 9 | `user must be able to not see api key in webhook component when auto login is enabled` | with `webhook_auth_enable: false` the generated cURL is a real command **and** carries no `x-api-key` — the anchor is new, see §3 |
| 10 | `user must be able to send an image on chat` | an uploaded `chain.png` renders in the chat messages after send |
| 11 | `input is locked while a run is in progress and recovers after it completes` | in flight: stop visible, send at count 0, input disabled. After: input re-enabled and **exactly one** message — so the lock neither leaks a second send nor fails to release |
| 12 | `navigating between two folders scopes the listing to each folder's flows` | mutual exclusion — folder A lists flow A and **count 0** of flow B, and the reverse — which proves the sidebar re-scopes the listing rather than showing a global one |

## 2. What changed

`@stable` added first in the tag array of all 12 `test()` calls, plus the two fixes below and `Last validated` moved to `1.13.0.dev7` on all 7 docs. `QA-CHECKLIST.md`: 11 manual Part II bullets flipped `[-]` → `[x]`; **generated blocks untouched** (#741).

## 3. Two defects the force-failability audit found before the green was trusted

Design §3 says to audit force-failability *before* trusting a green baseline. It paid twice.

**The webhook absence test was green-able on nothing.** `expect(curl).not.toContain("x-api-key")` is satisfied by the **empty string**. The failure mode is measured, not hypothetical: the component declares the field as a placeholder the frontend substitutes — `MultilineInput(name="curl", value="CURL_WEBHOOK")` in `lfx/components/input_output/webhook.py` — and the command is assembled in the frontend as `curl -X POST '<endpoint>' …` with the auth header in a conditional slot. A failed substitution leaves the literal `CURL_WEBHOOK`, which carries no `x-api-key` and **would have passed** with cURL generation broken. Both tests now assert `curl -X POST` before any key claim, so they fail identically when generation breaks instead of one failing on the key and the other passing on an empty value. Its spec doc encoded the same weakness and was corrected first, per SDD.

**`flow-navigation-between-folders` leaked two flows per run.** Its own docblock claimed id-scoped cleanup — true of the ids it creates through `request.post`, false of the instance: `awaitBootstrapTest` creates `New Flow` and a second copy of `Basic Prompting`, ids the `finally` had never seen. Found by elimination, running each of the six specs in isolation with a flow count around it — five leak 0, this one leaks 2. Fixed with the pattern the sibling specs already use (capture the **page's** `POST /api/v1/flows` → `201`); the API setup uses a separate `APIRequestContext`, so the two sets are disjoint by construction and nothing is deleted twice. Verified **26 → 26** across four further runs, green and red path.

## 4. Dependencies and execution

`workflows-v2-job-lifecycle` is API-only. `chatInputOutputUser-shard-0` needs a configured OpenAI provider (`providerSkipGate("openai")` + `initialGPTsetup`) but asserts an image render, not a completion — it does not consume model credit. The other four are pure UI with `page.route` mocks. `configure-mcp-and-custom-component` requires `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` (verified on the instance; the nightly image defaults it to `false`, which hides the sidebar button and makes `POST /api/v1/custom_component` answer 403). All runs `--workers=1 --retries=0`.

## 5. Validation (nightly `1.13.0.dev7`, digest `sha256:080f47f8…`, `--retries=0`)

The instance is the **same version the nine #1784 measurement dispatches ran against** (run 34402172979 preflight: `backend healthy — Langflow Nightly 1.13.0.dev7`), so nothing here is validated on a different build than it was measured on.

Burst 3/3 per spec, zero `unexpected`, zero `flaky`, zero `skipped`, `backendErrors=false`:

```
workflows-v2-job-lifecycle              3× expected=5
configure-mcp-and-custom-component      3× expected=2
general-bugs-component-webhook-api-key  3× expected=2
chatInputOutputUser-shard-0             3× expected=1
playground-send-while-in-progress       3× expected=1
flow-navigation-between-folders         3× expected=1  (+3 more after the cleanup fix)
```

Force-fail: **12/12**, every mutation reverted, zero `FF-MUTATION` markers in the diff, final green run per file (6/6). One mutation per test, each inverting the assertion that carries the claim — e.g. `toHaveCount(0)` → `toHaveCount(7)` on the folder-isolation row, and for the `test.fail()` row the mutation makes the body **pass**, which Playwright reports as *expected to fail but passed*.

Gates: `typecheck` ✅ · `lint` ✅ · `check:checklist-coverage` ✅ · QA-CHECKLIST guard ✅ · spec-doc dependency paths ✅ · `test:units` `fail 0` ✅ · `test:pipeline` `fail 0` ✅ · `test:scripts` `fail 1` — the known macOS-only `EACCES`/`ENOTEMPTY` divergence in `a directory the sweep cannot remove costs a leak, never a failed run` (1340 pass), green in CI and unrelated to this diff. Zero `🚨 Backend Error`. Flow count returned to its 26-flow baseline with **zero orphans**.

`--trace=on` was deliberately not used: it hangs UI specs on this host (Colima).

## 6. Three judgment calls a reviewer should see

**`QA-CHECKLIST.md` line 134 stays `[!]`.** It is the `test.fail()` row. The legend has no *declared failing* state, and `[x]` would claim coverage that does not exist — the test pins a known product defect rather than validating working behaviour. The other 11 bullets flipped to `[x]`.

**No functional tag was added.** Ten of the thirteen tests carry none, and for `workflows-v2` (the v2 workflows API), the Webhook component and the custom component **no tag in CLAUDE.md's table fits** — `@api`, `@components`, `@workspace` and `@mainpage` are all cross-cutting. Inventing one is against the guardrail, and CLAUDE.md itself measures 104 of 298 specs in this state. Reported rather than papered over.

**`flow-navigation-between-folders`'s force-fail was re-done by hand.** The cleanup fix landed *after* the pipeline's FORCE_FAIL phase closed, and `ff-run` refuses outside that phase (`✖ ff-run only valid in FORCE_FAIL (now: REPORT)`). Re-verified manually on the fixed file — force-fail `1 failed`, burst 3/3 clean — and stated here rather than letting the phase's earlier record stand in for the current file.

## 7. Why `chatInputOutputUser-shard-2` is not in this PR

It is the only one of the 13 tests that requires a real model reply, and it fails **3/3 deterministically** here for a reason that is neither a spec defect nor a Langflow regression. The fixture diagnosed it in the run stream:

```
⚠️  Provider outage in run stream (credit-exhausted) - /api/v2/workflows
   Error code: 429 — 'You have no credits remaining.'
   'type': 'insufficient_quota', 'code': 'credit_balance_exhausted'
   NOT a flow error: the provider refused the call, so this run says nothing
   about Langflow. Counted as unevaluated (#1165).
```

Its `@stable` tag was reverted and the file is untouched by this PR. A note worth carrying: `providerSkipGate("openai")` reported **active** — `collect-models` validated the key and settled `gpt-4o-mini` — while the completion 429s, so a credit-less key passes the gate and the spec runs to die mid-flight. That gap gets recorded with the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
