### PR TITLE
docs(upstream-bugs): record that the export-binding fix has NOT landed (#1546)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -1006,6 +1006,7 @@
       in the trace detail (`langflow-ai/langflow#7313` — TracingService exposing secrets)
       → security/credential-secret-exposure.spec.ts
 - [!] The same secret is absent from the exported flow JSON
+      (**quarantined** — `test.fixme` against the upstream export regression, #1546)
       → security/credential-secret-exposure.spec.ts
 - [x] The same secret is absent from the API response of a run
       → security/credential-secret-exposure.spec.ts

--- a/docs/security/credential-secret-exposure.md
+++ b/docs/security/credential-secret-exposure.md
@@ -29,7 +29,9 @@ No **functional** tag applies: the tag table has no security area, and the sibli
 
 **Test 2 currently runs without `@stable`** — quarantined via `test.fixme` against the upstream export regression tracked by issue #1546 (see the note on Test 2 below). Tests 1 and 3 keep `@stable`.
 
-The three `QA-CHECKLIST.md` §17.3 bullets therefore become `[x]`.
+Bullets 1 and 3 of `QA-CHECKLIST.md` §17.3 are therefore `[x]`; bullet 2 is `[!]`
+while Test 2 is quarantined (#1546). Re-checked 2026-09-10 — the upstream fix has
+not landed; see §6 of `docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md`.
 
 ---
 

--- a/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
@@ -1,8 +1,8 @@
-# `POST /api/v1/flows/download/` drops the credential variable binding — exported flows no longer import with their secrets bound
+# `POST /api/v1/flows/download/` drops the credential variable binding — exported flows no longer import with their variables bound
 
 | Field | Value |
 |---|---|
-| **Filed upstream** | _still pending_ (draft in §6; owner: QA team) — **the blocking deliverable**: nothing has been reported to the people who can fix this, and the quarantine hides it from our own dailies |
+| **Filed upstream** | _still pending_ (report in §1–§4, suggested title in §6; owner: QA team) — **the blocking deliverable**: nothing has been reported to the people who can fix this, and the quarantine hides it from our own dailies |
 | **Last re-checked** | 2026-09-10 — **no upstream fix has landed**; the quarantine stands. Evidence in §6 |
 | **Repo issue** | [oriontech-me/langflow-e2e#1546](https://github.com/oriontech-me/langflow-e2e/issues/1546) (spun out of daily triage #1544) |
 | **Affected builds** | `langflowai/langflow-nightly:latest` since `2026-08-20` (first nightly cut after the causing merge); reproduced 5/5 on `1.12.0.dev33` |
@@ -121,38 +121,88 @@ mode; the fix is plausibly one line per call site
 
 **2026-09-10 — no upstream fix. The quarantine stands and nothing about the
 product has changed.** Checked against `langflow-ai/langflow` rather than against
-a nightly, because the question "did the fix land" is answerable from the history
-of the three paths this defect lives in:
+a nightly, because "did the fix land" is answerable from the code itself.
 
-| Path | Commits since 2026-08-19 |
-|---|---|
-| `src/backend/base/langflow/utils/flow_secrets.py` (the scrubber) | `fc3810da` only — **the commit that caused this** (#14639) |
-| `src/backend/base/langflow/api/v1/flows_helpers.py` (the `POST /api/v1/flows/download/` call site) | `fc3810da` only |
-| `src/backend/base/langflow/api/v1/projects.py` (sibling surface) | `c3bfdb7d`, a `release-1.12.0` → `main` back-merge |
+**Named refs, because the answer is ref-dependent and this repo has been bitten
+by that**: the nightly is cut from the release line under development, *not* from
+`main`, and merge-back is sporadic — so a `main`-only walk can report "not fixed"
+about a fix that shipped. Checked on `origin/main` **and** `origin/release-1.12.0`,
+`release-1.12.1`, `release-1.12.2`, `release-1.13.0`.
 
-**Reading the current file alone is misleading here, and that trap is worth
-recording so the next check does not fall into it.** `flow_secrets.py` on `main`
-today carries `load_from_db` handling (`_is_variable_reference`) and a scrub
-narrowed to fields that are `password`-marked *and* named like a secret — which
-reads exactly like the repair §4 asks for. It is not: the history shows both
-arrived **inside the causing commit**, which replaced the legacy `remove_api_keys`
-(that narrow rule) with the metadata-driven scrubber. So the file looks fixed
-because it looks *deliberate*, not because it changed.
+**Every file the causing commit touched is byte-identical to its own tree, on all
+five refs.** This is stronger than a commit walk and immune to the two mistakes
+the first version of this section made (below):
 
-A `manual.yml` dispatch to re-measure was considered and declined: the code path
-is byte-identical to the one that reproduced 5/5 on `1.12.0.dev33`, so a run would
-spend CI to confirm what an untouched path already settles. It becomes the right
-move the moment any of the three rows above gains a commit.
+```bash
+for p in utils/flow_secrets.py api/v1/flows_helpers.py \
+         api/v1/projects_files.py api/v1/flow_version.py; do
+  for r in fc3810da origin/main origin/release-1.12.{0,1,2} origin/release-1.13.0; do
+    git rev-parse "$r:src/backend/base/langflow/$p"
+  done
+done
+# flow_secrets.py    12f2a5e … (identical on all six)
+# flows_helpers.py   96dab51 … (identical on all six)
+# projects_files.py  05ecd47 … (identical on all six)
+# flow_version.py    b946d66 … (identical on all six)
+```
+
+The paths are **the three export call sites plus the scrubber** — `flows_helpers.py`
+(`POST /api/v1/flows/download/`), `projects_files.py` (`download_project_flows`,
+i.e. `GET /api/v1/projects/download/{id}`) and `flow_version.py`
+(`strip_version_data`). An earlier version of this table watched
+`api/v1/projects.py`, which only *imports* `download_project_flows` and was not
+touched by the cause, and omitted `flow_version.py` altogether — so its stated
+trigger was blind to a fix landing on either real sibling surface. It also listed
+`c3bfdb7d` (a `release-1.12.0` → `main` back-merge) as a commit "since 2026-08-19"
+when it is dated 2026-08-18, i.e. *before* the cause.
+
+### The trap: the binding-preserving mode predates the bug
+
+**Reading `flow_secrets.py` and concluding "already fixed" is the mistake to avoid,
+and the true story is not the one this section first recorded.** The file carries
+`_is_variable_reference` and a `variable_references` mode that preserves
+`load_from_db` bindings — which reads exactly like the repair §4 asks for. Both
+arrived in `0a1833f234` (#14437, *deterministic project deployment artifacts*,
+2026-08-10), **nine days before** the cause:
+
+```bash
+git log origin/main --reverse -S'_is_variable_reference' --oneline \
+  -- src/backend/base/langflow/utils/flow_secrets.py
+# 0a1833f234 feat: add deterministic project deployment artifacts (#14437)
+git show fc3810da^:src/backend/base/langflow/utils/flow_secrets.py | grep -c _is_variable_reference
+# 3   ← already there, pre-cause
+```
+
+`fc3810da`'s entire change to that file is adding `strip_flow_secrets` (+24/−1).
+What it did was move the export call sites off the legacy `remove_api_keys`
+(`password`-marked **and** API-key-named) onto the broader metadata-driven scrubber
+— `password` **or** secret-named, `flow_secrets.py:308` — **without** passing the
+`variable_references` mode #14437 had already added. So the correct machinery is
+sitting in the file, unreferenced by the export path. (§2 point 3 credits #14437
+correctly; an earlier version of this section contradicted it.)
+
+### Why a re-measurement is not the next step
+
+Two reasons, and the mechanical one comes first: the test is `test.fixme`, so **no
+`manual.yml` dispatch runs it at all** — not by tag, not by `--grep`. Re-measuring
+today means §3's by-hand reproduction, or lifting the quarantine first. And even
+then it would spend CI to confirm what the blob identity above already settles.
+
+It becomes the right move the moment any of those four blobs changes on any watched
+ref — and at that point the order is: reproduce by hand (§3), then lift.
 
 ### What filing it needs
 
 §1–§4 are the report; §3 is a deterministic reproduction that needs no LLM key.
-The one thing missing is the act of posting, which is deliberately left to a human
-with an upstream account: it is a public statement in a third-party repository,
-made in someone's name. Suggested title:
+The one thing missing is the act of posting. **The usual channel here is DataStax
+Jira** — six of the eight docs in this directory carry an `LE-####`, and
+`REGRESSIONS.md` accepts either a Jira ticket or a `langflow-ai/langflow` issue —
+so this does not require an upstream GitHub account or a public statement; a Jira
+ticket is enough to unblock the deliverable. Suggested title, covering all three
+surfaces rather than only the one the H1 names:
 
-> `POST /api/v1/flows/download/` nulls `load_from_db` credential bindings — exported flows no longer import with their variables bound
+> Flow and project export null `load_from_db` credential bindings — `POST /api/v1/flows/download/`, `GET /api/v1/projects/download/{id}` and `strip_version_data` all drop the variable name
 
-Once posted, put the issue URL in the **Filed upstream** row above and, if
-upstream disputes the intent (§2), record the answer in §4 rather than in the
-issue thread alone — the quarantine's lifetime depends on it.
+Once filed, put the ticket in the **Filed upstream** row above and, if upstream
+disputes the intent (§2), record the answer in §4 rather than in the ticket thread
+alone — the quarantine's lifetime depends on it.

--- a/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
@@ -206,7 +206,7 @@ Two reasons, and the mechanical one comes first: the test is `test.fixme`, so **
 today means §3's by-hand reproduction, or lifting the quarantine first. And even
 then it would spend CI to confirm what the blob identity above already settles.
 
-It becomes the right move the moment any of those six blobs changes on any watched
+It becomes the right move the moment any of those blobs changes on any watched
 ref — and at that point the order is: reproduce by hand (§3), then lift.
 
 ### What filing it needs

--- a/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
@@ -129,11 +129,9 @@ by that**: the nightly is cut from the release line under development, *not* fro
 about a fix that shipped. Checked on `origin/main` **and** `origin/release-1.12.0`,
 `release-1.12.1`, `release-1.12.2`, `release-1.13.0`.
 
-**Every one of the six product files the causing commit touched is byte-identical
-to its own tree, on all five refs.** This is stronger than a commit walk and
-immune to the two mistakes the first version of this section made (below). The
-loop covers all six rather than the four that carry the logic, because the point
-is a trigger the next re-check can trust:
+**Every file the causing commit touched is byte-identical to its own tree, on all
+five refs** — the six product files and its own unit test. That is stronger than a
+commit walk, and it is what the trigger below keys on:
 
 ```bash
 for p in utils/flow_secrets.py api/v1/flows_helpers.py api/v1/projects_files.py \
@@ -142,39 +140,37 @@ for p in utils/flow_secrets.py api/v1/flows_helpers.py api/v1/projects_files.py 
     git rev-parse "$r:src/backend/base/langflow/$p"
   done
 done
-# flow_secrets.py    12f2a5e … (identical on all six refs)
-# flows_helpers.py   96dab51 …
-# projects_files.py  05ecd47 …
-# flow_version.py    b946d66 …
-# api/utils/core.py  a7e336c …
-# api/utils/__init__ d78506f …
+# flow_secrets.py    12f2a5e   flow_version.py     b946d66
+# flows_helpers.py   96dab51   api/utils/core.py   a7e336c
+# projects_files.py  05ecd47   api/utils/__init__  d78506f
+# each identical on fc3810da and on all five watched refs
 ```
 
-(The seventh file is the cause's own unit test,
-`tests/unit/api/v1/test_export_secret_sanitization.py` — also unchanged, and §2
-point 2 already records what it does not assert.)
+Four of the six carry the logic: the scrubber, plus the three call sites the cause
+migrated onto it — `flows_helpers.py` (`POST /api/v1/flows/download/`),
+`projects_files.py` (`download_project_flows`, i.e.
+`GET /api/v1/projects/download/{id}`) and `flow_version.py` (`strip_version_data`,
+which serves `GET /api/v1/flows/{flow_id}/versions/{version_id}`; the header row
+lists it under *Sibling surfaces* because the same PR moved it onto the same
+scrubber, not because it is an export endpoint). `api/utils/` contributes
+`normalize_flow_for_export`, which runs **after** `strip_flow_secrets` on both
+download surfaces (`flows_helpers.py:808`, `projects_files.py:78`) and so cannot
+restore a value already nulled.
 
-The two `api/utils/` files are an `__all__` list and four alias assignments, so
-they carry no logic a fix could land in; they are in the loop anyway because a
-trigger that skips files "unlikely to matter" is how the first version of this
-section went blind. The one piece of export-path logic outside the six is
-`normalize_flow_for_export` (`api/utils/core.py:158`), which runs **after**
-`strip_flow_secrets` on both download surfaces and therefore cannot restore a
-value already nulled — and there is no `lfx` copy of the scrubber
-(`git grep -l strip_secret_field_values origin/main -- 'src/lfx/**'` is empty).
+Outside the six sit the two route handlers — `flows.py:1292`
+(`download_multiple_file`) and `projects.py:1074` (`download_file`) — which fetch
+and authorize but hold no scrubber call. There is no `lfx` copy of the scrubber
+either: `git grep -l strip_secret_field_values <ref> -- 'src/lfx/**'` is empty on
+all five refs, where the control `secret_value_to_str` returns four files.
 
-The paths are **the three export call sites plus the scrubber** — `flows_helpers.py`
-(`POST /api/v1/flows/download/`), `projects_files.py` (`download_project_flows`,
-i.e. `GET /api/v1/projects/download/{id}`) and `flow_version.py`
-(`strip_version_data`, which is a version **read** rather than an export endpoint —
-the header row calls it a sibling surface for that reason). An earlier version of this table watched
-`api/v1/projects.py` — which *declares* the `GET /download/{project_id}` route and
-calls `download_project_flows` (`projects.py:1103`), but holds no scrubber call of
-its own and was not touched by the cause — and omitted `flow_version.py`
-altogether — so its stated
-trigger was blind to a fix landing on either real sibling surface. It also listed
-`c3bfdb7d` (a `release-1.12.0` → `main` back-merge) as a commit "since 2026-08-19"
-when it is dated 2026-08-18, i.e. *before* the cause.
+**Two mistakes the first version of this section made**, recorded because both
+made the trigger narrower than it looked. Its watch table omitted
+`flow_version.py` and watched `api/v1/projects.py` instead — which declares the
+`GET /download/{project_id}` route and calls `download_project_flows`
+(`projects.py:1103`), but holds no scrubber call and was not touched by the cause
+— so a fix landing on either real sibling surface was invisible to it. And it
+listed `c3bfdb7d` as a commit "since 2026-08-19" when it is dated 2026-08-18,
+before the cause.
 
 ### The trap: the binding-preserving mode predates the bug
 
@@ -217,9 +213,10 @@ ref — and at that point the order is: reproduce by hand (§3), then lift.
 
 §1–§4 are the report; §3 is a deterministic reproduction that needs no LLM key.
 The one thing missing is the act of posting. **The usual channel here is DataStax
-Jira** — seven of the eight other upstream-bug docs in this directory name an
-`LE-####` (the eighth reads *"Not yet — evidence collected here first"*), and
-`REGRESSIONS.md:12` accepts either a Jira ticket or a `langflow-ai/langflow` issue —
+Jira** — every other `UPSTREAM-BUG-*` file in this directory names an `LE-####`
+except one, which reads *"Not yet — evidence collected here first"* — and
+`REGRESSIONS.md:12` accepts either a Jira ticket or a `langflow-ai/langflow`
+issue —
 so this does not require an upstream GitHub account or a public statement; a Jira
 ticket is enough to unblock the deliverable. Suggested title, covering all three
 surfaces rather than only the one the H1 names:

--- a/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
@@ -2,7 +2,8 @@
 
 | Field | Value |
 |---|---|
-| **Filed upstream** | _pending_ (draft below; owner: QA team) |
+| **Filed upstream** | _still pending_ (draft in §6; owner: QA team) — **the blocking deliverable**: nothing has been reported to the people who can fix this, and the quarantine hides it from our own dailies |
+| **Last re-checked** | 2026-09-10 — **no upstream fix has landed**; the quarantine stands. Evidence in §6 |
 | **Repo issue** | [oriontech-me/langflow-e2e#1546](https://github.com/oriontech-me/langflow-e2e/issues/1546) (spun out of daily triage #1544) |
 | **Affected builds** | `langflowai/langflow-nightly:latest` since `2026-08-20` (first nightly cut after the causing merge); reproduced 5/5 on `1.12.0.dev33` |
 | **Introduced by** | [langflow-ai/langflow#14639](https://github.com/langflow-ai/langflow/pull/14639) — *fix(security): scrub all secret fields on flow and project export* (commit `fc3810da0`, merged 2026-08-19T17:36Z into `release-1.12.0`) |
@@ -115,3 +116,43 @@ mode; the fix is plausibly one line per call site
   lands in `langflowai/langflow-nightly:latest`.
 - The serial sibling *"the run resolves the credential without echoing it"*
   resumes running (it was cascade-skipped while the export test hard-failed).
+
+## 6. Re-check log, and why re-measuring is not the next step
+
+**2026-09-10 — no upstream fix. The quarantine stands and nothing about the
+product has changed.** Checked against `langflow-ai/langflow` rather than against
+a nightly, because the question "did the fix land" is answerable from the history
+of the three paths this defect lives in:
+
+| Path | Commits since 2026-08-19 |
+|---|---|
+| `src/backend/base/langflow/utils/flow_secrets.py` (the scrubber) | `fc3810da` only — **the commit that caused this** (#14639) |
+| `src/backend/base/langflow/api/v1/flows_helpers.py` (the `POST /api/v1/flows/download/` call site) | `fc3810da` only |
+| `src/backend/base/langflow/api/v1/projects.py` (sibling surface) | `c3bfdb7d`, a `release-1.12.0` → `main` back-merge |
+
+**Reading the current file alone is misleading here, and that trap is worth
+recording so the next check does not fall into it.** `flow_secrets.py` on `main`
+today carries `load_from_db` handling (`_is_variable_reference`) and a scrub
+narrowed to fields that are `password`-marked *and* named like a secret — which
+reads exactly like the repair §4 asks for. It is not: the history shows both
+arrived **inside the causing commit**, which replaced the legacy `remove_api_keys`
+(that narrow rule) with the metadata-driven scrubber. So the file looks fixed
+because it looks *deliberate*, not because it changed.
+
+A `manual.yml` dispatch to re-measure was considered and declined: the code path
+is byte-identical to the one that reproduced 5/5 on `1.12.0.dev33`, so a run would
+spend CI to confirm what an untouched path already settles. It becomes the right
+move the moment any of the three rows above gains a commit.
+
+### What filing it needs
+
+§1–§4 are the report; §3 is a deterministic reproduction that needs no LLM key.
+The one thing missing is the act of posting, which is deliberately left to a human
+with an upstream account: it is a public statement in a third-party repository,
+made in someone's name. Suggested title:
+
+> `POST /api/v1/flows/download/` nulls `load_from_db` credential bindings — exported flows no longer import with their variables bound
+
+Once posted, put the issue URL in the **Filed upstream** row above and, if
+upstream disputes the intent (§2), record the answer in §4 rather than in the
+issue thread alone — the quarantine's lifetime depends on it.

--- a/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-flow-export-drops-credential-binding.md
@@ -129,29 +129,49 @@ by that**: the nightly is cut from the release line under development, *not* fro
 about a fix that shipped. Checked on `origin/main` **and** `origin/release-1.12.0`,
 `release-1.12.1`, `release-1.12.2`, `release-1.13.0`.
 
-**Every file the causing commit touched is byte-identical to its own tree, on all
-five refs.** This is stronger than a commit walk and immune to the two mistakes
-the first version of this section made (below):
+**Every one of the six product files the causing commit touched is byte-identical
+to its own tree, on all five refs.** This is stronger than a commit walk and
+immune to the two mistakes the first version of this section made (below). The
+loop covers all six rather than the four that carry the logic, because the point
+is a trigger the next re-check can trust:
 
 ```bash
-for p in utils/flow_secrets.py api/v1/flows_helpers.py \
-         api/v1/projects_files.py api/v1/flow_version.py; do
+for p in utils/flow_secrets.py api/v1/flows_helpers.py api/v1/projects_files.py \
+         api/v1/flow_version.py api/utils/core.py api/utils/__init__.py; do
   for r in fc3810da origin/main origin/release-1.12.{0,1,2} origin/release-1.13.0; do
     git rev-parse "$r:src/backend/base/langflow/$p"
   done
 done
-# flow_secrets.py    12f2a5e … (identical on all six)
-# flows_helpers.py   96dab51 … (identical on all six)
-# projects_files.py  05ecd47 … (identical on all six)
-# flow_version.py    b946d66 … (identical on all six)
+# flow_secrets.py    12f2a5e … (identical on all six refs)
+# flows_helpers.py   96dab51 …
+# projects_files.py  05ecd47 …
+# flow_version.py    b946d66 …
+# api/utils/core.py  a7e336c …
+# api/utils/__init__ d78506f …
 ```
+
+(The seventh file is the cause's own unit test,
+`tests/unit/api/v1/test_export_secret_sanitization.py` — also unchanged, and §2
+point 2 already records what it does not assert.)
+
+The two `api/utils/` files are an `__all__` list and four alias assignments, so
+they carry no logic a fix could land in; they are in the loop anyway because a
+trigger that skips files "unlikely to matter" is how the first version of this
+section went blind. The one piece of export-path logic outside the six is
+`normalize_flow_for_export` (`api/utils/core.py:158`), which runs **after**
+`strip_flow_secrets` on both download surfaces and therefore cannot restore a
+value already nulled — and there is no `lfx` copy of the scrubber
+(`git grep -l strip_secret_field_values origin/main -- 'src/lfx/**'` is empty).
 
 The paths are **the three export call sites plus the scrubber** — `flows_helpers.py`
 (`POST /api/v1/flows/download/`), `projects_files.py` (`download_project_flows`,
 i.e. `GET /api/v1/projects/download/{id}`) and `flow_version.py`
-(`strip_version_data`). An earlier version of this table watched
-`api/v1/projects.py`, which only *imports* `download_project_flows` and was not
-touched by the cause, and omitted `flow_version.py` altogether — so its stated
+(`strip_version_data`, which is a version **read** rather than an export endpoint —
+the header row calls it a sibling surface for that reason). An earlier version of this table watched
+`api/v1/projects.py` — which *declares* the `GET /download/{project_id}` route and
+calls `download_project_flows` (`projects.py:1103`), but holds no scrubber call of
+its own and was not touched by the cause — and omitted `flow_version.py`
+altogether — so its stated
 trigger was blind to a fix landing on either real sibling surface. It also listed
 `c3bfdb7d` (a `release-1.12.0` → `main` back-merge) as a commit "since 2026-08-19"
 when it is dated 2026-08-18, i.e. *before* the cause.
@@ -173,7 +193,9 @@ git show fc3810da^:src/backend/base/langflow/utils/flow_secrets.py | grep -c _is
 # 3   ← already there, pre-cause
 ```
 
-`fc3810da`'s entire change to that file is adding `strip_flow_secrets` (+24/−1).
+`fc3810da`'s change to that file is +24/−1: it adds `strip_flow_secrets` and
+tightens `strip_secret_field_values`'s short-circuit from `if not flow_data:` to
+`if flow_data is None:`.
 What it did was move the export call sites off the legacy `remove_api_keys`
 (`password`-marked **and** API-key-named) onto the broader metadata-driven scrubber
 — `password` **or** secret-named, `flow_secrets.py:308` — **without** passing the
@@ -188,20 +210,21 @@ Two reasons, and the mechanical one comes first: the test is `test.fixme`, so **
 today means §3's by-hand reproduction, or lifting the quarantine first. And even
 then it would spend CI to confirm what the blob identity above already settles.
 
-It becomes the right move the moment any of those four blobs changes on any watched
+It becomes the right move the moment any of those six blobs changes on any watched
 ref — and at that point the order is: reproduce by hand (§3), then lift.
 
 ### What filing it needs
 
 §1–§4 are the report; §3 is a deterministic reproduction that needs no LLM key.
 The one thing missing is the act of posting. **The usual channel here is DataStax
-Jira** — six of the eight docs in this directory carry an `LE-####`, and
-`REGRESSIONS.md` accepts either a Jira ticket or a `langflow-ai/langflow` issue —
+Jira** — seven of the eight other upstream-bug docs in this directory name an
+`LE-####` (the eighth reads *"Not yet — evidence collected here first"*), and
+`REGRESSIONS.md:12` accepts either a Jira ticket or a `langflow-ai/langflow` issue —
 so this does not require an upstream GitHub account or a public statement; a Jira
 ticket is enough to unblock the deliverable. Suggested title, covering all three
 surfaces rather than only the one the H1 names:
 
-> Flow and project export null `load_from_db` credential bindings — `POST /api/v1/flows/download/`, `GET /api/v1/projects/download/{id}` and `strip_version_data` all drop the variable name
+> Flow and project export null `load_from_db` credential bindings — `POST /api/v1/flows/download/` and `GET /api/v1/projects/download/{id}` drop the variable name, and version reads (`strip_version_data`) do the same
 
 Once filed, put the ticket in the **Filed upstream** row above and, if upstream
 disputes the intent (§2), record the answer in §4 rather than in the ticket thread

--- a/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
+++ b/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
@@ -311,10 +311,11 @@ test.describe("Credential secret exposure", () => {
   // quarantine (remove test.fixme + restore @stable) is a deliverable of #1546,
   // due when the upstream fix lands in langflowai/langflow-nightly:latest.
   //
-  // Re-checked 2026-09-10: NOT fixed. The scrubber and both call sites carry no
-  // commit since the causing one, so the path is unchanged — see the doc's
-  // re-check log (§6), which also records why the current `flow_secrets.py` reads
-  // like a repair when it is the causing commit's own narrowing.
+  // Re-checked 2026-09-10: NOT fixed. The scrubber and all THREE export call sites
+  // are byte-identical to the causing commit's own trees on `main` and on all four
+  // release lines — see the doc's re-check log (§6), which also records why
+  // `flow_secrets.py` reads like a repair: the binding-preserving mode predates the
+  // bug (#14437, nine days earlier) and the export path simply never opts into it.
   test.fixme(
     "the exported flow carries the credential binding, never the secret",
     { tag: ["@api", "@regression"] },

--- a/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
+++ b/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
@@ -310,6 +310,11 @@ test.describe("Credential secret exposure", () => {
   // skip, not a failure) lets the serial sibling below run again. Lifting the
   // quarantine (remove test.fixme + restore @stable) is a deliverable of #1546,
   // due when the upstream fix lands in langflowai/langflow-nightly:latest.
+  //
+  // Re-checked 2026-09-10: NOT fixed. The scrubber and both call sites carry no
+  // commit since the causing one, so the path is unchanged — see the doc's
+  // re-check log (§6), which also records why the current `flow_secrets.py` reads
+  // like a repair when it is the causing commit's own narrowing.
   test.fixme(
     "the exported flow carries the credential binding, never the secret",
     { tag: ["@api", "@regression"] },

--- a/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
+++ b/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
@@ -311,10 +311,11 @@ test.describe("Credential secret exposure", () => {
   // quarantine (remove test.fixme + restore @stable) is a deliverable of #1546,
   // due when the upstream fix lands in langflowai/langflow-nightly:latest.
   //
-  // Re-checked 2026-09-10: NOT fixed. Every product file the causing commit touched
-  // is byte-identical to its own tree on `main` and on all four release lines — see the doc's re-check log (§6), which also records why
-  // `flow_secrets.py` reads like a repair: the binding-preserving mode predates the
-  // bug (#14437, nine days earlier) and the export path simply never opts into it.
+  // Re-checked 2026-09-10: NOT fixed. Every file the causing commit touched is
+  // byte-identical to its own tree on `main` and on all four release lines — see
+  // the doc's re-check log (§6), which also records why `flow_secrets.py` reads
+  // like a repair: the binding-preserving mode predates the bug (#14437, nine
+  // days earlier) and the export path simply never opts into it.
   test.fixme(
     "the exported flow carries the credential binding, never the secret",
     { tag: ["@api", "@regression"] },

--- a/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
+++ b/tests/tests-automations/regression/security/credential-secret-exposure.spec.ts
@@ -311,9 +311,8 @@ test.describe("Credential secret exposure", () => {
   // quarantine (remove test.fixme + restore @stable) is a deliverable of #1546,
   // due when the upstream fix lands in langflowai/langflow-nightly:latest.
   //
-  // Re-checked 2026-09-10: NOT fixed. The scrubber and all THREE export call sites
-  // are byte-identical to the causing commit's own trees on `main` and on all four
-  // release lines — see the doc's re-check log (§6), which also records why
+  // Re-checked 2026-09-10: NOT fixed. Every product file the causing commit touched
+  // is byte-identical to its own tree on `main` and on all four release lines — see the doc's re-check log (§6), which also records why
   // `flow_secrets.py` reads like a repair: the binding-preserving mode predates the
   // bug (#14437, nine days earlier) and the export path simply never opts into it.
   test.fixme(


### PR DESCRIPTION
## Type

- [ ] `feat` — new test or new helper/page object
- [ ] `fix` — fix for a broken or flaky test
- [ ] `chore` — CI, checklist, dependencies, internal refactoring
- [x] `docs` — documentation update

---

## Roadmap linkage (required — do not delete)

- [ ] **Current wave** — a `roadmap`-labeled issue in the current wave's milestone: #___
- [x] **Exception** — off-wave work backed by an issue: a `daily-failure` triage issue. Issue #1546 (reopened)

---

## What this PR does

#1546 was closed as COMPLETED by the quarantine PR (#1554), which left **both** of its deliverables untracked — and the code says so out loud:

> Lifting the quarantine (remove `test.fixme` + restore `@stable`) is a deliverable of #1546, due when the upstream fix lands in `langflowai/langflow-nightly:latest`.

The issue is reopened. This PR records the state, so the next person does not re-derive it.

### Re-checked 2026-09-10 — the upstream fix has NOT landed

Answered from the code rather than from a nightly, and **on named refs**, because the answer is ref-dependent: the nightly is cut from the release line under development, not from `main`, and merge-back is sporadic — so a `main`-only walk can report "not fixed" about a fix that shipped. Checked on `origin/main` plus `release-1.12.0`, `1.12.1`, `1.12.2`, `1.13.0`.

**Every one of the six product files the causing commit touched is byte-identical to its own tree on all five refs** — the scrubber, the three export/read call sites, and the two `api/utils/` re-export files. The seventh file the cause touched is its own unit test. That is stronger than a commit walk, and it is what the re-check trigger now keys on.

**The trap worth recording is not the one this PR first recorded.** `flow_secrets.py` carries `_is_variable_reference` and a `variable_references` mode that preserves `load_from_db` bindings — which reads exactly like the repair §4 asks for. It arrived in `0a1833f234` (#14437), **nine days before** the cause, and is present in `fc3810da^`. What the causing commit did was move the export call sites off the legacy `remove_api_keys` onto the broader metadata-driven scrubber **without** passing that mode. The correct machinery is sitting in the file, unreferenced by the export path.

A re-measurement was considered and **declined**, and the first reason is mechanical rather than about cost: the test is `test.fixme`, so **no `manual.yml` dispatch runs it at all** — not by tag, not by `--grep`. Re-measuring today means §3's by-hand reproduction, or lifting the quarantine first.

### What is still owed, and why this PR does not do it

`Filed upstream` still reads _pending_: the regression has been undisclosed to the people who can fix it since 2026-08-21, while the quarantine hides it from our own dailies. §1–§4 are the report and §3 is a deterministic reproduction needing no LLM key. The remaining step is the act of filing — and §6 now records that this repo's usual channel is **DataStax Jira** (seven of the eight other docs in `docs/upstream-bugs/` name an `LE-####`, and `REGRESSIONS.md:12` accepts either a Jira ticket or a GitHub issue), so it needs neither an upstream GitHub account nor a public statement.

---

## What the independent reviews changed

**Three rounds.** The PR's headline held throughout and is now evidenced more strongly than it was. What did not hold were its added factual claims — and one of the corrections repeated the mistake, which is why the count is now derived in the PR body too:

- **The recorded "trap" was false in both halves.** `_is_variable_reference` and the narrowed scrub did not arrive inside the causing commit (they predate it by nine days), and the current rule is `password` **or** secret-named — *broader*, not narrower. The paragraph also contradicted §2 point 3 of the same document.
- **The monitoring table watched a path that holds no scrubber call (`api/v1/projects.py`) and omitted one that does (`api/v1/flow_version.py`)**, so its own re-check trigger was blind to a fix landing on a sibling surface. It also listed a commit dated 2026-08-18 as one "since 2026-08-19".
- **The first correction then shipped a false count** ("six of the eight docs carry an `LE-####`" — it is seven of the eight others) and introduced a scope sentence ("every file the causing commit touched") over a loop covering four of seven. Both fixed; the loop now covers all six product files, including the two that carry no logic, because a trigger that skips files "unlikely to matter" is exactly how the first version went blind.
- Smaller: the `Filed upstream` row pointed at §6 for a draft that lives in §1–§4; the declined re-measurement priced a dispatch that cannot run a `test.fixme` test; `projects.py` does call `download_project_flows`; `strip_version_data` is a version read, not an export endpoint; and the H1 said "secrets bound" where §1 insists the finding is about the **name**, not the secret.
- Two adjacent files were left stale by the quarantine PR and are corrected here: the spec doc still claimed all three §17.3 checklist bullets are `[x]` when one has been `[!]` since the quarantine, and that bullet carried a bare `[!]` where this file annotates quarantines.

---

## What this PR does not cover

- **Lifting the quarantine.** Its condition is not met, and nothing here pretends otherwise.
- **Filing the upstream ticket** — see above; it needs a human to post it.
- **Re-measuring on a nightly** — declined, with the mechanical reason recorded rather than left implicit.

---

## Validation

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run test:units` — 1314 pass / 0 fail
- [x] QA-CHECKLIST guard — clean (no generated block touched); `check:checklist-coverage` passes
- [x] `npm run validate:specs` — exit 0
- [x] `scripts/watch-upstream-areas.mjs --mode=check-docs` — every dependency path in the changed docs resolves (this PR now modifies `docs/security/credential-secret-exposure.md`, so its paths are on the guard's failing branch; all eight resolve on `origin/main` and both derived release lines)

No test behaviour changes: the only `tests/` edit is the quarantine comment.
