### PR TITLE
test(triage): promote 5 measured-green T1 tests to @stable and lift an orphaned quarantine (#1787)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -256,7 +256,7 @@
 - [x] Edit table input → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit slider → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit tab component → `core-components/parameters-panel-field-types.spec.ts`
-- [-] Visibility toggle of a connected input is disabled (tooltip "Cannot change visibility of connected handles") and re-enables once the edge is deleted → `flow-functionality/general-bugs-hidden-input-edges.spec.ts`
+- [x] Visibility toggle of a connected input is disabled (tooltip "Cannot change visibility of connected handles") and re-enables once the edge is deleted → `flow-functionality/general-bugs-hidden-input-edges.spec.ts`
 - [x] Two nodes on the canvas exposing the same field name render distinct DOM ids, while `data-testid` stays unscoped so both nodes remain selectable (LE-2037 / langflow#14312) → `core-components/duplicate-dom-ids-regression.spec.ts`
 
 #### 2.2 Tool Mode
@@ -683,7 +683,7 @@
 - [x] Integrity after deletion — the deleted folder leaves the sidebar immediately, the page stays functional, and a sibling folder is untouched and still clickable → `core-functionality/project-management/folder-deletion-integrity.spec.ts`
 - [x] Create folder after deleting all folders — creating a folder right after a deletion works (no stale-cache collision) → `core-functionality/project-management/folder-deletion-integrity.spec.ts`
 - [-] Deleting every folder lands on the empty-project screen (sidebar empty message + `new_project_btn_empty_page`) → `core-functionality/project-management/folder-deletion-integrity.spec.ts` (`@destructive` — account-wide wiper, runs only in the low-concurrency lane via `PW_DESTRUCTIVE=1`, see #1010; stays `[-]` permanently, since `[x]` requires `@stable` and `@destructive` must never carry it — the pair would mean "runs nowhere")
-- [-] Upload flow by drag-and-drop to folder — dropping a collection file imports one flow per entry; dropping a single flow file imports exactly one → `flow-functionality/dragAndDrop.spec.ts`
+- [x] Upload flow by drag-and-drop to folder — dropping a collection file imports one flow per entry; dropping a single flow file imports exactly one → `flow-functionality/dragAndDrop.spec.ts`
 - [-] Move flow to another folder
 
 #### 10.2 Folder Navigation
@@ -810,7 +810,7 @@
 - [x] Exported JSON contains valid data.nodes structure → `flow-functionality/export-import-flow.spec.ts`
 - [x] Import flow via JSON file upload (drag-drop + upload button) → `flow-functionality/export-import-flow.spec.ts`
 - [x] Re-importing a live flow's own export through the UI adds a **copy** (`"<name> (1)"`, new id) instead of updating it — the UI import posts `POST /api/v1/flows/` and discards the export's id, unlike `POST /api/v1/flows/upload/`, which upserts → `flow-functionality/export-import-flow.spec.ts` (#1773)
-- [-] Import flow with outdated components → `flow-functionality/import-outdated-flow.spec.ts`
+- [x] Import flow with outdated components → `flow-functionality/import-outdated-flow.spec.ts`
 - [x] Import invalid JSON — should display error message → `flow-functionality/import-invalid-json.spec.ts`
 
 #### 12.5 Flow Operations
@@ -821,7 +821,7 @@
 - [x] Save flow components as template → `core-components/saveComponents.spec.ts`
 
 #### 12.6 Flow Execution
-- [x] Run Flow component executes another flow — `@stable` restored 2026-08-11 (#966). The upstream `New Flow` dead-click defect ([LE-2019](https://datastax.jira.com/browse/LE-2019)) is fixed by langflow#14349, present on the nightly line; the shared helper still gates on the flows list having rendered. Hardened for #1548 (daily 2026-08-21 flow-selector click intercepted by two overlays): the spec now seeds the assistant-onboarding suppression (#1220) and drags the Run Flow node to the upper-right canvas region so the flow-name popup stays clear of the canvas-controls band; re-validated on `1.12.0.dev33` → `flow-functionality/run-flow.spec.ts`
+- [x] Run Flow component executes another flow — restored to `@stable` 2026-09-10 (#1787), and the bullet had been over-reporting until then: it read `[x]` with "`@stable` restored 2026-08-11 (#966)" while the spec carried `test.fixme` and no tag from `ecf96d29` onward, which no guard detects (`check:checklist-coverage` enforces spec→bullet, never bullet→spec). Sequence, because it explains the gap: promoted, quarantined for #966, hardened once the upstream `New Flow` dead-click ([LE-2019](https://datastax.jira.com/browse/LE-2019)) was fixed by langflow#14349, then the 2026-08-21 daily hit an `assistant-onboarding-tooltip` overlay and TWO PRs answered it the same day — #1550 hardened the spec against that overlay (`seedAssistantDiscovered` + the upper-right node anchor) and #1553 muted it. #1553 merged second so the mute won, and #1548 — which carried the lift as a deliverable — closed without performing it, leaving the hardening for the mute's own cause unused in the file. Re-validated on `1.13.0.dev8`: 3/3 green with the modifier removed, and 3/3 in the #1784 measurement before that → `flow-functionality/run-flow.spec.ts`
 - [x] Run a flow from the canvas — terminal-node run builds the whole graph; all nodes reach build success and output is produced → `flow-functionality/flow-execution-canvas.spec.ts`
 - [x] Stop building flow → `flow-functionality/stop-building.spec.ts`
 - [ ] A cyclic graph is refused with a cycle-specific error, and the flow stays editable afterwards (the engine's own contract; a total engine failure is caught indirectly by the 63 `@stable` specs that trigger a run, a subtle one by nothing)

--- a/docs/flow-functionality/dragAndDrop.md
+++ b/docs/flow-functionality/dragAndDrop.md
@@ -39,6 +39,22 @@ Two independent tests:
   `POST /api/v1/flows/` 201 response and deleted in `afterEach`; the workspace
   precondition comes from `awaitBootstrapTest(page, { skipModal: true })` instead
   of opening a template.
+
+  **Corrected 2026-09-10 (#1787): "every 201" was the intent, not the behaviour.**
+  The capture listener was installed *after* `awaitBootstrapTest`, on the stated
+  grounds that the bootstrap's own flows are "shared bootstrap state, not ours to
+  delete" and that counting their 201s would break the import-count assertion.
+  The second half of that is right and is preserved; the first half conflates a
+  flow **this page created** with a flow another worker owns — the bootstrap of a
+  parallel worker creates a different id, so deleting by id can never touch it.
+  Measured on `1.13.0.dev7`: a green run left the instance two flows heavier,
+  `New Flow` plus a second `Basic Prompting`, once per run.
+
+  The fix keeps both reasons intact by separating the two populations. A
+  **bootstrap** listener is installed *before* `awaitBootstrapTest` and feeds its
+  own array, which `afterEach` deletes and no assertion ever counts; the
+  **import** listener still goes up afterwards and still feeds the array the count
+  assertion reads. Never a global sweep — the suite runs `fullyParallel`.
 - **Assertions anchored by id, not by list position or free text** — per the
   home-cards convention (the list sorts by `updated_at` DESC, so a positional
   match is another worker's flow under parallel CI).
@@ -75,4 +91,4 @@ clean and force-failed as part of that change.
 
 ## Last validated
 
-1.12.x (nightly `1.12.0.dev6`)
+1.13.x (nightly `1.13.0.dev8`)

--- a/docs/flow-functionality/general-bugs-hidden-input-edges.md
+++ b/docs/flow-functionality/general-bugs-hidden-input-edges.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/flow-functionality/general-bugs-hidden-input-edges.spec.ts`
 
-**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev8`)
 
 ---
 

--- a/docs/flow-functionality/import-outdated-flow.md
+++ b/docs/flow-functionality/import-outdated-flow.md
@@ -1,6 +1,6 @@
 # Import Flow with Outdated Components — UI Upload Path (§12.4 Export / Import Flow)
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev8`)
 
 ---
 
@@ -144,3 +144,17 @@ sibling `outdated-component-notification.spec.ts`'s concern, not this spec's.
 - **Flow cleanup.** The imported flow is a real persisted flow — its id is
   captured from the `POST /api/v1/flows` response and deleted id-scoped in
   `afterEach` (#490/#681), so no "Memory Chatbot" orphan leaks across runs.
+  **Since #1787 the bootstrap's own creates are captured too**, and the reason
+  is worth carrying because it hid itself: `awaitBootstrapTest` creates `New
+  Flow` plus a `Basic Prompting` when the project is empty, and only the upload
+  response was ever captured, so a run left the instance two flows heavier.
+  Measured on `1.13.0.dev8`, green path as well as red — this was never a
+  red-only defect.
+
+  **It was invisible while a sibling spec leaked.** A first audit ran the four
+  promoted specs in sequence and charged this one 0: `dragAndDrop` leaked the
+  same pair first, which left the project non-empty, so this spec's bootstrap
+  created nothing. Fixing `dragAndDrop` is what exposed it. Any per-spec flow
+  audit therefore has to **purge before each spec**, not once before the batch —
+  otherwise one leak masks the next and the clean specs are the ones that look
+  guilty.

--- a/docs/flow-functionality/run-flow.md
+++ b/docs/flow-functionality/run-flow.md
@@ -1,6 +1,6 @@
 # Flow Functionality — Run Flow
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev23`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev8`)
 
 ---
 

--- a/tests/tests-automations/regression/flow-functionality/dragAndDrop.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/dragAndDrop.spec.ts
@@ -32,10 +32,48 @@ test.describe("flow import by file drop on the home page", () => {
   let token: string;
   // Every flow the drop created, collected from the create responses.
   let importedIds: string[];
+  // Every flow the BOOTSTRAP created, kept apart from the line above on purpose:
+  // these are deleted like any other id this page made, and no assertion ever
+  // counts them (#1787). Measured on 1.13.0.dev7 before this split existed: a
+  // green run left `New Flow` plus a second `Basic Prompting` behind, once per
+  // run, because the import listener goes up only after the bootstrap and so
+  // never saw them. The old comment called them "shared bootstrap state, not
+  // ours to delete" -- but a parallel worker's bootstrap creates a DIFFERENT id,
+  // so deleting by id cannot reach it; what was actually load-bearing is that
+  // their 201s must stay out of the import count, which this split preserves.
+  let bootstrapIds: string[];
+  // Flips once the bootstrap has finished. Read SYNCHRONOUSLY inside the
+  // handler, never inside the `.then()`: `res.json()` settles on a later tick,
+  // so a bootstrap 201 whose body resolves after the flip would otherwise be
+  // misfiled -- and the reverse (deciding by "is the import array still empty")
+  // is a race between the two handlers' promises during the drop itself.
+  let bootstrapDone: boolean;
 
   test.beforeEach(async ({ page, request }) => {
     token = await getAuthToken(request);
     importedIds = [];
+    bootstrapIds = [];
+    bootstrapDone = false;
+
+    // Installed BEFORE the bootstrap so its own creates are captured for
+    // cleanup; feeds a separate array, so the import count is untouched.
+    page.on("response", (res) => {
+      if (
+        res.request().method() === "POST" &&
+        res.url().includes("/api/v1/flows/") &&
+        res.status() === 201
+      ) {
+        if (bootstrapDone) return;
+        res
+          .json()
+          .then((body: { id?: string }) => {
+            if (body?.id) bootstrapIds.push(body.id);
+          })
+          .catch(() => {
+            /* a non-JSON 201 cannot carry an id to clean up */
+          });
+      }
+    });
 
     // Home page with the flow list rendered. skipModal: the templates modal is
     // not part of this journey, and opening a template would create an extra
@@ -44,6 +82,8 @@ test.describe("flow import by file drop on the home page", () => {
     await expect(page.getByTestId(DROPZONE_TESTID)).toBeVisible({
       timeout: 30000,
     });
+    // Bootstrap is over: from here every 201 belongs to the drop under test.
+    bootstrapDone = true;
 
     // Listener installed only AFTER the bootstrap: on a freshly empty instance
     // awaitBootstrapTest itself creates a flow (shared bootstrap state, not ours
@@ -68,13 +108,15 @@ test.describe("flow import by file drop on the home page", () => {
   });
 
   test.afterEach(async ({ request }) => {
-    for (const id of importedIds) {
+    // Id-scoped, never a global sweep: under fullyParallel, deleting anything
+    // this page did not create would wipe a concurrent worker's flow.
+    for (const id of [...importedIds, ...bootstrapIds]) {
       await deleteFlow(request, id, { headers: { Authorization: token } });
     }
   });
 
   test("dropping a collection file imports every flow it contains",
-    { tag: ["@release", "@workspace", "@mainpage"] },
+    { tag: ["@stable", "@release", "@workspace", "@mainpage"] },
     async ({ page, request }) => {
       // Read the expected count from the asset itself, so adding a flow to the
       // fixture updates the expectation instead of reddening the test.
@@ -121,7 +163,7 @@ test.describe("flow import by file drop on the home page", () => {
     });
 
   test("dropping a single flow file imports that flow",
-    { tag: ["@release", "@workspace", "@mainpage"] },
+    { tag: ["@stable", "@release", "@workspace", "@mainpage"] },
     async ({ page, request }) => {
       const uniqueName = `dnd-flow-${Date.now()}-${Math.random()
         .toString(36)

--- a/tests/tests-automations/regression/flow-functionality/general-bugs-hidden-input-edges.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/general-bugs-hidden-input-edges.spec.ts
@@ -42,7 +42,7 @@ test.afterEach(async ({ request }) => {
 
 test(
   "user should not be able to hide connected inputs",
-  { tag: ["@release", "@api", "@database"] },
+  { tag: ["@stable", "@release", "@api", "@database"] },
   async ({ page }) => {
     trackCreatedFlows(page);
     await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/flow-functionality/import-outdated-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/import-outdated-flow.spec.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
@@ -23,19 +24,49 @@ const createdFlowIds: string[] = [];
 test.afterEach(async ({ request }) => {
   if (createdFlowIds.length === 0) return;
   const headers = { Authorization: await getAuthToken(request) };
-  for (const id of createdFlowIds.splice(0)) {
+  // Deduped: the upload id is pushed explicitly (it is also needed to open the
+  // flow) AND seen by the capture listener, so the same id can appear twice.
+  for (const id of new Set(createdFlowIds.splice(0))) {
     // Best-effort per-flow so one failure does not abort the sweep.
     await deleteFlow(request, id, { headers }).catch(() => {});
   }
 });
 
+/**
+ * Capture every flow the PAGE creates, installed before the bootstrap.
+ *
+ * `awaitBootstrapTest` creates `New Flow` plus a `Basic Prompting` when the
+ * project is empty, and capturing only the upload response left those two behind
+ * on every run -- green path as well as red (#1787, measured on 1.13.0.dev8).
+ * Id-scoped, never a global sweep: under `fullyParallel` deleting anything this
+ * page did not create would wipe a concurrent worker's flow, and a parallel
+ * worker's bootstrap creates different ids.
+ */
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
 test(
   "importing an outdated flow via the UI upload button surfaces the outdated notification on open",
-  { tag: ["@release", "@workspace", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression"] },
   async ({ page }) => {
     let importedFlowId: string | undefined;
 
     await test.step("Bootstrap the flows page", async () => {
+      trackCreatedFlows(page);
       await awaitBootstrapTest(page, { skipModal: true });
       await expect(page.getByTestId("mainpage_title")).toBeVisible({
         timeout: 30000,

--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -32,16 +32,27 @@ test.beforeEach(async ({ page }) => {
 // the product fix itself landed upstream in langflow#14349 (*stop flow route request
 // storm*), whose files are present on `release-1.12.0`, so `@stable` is restored here
 // after re-validation on `1.12.0.dev23` (#966). See docs/flow-functionality/run-flow.md.
-// Quarantined at triage (daily #1544): hard failure on all three attempts — the
-// click on `refresh-dropdown-list-flow_name_selected` is refused by two overlays
-// taking the pointer events, `main_canvas_controls` and an
-// `assistant-onboarding-tooltip` popper this repository references nowhere. It
-// ran on shard 1, which the in-run liveness recorder measured at zero outages,
-// so the day's mass-failure verdict does not cover it. Lifting the quarantine
-// (remove test.fixme + restore @stable) is a deliverable of #1548.
-test.fixme(
+// Quarantine LIFTED 2026-09-10 (#1787), and the reason it outlived its cause is
+// worth recording. The 2026-08-21 daily (#1544) hard-failed all three attempts:
+// the click on `refresh-dropdown-list-flow_name_selected` was refused by two
+// overlays taking the pointer events, `main_canvas_controls` and an
+// `assistant-onboarding-tooltip` popper the suite referenced nowhere. TWO PRs
+// answered that on the same day — #1550 HARDENED the spec against exactly that
+// overlay (the `seedAssistantDiscovered` beforeEach above, plus dragging the node
+// to the upper-right canvas region so the flow-name popup clears the controls
+// band) and #1553 QUARANTINED it. #1553 merged second, so the mute won, and
+// #1548 — which carried the lift as a checklist deliverable — closed without
+// performing it. The mute has therefore been redundant since the day it landed:
+// the hardening for its own stated cause is in this file.
+//
+// The lift is evidence-backed, not optimism: with the modifier removed the test
+// measured 3/3 green across the nine #1784 dispatches on `1.13.0.dev7`
+// (`docs/triage/inherited-spec-triage.md`) and 3/3 again in this promotion's
+// burst on the same version. #1746's reconciler had already flagged this spec as
+// an orphaned removal, and #1783 listed it as such.
+test(
   "user should be able to use Run Flow without any issues",
-  { tag: ["@release", "@workspace", "@api", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@api", "@regression"] },
   async ({ page, request }) => {
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });


### PR DESCRIPTION
Closes #1787

The other half of #1786: promotes to `@stable` the T1 specs the #1784 triage table measured **3/3 green**. That measurement supplies **one** of design §3's four conditions; this PR adds the other three — a force-fail run per test, the flow-leak audit the table cannot render, and docs at the current cycle.

**Scope is 4 specs / 5 tests, not the 5 / 6 the issue lists.** `mcp-client-agent` is left out on ownership grounds, not test grounds — detail in §6.

## 1. Covered tests

| # | Test | What it validates |
|---|---|---|
| 1 | `dropping a collection file imports every flow it contains` | the number of `POST /api/v1/flows/` → `201` equals the asset's own `flows.length` (read from the file, so adding a flow to the fixture updates the expectation); every imported id is readable via `GET /flows/{id}`; at least one renders its `flow-name-<id>` card — anchored by id because the home list sorts `updated_at` DESC, so a positional match resolves to another worker's flow |
| 2 | `dropping a single flow file imports that flow` | exactly one `201`; the card shows the per-run random name; the server read-back returns that same name |
| 3 | `user should not be able to hide connected inputs` | the visibility toggle is **visible and disabled** rather than absent, the graph keeps **2 edges**, and after disconnecting the toggle re-enables and the input disappears — the disabled state is the product claim, so asserting absence would pass on a missing element |
| 4 | `importing an outdated flow via the UI upload button surfaces the outdated notification on open` | the banner `/\d+ components? needs? updates?/i` renders (count-agnostic: the outdated total is emergent from diffing a 1.4.0 snapshot against the nightly, and this matches both i18n plurals), and `update-all-button` reads `Review All` **or** `Update All` — either, so a benign breaking↔non-breaking flip does not false-fail |
| 5 | `user should be able to use Run Flow without any issues` | after `built successfully`, the output-inspection field holds **exactly** `THIS IS A TEST FOR RUN FLOW COMPONENT` — which proves the inner flow actually executed and returned its input, not merely that the node rendered |

## 2. The quarantine this PR lifts, and why it outlived its cause

`run-flow` carried `test.fixme` and no `@stable`. On **2026-08-21 two PRs answered the same daily failure**: #1550 **hardened** the spec against the `assistant-onboarding-tooltip` overlay that broke it — the `seedAssistantDiscovered` `beforeEach` plus dragging the node to the upper-right canvas region so the flow-name popup clears the controls band — and #1553 **quarantined** it. #1553 merged second, so the mute won. Then **#1548, which carried "remove `test.fixme` + restore `@stable`" as a checklist deliverable, closed without performing it.**

So the hardening for the mute's own stated cause has been sitting unused in the file for three weeks. #1746's reconciler had already flagged this spec as an **orphaned removal** and #1783 listed it as such — this is the class those mechanisms exist to surface.

Lifted with evidence rather than optimism: **3/3 green on `1.13.0.dev8`** with the modifier removed, and 3/3 in the #1784 measurement before that.

## 3. Two specs leaked flows, and they masked each other

This is the part worth carrying beyond this PR.

`awaitBootstrapTest` creates `New Flow` plus a second `Basic Prompting` when the project is empty, and neither spec captured those ids — so each run left the instance two flows heavier, on the **green** path as much as the red.

**A first audit blamed the wrong spec.** It ran the four specs in sequence with a single purge at the start:

```
purge once, in sequence:          purge before EACH spec:
  dragAndDrop        2              dragAndDrop        0   (already fixed)
  hidden-input-edges 0              hidden-input-edges 0
  import-outdated    0  ← FALSE     import-outdated    2   ← the real one
  run-flow           0              run-flow           0
```

`dragAndDrop` leaked first; its leftovers left the project non-empty, so every later spec's bootstrap created nothing and measured clean. **Fixing `dragAndDrop` is what exposed `import-outdated-flow`.** Any per-spec flow audit therefore has to purge **before each spec** — otherwise one leak masks the next and the clean specs are the ones that look guilty. Recorded in both docs.

Both are fixed by capturing the page's `POST /api/v1/flows` → `201` responses **before** the bootstrap, in the shape each spec needs:

- **`dragAndDrop` keeps two populations.** Its import-count assertion reads the array, so bootstrap ids must not land there. The author had installed the listener after the bootstrap on two stated grounds — that those flows are "shared bootstrap state, not ours to delete" and that counting their 201s would break the count. The second is right and is preserved; the first conflates a flow **this page created** with one another worker owns, and a parallel worker's bootstrap creates a different id, so deleting by id can never reach it. The two populations are discriminated by a flag read **synchronously** in the handler: the first attempt keyed on "is the import array still empty", which is a race between the two handlers' promises during the drop itself.
- **`import-outdated-flow` uses one deduped array**, since nothing asserts over it — deduped because the upload id is also pushed explicitly (it is needed to open the flow).

Verified on **both** paths, per spec, with a purge before each: **26 flows in, 26 flows out**.

## 4. The checklist bullet is corrected, not flipped

`run-flow`'s Part II bullet already read `[x]` with the text "`@stable` restored 2026-08-11 (#966)" while the spec had carried `test.fixme` and no tag since `ecf96d29`. **No guard detects that:** `check:checklist-coverage`'s stated invariant is *"a spec whose coverage is CLAIMED must be referenced in `QA-CHECKLIST.md`"* — spec→bullet, one direction. A `[x]` bullet whose spec lost `@stable` is unguarded, so the Coverage Summary counted validated coverage that did not exist. The bullet now states the real sequence. The general guard is adjacent to #1770 and is not built here.

The other three bullets flip `[-]` → `[x]`. Generated blocks untouched (#741).

## 5. Validation (nightly `1.13.0.dev8`, `--retries=0 --workers=1`)

Burst 3× per spec, with a flow purge before each spec:

| Spec | exp/unexp/flaky/skip | leaked |
|---|---|---|
| `dragAndDrop` | `2/0/0/0` ×3 | 0 |
| `general-bugs-hidden-input-edges` | `1/0/0/0` ×3 | 0 |
| `import-outdated-flow` | `1/0/0/0` ×3 | 0 |
| `run-flow` | `1/0/0/0` ×3 | 0 |

Zero `🚨 Backend Error`; the instance returns to its 26-flow baseline.

**The bursts were re-run in full on `dev8`.** The originals ran on `dev7`, the local Docker daemon then died mid-issue, and the restart pulled a newer nightly — so rather than leave the evidence split across two versions, everything was re-measured. 15 clean executions on each. All four docs' `Last validated` say `dev8`.

Force-fail: **5/5 recorded**, every mutation reverted, zero `FF-MUTATION` markers in the diff, final green run per file (4/4):

```
FF: dropping a collection file ...      .toBe(expectedCount) -> expectedCount + 7
FF: dropping a single flow file ...     the server read-back name -> a literal no flow carries
FF: user should not be able to hide ... toHaveCount(2) -> toHaveCount(9)
FF: importing an outdated flow ...      toHaveText(/Review All|Update All/) -> a pattern never rendered
FF: user should be able to use Run Flow the output value -> a string the flow never returns
```

Gates: `typecheck` ✅ · `lint` ✅ · `check:checklist-coverage` ✅ · QA-CHECKLIST guard ✅ · spec-doc dependency paths ✅ · `test:units` `fail 0` ✅ · `test:pipeline` `fail 0` ✅.

`--trace=on` was deliberately not used: it hangs UI specs on this host (Colima).

## 6. Why `mcp-client-agent` is not here

**Ownership, not test quality.** #963 is **open on the exact same test and line**, assigned to another engineer, and #809 is open there too. The measurement's `6/6 green, 3 skipped` does **not** cover #963's case: it names `gemini-2.5-flash`, which `collect-models` reports as retired from the catalog, so the sweep settled on `gemini-3.5-flash` — a different model, which neither reproduces nor refutes the recorded symptom. The evidence was handed to #963 as a comment, explicitly as input rather than a verdict, and the spec is untouched by this PR.

## 7. Two things a reviewer should see

**No functional tag was added.** None of the five tests carries one, and no tag in `CLAUDE.md`'s table fits file drag-and-drop, flow import, connected-input visibility or Run Flow — `@workspace`, `@mainpage`, `@api` and `@database` are all cross-cutting. Inventing one is against the guardrail; `CLAUDE.md` itself measures 104 of 298 specs in this state.

**A pipeline gap found in passing, worth its own issue.** `ff-run` answered *"the test cannot detect it; strengthen the assert"* for a run whose `--grep` matched **zero tests** (an invented title on my side). The pipeline's own rule is that a run executing nothing is refused naming the cause; `ff-run` does not distinguish "ran and passed" from "matched nothing", and the inverted diagnosis invites weakening an assertion that is sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
