### PR TITLE
test(triage): promote the 4 T1 specs blocked on cleanup or a doc (#1788)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -429,7 +429,7 @@
 
 #### 4.3 Global Variables (API Keys)
 - [x] Create global variable
-- [-] Use global variable in component (API key) → `ui-ux/use-global-variable-in-component.spec.ts`
+- [x] Use global variable in component (API key) → `ui-ux/use-global-variable-in-component.spec.ts`
 - [x] Edit existing global variable — quarantine lifted 2026-08-11 (#1235). The row click was silently dropped while the RBAC permission query loaded, so the Update Variable modal never opened (dailies 2026-07-27 and 2026-08-03, [LE-2123](https://datastax.jira.com/browse/LE-2123)); fixed upstream by langflow#14404 (permission loading state) and re-validated on `1.12.0.dev23`. The provider-credential removal below (§7.5) was grouped here at triage and proved to be a separate *test* defect, fixed in #1276 → `ui-ux/global-variable-edit.spec.ts`
 - [x] Delete global variable → `ui-ux/global-variables-crud.spec.ts`
 - [x] Create global variable of type "Generic" → `ui-ux/global-variables-crud.spec.ts`
@@ -684,10 +684,12 @@
 - [x] Create folder after deleting all folders — creating a folder right after a deletion works (no stale-cache collision) → `core-functionality/project-management/folder-deletion-integrity.spec.ts`
 - [-] Deleting every folder lands on the empty-project screen (sidebar empty message + `new_project_btn_empty_page`) → `core-functionality/project-management/folder-deletion-integrity.spec.ts` (`@destructive` — account-wide wiper, runs only in the low-concurrency lane via `PW_DESTRUCTIVE=1`, see #1010; stays `[-]` permanently, since `[x]` requires `@stable` and `@destructive` must never carry it — the pair would mean "runs nowhere")
 - [x] Upload flow by drag-and-drop to folder — dropping a collection file imports one flow per entry; dropping a single flow file imports exactly one → `flow-functionality/dragAndDrop.spec.ts`
+- [x] Create a flow inside a specific folder via API — `POST /api/v1/flows/` with an explicit `folder_id` echoes back that same `folder_id`, so the flow lands in the folder and not in the default project → `core-functionality/project-management/folder-drag-drop-flow.spec.ts`
 - [-] Move flow to another folder
 
 #### 10.2 Folder Navigation
 - [x] Navigate between folders → `core-functionality/project-management/flow-navigation-between-folders.spec.ts`
+- [x] A folder lists the flows it contains — the folder created over the API appears in the home sidebar under either testid spelling (#1363) and clicking it lists the flow created inside it, addressed by its own unique name → `core-functionality/project-management/folder-drag-drop-flow.spec.ts`
 - [-] Search flow by name filters results correctly
 - [-] Folders in navigation sidebar
 
@@ -864,6 +866,7 @@
 - [x] Starter project with MCP → `mcp/server/mcp-server-starter-projects.spec.ts`
 - [x] Flow exposed as MCP server — verify generated endpoint, and that the transport takes an API key: the same `initialize` with no credential is refused `403` (#1522) → `mcp/server/mcp-server-protocol.spec.ts`
 - [x] Execute MCP server tool via MCP protocol → `mcp/server/mcp-server-protocol.spec.ts`
+- [x] A flow created MCP-enabled is exposed end to end — it is listed by name in the MCP Server tab's tool list, the JSON config advertises the project's `mcp/project/<id>/streamable` URL, and that endpoint answers a JSON-RPC `initialize` with `200` when carrying an `x-api-key` → `mcp/server/mcp-server-regression.spec.ts`
 - [x] Register an external MCP server through the stdio form — `command` + `args` resolves the server's real tools into the MCPTools node → `mcp/server/mcp-server.spec.ts`
 - [x] Add-server modal fields persist across save → reopen-for-edit — stdio (name, command, 4 args, 2 env pairs) and HTTP/SSE (name, URL, 2 headers, 2 env pairs) → `mcp/server/mcp-server.spec.ts`
 - [x] Tool list refreshes when a registered server is edited to run a different package → `mcp/server/mcp-server.spec.ts`

--- a/docs/core-functionality/project-management/folder-drag-drop-flow.md
+++ b/docs/core-functionality/project-management/folder-drag-drop-flow.md
@@ -1,0 +1,153 @@
+# Project Management – Flow Placement in a Folder (API and Listing)
+
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev8`)
+
+---
+
+## What this test validates *(required)*
+
+Validates that a folder (project) is a real container for flows on both surfaces
+the product exposes, one test per surface:
+
+1. **API placement** — `POST /api/v1/flows/` with an explicit `folder_id` creates
+   the flow **inside** that folder, and the `201` body echoes back the same
+   `folder_id` it was given. This is the contract every other spec relies on when
+   it seeds a flow into a folder over the API instead of dragging it in the UI.
+2. **Listing** — a folder created over the API appears in the home sidebar, and
+   clicking it lists the flow that was created inside it. The flow is addressed by
+   its own unique name (`ui-flow-<timestamp>`), so the assertion cannot be
+   satisfied by an unrelated pre-existing flow.
+
+The two tests are deliberately not one: the first is a pure API contract and
+finishes in ~1 s, the second needs a browser and the home page. Merging them
+would make an API regression indistinguishable from a sidebar regression.
+
+**Scope note — the folder MOVE assertion does not live here.** A third test
+(`moving a flow to another folder via API PATCH updates folder_id`) was removed
+from this file by #932: it duplicated `api/flows/api-folders-crud.spec.ts` test 4
+line for line, differing only in using the `/api/v1/folders/` legacy alias, and it
+was not quarantined — so silencing the canonical test left the identical failure
+reachable from a second file. The underlying failure is a product defect
+(`PATCH /api/v1/flows/{id}` answers `500 (sqlite3.OperationalError) database is
+locked` under two concurrent writers, 14/24; 0/30 serial — tracked upstream as
+LE-2020, evidence in
+`docs/upstream-bugs/UPSTREAM-BUG-flow-patch-500-under-contention.md`). The restore
+point is `api-folders-crud.spec.ts` test 4, not this file.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@workspace` `@regression`
+
+---
+
+## Step by step *(required)*
+
+### Test 1 — creating a flow in a specific folder via API places it in that folder
+
+1. Mint a bearer with `getAuthToken(request)`.
+2. `POST /api/v1/folders/` with a unique name (`test-folder-<timestamp>`); assert
+   `201` and capture the folder id. `/api/v1/folders/` is a `307` alias of
+   `/api/v1/projects/`, and it is used here on purpose — the alias is part of the
+   contract this file covers.
+3. `POST /api/v1/flows/` with `folder_id` set to that id, an empty graph
+   (`nodes: []`, `edges: []`) and `is_component: false`; assert `201`.
+4. Assert the response body's `folder_id` **equals** the folder id that was
+   requested.
+5. **Cleanup (finally):** delete the created flow id-scoped through `deleteFlow`,
+   then `DELETE /api/v1/folders/{id}`. Both are attempted even when the assertion
+   above failed.
+
+### Test 2 — folder listing shows flows correctly via UI
+
+1. Mint a bearer; create the folder (`ui-folder-<timestamp>`) and, inside it, a
+   flow (`ui-flow-<timestamp>`) over the API, exactly as in test 1.
+2. Enter the app with `awaitBootstrapTest(page, { skipModal: true })`.
+3. Assert the folder's home-sidebar entry is visible, addressed through
+   `projectSidebarEntry(page, { id, name })` — the nightly keys the testid on the
+   project **id** and `1.11.x` on its **name**, and the helper matches both (#1363).
+4. Click that entry.
+5. Assert the flow's unique name is visible in the main content area.
+6. **Cleanup (afterEach + finally):** the flow and the folder created here are
+   deleted id-scoped as in test 1, and every flow the **page** created is deleted
+   through `trackCreatedFlows` — see *Why the tracker is needed on top of the
+   explicit deletes* below.
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1 fails** if `POST /api/v1/flows/` answers anything but `201`, or answers
+  `201` with a `folder_id` that is not the one requested (a flow silently landing
+  in the default project).
+- **Test 2 fails** if the folder never appears in the home sidebar under either
+  testid spelling, or if the flow created inside it is not listed after the folder
+  is opened.
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/api/v1/projects.py` — the projects (folders) router
+  that `/api/v1/folders/` `307`-redirects onto: `POST /` (create) and `DELETE /{id}`.
+- `src/backend/base/langflow/api/v1/flows.py` — `POST /api/v1/flows/`, which is
+  what must honour an explicit `folder_id` instead of falling back to the default
+  project, and `DELETE /api/v1/flows/{id}`.
+- `src/frontend/src/components/core/folderSidebarComponent/components/sideBarFolderButtons/index.tsx`
+  — the home sidebar project list this spec clicks; it is where the project entry's
+  testid is spelled (`sidebar-nav-<id>` on the nightly, `sidebar-nav-<name>` on
+  `1.11.x` — #1363).
+- REST API: `POST`/`DELETE /api/v1/folders/` (a `307` alias of
+  `/api/v1/projects/`) and `POST`/`DELETE /api/v1/flows/` with `folder_id`; auth
+  via `getAuthToken`.
+- Home sidebar testids: the project entry and the container it is scoped to
+  (`project-sidebar`), both addressed through `tests/helpers/ui/project-sidebar.ts`,
+  which matches `sidebar-nav-<project id>` (the nightly) and `sidebar-nav-<name>`
+  (`main` and `1.11.x`) — see #1363.
+- Helpers: `tests/helpers/auth/get-auth-token.ts`,
+  `tests/helpers/flows/delete-flow.ts`,
+  `tests/helpers/flows/track-created-flows.ts`,
+  `tests/helpers/other/await-bootstrap-test.ts`,
+  `tests/helpers/ui/project-sidebar.ts`.
+- No LLM or provider API key required (model-independent).
+
+---
+
+## Why the tracker is needed on top of the explicit deletes *(optional)*
+
+Both tests already delete the flow and the folder they create by id. Measured on
+2026-09-10 against a **purged** instance (0 user flows, default project empty),
+the file still left **2** flows behind: `New Flow` and `Basic Prompting`.
+
+They come from `awaitBootstrapTest`, not from the test body: when the default
+project is empty the home page renders `new_project_btn_empty_page` and the helper
+calls `addFlowToTestOnEmptyLangflow`, which creates both. Nothing in this file ever
+saw their ids, so a source grep for `deleteFlow` reports this spec as clean while it
+leaks on every run against a fresh instance — which is why the leak audit is a
+measurement (purge, run, diff the flow list) and never a grep.
+
+`trackCreatedFlows(page)` captures every `POST /api/v1/flows/` → `201` the page
+performs and deletes those ids in `afterEach`, id-scoped. It never touches a flow
+another parallel worker created.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Folder CRUD through the UI (create / rename / delete) — `folder-crud.spec.ts`.
+- Moving a flow **between** folders — see the Scope note above;
+  `api/flows/api-folders-crud.spec.ts` test 4.
+- Drag-and-drop of a flow **file** onto a folder (import) —
+  `flow-functionality/dragAndDrop.spec.ts`.
+- Deletion integrity across folders — `folder-deletion-integrity.spec.ts`.
+- Navigating between two folders — `flow-navigation-between-folders.spec.ts`.
+
+---
+
+## Preconditions *(optional)*
+
+- A running Langflow instance at `PLAYWRIGHT_BASE_URL`, in auto-login mode or with
+  the superuser credentials configured (`getAuthToken` covers both).
+- No provider credential and no seeded flow required — both tests create every
+  object they assert on.

--- a/docs/mcp/server/mcp-server-regression.md
+++ b/docs/mcp/server/mcp-server-regression.md
@@ -1,0 +1,143 @@
+# MCP Server – A Flow Is Exposed as an MCP Tool, End to End
+
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev8`)
+
+---
+
+## What this test validates *(required)*
+
+One test, four observables, walking the whole path from "a flow exists" to "an MCP
+client can talk to the project that exposes it":
+
+1. **The flow is created MCP-enabled.** `setupPlayground` posts
+   `mcp_enabled: true` explicitly, because the SPA's `createNewFlow` hardcodes it
+   while the column defaults to `false` — a flow created over the API without it is
+   never exposed as a tool, and this spec is what catches that on a clean instance.
+2. **The MCP Server tab lists THIS flow by name.** The assertion is built from the
+   flow's own unique name, not from a `count > 0` on the tools list, which would
+   pass for any unrelated pre-existing flow.
+3. **The connection config advertises the project endpoint.** The JSON tab must
+   render a URL matching `mcp/project/<project id>/streamable`.
+4. **That endpoint actually answers the MCP handshake.** A JSON-RPC `initialize`
+   against `POST /api/v1/mcp/project/{project_id}/streamable` returns `200`.
+
+**The credential on step 4 is the assertion, not plumbing (#1522).** This POST used
+to carry no credential at all and assert `200`, which `1.12.0.dev31` answered — that
+build served the transport to anyone, so the assertion passed while exercising no
+auth whatsoever. Since `1.12.0.dev33` a keyless caller is refused `403`. The test
+therefore mints a real API key, sends it as `x-api-key` (the only credential the
+transport accepts — a JWT is also refused), and deletes the key in `finally`.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@mcp` `@regression`
+
+---
+
+## Step by step *(required)*
+
+1. Create a wired `ChatInput → ChatOutput` flow with `setupPlayground(page)`, which
+   returns its id. **No `awaitBootstrapTest` here, deliberately** (#988): the helper
+   creates the flow over the API and navigates straight to its canvas, whereas
+   entering through the home page would have the "New Flow" entry point eagerly
+   create a throwaway flow that nothing in this path disposes of. That decision is
+   why this file is the only one of the four in #1788 that leaks **zero** flows.
+2. Read the flow back (`GET /api/v1/flows/{id}`) and capture its server-assigned
+   name — `E2E Playground <16 hex>`. Assert the name is non-empty: an empty name
+   would turn every text assertion below into a match against anything.
+3. Go to `/`, open the MCP Server tab (`mcp-btn`) and assert its title
+   (`mcp-server-title`) is visible.
+4. Assert the tools container (`div-mcp-server-tools`) is visible and contains the
+   flow's slug — see *How the slug is derived* below.
+5. Click the **JSON** tab and assert the rendered config contains a URL matching
+   `/mcp\/project\/.+\/streamable/`.
+6. Resolve the project id from `GET /api/v1/projects/`, normalising both response
+   shapes (a bare array, or `{ folders: [...] }`), and assert at least one project
+   exists.
+7. Mint an API key (`createApiKey`, prefix `e2e-mcp-regression`), `POST` a JSON-RPC
+   `initialize` (protocol `2024-11-05`) to the project's `streamable` route with
+   `x-api-key`, and assert `200`.
+8. **Cleanup:** the API key is deleted in `finally`; the flow is deleted id-scoped
+   in `afterEach` through `deleteFlow`.
+
+---
+
+## Validation criterion *(required)*
+
+The test fails if any of these does not hold: the created flow's name never appears
+in the MCP Server tab's tools list; the JSON config carries no project `streamable`
+URL; or the `initialize` handshake against that endpoint answers anything but
+`200` while carrying a valid `x-api-key`.
+
+---
+
+## External dependencies *(required)*
+
+- REST API: `POST`/`GET`/`DELETE /api/v1/flows/` (with `mcp_enabled`),
+  `GET /api/v1/projects/`, `GET`/`PATCH /api/v1/mcp/project/{project_id}` (the tool
+  metadata this spec reads through the UI), `POST /api/v1/mcp/project/{project_id}/streamable`
+  (Streamable HTTP transport, `x-api-key` only), and the API-key endpoints behind
+  `createApiKey` / `deleteApiKey`.
+- UI testids: `mcp-btn`, `mcp-server-title`, `div-mcp-server-tools`, and the
+  **JSON** tab addressed by role/name.
+- `src/backend/base/langflow/api/v1/mcp_projects.py` — the project-scoped MCP
+  server: the `/{project_id}/streamable` route this spec handshakes against, and
+  the `GET`/`PATCH /{project_id}` tool metadata the tab renders.
+- `src/lfx/src/lfx/base/mcp/util.py` — `sanitize_mcp_name`, which derives the tool
+  name from the flow name (see *How the slug is derived* below).
+- `src/backend/base/langflow/api/v1/api_key.py` — the API-key endpoints behind
+  `createApiKey` / `deleteApiKey`; the transport accepts `x-api-key` and nothing
+  else (#1522).
+- `src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx` —
+  the MCP Server tab: the tools list (`div-mcp-server-tools`), the title
+  (`mcp-server-title`) and the JSON config panel.
+- Helpers: `tests/helpers/flows/setup-playground.ts`,
+  `tests/helpers/flows/delete-flow.ts`,
+  `tests/helpers/auth/create-api-key.ts`,
+  `tests/helpers/auth/get-auth-token.ts`.
+- No LLM or provider API key required — the flow is never run, only exposed.
+
+---
+
+## How the slug is derived *(optional)*
+
+`sanitize_mcp_name(name, max_length=46)` strips emoji and diacritics, replaces every
+run of spaces **and hyphens** with a single `_`, collapses repeats, trims leading and
+trailing `_`, **lowercases**, and truncates at 46 characters. Measured on
+`1.13.0.dev8`: a flow named `E2E Slug Probe abcdef0123456789` is exposed with
+`action_name: "e2e_slug_probe_abcdef0123456789"`.
+
+The test builds its expectation as `flowName.toUpperCase().replace(/\s+/g, "_")` and
+matches it with `getByText(slug, { exact: false })`, which is **case-insensitive**
+and whitespace-normalising — that, not an uppercase rendering, is why an uppercase
+expectation matches a lowercase tool name. The discriminating part of the slug is the
+16 hex digits, which is what makes the assertion about this flow and no other.
+
+Two constraints on the name follow from the same function and are already honoured by
+`setupPlayground`: hyphens normalise exactly like spaces, so a raw UUID would make the
+slug ambiguous (it strips them), and the 46-character truncation means the whole name
+has to stay well under it.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Executing the exposed tool over the protocol (`tools/list`, `tools/call`) and the
+  keyless-`403` assertion in isolation — `mcp-server-protocol.spec.ts`.
+- Registering an **external** MCP server (stdio / HTTP / SSE forms) —
+  `mcp-server.spec.ts`.
+- Selecting **which** flows a project exposes (`GET`/`PATCH /{project_id}`) —
+  `mcp-server-project-config.spec.ts`.
+- Flow files exposed as MCP **resources** — `mcp-server-resources.spec.ts`.
+- MCP prompts (`prompts/list`) — no product surface; the server returns `[]` (#829).
+
+---
+
+## Preconditions *(optional)*
+
+- A running Langflow instance at `PLAYWRIGHT_BASE_URL`, in auto-login mode or with
+  the superuser credentials configured.
+- At least one project must exist — the default `Starter Project` satisfies this, and
+  step 6 asserts it rather than assuming it.

--- a/docs/ui-ux/settings-shortcuts-edit.md
+++ b/docs/ui-ux/settings-shortcuts-edit.md
@@ -12,9 +12,13 @@ Key implementation detail: the shortcut store (`useShortcutsStore`) writes to `l
 
 ## Tags
 
-`@release` `@regression` `@settings` `@ui-ux`
+`@stable` `@release` `@regression` `@settings` `@ui-ux`
 
-<!-- @stable will be added in a follow-up PR after the full validation pipeline passes against a current Langflow nightly. -->
+`@stable` was added by #1788, on the evidence the inherited-spec triage table
+produced (`docs/triage/inherited-spec-triage.md`): 3/3 green over nine
+`manual.yml` dispatches at `retries=0`, plus the force-fail run and the
+id-scoped cleanup that promotion also requires. No lane selector is present, so
+the tag cannot silence the spec (#1010).
 
 ## Validation criterion
 
@@ -32,6 +36,24 @@ Key implementation detail: the shortcut store (`useShortcutsStore`) writes to `l
 - `src/frontend/src/stores/shortcuts.ts` — Zustand store persisting to `localStorage["langflow-shortcuts"]`.
 - `src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx` — `user-profile-settings` testid (entry point to Settings).
 
+## Flow cleanup
+
+The test creates flows on two paths and used to delete neither. Measured on
+2026-09-10 against a purged instance (0 user flows, default project empty), one
+run left **3** behind: `New Flow` and `Basic Prompting` — created by
+`awaitBootstrapTest` → `addFlowToTestOnEmptyLangflow` when the default project is
+empty — plus `New Flow (2)`, the blank flow the test itself opens to reach the
+canvas.
+
+`trackCreatedFlows(page)` now captures every `POST /api/v1/flows/` → `201` the
+page performs and `afterEach` deletes exactly those ids. The pre-existing
+`afterEach` still restores the shortcut table (UI **Restore**, with a
+`localStorage` fallback); the two teardowns are independent and both run.
+
+Reading this off a source grep does not work: the two bootstrap flows are created
+by a helper, so a file that never spells `deleteFlow` and a file that leaks are not
+the same set. The audit is purge → run one spec → diff the flow list.
+
 ## Last validated
 
-1.11.x
+1.13.x (nightly `1.13.0.dev8`)

--- a/docs/ui-ux/use-global-variable-in-component.md
+++ b/docs/ui-ux/use-global-variable-in-component.md
@@ -1,6 +1,6 @@
 # Use Global Variable in Component (API key)
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev8`)
 
 ---
 
@@ -30,11 +30,14 @@ typed directly into fields.
 
 ## Tags *(required)*
 
-`@release` `@workspace` `@regression`
+`@stable` `@release` `@workspace` `@regression`
 
-> `@stable` intentionally withheld until the full 7-step validation pipeline
-> (typecheck, lint, run `--retries=0`, force-fail, `--trace=on`, backend-error audit)
-> has been executed and the team has reviewed the spec.
+`@stable` was added by #1788, after the validation the tag requires actually ran:
+3/3 green in the inherited-spec triage table
+(`docs/triage/inherited-spec-triage.md`), then a force-fail run per test and the
+id-scoped flow cleanup. The promotion also **fixed a latent strict-mode defect the
+table could not see** — see *The `.or()` gate was flaky by construction* below.
+No lane selector is present, so the tag cannot silence the spec (#1010).
 
 ---
 
@@ -147,6 +150,14 @@ Confirmed testids (verified against the live DOM):
 - `try/finally` cleanup deletes the created variable via the REST API (looked up by name),
   so it runs even when assertions fail mid-test, preventing cross-run pollution. Uses the
   `request` fixture with a Bearer token from `getAuthToken`.
+- **The secret-absence assertion is narrower than it reads.** `expect(page.getByText(sentinelValue)).toHaveCount(0)`
+  matches **text nodes** only. The sentinel is typed into an `<input>`, and
+  `getByText` never reads an input's `value`, so a leak of the resolved credential
+  *into a field value* would not fail this. It is kept because it does cover the
+  case that matters most here — the secret rendered as visible page text, e.g. in
+  the bound-value badge or a tooltip — but "never leaks the secret" is not what it
+  proves. Widening it would take a `toHaveValue`/`inputValue` assertion on the
+  specific field, which is a separate piece of work.
 - **Indirect mechanism justified:** in the auto-bound state the field's dropdown-trigger
   button (the next sibling of the badge wrapper) has its icon fail to render — an upstream
   Langflow gap — leaving it a zero-width/zero-height but fully attached, click-functional
@@ -154,3 +165,78 @@ Confirmed testids (verified against the live DOM):
   the helper asserts `toBeAttached()` and fires `dispatchEvent("click")` (Playwright's
   documented geometry-independent click). The clean/empty-field path (no pre-existing
   variable, as on fresh CI) uses the normal visible `icon-Globe` + `.click()`.
+
+---
+
+## The `.or()` gate was flaky by construction *(optional)*
+
+`createAndBindCredentialVariable` waits for "the variable is bound **or** it is
+listed in the still-open dropdown" before binding. That was written as
+`expect(boundValue.or(optionRow)).toBeVisible()`, which asserts more than it means:
+`.or()` resolving to two elements is a **strict mode violation**, and the two states
+are not mutually exclusive.
+
+Measured on `1.13.0.dev8`, creating the variable from the field's own dropdown does
+**both** — it auto-binds the variable *and* leaves the dropdown open listing it — so
+the locator resolves to 2 elements and the assertion fails:
+
+```
+strict mode violation: ...getByText('gv-api-key-…').or(getByTestId('option-gv-api-key-…'))
+resolved to 2 elements
+```
+
+2/2 red locally on the spec the triage table recorded 3/3 green: CI happened to poll
+in the window where only the option row had rendered. This is a race, not a version
+regression, and promoting it unchanged would have imported a flake into the daily.
+
+Two changes fix it. The wait takes `.first()`, so it means "whichever of the two"
+rather than "exactly one of the two exists". And the explicit bind is guarded on the
+field **not** already showing the variable — clicking the option row of an
+already-bound variable is a second toggle on the same value, which is how a passing
+bind gets undone. After the fix: 2/2 green, and the real postcondition
+(`boundValue` visible) is asserted unconditionally, unchanged.
+
+---
+
+## What the force-fail audit changed *(optional)*
+
+#1788's force-fail run is the reason this spec grew an assertion, and the finding is
+worth keeping rather than just the fix.
+
+The test is titled *bind a **Credential** global variable*, and nothing in it verified
+the type. Removing the `credential-tab` click — the one line whose comment claimed it
+is what stops a **Generic** variable being created — left the test **green**: the
+bound value the field renders is the variable **name**, which is identical either way.
+A regression that made that tab write the wrong type would have gone unnoticed.
+
+`expectCredentialVariable(request, varName)` now reads the variable back over
+`GET /api/v1/variables/` and asserts `type === "Credential"`, because the type is not
+rendered anywhere on the canvas once the variable is bound.
+
+**The second half of that measurement corrected the spec's own comment.** With the
+type assertion in place, removing the `credential-tab` click *still* passes on
+`1.13.0.dev8`: opening "Add New Variable" from a `SecretStrInput`'s own dropdown
+already creates a Credential. So the click is belt-and-braces, not the thing that
+decides the type — the comment asserting otherwise was wrong, and is now corrected in
+the spec.
+
+The force-fail that does discriminate test 1 is creating and binding a
+**differently-named** variable than the one the assertions name: both the bound-value
+assertion and the type readback go red. For test 2 it is removing the autosave wait
+before the reload, which confirms the persistence claim is real — the rehydrated node
+comes back **without** the binding, so auto-bind does not silently rescue the
+assertion.
+
+---
+
+## Flow cleanup *(optional)*
+
+The `try/finally` deletes the global **variable**, and always did. It never deleted
+the **flows**. Measured on 2026-09-10 against a purged instance, one run of this file
+left **4** behind: `New Flow` and `Basic Prompting` (created by `awaitBootstrapTest`
+→ `addFlowToTestOnEmptyLangflow` when the default project is empty), plus one blank
+flow per test.
+
+`trackCreatedFlows(page)` now captures every `POST /api/v1/flows/` → `201` the page
+performs, and `afterEach` deletes exactly those ids. The variable deletion stays in
+each test's own `finally`, since it is scoped to that test's `varName`.

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-drag-drop-flow.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-drag-drop-flow.spec.ts
@@ -3,10 +3,11 @@ import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-te
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { projectSidebarEntry } from "../../../../helpers/ui/project-sidebar";
+import { trackCreatedFlows } from "../../../../helpers/flows/track-created-flows";
 
 test(
   "creating a flow in a specific folder via API places it in that folder",
-  { tag: ["@release", "@workspace", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression"] },
   async ({ request }) => {
     const authToken = await getAuthToken(request);
 
@@ -76,11 +77,12 @@ test(
 
 test(
   "folder listing shows flows correctly via UI",
-  { tag: ["@release", "@workspace", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression"] },
   async ({ page, request }) => {
     const authToken = await getAuthToken(request);
     const folderName = `ui-folder-${Date.now()}`;
     const flowName = `ui-flow-${Date.now()}`;
+    let pageFlows: ReturnType<typeof trackCreatedFlows> | undefined;
 
     // Create folder and flow via API
     const folderRes = await request.post("/api/v1/folders/", {
@@ -108,6 +110,15 @@ test(
       expect(flowRes.status()).toBe(201);
       const flow = await flowRes.json();
       flowId = flow.id;
+
+      // The explicit deletes below only reach what THIS file created over the API.
+      // `awaitBootstrapTest` also creates `New Flow` and `Basic Prompting` whenever
+      // the default project is empty, and nothing here ever saw those ids — measured
+      // 2 leaked flows per run against a purged instance, on a spec a source grep
+      // reports as id-scoped precisely because the creation happens inside a helper
+      // (#1788). Installed BEFORE the navigation, so the bootstrap's own creations
+      // are captured.
+      pageFlows = trackCreatedFlows(page);
 
       // Navigate to the home page and wait for it to load
       await awaitBootstrapTest(page, { skipModal: true });
@@ -137,6 +148,12 @@ test(
           headers: { Authorization: authToken },
         })
         .catch(() => {});
+      // Last, and unconditional: the folder delete above cascades only over flows
+      // INSIDE that folder, while the bootstrap's two land in the default project.
+      if (pageFlows) {
+        await pageFlows.cleanup(request);
+        pageFlows.dispose();
+      }
     }
   },
 );

--- a/tests/tests-automations/regression/mcp/server/mcp-server-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-regression.spec.ts
@@ -19,7 +19,7 @@ test.describe("MCP Server – Flow Exposed as MCP Tool", () => {
 
   test(
     "flow appears as MCP tool in MCP Server tab and endpoint responds",
-    { tag: ["@mcp", "@regression"] },
+    { tag: ["@stable", "@mcp", "@regression"] },
     async ({ page }) => {
       let flowName = "";
 
@@ -52,9 +52,16 @@ test.describe("MCP Server – Flow Exposed as MCP Tool", () => {
         await expect(page.getByTestId("div-mcp-server-tools")).toBeVisible({
           timeout: 10000,
         });
-        // Langflow renders flow names in the MCP tools list as uppercase slugs
-        // (e.g. "New Flow" → "NEW_FLOW"). Build the same slug to pinpoint THIS flow
-        // instead of asserting a generic count > 0 which can pass for any prior flow.
+        // Build the flow's own tool slug to pinpoint THIS flow, instead of
+        // asserting a generic count > 0 which can pass for any prior flow.
+        //
+        // The slug is NOT uppercase, as an earlier version of this comment said:
+        // `lfx.base.mcp.util.sanitize_mcp_name` lowercases, so the flow
+        // "E2E Slug Probe abcdef0123456789" is exposed as
+        // `e2e_slug_probe_abcdef0123456789` (measured on 1.13.0.dev8 via
+        // GET /api/v1/mcp/project/{id}). The uppercase expectation matches only
+        // because `getByText(..., { exact: false })` is case-insensitive; the
+        // discriminating part is the 16 hex digits, not the casing.
         const flowSlug = flowName.toUpperCase().replace(/\s+/g, "_");
         await expect(
           page.getByTestId("div-mcp-server-tools").getByText(flowSlug, { exact: false }),

--- a/tests/tests-automations/regression/ui-ux/settings-shortcuts-edit.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/settings-shortcuts-edit.spec.ts
@@ -1,8 +1,28 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-templates-modal";
+import { trackCreatedFlows } from "../../../helpers/flows/track-created-flows";
 
 test.describe("Settings — Edit Shortcut", () => {
+  // The test creates flows on two paths and deleted neither: `awaitBootstrapTest`
+  // creates `New Flow` and `Basic Prompting` whenever the default project is empty,
+  // and the canvas step opens a blank flow of its own. Measured against a purged
+  // instance, one run left 3 behind (#1788). A source grep could not see it — the
+  // first two are created inside a helper — so the tracker captures every
+  // `POST /api/v1/flows/` → 201 the page performs and deletes exactly those ids.
+  let flows: ReturnType<typeof trackCreatedFlows>;
+
+  test.beforeEach(async ({ page }) => {
+    flows = trackCreatedFlows(page);
+  });
+
+  // Two independent teardowns, both of which must run: this one sweeps the flows,
+  // the one below restores the shortcut table.
+  test.afterEach(async ({ request }) => {
+    await flows.cleanup(request);
+    flows.dispose();
+  });
+
   test.afterEach(async ({ page }) => {
     try {
       await page.goto("/settings/shortcuts");
@@ -27,7 +47,7 @@ test.describe("Settings — Edit Shortcut", () => {
 
   test(
     "editing the Duplicate shortcut persists and triggers the action on canvas",
-    { tag: ["@release", "@regression", "@settings", "@ui-ux"] },
+    { tag: ["@stable", "@release", "@regression", "@settings", "@ui-ux"] },
     async ({ page }) => {
       await test.step("load home", async () => {
         await awaitBootstrapTest(page, { skipModal: true });
@@ -41,7 +61,9 @@ test.describe("Settings — Edit Shortcut", () => {
           timeout: 10000,
         });
 
-        await page.getByRole("link", { name: "Shortcuts", exact: true }).click();
+        await page
+          .getByRole("link", { name: "Shortcuts", exact: true })
+          .click();
 
         await expect(page.getByTestId("settings_menu_header")).toContainText(
           "Shortcuts",
@@ -60,17 +82,15 @@ test.describe("Settings — Edit Shortcut", () => {
         await expect(
           page.getByText("Key Combination", { exact: true }),
         ).toBeVisible({ timeout: 5000 });
-        await expect(
-          page.getByText("Recording your keyboard"),
-        ).toBeVisible({ timeout: 5000 });
+        await expect(page.getByText("Recording your keyboard")).toBeVisible({
+          timeout: 5000,
+        });
       });
 
       await test.step("record Ctrl/Cmd+Alt+U and apply", async () => {
         await page.keyboard.press("ControlOrMeta+Alt+U");
 
-        await page
-          .getByRole("button", { name: "Apply", exact: true })
-          .click();
+        await page.getByRole("button", { name: "Apply", exact: true }).click();
 
         await expect(
           page.getByText("Duplicate shortcut successfully changed"),
@@ -80,7 +100,9 @@ test.describe("Settings — Edit Shortcut", () => {
           .locator("[role='row']")
           .filter({ hasText: "Duplicate" })
           .first();
-        await expect(duplicateRowAfter).toContainText(/Alt/i, { timeout: 5000 });
+        await expect(duplicateRowAfter).toContainText(/Alt/i, {
+          timeout: 5000,
+        });
         await expect(duplicateRowAfter).toContainText("U", { timeout: 5000 });
       });
 

--- a/tests/tests-automations/regression/ui-ux/use-global-variable-in-component.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/use-global-variable-in-component.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { trackCreatedFlows } from "../../../helpers/flows/track-created-flows";
 
 // Consumption side of global variables: binding a Credential-typed variable to a
 // component's secret field (OpenAI `api_key`, a SecretStrInput) via the field's
@@ -23,7 +24,9 @@ async function addOpenAiComponent(page: Page): Promise<void> {
 
   await page.getByTestId("sidebar-search-input").click();
   await page.getByTestId("sidebar-search-input").fill("openai");
-  await page.waitForSelector('[data-testid="openaiOpenAI"]', { timeout: 30000 });
+  await page.waitForSelector('[data-testid="openaiOpenAI"]', {
+    timeout: 30000,
+  });
   await page
     .getByTestId("openaiOpenAI")
     .hover()
@@ -32,7 +35,9 @@ async function addOpenAiComponent(page: Page): Promise<void> {
     });
 
   // The OpenAI node renders expanded, so its primary `api_key` field is on the canvas.
-  await expect(page.getByTestId(API_KEY_ANCHOR)).toBeVisible({ timeout: 15000 });
+  await expect(page.getByTestId(API_KEY_ANCHOR)).toBeVisible({
+    timeout: 15000,
+  });
 }
 
 /**
@@ -86,7 +91,11 @@ async function createAndBindCredentialVariable(
   });
 
   await page.getByPlaceholder("Enter a name for the variable...").fill(varName);
-  // Switch to Credential BEFORE saving — otherwise a Generic variable is created.
+  // Selects the Credential tab explicitly. Measured on 1.13.0.dev8 (#1788's
+  // force-fail audit): removing this click does NOT produce a Generic variable —
+  // opening "Add New Variable" from a `SecretStrInput`'s own dropdown already
+  // creates a Credential, so the click is belt-and-braces, not the thing that
+  // decides the type. The comment here used to claim the opposite.
   await page.getByTestId("credential-tab").click();
   await page
     .getByPlaceholder("Enter a value for the variable...")
@@ -101,11 +110,57 @@ async function createAndBindCredentialVariable(
   // After creation the variable is either left selectable in the still-open
   // dropdown or auto-bound to the referencing field. Wait for whichever occurs,
   // then bind explicitly only when it isn't bound yet.
-  await expect(boundValue.or(optionRow)).toBeVisible({ timeout: 10000 });
-  if ((await optionRow.count()) > 0) {
+  //
+  // `.first()` is load-bearing, and its absence was a latent strict-mode defect
+  // rather than a style choice: the two states are not exclusive. On
+  // 1.13.0.dev8 creating the variable from this field auto-binds it AND leaves
+  // the dropdown open listing it, so `boundValue.or(optionRow)` resolves to TWO
+  // elements and `toBeVisible` fails with `strict mode violation` — measured
+  // 2/2 red locally on a spec the T1 triage table recorded 3/3 green, because
+  // CI happened to poll while only the option row had rendered. Waiting for
+  // "whichever of the two" is what this line means; it must not also assert
+  // that only one of them exists.
+  await expect(boundValue.or(optionRow).first()).toBeVisible({
+    timeout: 10000,
+  });
+  // Bind only when the field does NOT already show the variable: clicking the
+  // option row of an already-bound variable is a second toggle on the same
+  // value, which is how a passing bind would be undone.
+  if ((await boundValue.count()) === 0 && (await optionRow.count()) > 0) {
     await optionRow.click();
   }
   await expect(boundValue).toBeVisible({ timeout: 10000 });
+}
+
+/**
+ * Asserts the variable the test just created is actually a **Credential**.
+ *
+ * Added by #1788's force-fail audit, which is the only reason it exists: skipping
+ * the `credential-tab` click — so a **Generic** variable is created instead — left
+ * the test GREEN. The dropdown offers Generic variables to this field too, and the
+ * binding assertion reads the variable NAME, which is identical either way, so the
+ * word "Credential" in the test title was not verified by anything. A regression
+ * that made the credential tab write the wrong type would have gone unnoticed.
+ *
+ * Read over the API rather than off the UI: the type is not rendered anywhere on the
+ * canvas once the variable is bound.
+ */
+async function expectCredentialVariable(
+  request: import("@playwright/test").APIRequestContext,
+  varName: string,
+): Promise<void> {
+  const authToken = await getAuthToken(request);
+  const listRes = await request.get("/api/v1/variables/", {
+    headers: { Authorization: authToken },
+  });
+  expect(listRes.ok()).toBeTruthy();
+  const variables = (await listRes.json()) as Array<{
+    name: string;
+    type?: string;
+  }>;
+  const match = variables.find((v) => v.name === varName);
+  expect(match, `global variable ${varName} must exist`).toBeTruthy();
+  expect(match?.type).toBe("Credential");
 }
 
 /**
@@ -120,7 +175,10 @@ async function deleteVariableByName(
     headers: { Authorization: authToken },
   });
   if (!listRes.ok()) return;
-  const variables = (await listRes.json()) as Array<{ id: string; name: string }>;
+  const variables = (await listRes.json()) as Array<{
+    id: string;
+    name: string;
+  }>;
   const match = variables.find((v) => v.name === varName);
   if (match) {
     await request.delete(`/api/v1/variables/${match.id}`, {
@@ -129,71 +187,98 @@ async function deleteVariableByName(
   }
 }
 
-test(
-  "bind a Credential global variable to a component secret field",
-  { tag: ["@release", "@workspace", "@regression"] },
-  async ({ page, request }) => {
-    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const varName = `gv-api-key-${stamp}`;
-    const sentinelValue = `SECRET-SENTINEL-${stamp}`;
+// Both tests reach the canvas through `awaitBootstrapTest`, which creates `New Flow`
+// and `Basic Prompting` whenever the default project is empty, and then open a blank
+// flow of their own. None of those ids was ever seen by this file, so the `finally`
+// blocks below — which delete the global VARIABLE, correctly — left the flows behind:
+// measured 4 per run against a purged instance (#1788). `trackCreatedFlows` captures
+// every `POST /api/v1/flows/` → 201 the page performs and deletes exactly those ids.
+test.describe("Global variable bound to a component secret field", () => {
+  let flows: ReturnType<typeof trackCreatedFlows>;
 
-    try {
-      await test.step("Add an OpenAI component with an api_key secret field", async () => {
-        await addOpenAiComponent(page);
-      });
+  test.beforeEach(async ({ page }) => {
+    flows = trackCreatedFlows(page);
+  });
 
-      await test.step("Create a Credential variable and bind it to the api_key field", async () => {
-        await createAndBindCredentialVariable(page, varName, sentinelValue);
-      });
+  test.afterEach(async ({ request }) => {
+    await flows.cleanup(request);
+    flows.dispose();
+  });
 
-      await test.step("Field shows the variable name and never leaks the secret value", async () => {
-        // The field displays the variable NAME as its bound value.
-        await expect(
-          page.getByTestId(API_KEY_ANCHOR).getByText(varName, { exact: true }),
-        ).toBeVisible({ timeout: 10000 });
+  test(
+    "bind a Credential global variable to a component secret field",
+    { tag: ["@stable", "@release", "@workspace", "@regression"] },
+    async ({ page, request }) => {
+      const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const varName = `gv-api-key-${stamp}`;
+      const sentinelValue = `SECRET-SENTINEL-${stamp}`;
 
-        // The secret value is never rendered as visible text anywhere on the page.
-        // Substring match (no `exact`) also catches a leak embedded in a longer string.
-        await expect(page.getByText(sentinelValue)).toHaveCount(0, {
-          timeout: 5000,
+      try {
+        await test.step("Add an OpenAI component with an api_key secret field", async () => {
+          await addOpenAiComponent(page);
         });
-      });
-    } finally {
-      await deleteVariableByName(request, varName);
-    }
-  },
-);
 
-test(
-  "component secret-field global-variable binding persists across reload",
-  { tag: ["@release", "@workspace", "@regression"] },
-  async ({ page, request }) => {
-    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const varName = `gv-api-key-${stamp}`;
-    const sentinelValue = `SECRET-SENTINEL-${stamp}`;
-
-    try {
-      await test.step("Add an OpenAI component and bind a Credential variable to api_key", async () => {
-        await addOpenAiComponent(page);
-        await createAndBindCredentialVariable(page, varName, sentinelValue);
-      });
-
-      await test.step("Reload the page and confirm the binding survived", async () => {
-        // Let the flow autosave the binding, then reload from scratch.
-        await page.waitForTimeout(2000);
-        await page.reload();
-
-        // The rehydrated node still shows the same variable as its bound value —
-        // auto-bind never overrides an explicit binding saved in the flow.
-        await expect(page.getByTestId(API_KEY_ANCHOR)).toBeVisible({
-          timeout: 30000,
+        await test.step("Create a Credential variable and bind it to the api_key field", async () => {
+          await createAndBindCredentialVariable(page, varName, sentinelValue);
         });
-        await expect(
-          page.getByTestId(API_KEY_ANCHOR).getByText(varName, { exact: true }),
-        ).toBeVisible({ timeout: 15000 });
-      });
-    } finally {
-      await deleteVariableByName(request, varName);
-    }
-  },
-);
+
+        await test.step("The variable created from the field is a Credential", async () => {
+          await expectCredentialVariable(request, varName);
+        });
+
+        await test.step("Field shows the variable name and never leaks the secret value", async () => {
+          // The field displays the variable NAME as its bound value.
+          await expect(
+            page
+              .getByTestId(API_KEY_ANCHOR)
+              .getByText(varName, { exact: true }),
+          ).toBeVisible({ timeout: 10000 });
+
+          // The secret value is never rendered as visible text anywhere on the page.
+          // Substring match (no `exact`) also catches a leak embedded in a longer string.
+          await expect(page.getByText(sentinelValue)).toHaveCount(0, {
+            timeout: 5000,
+          });
+        });
+      } finally {
+        await deleteVariableByName(request, varName);
+      }
+    },
+  );
+
+  test(
+    "component secret-field global-variable binding persists across reload",
+    { tag: ["@stable", "@release", "@workspace", "@regression"] },
+    async ({ page, request }) => {
+      const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const varName = `gv-api-key-${stamp}`;
+      const sentinelValue = `SECRET-SENTINEL-${stamp}`;
+
+      try {
+        await test.step("Add an OpenAI component and bind a Credential variable to api_key", async () => {
+          await addOpenAiComponent(page);
+          await createAndBindCredentialVariable(page, varName, sentinelValue);
+        });
+
+        await test.step("Reload the page and confirm the binding survived", async () => {
+          // Let the flow autosave the binding, then reload from scratch.
+          await page.waitForTimeout(2000);
+          await page.reload();
+
+          // The rehydrated node still shows the same variable as its bound value —
+          // auto-bind never overrides an explicit binding saved in the flow.
+          await expect(page.getByTestId(API_KEY_ANCHOR)).toBeVisible({
+            timeout: 30000,
+          });
+          await expect(
+            page
+              .getByTestId(API_KEY_ANCHOR)
+              .getByText(varName, { exact: true }),
+          ).toBeVisible({ timeout: 15000 });
+        });
+      } finally {
+        await deleteVariableByName(request, varName);
+      }
+    },
+  );
+});


### PR DESCRIPTION
**Closes #1788.**

Wave 8's T1 batch of four specs the inherited-spec triage table measured **green** and that design §3 still refuses to promote. The table supplied one of the four PROMOTE conditions (3/3 green over nine `manual.yml` dispatches at `retries=0`); this PR supplies the other three per spec — id-scoped cleanup, a spec doc with the four mandatory sections, and a force-fail run — and adds `@stable`.

Measuring instead of trusting the table changed two of its rows.

## 1. `folder-drag-drop-flow` leaks too — the table's `Cleanup` column is a grep

The column is a source grep with comments stripped. It reports this file as id-scoped, which it is **for what the file creates explicitly**. What it never deletes is the pair `awaitBootstrapTest` creates when the default project is empty (`new_project_btn_empty_page` → `addFlowToTestOnEmptyLangflow`: the CTA creates `New Flow`, the chosen template creates `Basic Prompting`) — inside a helper the grep cannot see.

Audited by **purging before EACH spec** and diffing `GET /api/v1/flows/`, against a fresh `1.13.0.dev8` with 0 user flows and an empty default project. Purging once and running all four in sequence is not the same measurement: the specs mask each other, which is how #1787 got the wrong spec blamed.

| Spec | Tests | Leaked before | After |
|---|---|---|---|
| `ui-ux/settings-shortcuts-edit` | 1 | **3** — `New Flow`, `Basic Prompting`, `New Flow (2)` | 0 |
| `ui-ux/use-global-variable-in-component` | 2 | **4** — the above + `New Flow (3)` | 0 |
| `core-functionality/project-management/folder-drag-drop-flow` | 2 | **2** — `New Flow`, `Basic Prompting` | 0 |
| `mcp/server/mcp-server-regression` | 1 | **0** | 0 |

`mcp-server-regression` is the one that leaks nothing, and for a stated reason: `setupPlayground` creates the flow over the API and navigates straight to its canvas rather than entering through the home page, whose "New Flow" entry point eagerly creates a throwaway (#988).

Every leaking spec now installs `trackCreatedFlows` (the #1108 standard) and deletes exactly the ids the page created. **0 flows left behind across the 12 VALIDATE runs plus the entire force-fail phase.**

## 2. `use-global-variable-in-component` was RED, 2/2 — and the mechanism is why it read as green

```
strict mode violation: ...getByText('gv-api-key-…').or(getByTestId('option-gv-api-key-…'))
resolved to 2 elements
```

`expect(boundValue.or(optionRow)).toBeVisible()` asserts more than it means. The gate wants "the variable is bound **or** it is listed in the still-open dropdown", but `.or()` resolving to two elements is a strict mode violation, and the two states are **not exclusive**: on `1.13.0.dev8` creating the variable from the field's own dropdown auto-binds it *and* leaves the dropdown open listing it.

So this is a **race, not a version regression**. CI polled in the window where only the option row had rendered, three times in a row, and the table recorded 3/3 green. Promoting it unchanged would have imported a flake into the daily.

Two changes, and the real postcondition assertion (`boundValue` visible) is untouched:
- the wait takes `.first()`, so it means "whichever of the two" rather than "exactly one of the two exists";
- the explicit bind is guarded on the field **not** already showing the variable — clicking the option row of an already-bound variable is a second toggle on the same value, which is how a passing bind gets undone.

## 3. What the force-fail audit found

**The test titled "bind a *Credential* global variable" verified no type at all.** Removing the `credential-tab` click — the line whose comment claimed it is what prevents a Generic variable — left the test **green**, because the bound value the field renders is the variable **name**, identical either way. A regression making that tab write the wrong type would have gone unnoticed. `expectCredentialVariable` now reads the variable back over `GET /api/v1/variables/` and asserts `type === "Credential"`; the type is not rendered anywhere on the canvas once bound.

**And that measurement corrected the spec's own comment.** With the type assertion in place, removing the click *still* passes: opening "Add New Variable" from a `SecretStrInput`'s own dropdown already creates a Credential. The click is belt-and-braces, not the thing that decides the type.

Also corrected: `mcp-server-regression` claimed Langflow renders MCP tool names as **uppercase** slugs. `lfx.base.mcp.util.sanitize_mcp_name` **lowercases** — measured in the running image, a flow named `E2E Slug Probe abcdef0123456789` is exposed as `action_name: "e2e_slug_probe_abcdef0123456789"`. The uppercase expectation matches only because `getByText(..., { exact: false })` is case-insensitive; the discriminating part of the slug is the 16 hex digits.

## 4. Per spec — outcome and the triage row it came from

All four rows come from `docs/triage/inherited-spec-triage.md` (landed by #1784 / PR #1785). Outcome for every one of them is **promote**.

| Spec · test | Triage row | Was missing | Delivered |
|---|---|---|---|
| `folder-drag-drop-flow` · *creating a flow in a specific folder via API places it in that folder* | 3/3 green, id-scoped, ⚠️ no resolvable doc | doc + FF | new `docs/core-functionality/project-management/folder-drag-drop-flow.md`, FF, `@stable` |
| `folder-drag-drop-flow` · *folder listing shows flows correctly via UI* | 3/3 green, id-scoped, ⚠️ no resolvable doc | doc + FF + **bootstrap cleanup (measured)** | as above + `trackCreatedFlows` |
| `mcp-server-regression` · *flow appears as MCP tool in MCP Server tab and endpoint responds* | 3/3 green, id-scoped, ⚠️ no resolvable doc | doc + FF | new `docs/mcp/server/mcp-server-regression.md`, FF, `@stable` |
| `settings-shortcuts-edit` · *editing the Duplicate shortcut persists and triggers the action on canvas* | 3/3 green, **no id-scoped delete**, doc ✅ | cleanup + FF | `trackCreatedFlows`, FF, `@stable` |
| `use-global-variable-in-component` · *bind a Credential global variable to a component secret field* | 3/3 green, **no id-scoped delete**, doc ✅ | cleanup + FF + **strict-mode fix** | `trackCreatedFlows`, type readback, FF, `@stable` |
| `use-global-variable-in-component` · *component secret-field global-variable binding persists across reload* | 3/3 green, **no id-scoped delete**, doc ✅ | cleanup + FF + **strict-mode fix** | as above |

**Nothing here was re-measured** — design §4 forbids it once the table lands. The green runs below are the promotion's own validation burst, not a second measurement of the verdict.

## 5. Covered tests — what each one validates

| # | Test | What it validates |
|---|---|---|
| 1 | `creating a flow in a specific folder via API places it in that folder` | `POST /api/v1/flows/` with an explicit `folder_id` answers `201` and echoes back **that same** `folder_id` — the flow did not fall into the default project |
| 2 | `folder listing shows flows correctly via UI` | the folder's home-sidebar entry is present under **either** upstream testid spelling (`sidebar-nav-<id>` on the nightly, `sidebar-nav-<name>` on 1.11.x — #1363), and clicking it lists the flow created inside it, addressed by its own unique name |
| 3 | `flow appears as MCP tool in MCP Server tab and endpoint responds` | four observables: `mcp-server-title` visible; **this** flow's slug present in `div-mcp-server-tools`; the JSON tab advertising a `mcp/project/<id>/streamable` URL; and that route answering `200` to a JSON-RPC `initialize` **carrying `x-api-key`** — the keyless caller is refused `403` since 1.12.0.dev33 (#1522), so the credential is the assertion, not plumbing |
| 4 | `editing the Duplicate shortcut persists and triggers the action on canvas` | the `"Duplicate shortcut successfully changed"` toast; the Duplicate row now reading `Alt` + `U`; and — the load-bearing half — pressing the **new** combination on a canvas with one Ollama node takes `title-Ollama` from 1 to 2 |
| 5 | `bind a Credential global variable to a component secret field` | the created variable is `type === "Credential"` (API readback); the `api_key` field displays the variable **name** as its bound value; and the secret sentinel never appears as visible page text |
| 6 | `component secret-field global-variable binding persists across reload` | after the autosave debounce and a full reload, the rehydrated node still shows the **same** variable — auto-bind never overrides an explicit binding saved in the flow |

## 6. Force-fail — one verified red per test, then reverted

Behavioural mutations wherever one existed, rather than only tweaking an `expect`:

- **1** — `folder_id` omitted from the POST body → the flow lands in the default project → the echo assertion goes red.
- **2** — same omission → the flow is not listed inside the folder the test opens.
- **3** — expected slug suffixed `_NOT_A_REAL_TOOL` → proves the tools-list assertion reads this flow's name out of the DOM.
- **4** — pressed `ControlOrMeta+Alt+J`, bound to nothing, instead of the rebound `ControlOrMeta+Alt+U` → the node is not duplicated.
- **5** — created and bound a **differently-named** variable than the assertions name → both the bound-value assertion and the type readback go red.
- **6** — removed the autosave wait before the reload → the node rehydrates **without** the binding. This is the one worth keeping: it proves auto-bind does **not** silently rescue the persistence claim.

Two mutations were **refused by the gate before being replaced**, which is what produced §3's findings: skipping the `credential-tab` click left test 5 green both before *and* after the type readback was added.

## 7. Docs

Two new spec docs with the four mandatory sections, plus the two existing docs updated: `@stable` added to their **Tags** section, the now-false "`@stable` intentionally withheld" notes removed, `Last validated` bumped to `1.13.x (nightly 1.13.0.dev8)`, and the measured findings recorded.

The new docs declare **7 upstream `src/` paths, each verified individually** against `origin/main`, `release-1.13.0` and `release-1.12.2`. That verification was necessary rather than belt-and-braces: running `scripts/watch-upstream-areas.mjs --mode=check-docs` locally **without** `--root <upstream clone>` resolves against *this* repo's HEAD, which has no `src/`, and reports **593 paths as dead** — including the ones in `mcp-server-resources.md` that pass in CI. Reading that output as a measurement would mean "fixing" paths that are correct.

`QA-CHECKLIST.md` — **manual Part II bullets only** (#741): two new bullets (§10.1 API folder placement, §10.2 the folder's own listing, §14.1 end-to-end MCP tool exposure) and the `use-global-variable` bullet flipped `[-]` → `[x]`. `settings-shortcuts-edit`'s bullet was already `[x]`, which was premature on a spec carrying no `@stable`; this PR makes it true.

## 8. Dependencies

No LLM, no provider key, no Ollama run — the Ollama node in test 4 is only dragged onto the canvas, never executed. Parallel-safe: every object each test asserts on is created by that test and deleted id-scoped, and no test performs a global sweep. Tags stay legal — each spec keeps ≥1 cross-cutting and ≥1 functional tag, and **none carries a lane selector**, so `@stable` cannot silence any of them (#1010).

## Validation (nightly `1.13.0.dev8`, `--retries=0 --workers=1`)

```
run 1..3/3 folder-drag-drop-flow.spec.ts:            clean expected=2 unexpected=0 flaky=0 backendErrors=false skipped=0
run 1..3/3 mcp-server-regression.spec.ts:            clean expected=1 unexpected=0 flaky=0 backendErrors=false skipped=0
run 1..3/3 settings-shortcuts-edit.spec.ts:          clean expected=1 unexpected=0 flaky=0 backendErrors=false skipped=0
run 1..3/3 use-global-variable-in-component.spec.ts: clean expected=2 unexpected=0 flaky=0 backendErrors=false skipped=0
typecheck=0 lint=0 · QA-CHECKLIST diff ok
FF coverage: complete · no FF-MUTATION markers in diff ✓ · final green run after reverts ✓ (4 file(s))
```

- 12 clean runs, zero flaky, zero `🚨 Backend Error` ✅
- force-fail 6/6 verified red, all reverted, final green per file ✅
- `npm run typecheck` ✅ · `npm run lint` 0 errors ✅
- `check:checklist-coverage` ✅ — `@stable` goes 238 → **242** spec files and 614 → **620** `test()` calls, exactly +4 files / +6 tests
- `check-checklist-guard` ✅ — no auto-generated block edited
- **flow leak: 0** after 12 runs + the force-fail phase, verified against `GET /api/v1/flows/` ✅

`--trace=on` was deliberately not used: it hangs UI specs on this local Docker setup, and the run it would have produced is not evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
