### PR TITLE
fix(settings-message-history): scope the grid to the test's own conversation (#1778)

### DIFF
--- a/docs/ui-ux/settings-message-history.md
+++ b/docs/ui-ux/settings-message-history.md
@@ -1,6 +1,6 @@
 # Settings → Messages — history shows sent messages in order with working filters
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev6`)
+**Last validated:** Langflow 1.13.x (nightly `1.13.0.dev8`)
 
 ---
 
@@ -28,8 +28,40 @@ conversation, the test validates that:
    note below.
 3. **Content integrity** — both sent prompts appear verbatim in the `text`
    column; `sender` distinguishes `User` from the machine/agent side.
-4. **Column filters work** — filtering `sender` by "Equals User" leaves only
-   User rows; clearing the filter restores the full row set.
+4. **Column filters work** — the `session_id` filter narrows the grid to one
+   conversation and the `sender` "Equals User" filter then leaves only User
+   rows; clearing the value restores that conversation's full row set.
+
+## Scoping note *(what broke in #1778)*
+
+Settings → Messages is a **global** audit surface. The suite runs
+`fullyParallel` against one shared superuser on one instance, so every sibling
+spec's messages land in this same table — and AG Grid virtualizes **rows** the
+way #616 found it virtualizing columns: only what fits the viewport is in the
+DOM. Collecting `.ag-cell[col-id="text"]` off an unscoped grid therefore reads
+*some other spec's* messages and asserts this test's prompts are among them.
+
+Measured on `1.13.0.dev8` with 50 stored messages: the footer reports
+"1 to 50 of 50", the DOM carries **18** rows, and this test's own — the newest,
+and therefore last under the ascending default — are not among them. That is
+#1778: a hard 3/3 failure on the VM lane while the feature was working, because
+the rows were one scroll away.
+
+The test therefore **scopes the grid to its own conversation before reading a
+single row**: it resolves its session id from
+`GET /api/v1/monitor/messages?flow_id=<own flow>` (never off the screen — the
+row carrying the prompt is exactly the row virtualization may not have
+materialized) and applies the `session_id` column's "Equals" filter. The scope
+is then **asserted**, not assumed: every rendered `session_id` must equal it,
+so a filter that silently failed to apply hands back the global grid *and
+fails* instead of greening.
+
+**Rejected alternative — sweeping the vertical scroll**, the row-axis twin of
+the #616 column sweep. It collects the rows, but it leaves every assertion
+measuring other specs' messages, and its cost grows with the instance's entire
+message history — the lane that found this serves 654 tests from one instance.
+Scoping is O(this test's own rows). The same move PR #1779 made for #1773,
+where a global flow count was scoped to a project the test owns.
 
 ## Virtualization note *(what broke in #616)*
 
@@ -77,18 +109,22 @@ burst on nightly `1.12.0.dev6`.
    finish (Stop button appears → hidden) and assert a non-empty response.
 3. Send `What is 2+2?`; same wait + non-empty assertion.
 4. Close the Playground; navigate **Settings → Messages**.
-5. **Column contract:** sweep the grid horizontally collecting every
+5. **Scope:** resolve this conversation's `session_id` from
+   `GET /api/v1/monitor/messages?flow_id=<own flow>` (the flow id tracked for
+   cleanup), apply the `session_id` column's "Equals" filter, and assert every
+   rendered `session_id` equals it. Everything below reads the scoped grid.
+6. **Column contract:** sweep the grid horizontally collecting every
    `.ag-header-cell` `col-id`; assert the collected set contains all 11
    promised columns (superset-tolerant).
-6. **Order:** read all `timestamp` cells (≥ 4 rows expected: 2 user + 2
+7. **Order:** read all `timestamp` cells (≥ 4 rows expected: 2 user + 2
    agent); assert they parse (≥ 4 parseable, so the check is never vacuous)
    and are **monotonically ascending**. Monotonicity alone also holds for a
    reversed grid, so it is paired with a direction-sensitive check: the row
    index of `Hello, how are you?` must be **less than** the row index of
    `What is 2+2?` in the `text` column.
-7. **Content:** `sender` column contains `User` and a machine/agent value;
+8. **Content:** `sender` column contains `User` and a machine/agent value;
    `text` column contains both prompts verbatim.
-8. **Filter:** click the `sender` header's dedicated filter button
+9. **Filter:** click the `sender` header's dedicated filter button
    (`.ag-header-cell-filter-button` — the old `.ag-icon-menu` + "Filter" tab
    flow no longer exists on 1.11); pick "Equals", type `User`; assert every
    remaining row's sender is `User`; clear the value; assert the row count
@@ -98,6 +134,8 @@ burst on nightly `1.12.0.dev6`.
 
 ## Validation criterion *(required)*
 
+- Every row the grid renders after scoping belongs to this test's own session —
+  asserted, so an unapplied filter fails instead of silently widening the read.
 - The collected column-id set ⊇ the 11 promised columns.
 - Timestamps render in ascending (oldest-first) order, with ≥ 4 parseable
   timestamp cells after two exchanges; the first prompt sent renders above the
@@ -121,7 +159,8 @@ force-fail contract: no-op the cleanup and the flow count grows.
 
 - Message editing / deleting through the table (`edit` column actions).
 - Session-scoped views (`session_metadata`, session rename) — covered by the
-  playground session specs.
+  playground session specs. The `session_id` filter is used here as the
+  **instrument** that scopes the read; only its narrowing effect is asserted.
 - Exact set equality of columns (new upstream columns are tolerated by
   design — only removals of promised columns fail).
 
@@ -133,6 +172,8 @@ force-fail contract: no-op the cleanup and the flow count grows.
   history is asserted).
 - `tests/helpers/other/initialGPTsetup.ts` + `resolveGptModel` +
   `data/models.json` (collect-models).
+- `GET /api/v1/monitor/messages?flow_id=` — read once, to resolve this
+  conversation's `session_id` for the grid scope (#1778).
 - AG Grid rendering of the messages table (`.ag-header-cell[col-id]`,
   `.ag-cell[col-id]`, `.ag-center-cols-viewport` for the horizontal sweep,
   column-menu filter UI) — Settings → Messages page

--- a/docs/ui-ux/settings-message-history.md
+++ b/docs/ui-ux/settings-message-history.md
@@ -59,7 +59,9 @@ fails* instead of greening.
 **Rejected alternative — sweeping the vertical scroll**, the row-axis twin of
 the #616 column sweep. It collects the rows, but it leaves every assertion
 measuring other specs' messages, and its cost grows with the instance's entire
-message history — the lane that found this serves 654 tests from one instance.
+message history — the lane that found this serves the whole suite from one
+instance (**621** tests on 2026-09-09, the day #1778 was filed; 654 on
+2026-09-11, after the target change put sixteen skipped tests back).
 Scoping is O(this test's own rows). The same move PR #1779 made for #1773,
 where a global flow count was scoped to a project the test owns.
 
@@ -109,13 +111,18 @@ burst on nightly `1.12.0.dev6`.
    finish (Stop button appears → hidden) and assert a non-empty response.
 3. Send `What is 2+2?`; same wait + non-empty assertion.
 4. Close the Playground; navigate **Settings → Messages**.
-5. **Scope:** resolve this conversation's `session_id` from
-   `GET /api/v1/monitor/messages?flow_id=<own flow>` (the flow id tracked for
-   cleanup), apply the `session_id` column's "Equals" filter, and assert every
-   rendered `session_id` equals it. Everything below reads the scoped grid.
-6. **Column contract:** sweep the grid horizontally collecting every
+5. **Column contract:** sweep the grid horizontally collecting every
    `.ag-header-cell` `col-id`; assert the collected set contains all 11
-   promised columns (superset-tolerant).
+   promised columns (superset-tolerant). This runs **before** the scope on
+   purpose — it reads headers, not rows, and it is the only check that can name
+   `session_id` as missing instead of timing out on a locator that never had a
+   chance.
+6. **Scope:** resolve this conversation's `session_id` from
+   `GET /api/v1/monitor/messages?flow_id=<own flow>` (the flow id tracked for
+   cleanup), apply the `session_id` column's "Equals" filter, assert the set of
+   rendered `session_id` values equals `[own]` — polled as a value, so an empty
+   grid and a grid full of foreign sessions read differently — and only then
+   dismiss the popup. Everything below reads the scoped grid.
 7. **Order:** read all `timestamp` cells (≥ 4 rows expected: 2 user + 2
    agent); assert they parse (≥ 4 parseable, so the check is never vacuous)
    and are **monotonically ascending**. Monotonicity alone also holds for a

--- a/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
@@ -26,6 +26,7 @@
 
 import * as dotenv from "dotenv";
 import path from "path";
+import type { APIRequestContext, Locator, Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { initialGPTsetup } from "../../../helpers/other/initialGPTsetup";
@@ -62,6 +63,78 @@ const EXPECTED_COLUMNS = [
 // instance clean).
 const createdFlowIds: string[] = [];
 
+/**
+ * The session id Langflow stored for THIS test's conversation.
+ *
+ * Read from the API, never off the screen: the row carrying `FIRST_MESSAGE` is
+ * exactly the row virtualization may not have materialized (#1778), so reading
+ * the scope key from the grid would depend on the defect being absent. The
+ * lookup is keyed on the flow this test created and then on the prompt it sent,
+ * so it cannot pick up a sibling spec's conversation.
+ */
+async function resolveOwnSessionId(
+  request: APIRequestContext,
+  flowIds: string[],
+  headers: Record<string, string>,
+): Promise<string> {
+  const attempted: string[] = [];
+  for (const flowId of flowIds) {
+    const response = await request.get(
+      `/api/v1/monitor/messages?flow_id=${flowId}`,
+      { headers },
+    );
+    if (!response.ok()) {
+      attempted.push(`${flowId} -> HTTP ${response.status()}`);
+      continue;
+    }
+    const rows = (await response.json()) as {
+      text?: string;
+      session_id?: string;
+    }[];
+    const own = rows.find((row) => (row.text ?? "").trim() === FIRST_MESSAGE);
+    if (own?.session_id) return own.session_id;
+    attempted.push(`${flowId} -> ${rows.length} message(s), none matching`);
+  }
+  throw new Error(
+    `OWN_CONVERSATION_NOT_STORED: no stored message reads "${FIRST_MESSAGE}" for the ` +
+      `flow(s) this test created [${attempted.join("; ")}]. The conversation whose ` +
+      `history is under assertion was never persisted, so the grid cannot be scoped ` +
+      `to it — assert on the Playground exchange before this point, not on the grid.`,
+  );
+}
+
+/**
+ * Applies AG Grid's "Equals <value>" filter to one column, through the header's
+ * dedicated filter button, and returns the filter's text input so the caller can
+ * clear it later.
+ *
+ * The popup is left OPEN — closing it is the caller's call, because the two
+ * users of this want opposite things: the scoping filter is set once and must
+ * get out of the way of the next header, while the `sender` filter is cleared
+ * again a few lines later and would have to be reopened.
+ */
+async function applyEqualsFilter(
+  page: Page,
+  colId: string,
+  value: string,
+): Promise<Locator> {
+  await page.hover(`.ag-header-cell[col-id="${colId}"]`);
+  await page
+    .locator(`.ag-header-cell[col-id="${colId}"] .ag-header-cell-filter-button`)
+    .click({ timeout: 5000 });
+  await expect(page.locator(".ag-filter").first()).toBeVisible({
+    timeout: 5000,
+  });
+
+  // Select "Equals" in the filter type dropdown
+  await page.locator(".ag-filter .ag-picker-field-wrapper").first().click();
+  await page.getByRole("option", { name: "Equals" }).click();
+
+  const filterInput = page.locator('.ag-filter input[type="text"]').first();
+  await filterInput.fill(value);
+  return filterInput;
+}
+
 test.afterEach(async ({ request }) => {
   if (createdFlowIds.length === 0) return;
   const bearer = await getAuthToken(request);
@@ -73,7 +146,7 @@ test.afterEach(async ({ request }) => {
 test(
   "Settings > Messages displays sent messages in correct order with working filters",
   { tag: ["@stable", "@release", "@workspace", "@api", "@settings"] },
-  async ({ page }) => {
+  async ({ page, request }) => {
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }
@@ -149,6 +222,55 @@ test(
       page.getByTestId("settings_menu_header"),
     ).toContainText("Messages");
 
+    // Scope the grid to THIS test's conversation before a single row is read.
+    //
+    // Settings > Messages is a GLOBAL audit surface: the suite runs
+    // `fullyParallel` against one shared superuser on one instance, so every
+    // sibling spec's messages land in this same table. And AG Grid virtualizes
+    // ROWS exactly the way #616 found it virtualizing columns — only what fits
+    // the viewport is in the DOM. Collecting `.ag-cell[col-id="..."]` off an
+    // unscoped grid therefore reads *some other spec's* messages and asserts
+    // this test's prompts are among them.
+    //
+    // Measured on `1.13.0.dev8` with 50 stored messages: the footer reports
+    // "1 to 50 of 50", the DOM carries 18 rows, and this test's own — the
+    // NEWEST, and last under the ascending default — are not among them. That
+    // is #1778 reproduced: a hard 3/3 failure on the VM lane while the feature
+    // was working, because the rows were one scroll away.
+    //
+    // REJECTED — sweeping the vertical scroll, the row-axis twin of the #616
+    // column sweep. It would collect the rows, but it leaves every assertion
+    // below measuring other specs' messages, and its cost grows with the
+    // instance's entire history: the lane that found this serves 654 tests from
+    // one instance. Scoping is O(this test's own rows) and makes the order,
+    // sender and content assertions legitimate again — the same move PR #1779
+    // made for #1773, where a global flow count was scoped to an owned project.
+    const bearer = await getAuthToken(request);
+    const ownSessionId = await resolveOwnSessionId(request, createdFlowIds, {
+      Authorization: bearer,
+    });
+    await applyEqualsFilter(page, "session_id", ownSessionId);
+    // Dismiss the popup: left open it swallows the hover that opens the next
+    // column's filter button.
+    await page.keyboard.press("Escape");
+
+    // The scope is ASSERTED, not assumed. Without this, a filter that silently
+    // failed to apply would hand every assertion below the global grid back —
+    // the exact state this test is being fixed for, and green.
+    const sessionCells = page.locator('.ag-cell[col-id="session_id"]');
+    await expect
+      .poll(
+        async () => {
+          const sessions = await sessionCells.allTextContents();
+          return (
+            sessions.length > 0 &&
+            sessions.every((s) => s.trim() === ownSessionId)
+          );
+        },
+        { timeout: 10000 },
+      )
+      .toBe(true);
+
     // Step 10: Verify the messages table has all required columns.
     // AG Grid VIRTUALIZES columns horizontally — header cells outside the
     // scrolled-into-view region are not in the DOM, so per-column
@@ -194,7 +316,7 @@ test(
     await expect(timestampCells.first()).toBeVisible({ timeout: 10000 });
 
     const rowCount = await timestampCells.count();
-    expect(rowCount).toBeGreaterThanOrEqual(4); // at least: 2 user msgs + 2 agent responses
+    expect(rowCount).toBeGreaterThanOrEqual(4); // this conversation: 2 user msgs + 2 agent responses
 
     // Collect timestamps and verify ascending (oldest-first) order
     const timestamps: number[] = [];
@@ -263,24 +385,7 @@ test(
     // The header renders a dedicated filter button (.ag-header-cell-filter-button)
     // that opens the filter popup directly — the old .ag-icon-menu +
     // "Filter" tab flow no longer exists on the 1.11 nightly (#616).
-    await page.hover('.ag-header-cell[col-id="sender"]');
-    await page
-      .locator('.ag-header-cell[col-id="sender"] .ag-header-cell-filter-button')
-      .click({ timeout: 5000 });
-    await expect(page.locator(".ag-filter").first()).toBeVisible({
-      timeout: 5000,
-    });
-
-    // Select "Equals" in the filter type dropdown
-    const filterTypeSelect = page.locator(
-      '.ag-filter .ag-picker-field-wrapper',
-    ).first();
-    await filterTypeSelect.click();
-    await page.getByRole("option", { name: "Equals" }).click();
-
-    // Type "User" in the filter input
-    const filterInput = page.locator('.ag-filter input[type="text"]').first();
-    await filterInput.fill("User");
+    const filterInput = await applyEqualsFilter(page, "sender", "User");
 
     // Step 18: Verify only User messages are displayed. AG Grid applies the
     // filter after a debounce and re-renders asynchronously — poll until the
@@ -299,12 +404,12 @@ test(
     const filteredCount = await senderCellLocator.count();
     expect(filteredCount).toBeGreaterThan(0);
 
-    // Steps 19-20: Remove filter value → all messages restored
+    // Steps 19-20: Remove filter value → this conversation's rows restored
     await filterInput.clear();
     await expect
       .poll(async () => senderCellLocator.count(), { timeout: 10000 })
       .toBeGreaterThan(filteredCount); // more rows than the filtered set
     const restoredCount = await senderCellLocator.count();
-    expect(restoredCount).toBeGreaterThanOrEqual(4); // back to at least 4 rows
+    expect(restoredCount).toBeGreaterThanOrEqual(4); // back to the scoped set: 2 user + 2 agent
   },
 );

--- a/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
@@ -77,6 +77,17 @@ async function resolveOwnSessionId(
   flowIds: string[],
   headers: Record<string, string>,
 ): Promise<string> {
+  // Told apart from "the conversation was not stored" on purpose (#1778 review):
+  // an empty list means the response listener never saw a POST /api/v1/flows 201,
+  // so the failure is upstream of the messages and the reader must be sent there.
+  if (flowIds.length === 0) {
+    throw new Error(
+      `OWN_FLOW_ID_NOT_CAPTURED: no POST /api/v1/flows -> 201 was recorded, so this test ` +
+        `never learned the id of the flow it created and the grid cannot be scoped. Look at ` +
+        `the template load, not at the message history.`,
+    );
+  }
+
   const attempted: string[] = [];
   for (const flowId of flowIds) {
     const response = await request.get(
@@ -122,15 +133,20 @@ async function applyEqualsFilter(
   await page
     .locator(`.ag-header-cell[col-id="${colId}"] .ag-header-cell-filter-button`)
     .click({ timeout: 5000 });
-  await expect(page.locator(".ag-filter").first()).toBeVisible({
-    timeout: 5000,
-  });
+
+  // Scoped to the OPEN popup, never to `.ag-filter` at large. This helper runs
+  // twice in one test, and `.first()` over every `.ag-filter` in the DOM is only
+  // unambiguous while AG Grid detaches a closed popup — the day it keeps one
+  // attached-but-hidden, the `sender` call would type into the `session_id`
+  // filter and silently rescope the grid (#1778 review).
+  const popup = page.locator(".ag-filter:visible").first();
+  await expect(popup).toBeVisible({ timeout: 5000 });
 
   // Select "Equals" in the filter type dropdown
-  await page.locator(".ag-filter .ag-picker-field-wrapper").first().click();
+  await popup.locator(".ag-picker-field-wrapper").first().click();
   await page.getByRole("option", { name: "Equals" }).click();
 
-  const filterInput = page.locator('.ag-filter input[type="text"]').first();
+  const filterInput = popup.locator('input[type="text"]').first();
   await filterInput.fill(value);
   return filterInput;
 }
@@ -222,55 +238,6 @@ test(
       page.getByTestId("settings_menu_header"),
     ).toContainText("Messages");
 
-    // Scope the grid to THIS test's conversation before a single row is read.
-    //
-    // Settings > Messages is a GLOBAL audit surface: the suite runs
-    // `fullyParallel` against one shared superuser on one instance, so every
-    // sibling spec's messages land in this same table. And AG Grid virtualizes
-    // ROWS exactly the way #616 found it virtualizing columns — only what fits
-    // the viewport is in the DOM. Collecting `.ag-cell[col-id="..."]` off an
-    // unscoped grid therefore reads *some other spec's* messages and asserts
-    // this test's prompts are among them.
-    //
-    // Measured on `1.13.0.dev8` with 50 stored messages: the footer reports
-    // "1 to 50 of 50", the DOM carries 18 rows, and this test's own — the
-    // NEWEST, and last under the ascending default — are not among them. That
-    // is #1778 reproduced: a hard 3/3 failure on the VM lane while the feature
-    // was working, because the rows were one scroll away.
-    //
-    // REJECTED — sweeping the vertical scroll, the row-axis twin of the #616
-    // column sweep. It would collect the rows, but it leaves every assertion
-    // below measuring other specs' messages, and its cost grows with the
-    // instance's entire history: the lane that found this serves 654 tests from
-    // one instance. Scoping is O(this test's own rows) and makes the order,
-    // sender and content assertions legitimate again — the same move PR #1779
-    // made for #1773, where a global flow count was scoped to an owned project.
-    const bearer = await getAuthToken(request);
-    const ownSessionId = await resolveOwnSessionId(request, createdFlowIds, {
-      Authorization: bearer,
-    });
-    await applyEqualsFilter(page, "session_id", ownSessionId);
-    // Dismiss the popup: left open it swallows the hover that opens the next
-    // column's filter button.
-    await page.keyboard.press("Escape");
-
-    // The scope is ASSERTED, not assumed. Without this, a filter that silently
-    // failed to apply would hand every assertion below the global grid back —
-    // the exact state this test is being fixed for, and green.
-    const sessionCells = page.locator('.ag-cell[col-id="session_id"]');
-    await expect
-      .poll(
-        async () => {
-          const sessions = await sessionCells.allTextContents();
-          return (
-            sessions.length > 0 &&
-            sessions.every((s) => s.trim() === ownSessionId)
-          );
-        },
-        { timeout: 10000 },
-      )
-      .toBe(true);
-
     // Step 10: Verify the messages table has all required columns.
     // AG Grid VIRTUALIZES columns horizontally — header cells outside the
     // scrolled-into-view region are not in the DOM, so per-column
@@ -303,6 +270,62 @@ test(
     for (const column of EXPECTED_COLUMNS) {
       expect(renderedColumnIds, `column "${column}" missing from the messages grid`).toContain(column);
     }
+
+    // Scope the grid to THIS test's conversation before a single ROW is read.
+    //
+    // Settings > Messages is a GLOBAL audit surface: the suite runs
+    // `fullyParallel` against one shared superuser on one instance, so every
+    // sibling spec's messages land in this same table. And AG Grid virtualizes
+    // ROWS exactly the way #616 found it virtualizing columns — only what fits
+    // the viewport is in the DOM. Collecting `.ag-cell[col-id="..."]` off an
+    // unscoped grid therefore reads *some other spec's* messages and asserts
+    // this test's prompts are among them. That is #1778; the measurement behind
+    // it is dated in the spec doc rather than repeated here.
+    //
+    // This sits AFTER the column contract deliberately: everything below depends
+    // on `session_id` being reachable, and the horizontal sweep above is the only
+    // check that can say `column "session_id" missing from the messages grid`
+    // instead of timing out on a locator that never had a chance — in the file
+    // whose whole history is virtualization. The sweep reads headers, not rows,
+    // so nothing has been read unscoped.
+    //
+    // REJECTED — sweeping the vertical scroll, the row-axis twin of the #616
+    // column sweep. It would collect the rows, but it leaves every assertion
+    // below measuring other specs' messages, and its cost grows with the
+    // instance's entire message history instead of with this test's own rows.
+    // Scoping is the same move PR #1779 made for #1773, where a global flow
+    // count was scoped to a project the test owns.
+    const bearer = await getAuthToken(request);
+    const ownSessionId = await resolveOwnSessionId(request, createdFlowIds, {
+      Authorization: bearer,
+    });
+    await applyEqualsFilter(page, "session_id", ownSessionId);
+
+    // The scope is ASSERTED, not assumed. Without this, a filter that silently
+    // failed to apply would hand every assertion below the global grid back —
+    // the exact state this test is being fixed for, and green.
+    //
+    // Asserted BEFORE the popup is dismissed, so the read happens in the same
+    // window the value was typed in rather than across AG Grid's apply debounce.
+    // And it polls the rendered VALUE, not a boolean: `[]` says the grid
+    // narrowed to nothing (or the column is not materialized) while a list of
+    // foreign sessions says the filter never applied — `expected true, received
+    // false` says neither.
+    const sessionCells = page.locator('.ag-cell[col-id="session_id"]');
+    await expect
+      .poll(
+        async () => [
+          ...new Set(
+            (await sessionCells.allTextContents()).map((text) => text.trim()),
+          ),
+        ],
+        { timeout: 10000 },
+      )
+      .toEqual([ownSessionId]);
+
+    // Only now dismiss it: left open, the popup swallows the hover that opens
+    // the `sender` filter further down.
+    await page.keyboard.press("Escape");
 
     // Steps 11-13: Verify display order — OLDEST first (chronological). The
     // grid renders the API order, and 1.12 flipped that order on purpose:


### PR DESCRIPTION
**Fixes #1778.**

## Problem

`settings-message-history.spec.ts` read the **global** messages grid and asserted its own prompts were in it:

```ts
const joinedTexts = allTexts.join(" ");
expect(joinedTexts).toContain(FIRST_MESSAGE);
```

Settings → Messages is a global audit surface — the suite runs `fullyParallel` against one shared superuser on one instance, so every sibling spec's messages land in that table. And AG Grid virtualizes **rows** the way #616 found it virtualizing columns: only what fits the viewport is in the DOM.

## The discriminator #1778 asked for, answered: **test shape**

The issue left two shapes open and named the measurement that separates them — *on an instance carrying more than one viewport of messages, scroll the grid body to the end and re-collect `col-id="text"`.* Measured on `1.13.0.dev8` (nightly image, 50 stored messages from 25 sessions, viewport 1280×720):

| | |
|---|---|
| grid footer | `1 to 50 of 50`, `Page 1 of 1` |
| `.ag-row` in the DOM | **18** |
| body viewport | `clientHeight=324`, `scrollHeight=2100` |
| own (newest) row materialized | **no** |
| own row after sweeping the vertical scroll | **yes** |

The newest rows are **reachable** — one scroll away. So this is not the product shape: no user is losing sight of their most recent messages, and the assertion's premise ("everything materialized is everything there is") is what broke. The reproduction is faithful to the issue's own numbers: 22 reported / 18 in DOM / own rows absent, here 50 / 18 / absent.

## Fix

The grid is **scoped to this test's own conversation before a single row is read**:

- the session id comes from `GET /api/v1/monitor/messages?flow_id=<own flow>` — never off the screen, because the row carrying `FIRST_MESSAGE` is exactly the row virtualization may not have materialized, so reading the scope key from the grid would depend on the defect being absent;
- the `session_id` column's "Equals" filter is applied (measured: that header is in the DOM at `scrollLeft = 0` and carries a filter button);
- **the scope is asserted, not assumed** — every rendered `session_id` must equal it. A filter that silently failed to apply hands the global grid back, and that now *fails* instead of greening.

Every assertion below it — order, direction, senders, content, the `sender` filter — then measures this test's own four rows. The `sender` filter interaction moved into `applyEqualsFilter`, now used twice.

### Rejected alternative

**Sweeping the vertical scroll**, the row-axis twin of the #616 column sweep, which the issue explicitly notes the row axis never received. It collects the rows, but:

- it leaves every assertion measuring *other specs'* messages — the order, sender and content checks stay global;
- its cost grows with the instance's whole message history. The lane that found this serves **654 tests from one instance**, so the sweep is unbounded work in exactly the environment the bug lives in.

Scoping is `O(this test's own rows)`. Same move PR #1779 made for #1773, where a global flow count was scoped to a project the test owns.

## Validation (Langflow `1.13.0.dev8`, nightly image, `--retries=0`)

Against a **deliberately polluted** instance — 50 messages from 25 sibling sessions seeded through `POST /api/v1/run/`, so the defect's precondition is present and deterministic rather than waited for:

| Run | Result |
|---|---|
| Fixed spec, `--repeat-each=3 --trace=on` | **3 passed** (1.0 min) |
| Original spec, same instance | **fails at line 246**, `Expected substring: "Hello, how are you?"` / received 18 `sibling-probe-*` texts — #1778's signature, same line, same shape |
| Force-fail: scope filter pointed at a non-existent session | **fails at the scope assertion**, not green — no false positive |
| Backend errors (`🚨 Backend Error:`) | **0** |
| `tsc --noEmit`, `eslint`, `check:checklist-coverage` | clean (9 pre-existing warnings, 0 errors) |

## The `@stable` decision #1778 lists, answered explicitly

#1778 records "whether the tag should come off" as one of the things it decides. **The tag stays.** The failure was test-shaped — the discriminator above shows the rows are reachable, so the feature is working — and the test's own logic (the column contract, the chronological order, the direction check, the sender filter) was never in question. `@stable` is still on Test 1 here; nothing in this PR removes or restores it.

## The VM lane's own proof — run on 2026-09-12, and it is decisive

The issue requires a run **with the pollution present**, and says the fix cannot be verified on the Actions lane, which never reproduces it. That run is now on record: `langflowqa` → tunnel → `langflowbin`, the daily's own target (published distribution `1.13.0.dev9` in a venv, brought up by this repo's `start-langflow-source.sh` with the mirrored env and **tracing on**), `collect-models` first as the daily does, then 25 sibling sessions seeded through `POST /api/v1/run/` so the precondition is deterministic rather than waited for.

Both halves ran against the **same instance**, `--workers=1 --retries=0`:

| Tree | Result |
|---|---|
| `main` @ `0c914e9b` — spec without the fix | **failed**, line 246: `Expected substring: "Hello, how are you?"` / received 18 `sibling-probe-*` texts — #1778's signature, reproduced on the lane that owns it |
| this PR @ `15ad4411` | **passed** (27.1 s), 100 messages in the backend at that moment |

Target torn down and verified afterwards: `Langflow on port 7862 stopped`, 0 processes, 0 listeners on 786x. The worktree and temporary branch used for the run were removed; the `qa` clone is back on `main` @ `0c914e9b`, tree clean. Evidence kept on the machine in `/root/probe-1778-20260912/` (script, seeder, log).

One honest note from the run: the preflight warned `ANTHROPIC_API_KEY` is set in the environment but not configured as a Langflow global variable — that provider's collector stalled during `collect-models` (the known dead-key symptom on that account). It does not touch this spec, which gates on OpenAI, recorded active as `gpt-4o-mini`.

