### PR TITLE
feat(vm): forward the target's run command and frontend dir, and record which artifact served

### DIFF
--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -422,6 +422,39 @@ mirrored_target_env() {
   done
 }
 
+# The command that SERVES the target, passed through to the starter when the caller
+# names one. The starter already accepts it — LANGFLOW_SRC_RUN_CMD is how a machine
+# without uv, or a run against the PUBLISHED distribution rather than the clone, is
+# served — but the remote environment above is composed from a fixed list, so an
+# override exported on the qa wrapper never crossed the ssh boundary. The knob existed
+# on one side of the connection and not the other.
+#
+# Why this lane needs it, measured rather than supposed: on 2026-09-10 the published
+# distribution served the traces family with tracing ON, 23 of 23 and no gunicorn
+# WORKER TIMEOUT, where the source clone wedges under the same selection on the same
+# machine (7, 8 and 9 failures across the three attribution runs of #1720). Which artifact
+# serves is therefore a property of the run, not a detail of how it was launched.
+#
+# The two overrides are NOT symmetric, and that asymmetry is the reason this is a
+# function instead of two more entries on the line above:
+#
+#   LANGFLOW_SRC_RUN_CMD   the starter tests it with `-n "${VAR:-}"`, so an empty value
+#                          is indistinguishable from an absent one. Safe either way.
+#   LANGFLOW_SRC_SYNC_CMD  the starter reads it as `${VAR-default}` DELIBERATELY, so
+#                          empty-but-SET means "skip the sync entirely". Forwarding it
+#                          unconditionally would silently disable `uv sync --frozen` on
+#                          every run of the source path — a mutation of what is under
+#                          test, arriving from a line that looks like plumbing.
+#
+# Hence: RUN_CMD forwarded when non-empty, SYNC_CMD forwarded when SET. `return 0`
+# because the last `[` fails whenever nothing is forwarded, and this runs inside a
+# command substitution under `set -e`.
+target_cmd_env() {
+  [ -n "${LANGFLOW_SRC_RUN_CMD:-}" ] && printf 'LANGFLOW_SRC_RUN_CMD=%s ' "$(shq "$LANGFLOW_SRC_RUN_CMD")"
+  [ -n "${LANGFLOW_SRC_SYNC_CMD+set}" ] && printf 'LANGFLOW_SRC_SYNC_CMD=%s ' "$(shq "$LANGFLOW_SRC_SYNC_CMD")"
+  return 0
+}
+
 # Should this run place the target's clone, and if not, why not?
 #
 # Split out of phase_preflight so the decision is testable without ssh — the phase
@@ -1014,7 +1047,7 @@ start_backend_for_shard() {
   # clone, and its absence fails with the right message for the wrong reason.
   # shellcheck disable=SC2086
   ssh -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=30 $TARGET_SSH_OPTS "$TARGET_SSH" \
-    "PATH=\$HOME/.local/bin:\$PATH LANGFLOW_SRC_REPO=\${LANGFLOW_SRC_REPO:-\$HOME/langflow} LANGFLOW_REQUIRE_BUILD_STAMP=$STAMP_REQUIRED $(mirrored_target_env)${bind_env}LANGFLOW_PORT=$port bash -s; sleep 86400" \
+    "PATH=\$HOME/.local/bin:\$PATH LANGFLOW_SRC_REPO=\${LANGFLOW_SRC_REPO:-\$HOME/langflow} LANGFLOW_REQUIRE_BUILD_STAMP=$STAMP_REQUIRED $(mirrored_target_env)$(target_cmd_env)${bind_env}LANGFLOW_PORT=$port bash -s; sleep 86400" \
     < scripts/start-langflow-source.sh > "$holder_log" 2>&1 &
   HELD_SESSIONS+=("$!")
 

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -449,8 +449,18 @@ mirrored_target_env() {
 # workflow `env:` block, where an absent input arrives as empty-but-set. Forwarding it
 # would put a silent skip of the dependency reconciliation one typo away, to serve a
 # knob nothing in this repository sets today.
+#
+# LANGFLOW_SRC_FRONTEND_DIR travels with it, and without it the run command does not
+# actually reach the state it was added for. The starter refuses to serve a clone with
+# no built UI — a backend answering /health_check while every browser spec dies at page
+# load is the failure it exists to prevent — and it looks for those assets under the
+# CLONE. A published distribution ships its own built frontend inside the package, so
+# the two knobs are one decision: name the command that serves and the assets it serves.
+# Forwarded the same way and for the same reason, and just as safely: the starter reads
+# it as `${VAR:-default}`, so empty falls back to the clone's path.
 target_cmd_env() {
   printf 'LANGFLOW_SRC_RUN_CMD=%s ' "$(shq "${LANGFLOW_SRC_RUN_CMD:-}")"
+  printf 'LANGFLOW_SRC_FRONTEND_DIR=%s ' "$(shq "${LANGFLOW_SRC_FRONTEND_DIR:-}")"
 }
 
 # The two switches a run command silently collides with, warned about once, in the

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -453,6 +453,36 @@ target_cmd_env() {
   printf 'LANGFLOW_SRC_RUN_CMD=%s ' "$(shq "${LANGFLOW_SRC_RUN_CMD:-}")"
 }
 
+# The two switches a run command silently collides with, warned about once, in the
+# phase where there is still time to act.
+#
+# Neither collision is hypothetical, and neither announces itself as the cause:
+#
+#   PREPARE_TARGET=1 (the default) still checks out and REBUILDS the clone — the
+#   longest thing this run does — for a tree that is not going to serve. Worse than the
+#   wasted minutes, run-metadata.json then carries langflow_prepared_sha beside
+#   langflow_target_run_cmd, and the prepared sha describes something nobody ran.
+#
+#   REQUIRE_TARGET_VERSION=1 (the default) compares the version scraped from the LIVE
+#   instance against the one resolved from upstream's nightly, which moves daily. A
+#   pinned distribution therefore fails the verdict on a difference the operator
+#   introduced on purpose, and the message it fails with talks about authoritative
+#   version checks rather than about the pin.
+#
+# A warning and not a `die`: both combinations are legitimate — a venv pinned to the
+# resolved version passes the gate, and someone may want the clone placed anyway. What
+# is not legitimate is discovering either one from a shard timeout or a red verdict.
+warn_target_cmd_conflicts() {
+  [ -n "${LANGFLOW_SRC_RUN_CMD:-}" ] || return 0
+  if [ "${PREPARE_TARGET:-1}" = "1" ]; then
+    warn "LANGFLOW_SRC_RUN_CMD is set, and PREPARE_TARGET=1: this run will still place and rebuild the clone, which is not what will serve. Set PREPARE_TARGET=0 unless you mean both."
+  fi
+  if [ "${REQUIRE_TARGET_VERSION:-1}" = "1" ]; then
+    warn "LANGFLOW_SRC_RUN_CMD is set, and REQUIRE_TARGET_VERSION=1: the served version must equal the one resolved from upstream, or the verdict fails on a difference you introduced. Pin the distribution to the resolved version, or set REQUIRE_TARGET_VERSION=0 and accept the blind axis."
+  fi
+  return 0
+}
+
 # Should this run place the target's clone, and if not, why not?
 #
 # Split out of phase_preflight so the decision is testable without ssh — the phase
@@ -756,6 +786,7 @@ phase_preflight() {
   # artifact was ASKED to serve has to be readable without waiting for a metadata file
   # the run may never write.
   info "target env: $(mirrored_target_env)$(target_cmd_env)"
+  warn_target_cmd_conflicts
 
   [ -n "$TARGET_SSH" ] || die "TARGET_SSH is required — this script drives a second machine and will not guess its name."
   command -v node > /dev/null || die "node is not on PATH."

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1411,6 +1411,7 @@ phase_merge() {
     langflow_prepared_rebuilt "${TARGET_REBUILT:-no}" \
     langflow_prepared_reason "${TARGET_REBUILD_REASON:-}" \
     langflow_prepare_seconds "${TARGET_PREPARE_S:-}" \
+    langflow_target_run_cmd "${LANGFLOW_SRC_RUN_CMD:-}" \
     shards "$SHARD_TOTAL" \
     tunnel "$LANGFLOW_TUNNEL" \
     tests_total "${RUN_TESTS:-0}" \

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -422,37 +422,35 @@ mirrored_target_env() {
   done
 }
 
-# The command that SERVES the target, passed through to the starter when the caller
-# names one. The starter already accepts it — LANGFLOW_SRC_RUN_CMD is how a machine
+# The command that SERVES the target, forwarded to the starter on every run.
+#
+# The starter has accepted LANGFLOW_SRC_RUN_CMD since #1658 — it is how a machine
 # without uv, or a run against the PUBLISHED distribution rather than the clone, is
 # served — but the remote environment above is composed from a fixed list, so an
 # override exported on the qa wrapper never crossed the ssh boundary. The knob existed
 # on one side of the connection and not the other.
 #
-# Why this lane needs it, measured rather than supposed: on 2026-09-10 the published
+# Why the lane needs it, measured rather than supposed: on 2026-09-10 the published
 # distribution served the traces family with tracing ON, 23 of 23 and no gunicorn
 # WORKER TIMEOUT, where the source clone wedges under the same selection on the same
-# machine (7, 8 and 9 failures across the three attribution runs of #1720). Which artifact
-# serves is therefore a property of the run, not a detail of how it was launched.
+# machine — 7, 8 and 9 failures across the three attribution runs of #1720.
 #
-# The two overrides are NOT symmetric, and that asymmetry is the reason this is a
-# function instead of two more entries on the line above:
+# Sent UNCONDITIONALLY, including empty, for the reason mirrored_target_env sends its
+# four the same way: a value that crosses only sometimes cannot be recorded as the one
+# in force, and run-metadata.json records this one. The starter tests it with
+# `-n "${VAR:-}"`, so an empty assignment is indistinguishable from no assignment on
+# the far side — unconditional forwarding is therefore free, and it gives the field the
+# same standing the mirrored four have: what this side holds is what the starter reads,
+# unless the target's own profile re-exports it. Same standing, same residual.
 #
-#   LANGFLOW_SRC_RUN_CMD   the starter tests it with `-n "${VAR:-}"`, so an empty value
-#                          is indistinguishable from an absent one. Safe either way.
-#   LANGFLOW_SRC_SYNC_CMD  the starter reads it as `${VAR-default}` DELIBERATELY, so
-#                          empty-but-SET means "skip the sync entirely". Forwarding it
-#                          unconditionally would silently disable `uv sync --frozen` on
-#                          every run of the source path — a mutation of what is under
-#                          test, arriving from a line that looks like plumbing.
-#
-# Hence: RUN_CMD forwarded when non-empty, SYNC_CMD forwarded when SET. `return 0`
-# because the last `[` fails whenever nothing is forwarded, and this runs inside a
-# command substitution under `set -e`.
+# The SYNC command is deliberately NOT forwarded, and that is a decision rather than an
+# omission. The starter reads it as `${VAR-default}` on purpose, so empty-but-SET means
+# "skip `uv sync --frozen` entirely" — and a caller cannot express "unset" through a
+# workflow `env:` block, where an absent input arrives as empty-but-set. Forwarding it
+# would put a silent skip of the dependency reconciliation one typo away, to serve a
+# knob nothing in this repository sets today.
 target_cmd_env() {
-  [ -n "${LANGFLOW_SRC_RUN_CMD:-}" ] && printf 'LANGFLOW_SRC_RUN_CMD=%s ' "$(shq "$LANGFLOW_SRC_RUN_CMD")"
-  [ -n "${LANGFLOW_SRC_SYNC_CMD+set}" ] && printf 'LANGFLOW_SRC_SYNC_CMD=%s ' "$(shq "$LANGFLOW_SRC_SYNC_CMD")"
-  return 0
+  printf 'LANGFLOW_SRC_RUN_CMD=%s ' "$(shq "${LANGFLOW_SRC_RUN_CMD:-}")"
 }
 
 # Should this run place the target's clone, and if not, why not?

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -749,7 +749,13 @@ phase_preflight() {
   # dies in prep or in a shard never reaches phase_merge. The run that most needs this
   # record would be exactly the one that produced none. First line of the first phase
   # costs nothing and survives every abort after it.
-  info "target env: $(mirrored_target_env)"
+  #
+  # The target's run command is printed from the same composer for the same reason, and
+  # the reason is sharper for it than for the mirrored four: a wrong path there is a
+  # backend that never answers, which reaches the operator as a shard timeout. Which
+  # artifact was ASKED to serve has to be readable without waiting for a metadata file
+  # the run may never write.
+  info "target env: $(mirrored_target_env)$(target_cmd_env)"
 
   [ -n "$TARGET_SSH" ] || die "TARGET_SSH is required — this script drives a second machine and will not guess its name."
   command -v node > /dev/null || die "node is not on PATH."

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -338,9 +338,21 @@ test("the target's run command crosses on every run, and the sync command never 
   // on: a value that crosses only sometimes cannot be recorded as the one in force.
   // Turning this back into a conditional makes langflow_target_run_cmd a guess, so it
   // is pinned here and not only where the field is written.
-  const unset = sourced(`(unset LANGFLOW_SRC_RUN_CMD; target_cmd_env)`);
+  const unset = sourced(`(unset LANGFLOW_SRC_RUN_CMD LANGFLOW_SRC_FRONTEND_DIR; target_cmd_env)`);
   assert.equal(unset.status, 0, unset.stderr);
   assert.match(unset.stdout, /(^|\s)LANGFLOW_SRC_RUN_CMD=/, "an unset command still has to cross, as empty");
+
+  // The frontend directory travels with the command, because without it the command
+  // cannot reach the state it was added for: the starter refuses a clone with no built
+  // UI, and it looks for those assets under the CLONE, while a published distribution
+  // ships its own inside the package. Naming what serves and not naming the assets it
+  // serves would be half a knob.
+  assert.match(unset.stdout, /(^|\s)LANGFLOW_SRC_FRONTEND_DIR=/, "the frontend dir has to cross too");
+  const fe = sourced(`target_cmd_env`, {
+    LANGFLOW_SRC_RUN_CMD: "/root/venv-dev8/bin/langflow run",
+    LANGFLOW_SRC_FRONTEND_DIR: "/root/venv-dev8/lib/python3.14/site-packages/langflow/frontend",
+  });
+  assert.match(fe.stdout, /LANGFLOW_SRC_FRONTEND_DIR='?\/root\/venv-dev8/, "and carry the value it was given");
 
   // The sync command is a deliberate NON-feature. The starter reads it as
   // `${VAR-default}`, so empty-but-SET means "skip `uv sync --frozen` entirely", and a

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -324,6 +324,16 @@ test("the target's run command crosses on every run, and the sync command never 
   assert.ok(line, "could not find the command that starts the backend on the target");
   assert.match(line, /\$\(target_cmd_env\)/);
 
+  // And it reaches the run's EARLY log, not only its metadata. The preflight line
+  // exists because a run that dies in prep or in a shard never reaches phase_merge, and
+  // that is the run whose record matters most — a wrong run command is a backend that
+  // never answers, which arrives as a shard timeout with nothing naming the cause.
+  const preflight = readFileSync(SCRIPT, "utf8")
+    .split("\n")
+    .find((l) => l.includes('info "target env:'));
+  assert.ok(preflight, "could not find the preflight line that records the target's environment");
+  assert.match(preflight, /\$\(target_cmd_env\)/, "the run command must be readable before phase_merge");
+
   // Unconditional, EMPTY INCLUDED, and that is the property the metadata field rests
   // on: a value that crosses only sometimes cannot be recorded as the one in force.
   // Turning this back into a conditional makes langflow_target_run_cmd a guess, so it

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -313,6 +313,63 @@ test("the mirrored values cross the ssh boundary, which a default alone does not
   }
 });
 
+test("the target's RUN command crosses the ssh boundary, and the SYNC override keeps its off switch", () => {
+  // A measured need rather than a knob for its own sake: on 2026-09-10 the PUBLISHED
+  // distribution served the traces family with tracing ON — 23 of 23, no gunicorn
+  // WORKER TIMEOUT — where the source clone wedges under the same selection on the same
+  // machine (7, 8 and 9 failures across three attribution runs, #1720). The starter
+  // already accepted LANGFLOW_SRC_RUN_CMD; this script composed the remote environment
+  // from a fixed list, so the override existed on one side of the connection only.
+  const line = readFileSync(SCRIPT, "utf8")
+    .split("\n")
+    .find((l) => l.includes("bash -s; sleep 86400"));
+  assert.ok(line, "could not find the command that starts the backend on the target");
+  assert.match(line, /\$\(target_cmd_env\)/);
+
+  // Nothing forwarded when the caller names nothing — the starter's own default (uv
+  // against the clone) has to stay reachable — and the composition must not return
+  // non-zero, because it runs inside a command substitution under `set -e`.
+  const none = sourced(`(unset LANGFLOW_SRC_RUN_CMD LANGFLOW_SRC_SYNC_CMD; target_cmd_env); echo "rc=$?"`);
+  assert.equal(none.status, 0, none.stderr);
+  assert.match(none.stdout, /^rc=0$/m, "an empty composition must still succeed");
+  assert.doesNotMatch(none.stdout, /LANGFLOW_SRC_(RUN|SYNC)_CMD=/);
+
+  // The asymmetry, and it is the whole reason this is a function instead of two more
+  // entries on the ssh line. The starter reads the SYNC override as `${VAR-default}`
+  // DELIBERATELY, so empty-but-SET means "skip the sync entirely". Forwarding it
+  // unconditionally would silently disable `uv sync --frozen` on every run of the
+  // source path — a mutation of the thing under test, arriving from a line that reads
+  // like plumbing.
+  const runOnly = sourced(
+    `(unset LANGFLOW_SRC_SYNC_CMD; LANGFLOW_SRC_RUN_CMD="/opt/venv/bin/langflow run" target_cmd_env)`,
+  );
+  assert.equal(runOnly.status, 0, runOnly.stderr);
+  assert.match(runOnly.stdout, /(^|\s)LANGFLOW_SRC_RUN_CMD=/);
+  assert.doesNotMatch(runOnly.stdout, /LANGFLOW_SRC_SYNC_CMD=/, "an UNSET sync override must not cross as empty");
+
+  const emptySync = sourced(`(unset LANGFLOW_SRC_RUN_CMD; LANGFLOW_SRC_SYNC_CMD= target_cmd_env)`);
+  assert.equal(emptySync.status, 0, emptySync.stderr);
+  assert.match(
+    emptySync.stdout,
+    /(^|\s)LANGFLOW_SRC_SYNC_CMD=/,
+    "empty-but-SET is how the caller asks for no sync at all, so it has to cross",
+  );
+
+  // Parsed on the far side rather than string-matched here. A command with a space is
+  // the ORDINARY case ("/…/bin/langflow run"), so the quoting is load-bearing from the
+  // first use — not on the day someone gets exotic.
+  const cmd = "/opt/venv with space/bin/langflow run";
+  const round = sourced(
+    [
+      `remote="$(target_cmd_env)bash -s"`,
+      `printf '%s\\n' 'printf "%s" "$LANGFLOW_SRC_RUN_CMD"' | env -u LANGFLOW_SRC_RUN_CMD bash -c "$remote"`,
+    ].join("\n"),
+    { LANGFLOW_SRC_RUN_CMD: cmd },
+  );
+  assert.equal(round.status, 0, round.stderr);
+  assert.equal(round.stdout, cmd, "the far side must READ the command back, spaces included");
+});
+
 test("the remote quoting survives a value carrying a quote, which no current value does", () => {
   // The branch none of today's values reach, and therefore the one that will be wrong
   // when it is first needed — the day someone overrides a mirrored variable from the

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -313,52 +313,41 @@ test("the mirrored values cross the ssh boundary, which a default alone does not
   }
 });
 
-test("the target's RUN command crosses the ssh boundary, and the SYNC override keeps its off switch", () => {
+test("the target's run command crosses on every run, and the sync command never crosses", () => {
   // A measured need rather than a knob for its own sake: on 2026-09-10 the PUBLISHED
   // distribution served the traces family with tracing ON — 23 of 23, no gunicorn
   // WORKER TIMEOUT — where the source clone wedges under the same selection on the same
-  // machine (7, 8 and 9 failures across three attribution runs, #1720). The starter
-  // already accepted LANGFLOW_SRC_RUN_CMD; this script composed the remote environment
-  // from a fixed list, so the override existed on one side of the connection only.
+  // machine (7, 8 and 9 failures across the three attribution runs of #1720).
   const line = readFileSync(SCRIPT, "utf8")
     .split("\n")
     .find((l) => l.includes("bash -s; sleep 86400"));
   assert.ok(line, "could not find the command that starts the backend on the target");
   assert.match(line, /\$\(target_cmd_env\)/);
 
-  // Nothing forwarded when the caller names nothing — the starter's own default (uv
-  // against the clone) has to stay reachable — and the composition must not return
-  // non-zero, because it runs inside a command substitution under `set -e`.
-  const none = sourced(`(unset LANGFLOW_SRC_RUN_CMD LANGFLOW_SRC_SYNC_CMD; target_cmd_env); echo "rc=$?"`);
-  assert.equal(none.status, 0, none.stderr);
-  assert.match(none.stdout, /^rc=0$/m, "an empty composition must still succeed");
-  assert.doesNotMatch(none.stdout, /LANGFLOW_SRC_(RUN|SYNC)_CMD=/);
+  // Unconditional, EMPTY INCLUDED, and that is the property the metadata field rests
+  // on: a value that crosses only sometimes cannot be recorded as the one in force.
+  // Turning this back into a conditional makes langflow_target_run_cmd a guess, so it
+  // is pinned here and not only where the field is written.
+  const unset = sourced(`(unset LANGFLOW_SRC_RUN_CMD; target_cmd_env)`);
+  assert.equal(unset.status, 0, unset.stderr);
+  assert.match(unset.stdout, /(^|\s)LANGFLOW_SRC_RUN_CMD=/, "an unset command still has to cross, as empty");
 
-  // The asymmetry, and it is the whole reason this is a function instead of two more
-  // entries on the ssh line. The starter reads the SYNC override as `${VAR-default}`
-  // DELIBERATELY, so empty-but-SET means "skip the sync entirely". Forwarding it
-  // unconditionally would silently disable `uv sync --frozen` on every run of the
-  // source path — a mutation of the thing under test, arriving from a line that reads
-  // like plumbing.
-  const runOnly = sourced(
-    `(unset LANGFLOW_SRC_SYNC_CMD; LANGFLOW_SRC_RUN_CMD="/opt/venv/bin/langflow run" target_cmd_env)`,
-  );
-  assert.equal(runOnly.status, 0, runOnly.stderr);
-  assert.match(runOnly.stdout, /(^|\s)LANGFLOW_SRC_RUN_CMD=/);
-  assert.doesNotMatch(runOnly.stdout, /LANGFLOW_SRC_SYNC_CMD=/, "an UNSET sync override must not cross as empty");
+  // The sync command is a deliberate NON-feature. The starter reads it as
+  // `${VAR-default}`, so empty-but-SET means "skip `uv sync --frozen` entirely", and a
+  // workflow `env:` block cannot express "unset" — an absent input arrives as
+  // empty-but-set. Forwarding it would put a silent skip of the dependency
+  // reconciliation one typo away.
+  for (const env of [{}, { LANGFLOW_SRC_SYNC_CMD: "" }, { LANGFLOW_SRC_SYNC_CMD: "uv sync --frozen --offline" }]) {
+    const r = sourced(`target_cmd_env`, env);
+    assert.doesNotMatch(r.stdout, /LANGFLOW_SRC_SYNC_CMD/, `sync must not cross: ${JSON.stringify(env)}`);
+  }
 
-  const emptySync = sourced(`(unset LANGFLOW_SRC_RUN_CMD; LANGFLOW_SRC_SYNC_CMD= target_cmd_env)`);
-  assert.equal(emptySync.status, 0, emptySync.stderr);
-  assert.match(
-    emptySync.stdout,
-    /(^|\s)LANGFLOW_SRC_SYNC_CMD=/,
-    "empty-but-SET is how the caller asks for no sync at all, so it has to cross",
-  );
-
-  // Parsed on the far side rather than string-matched here. A command with a space is
-  // the ORDINARY case ("/…/bin/langflow run"), so the quoting is load-bearing from the
-  // first use — not on the day someone gets exotic.
-  const cmd = "/opt/venv with space/bin/langflow run";
+  // Read back on the far side rather than string-matched here. The ordinary value
+  // carries a space (`…/bin/langflow run`), so the quoting is load-bearing from the
+  // first use. Only the ARGUMENT separator is supported, and deliberately so: the
+  // starter launches `${RUN_CMD}` unquoted, so `cmd arg` splits into words — a path
+  // that itself contains a space could never serve, whatever this test proved.
+  const cmd = "/opt/venv/bin/langflow run --extra 'a b'";
   const round = sourced(
     [
       `remote="$(target_cmd_env)bash -s"`,
@@ -367,7 +356,21 @@ test("the target's RUN command crosses the ssh boundary, and the SYNC override k
     { LANGFLOW_SRC_RUN_CMD: cmd },
   );
   assert.equal(round.status, 0, round.stderr);
-  assert.equal(round.stdout, cmd, "the far side must READ the command back, spaces included");
+  assert.equal(round.stdout, cmd, "the far side must READ the command back, quoting included");
+
+  // The trailing space is part of the contract, because the caller concatenates. Drop
+  // it and the assignment glues onto the next one, producing a single corrupt
+  // assignment out of two — a failure that reaches the operator as "the backend did not
+  // answer", which is the wrong message for the right reason.
+  const glued = sourced(
+    [
+      `remote="$(target_cmd_env)LANGFLOW_PORT=7999 bash -s"`,
+      `printf '%s\\n' 'printf "%s" "$LANGFLOW_PORT"' | env -u LANGFLOW_PORT bash -c "$remote"`,
+    ].join("\n"),
+    { LANGFLOW_SRC_RUN_CMD: "/opt/venv/bin/langflow run" },
+  );
+  assert.equal(glued.status, 0, glued.stderr);
+  assert.equal(glued.stdout, "7999", "the assignment that follows has to survive");
 });
 
 test("the remote quoting survives a value carrying a quote, which no current value does", () => {

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -383,6 +383,38 @@ test("the target's run command crosses on every run, and the sync command never 
   assert.equal(glued.stdout, "7999", "the assignment that follows has to survive");
 });
 
+test("a run command set against the default switches is warned about, in the phase that can still act", () => {
+  // Both collisions are silent and neither names itself as the cause. PREPARE_TARGET=1
+  // rebuilds the clone that is not going to serve, and then run-metadata.json carries a
+  // prepared sha describing a tree nobody ran. REQUIRE_TARGET_VERSION=1 compares the
+  // LIVE instance's version against upstream's nightly resolution, which moves daily,
+  // so a pinned distribution fails the verdict on a difference the operator introduced
+  // — with a message about authoritative version checks.
+  const cmd = "/root/venv-dev8/bin/langflow run";
+
+  const both = sourced(`PREPARE_TARGET=1 REQUIRE_TARGET_VERSION=1 LANGFLOW_SRC_RUN_CMD="${cmd}" warn_target_cmd_conflicts`);
+  assert.equal(both.status, 0, both.stderr);
+  assert.match(both.stderr, /PREPARE_TARGET=0/, "the warning has to name the switch that stops the rebuild");
+  assert.match(both.stderr, /REQUIRE_TARGET_VERSION=1/, "and the one that fails the verdict");
+
+  // Silent when the caller has already dealt with both — a warning that fires anyway is
+  // a warning nobody reads.
+  const handled = sourced(`PREPARE_TARGET=0 REQUIRE_TARGET_VERSION=0 LANGFLOW_SRC_RUN_CMD="${cmd}" warn_target_cmd_conflicts`);
+  assert.equal(handled.status, 0, handled.stderr);
+  assert.doesNotMatch(handled.stderr, /LANGFLOW_SRC_RUN_CMD is set/);
+
+  // And silent on the default path, which is how this script runs every weekday: no
+  // run command, nothing to warn about, whatever the other two switches say.
+  const none = sourced(`(unset LANGFLOW_SRC_RUN_CMD; PREPARE_TARGET=1 REQUIRE_TARGET_VERSION=1 warn_target_cmd_conflicts)`);
+  assert.equal(none.status, 0, none.stderr);
+  assert.doesNotMatch(none.stderr, /LANGFLOW_SRC_RUN_CMD is set/);
+
+  // Wired into the phase, not merely defined: a guard nothing calls is a guard that
+  // does not exist.
+  const body = readFileSync(SCRIPT, "utf8");
+  assert.match(body, /^\s+warn_target_cmd_conflicts$/m, "phase_preflight has to call it");
+});
+
 test("the remote quoting survives a value carrying a quote, which no current value does", () => {
   // The branch none of today's values reach, and therefore the one that will be wrong
   // when it is first needed — the day someone overrides a mirrored variable from the

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -1126,6 +1126,21 @@ function metadataFrom(env, after = "") {
   return { meta: JSON.parse(readFileSync(file, "utf8")), stdout: r.stdout, stderr: r.stderr };
 }
 
+test("the metadata names the command that served the target, so two artifacts are not one run", () => {
+  // Without this field a run against the published distribution is byte-identical to
+  // one against the clone: same version string, same suite sha, same mirrored env. It
+  // is the "green run against the wrong instance" class the starter's build stamp
+  // exists for (#1658), arriving through the ARTIFACT instead of through stale assets —
+  // and the comparison this lane produces is only about the environment if both sides
+  // are known to have run the same product.
+  const { meta } = metadataFrom({ ...BLANKED, LANGFLOW_SRC_RUN_CMD: "/root/venv-dev8/bin/langflow run" });
+  assert.equal(meta.langflow_target_run_cmd, "/root/venv-dev8/bin/langflow run");
+
+  // Empty is not "unknown": it is the starter's own default, uv against the clone.
+  const { meta: dflt } = metadataFrom({ ...BLANKED });
+  assert.equal(dflt.langflow_target_run_cmd, "");
+});
+
 test("the metadata records the mirrored values that were IN FORCE, not the defaults", () => {
   // The property #1748 exists for. On 2026-09-07 the instance under test ran with
   // tracing OFF against the workflow's `false`; the override was an export in the

--- a/scripts/run-e2e.test.mjs
+++ b/scripts/run-e2e.test.mjs
@@ -1140,7 +1140,13 @@ test("the metadata names the command that served the target, so two artifacts ar
   assert.equal(meta.langflow_target_run_cmd, "/root/venv-dev8/bin/langflow run");
 
   // Empty is not "unknown": it is the starter's own default, uv against the clone.
-  const { meta: dflt } = metadataFrom({ ...BLANKED });
+  //
+  // The name is blanked EXPLICITLY, for the reason the mirrored test states three
+  // paragraphs down: `sourced()` forwards process.env, and BLANKED only neutralises the
+  // four mirrored names. Without this the default case asserts "" against whatever the
+  // operator exported — so the test would go red on exactly the machine this feature is
+  // for, the qa VM whose wrapper carries the override. Found by review, reproduced.
+  const { meta: dflt } = metadataFrom({ ...BLANKED, LANGFLOW_SRC_RUN_CMD: "" });
   assert.equal(dflt.langflow_target_run_cmd, "");
 });
 


### PR DESCRIPTION
## Why

The starter has accepted `LANGFLOW_SRC_RUN_CMD` since #1658 — it is how a machine without `uv`, or a run against the **published distribution** rather than the clone, is served. `run-e2e.sh` composed the remote environment from a fixed list, so an override exported on the `qa` wrapper never crossed the ssh boundary. **The knob existed on one side of the connection and not the other.**

## The measurement that made it necessary

On 2026-09-10, on the `bin` VM, with the four mirrored variables and tracing **ON**:

| Artifact serving the target | Traces family, same selection, same machine | Wedge |
|---|---|---|
| source clone via `uv run` | **7 / 8 / 9 failures** (the three attribution runs of #1720) | `auto_login` timeouts |
| published `langflow==1.13.0.dev8` in a venv | **23 of 23 passed**, 1.3 min | zero gunicorn `WORKER TIMEOUT` |

Two further slices against the same distribution: `ui-ux` 44 passed / 1 skipped / 0 failed, and the whole `regression/api` tree 110 of 111 — the single failure being `api-files-v2-store.spec.ts:137`, which `reports/daily-history.jsonl` already records as flaky on 2026-09-07 and which `--retries=0` renders as a failure.

## What the two reviews changed, and it was the shape

The first two commits were reviewed twice: once with this session's context, once by a reader given only the worktree and the branch. **They did not find a defect so much as an over-built design** — six findings pointed at the same place, and the answer was to make the change smaller, which is the lesson #1726 recorded about two defects in one hunk.

| Commit | What it does |
|---|---|
| `1ec94465` | Forwards `RUN_CMD` **unconditionally**, empty included, and **drops the `SYNC_CMD` passthrough entirely**. Removes the asymmetry, the fourteen lines explaining it, two unpinned properties, and a hazard the comment had not considered: a workflow `env:` block cannot express "unset", so an absent input arrives as empty-but-**set**, which is exactly the value that skips `uv sync --frozen`. Also removes `return 0`, whose stated reason **was wrong** — a command substitution used as a word has its status discarded, so the failing `[` could never have tripped `set -e` at the call site. |
| `a6a26247` | The metadata default case stops depending on the operator's environment. Reproduced first: with the override exported, 71 pass / 1 fail — red on exactly the machine this feature is for. |
| `536f50f2` | The run command reaches the run's **early log**, not only its metadata. A wrong path is a backend that never answers, which arrives as a shard timeout; the preflight line exists because the run that dies in prep never reaches `phase_merge`. |
| `f69dbb3a` | Warns when the knob collides with `PREPARE_TARGET=1` and `REQUIRE_TARGET_VERSION=1`. **With the defaults, using this as the first commit documented it makes the run red** — the clone is rebuilt for a tree that will not serve, and the version gate fails on a difference the operator introduced. A warning and not a `die`, because both combinations are legitimate. |
| `b0e557dd` | Forwards `LANGFLOW_SRC_FRONTEND_DIR` too. Without it the published-distribution path **was unreachable**: the starter refuses a clone with no built UI and looks for those assets under the clone, while a distribution ships its own. Naming what serves without naming the assets it serves was half a knob. |

## Verification

- `node --test scripts/run-e2e.test.mjs` — 73/73.
- **Nine mutations, nine failures.** Removing the composer from the launch line; removing it from the preflight line; making the forwarding conditional again; removing `shq`; removing the trailing space that keeps the next assignment from gluing onto this one; adding the sync passthrough back; dropping the frontend directory; silencing either warning; warning with no run command set. Three of those properties — the quoting, the trailing space and the conditional — were **asserted and not pinned** in the first two commits. The claim "every new pin verified to fire" was false when it was first written here, and this line replaces it.
- **End to end, through the repository's own starter** rather than a hand-rolled launch: `start-langflow-source.sh` with the two knobs and `LANGFLOW_REQUIRE_BUILD_STAMP=0` served `1.13.0.dev8`, ready in 10 s, root answering `200 text/html` from the venv's frontend, and 5 specs green across `api-projects-transfer` and `ui-ux/sticky-notes`. Stopped by `stop-langflow-source.sh`: 0 processes, 0 listeners.
- `npm run test:scripts` — 1391 pass, 4 fail. The four also fail on a clean checkout of this branch's base and are environment-bound here: two need a real Playwright run, two are the CommonJS/ESM anti-drift guard.

## How a caller uses it, which the first commits did not say

```
PREPARE_TARGET=0 \
LANGFLOW_SRC_RUN_CMD="/root/venv-dev8/bin/langflow run" \
LANGFLOW_SRC_FRONTEND_DIR="/root/venv-dev8/lib/python3.14/site-packages/langflow/frontend" \
  ./scripts/run-e2e.sh
```

`PREPARE_TARGET=0` also turns the build stamp off, so a missing stamp is a note rather than a refusal. The version gate is a separate decision: pin the distribution to the version upstream resolved, or set `REQUIRE_TARGET_VERSION=0` and accept that the axis goes blind.

## Known limits, stated rather than discovered later

- **The starter still names the clone.** Its first line reads `Langflow source: /root/langflow @ <sha>` even when a distribution is serving, and `langflow_prepared_sha` sits in the same metadata file. The warning added in `f69dbb3a` is the mitigation; making the starter echo the artifact it actually chose would be the fix, and it is not in this PR.
- **Neither value is validated**, unlike the tracing flag, the worker timeout and the pragma set on the same line. A typo produces a start that never answers and a shard timeout. Left out deliberately: the narrower change is the one this lane needs today.
- **Not the image.** The OS layer, the entrypoint and the interpreter of `langflowai/langflow-nightly` remain untested by any of this.
- **The residual on authority.** Forwarding unconditionally gives the field the standing the mirrored four have, no more: a target-side profile that re-exports the name still wins.

## What this does not do

It does not switch the lane's target. The choice of artifact stays with the caller, and `prepare-target-source.sh` remains the only way to test a `release-*` before a wheel of it is published.
